### PR TITLE
Check for duplicate IDs in payload, remove duplicate objects if found…

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode
     E5000( "Found matching object for given reference, but import mode is CREATE. Identifier was {0}, and object was {1}." ),
     E5001( "No matching object for given reference. Identifier was {0}, and object was {1}." ),
     E5002( "Invalid reference {0} on object {1} for association `{2}`." ),
-    E5003( "Property `{0}` with value `{1}` on object {2} already exists on object {3}." );
+    E5003( "Property `{0}` with value `{1}` on object {2} already exists on object {3}." ),
+    E5004( "Id `{0}` for type `{1}` exists on more than 1 object in the payload, removing all but the first found." );
 
     private String message;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata2/objectbundle/ObjectBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata2/objectbundle/ObjectBundleServiceTest.java
@@ -1299,6 +1299,53 @@ public class ObjectBundleServiceTest
     }
 
     @Test
+    public void testCreateMetadataWithDuplicateDataElementUid() throws IOException
+    {
+        createUserAndInjectSecurityContext( true );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/de_duplicate_uid.json" ).getInputStream(), RenderFormat.JSON );
+
+        ObjectBundleParams params = new ObjectBundleParams();
+        params.setObjectBundleMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE_AND_UPDATE );
+        params.setAtomicMode( AtomicMode.NONE );
+        params.setObjects( metadata );
+
+        ObjectBundle bundle = objectBundleService.create( params );
+        objectBundleValidationService.validate( bundle );
+
+        objectBundleService.commit( bundle );
+
+        assertEquals( 1, manager.getAll( DataElement.class ).size() );
+
+        DataElement dataElement = manager.get( DataElement.class, "CCwk5Yx440o" );
+        assertEquals( "CCwk5Yx440o", dataElement.getUid() );
+        assertEquals( "DataElementB", dataElement.getName() );
+    }
+
+    @Test
+    public void testCreateMetadataWithDuplicateDataElementUidALL() throws IOException
+    {
+        createUserAndInjectSecurityContext( true );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/de_duplicate_uid.json" ).getInputStream(), RenderFormat.JSON );
+
+        ObjectBundleParams params = new ObjectBundleParams();
+        params.setObjectBundleMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE_AND_UPDATE );
+        params.setObjects( metadata );
+
+        ObjectBundle bundle = objectBundleService.create( params );
+        objectBundleValidationService.validate( bundle );
+
+        objectBundleService.commit( bundle );
+
+        assertEquals( 0, manager.getAll( DataElement.class ).size() );
+    }
+
+    @Test
     public void testCreateOrgUnitWithLevels() throws IOException
     {
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/de_duplicate_uid.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/de_duplicate_uid.json
@@ -1,0 +1,42 @@
+{
+  "dataElements": [
+    {
+      "attributeValues": [ ],
+      "userGroupAccesses": [ ],
+      "valueType": "TEXT",
+      "aggregationType": "SUM",
+      "created": "2016-02-17T06:15:06.079+0000",
+      "shortName": "DataElementShortB",
+      "categoryCombo": {
+        "id": "zU1OZFVxnw7"
+      },
+      "aggregationLevels": [ ],
+      "id": "CCwk5Yx440o",
+      "domainType": "AGGREGATE",
+      "lastUpdated": "2016-02-17T06:15:59.378+0000",
+      "zeroIsSignificant": false,
+      "publicAccess": "rw------",
+      "code": "DataElementCodeB",
+      "name": "DataElementB"
+    },
+    {
+      "code": "DataElementCodeA",
+      "publicAccess": "rw------",
+      "name": "DataElementA",
+      "attributeValues": [ ],
+      "userGroupAccesses": [ ],
+      "valueType": "TEXT",
+      "aggregationType": "SUM",
+      "shortName": "DataElementShortA",
+      "created": "2016-02-17T06:15:49.487+0000",
+      "categoryCombo": {
+        "id": "zU1OZFVxnw7"
+      },
+      "id": "CCwk5Yx440o",
+      "aggregationLevels": [ ],
+      "domainType": "AGGREGATE",
+      "lastUpdated": "2016-02-17T06:16:08.180+0000",
+      "zeroIsSignificant": false
+    }
+  ]
+}


### PR DESCRIPTION
… (follows normal `atomicMode` functionality) (#35)

* added failing test case for cases where same file has duplicate uid

* adds new validation check for duplicate IDs in payload, keep first object, then removes the rest (if duplicates are found)