### PR TITLE
Fix bug with file upload fields and locked data sets in data entry

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueController.java
@@ -387,12 +387,6 @@ public class DataValueController
         OrganisationUnit organisationUnit = getAndValidateOrganisationUnit( ou );
 
         // ---------------------------------------------------------------------
-        // Locking validation
-        // ---------------------------------------------------------------------
-
-        validateDataSetNotLocked( dataElement, period, organisationUnit, attributeOptionCombo );
-
-        // ---------------------------------------------------------------------
         // Get data value
         // ---------------------------------------------------------------------
 
@@ -441,12 +435,6 @@ public class DataValueController
         Period period = getAndValidatePeriod( pe );
 
         OrganisationUnit organisationUnit = getAndValidateOrganisationUnit( ou );
-
-        // ---------------------------------------------------------------------
-        // Locking validation
-        // ---------------------------------------------------------------------
-
-        validateDataSetNotLocked( dataElement, period, organisationUnit, attributeOptionCombo );
 
         // ---------------------------------------------------------------------
         // Get data value

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.fileresource.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.fileresource.js
@@ -80,7 +80,7 @@
                     }
                 } );
             } );
-            $button.button( 'enable' );
+            $button.button( isDisabled( $field ) ? 'disable' : 'enable' );
         };
 
         var setButtonUpload = function() {
@@ -95,7 +95,7 @@
             {
                 $fileInput.click();
             } );
-            $button.button( 'enable' );
+            $button.button( isDisabled( $field ) ? 'disable' : 'enable' );
         };
 
         var setButtonBlocked = function() {
@@ -221,5 +221,10 @@
                 } );
             }
         } );
+
+        function isDisabled( jqField ) {
+            var value = jqField.data( 'disabled' );
+            return value == 'undefined' ? false : value;
+        }
     };
 } )( jQuery );

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1707,7 +1707,10 @@ function insertDataValues( json )
         $( '#contentDiv textarea' ).removeAttr( 'readonly' );
 		$( '#completenessDiv' ).show();
 	}
-	
+
+    // Set the data-disabled attribute on any file upload fields
+    $( '#contentDiv .entryfileresource' ).data( 'disabled', json.locked );
+
     // Set data values, works for selects too as data value=select value
 
     $.safeEach( json.dataValues, function( i, value )


### PR DESCRIPTION
Fixes bug where web-api would refuse reading 'locked' data values (should only refuse write and/or delete). Also implemented proper handling of the locket data set case for the DE file upload fields (i.e. button is disabled when dataset is locked).