### PR TITLE
Remove extra options from meta data import ui

### DIFF
--- a/dhis-2/dhis-web/dhis-web-importexport/src/main/webapp/dhis-web-importexport/dxf2MetaDataImport.vm
+++ b/dhis-2/dhis-web/dhis-web-importexport/src/main/webapp/dhis-web-importexport/dxf2MetaDataImport.vm
@@ -58,10 +58,6 @@
 </tr>
 <tr>
 	<td></td>
-	<td><a href="javascript:toggleOptions()">$i18n.getString( "more_options" )</a></td>
-</tr>
-<tr>
-	<td></td>
 	<td><input type="button" value="$i18n.getString( 'import' )" style="width:120px" onclick="importMetaData()"/></td>
 </tr>
 </table>


### PR DESCRIPTION
The extra options have been removed but the button was left
this causes confusion as when it is clicked nothing happens.