### PR TITLE
Translations. Removed Hibernate filter and instead loading all translations.

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/ObjectTranslation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/ObjectTranslation.java
@@ -88,7 +88,19 @@ public class ObjectTranslation
             && Objects.equals( this.property, other.property )
             && Objects.equals( this.value, other.value );
     }
-
+    
+    /**
+     * Creates a cache key.
+     * 
+     * @param locale the locale string, i.e. Locale.toString().
+     * @param property the translation property.
+     * @return a unique cache key valid for a given translated objects, or null
+     *         if either locale or property is null.
+     */
+    public static String getCacheKey( String locale, TranslationProperty property )
+    {
+        return locale != null && property != null ? ( locale + property.name() ) : null;
+    }
 
     //-------------------------------------------------------------------------------
     // Accessors

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
@@ -86,17 +86,9 @@
     <set name="translations" table="attributetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="attributeid" foreign-key="fk_objecttranslation_attributeid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/chart/hibernate/Chart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/chart/hibernate/Chart.hbm.xml
@@ -179,11 +179,7 @@
     <set name="translations" table="charttranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="chartid" foreign-key="fk_objecttranslation_chartid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -200,9 +196,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/color/hibernate/Color.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/color/hibernate/Color.hbm.xml
@@ -23,17 +23,9 @@
     <set name="translations" table="colortranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="colorid" foreign-key="fk_objecttranslation_colorid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/color/hibernate/ColorSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/color/hibernate/ColorSet.hbm.xml
@@ -28,17 +28,9 @@
     <set name="translations" table="colorsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="colorsetid" foreign-key="fk_objecttranslation_colorsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/constant/hibernate/Constant.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/constant/hibernate/Constant.hbm.xml
@@ -27,11 +27,7 @@
     <set name="translations" table="constanttranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="colorid" foreign-key="fk_objecttranslation_colorid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -53,9 +49,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/Dashboard.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/Dashboard.hbm.xml
@@ -28,11 +28,7 @@
     <set name="translations" table="dashboardtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dashboardid" foreign-key="fk_objecttranslation_dashboardid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -49,9 +45,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/DashboardItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/DashboardItem.hbm.xml
@@ -47,11 +47,7 @@
     <set name="translations" table="dashboarditemtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dashboarditemid" foreign-key="fk_objecttranslation_dashboarditemid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <property name="messages" />
@@ -67,9 +63,5 @@
     </property>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataapproval/hibernate/DataApprovalLevel.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataapproval/hibernate/DataApprovalLevel.hbm.xml
@@ -27,11 +27,7 @@
     <set name="translations" table="dataapprovalleveltranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dataapprovallevelid" foreign-key="fk_objecttranslation_dataapprovallevelid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -46,9 +42,5 @@
     </set>
 
     </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataapproval/hibernate/DataApprovalWorkflow.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataapproval/hibernate/DataApprovalWorkflow.hbm.xml
@@ -34,11 +34,7 @@
     <set name="translations" table="dataapprovalworkflowtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="workflowid" foreign-key="fk_objecttranslation_workflowid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -53,9 +49,5 @@
     </set>
 
     </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/CategoryOptionGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/CategoryOptionGroup.hbm.xml
@@ -36,16 +36,11 @@
       <many-to-many class="org.hisp.dhis.attribute.AttributeValue" column="attributevalueid" unique="true" />
     </set>
 
-
     <!-- Object Translation -->
     <set name="translations" table="categoryoptiongrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="categoryoptiongroupid" foreign-key="fk_objecttranslation_categoryoptiongroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -65,10 +60,5 @@
     </join>
 
   </class>
-
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/CategoryOptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/CategoryOptionGroupSet.hbm.xml
@@ -35,11 +35,7 @@
     <set name="translations" table="categoryoptiongroupsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="categoryoptiongroupsetid" foreign-key="fk_objecttranslation_categoryoptiongroupsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -54,9 +50,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
@@ -89,11 +89,7 @@
     <set name="translations" table="dataelementtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dataelementid" foreign-key="fk_objecttranslation_dataelementid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -109,7 +105,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategory.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategory.hbm.xml
@@ -41,11 +41,7 @@
     <set name="translations" table="dataelementcategorytranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="categoryid" foreign-key="fk_objecttranslation_categoryid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -60,9 +56,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategoryCombo.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategoryCombo.hbm.xml
@@ -40,11 +40,7 @@
     <set name="translations" table="categorycombotranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="categorycomboid" foreign-key="fk_objecttranslation_categorycomboid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -60,8 +56,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
-
-  </hibernate-mapping>
+</hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategoryOption.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategoryOption.hbm.xml
@@ -53,11 +53,7 @@
     <set name="translations" table="categoryoptiontranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="categoryoptionid" foreign-key="fk_objecttranslation_categoryoptionid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Dynamic attribute values -->
@@ -80,9 +76,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategoryOptionCombo.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementCategoryOptionCombo.hbm.xml
@@ -28,11 +28,7 @@
     <set name="translations" table="categoryoptioncombotranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="categoryoptioncomboid" foreign-key="fk_objecttranslation_categoryoptioncomboid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <property name="ignoreApproval" column="ignoreapproval" />
@@ -43,9 +39,5 @@
     </join>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroup.hbm.xml
@@ -38,11 +38,7 @@
     <set name="translations" table="dataelementgrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dataelementgroupid" foreign-key="fk_objecttranslation_dataelementgroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -63,7 +59,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSet.hbm.xml
@@ -35,11 +35,7 @@
     <set name="translations" table="dataelementgroupsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dataelementgroupsetid" foreign-key="fk_objecttranslation_dataelementgroupsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -55,7 +51,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
@@ -18,17 +18,6 @@
     <many-to-one name="categoryOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
       column="categoryoptioncomboid" foreign-key="fk_dataelementoperand_dataelementcategoryoptioncombo" unique-key="dataelement_operand_unique_key" />
 
-    <!-- Object Translation -->
-    <set name="translations" table="dataelementoperandtranslations" cascade="delete-orphan">
-      <cache usage="read-write" />
-      <key column="dataelementoperandid" foreign-key="fk_objecttranslation_dataelementoperandid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
 
   <filter-def name="locale">

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataentryform/hibernate/DataEntryForm.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataentryform/hibernate/DataEntryForm.hbm.xml
@@ -29,11 +29,7 @@
     <set name="translations" table="dataentryformtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="dataentryformid" foreign-key="fk_objecttranslation_dataentryformid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 	
     <property name="htmlCode" column="htmlcode" type="text" />
@@ -41,9 +37,5 @@
     <property name="format" />
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataSet.hbm.xml
@@ -120,11 +120,7 @@
     <set name="translations" table="datasettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="datasetid" foreign-key="fk_objecttranslation_datasetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -139,9 +135,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
@@ -61,17 +61,9 @@
     <set name="translations" table="datasetsectiontranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="sectionid" foreign-key="fk_objecttranslation_sectionid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/datastatistics/hibernate/DataStatistics.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/datastatistics/hibernate/DataStatistics.hbm.xml
@@ -32,22 +32,6 @@
     <property name="savedDataValues" column="datavalues" type="double"/>
     <property name="users" column="users" type="int"/>
 
-
-    <!-- Object Translation -->
-    <set name="translations" table="statisticstranslations" cascade="delete-orphan">
-      <cache usage="read-write" />
-      <key column="statisticsid" foreign-key="fk_objecttranslation_statisticsid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/document/hibernate/Document.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/document/hibernate/Document.hbm.xml
@@ -49,17 +49,9 @@
     <set name="translations" table="documenttranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="documentid" foreign-key="fk_objecttranslation_documentid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
@@ -215,22 +215,13 @@
       <many-to-many class="org.hisp.dhis.user.UserGroupAccess" column="usergroupaccessid" unique="true" />
     </set>
 
-
     <!-- Object Translation -->
     <set name="translations" table="eventcharttranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="eventchartid" foreign-key="fk_objecttranslation_eventchartid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
@@ -221,17 +221,9 @@
     <set name="translations" table="eventreporttranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="eventreportid" foreign-key="fk_objecttranslation_eventreportid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/Indicator.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/Indicator.hbm.xml
@@ -80,17 +80,9 @@
     <set name="translations" table="indicatortranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="indicatorid" foreign-key="fk_objecttranslation_indicatorid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroup.hbm.xml
@@ -28,11 +28,7 @@
     <set name="translations" table="indicatorgrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="indicatorgroupid" foreign-key="fk_objecttranslation_indicatorgroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
 
@@ -61,9 +57,5 @@
     </join>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroupSet.hbm.xml
@@ -33,11 +33,7 @@
     <set name="translations" table="indicatorgroupsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="indicatorgroupsetid" foreign-key="fk_objecttranslation_indicatorgroupsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -53,8 +49,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
-
-  </hibernate-mapping>
+</hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorType.hbm.xml
@@ -25,17 +25,9 @@
     <set name="translations" table="indicatortypetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="indicatortypeid" foreign-key="fk_objecttranslation_indicatortypeid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/Interpretation.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/Interpretation.hbm.xml
@@ -67,20 +67,6 @@
       <many-to-many class="org.hisp.dhis.user.UserGroupAccess" column="usergroupaccessid" unique="true" />
     </set>
 
-    <!-- Object Translation -->
-    <set name="translations" table="interpretationtranslations" cascade="delete-orphan">
-      <key column="interpretationid" foreign-key="fk_objecttranslation_interpretationid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/InterpretationComment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/InterpretationComment.hbm.xml
@@ -20,20 +20,6 @@
 		
 	<property name="created" not-null="true" type="timestamp" />
 
-    <!-- Object Translation -->
-    <set name="translations" table="interpretationcommenttranslations" cascade="delete-orphan">
-      <key column="interpretationcommentid" foreign-key="fk_objecttranslation_interpretationcommentid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/legend/hibernate/Legend.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/legend/hibernate/Legend.hbm.xml
@@ -29,17 +29,9 @@
     <set name="translations" table="maplegendtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="maplegendid" foreign-key="fk_objecttranslation_maplegendid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/legend/hibernate/LegendSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/legend/hibernate/LegendSet.hbm.xml
@@ -36,17 +36,9 @@
     <set name="translations" table="maplegendsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="maplegendsetid" foreign-key="fk_objecttranslation_maplegendsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/ExternalMapLayer.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/ExternalMapLayer.hbm.xml
@@ -1,34 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~
-  ~  Copyright (c) 2004-2016, University of Oslo
-  ~  All rights reserved.
-  ~
-  ~  Redistribution and use in source and binary forms, with or without
-  ~  modification, are permitted provided that the following conditions are met:
-  ~  Redistributions of source code must retain the above copyright notice, this
-  ~  list of conditions and the following disclaimer.
-  ~
-  ~  Redistributions in binary form must reproduce the above copyright notice,
-  ~  this list of conditions and the following disclaimer in the documentation
-  ~  and/or other materials provided with the distribution.
-  ~  Neither the name of the HISP project nor the names of its contributors may
-  ~  be used to endorse or promote products derived from this software without
-  ~  specific prior written permission.
-  ~
-  ~  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-  ~  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-  ~  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  ~  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-  ~  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-  ~  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  ~  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-  ~  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  ~  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-  ~  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  ~
-  -->
-
 <!DOCTYPE hibernate-mapping PUBLIC
   "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
   "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd"
@@ -62,21 +32,6 @@
     <many-to-one name="legendSet" class="org.hisp.dhis.legend.LegendSet"
       column="legendsetid" foreign-key="fk_externalmaplayer_legendsetid" />
 
-    <!-- Object Translation -->
-    <set name="translations" table="externalmaplayertranslations" cascade="delete-orphan">
-      <cache usage="read-write" />
-      <key column="externalmaplayerid" foreign-key="fk_objecttranslation_externalmaplayerid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/Map.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/Map.hbm.xml
@@ -55,21 +55,6 @@
       <many-to-many class="org.hisp.dhis.user.UserGroupAccess" column="usergroupaccessid" unique="true" />
     </set>
 
-    <!-- Object Translation -->
-    <set name="translations" table="maptranslations" cascade="delete-orphan">
-      <cache usage="read-write" />
-      <key column="mapid" foreign-key="fk_objecttranslation_mapid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
@@ -148,17 +148,9 @@
     <set name="translations" table="mapviewtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="mapviewid" foreign-key="fk_objecttranslation_mapviewid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/message/hibernate/MessageConversation.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/message/hibernate/MessageConversation.hbm.xml
@@ -62,9 +62,9 @@
       foreign-key="fk_messageconversation_user_userid" />
 
   </class>
-
+  
   <filter-def name="userMessageUser">
     <filter-param name="userid" type="int" />
   </filter-def>
-
+  
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
@@ -33,17 +33,9 @@
     <set name="translations" table="optionvaluetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="optionvalueid" foreign-key="fk_objecttranslation_optionvalueid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionSet.hbm.xml
@@ -56,17 +56,9 @@
     <set name="translations" table="optionsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="optionsetid" foreign-key="fk_objecttranslation_optionsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
@@ -95,14 +95,9 @@
     <!-- Object Translation -->
     <set name="translations" table="organisationunittranslations" cascade="delete-orphan">
       <cache usage="read-write" />
-      <key column="organisationunitid" foreign-key="fk_objecttranslation_organisationunitid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <key column="organisationunitid" foreign-key="fk_objecttranslation_organisationunitid"  />
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
-
 
     <!-- Access properties -->
     <many-to-one name="user" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_organisationunit_userid" />
@@ -116,9 +111,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroup.hbm.xml
@@ -32,11 +32,7 @@
     <set name="translations" table="orgunitgrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="orgunitgroupid" foreign-key="fk_objecttranslation_orgunitgroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -64,9 +60,5 @@
     </join>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSet.hbm.xml
@@ -42,11 +42,7 @@
     <set name="translations" table="orgunitgroupsettranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="orgunitgroupsetid" foreign-key="fk_objecttranslation_orgunitgroupsetid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -61,9 +57,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitLevel.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitLevel.hbm.xml
@@ -25,17 +25,9 @@
     <set name="translations" table="orgunitleveltranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="orgunitlevelid" foreign-key="fk_objecttranslation_orgunitlevelid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/Period.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/Period.hbm.xml
@@ -19,21 +19,6 @@
       <property name="endDate" not-null="true" type="date" column="enddate" />
     </properties>
 
-    <!-- Object Translation -->
-    <set name="translations" table="periodtranslations" cascade="delete-orphan">
-      <cache usage="read-write" />
-      <key column="periodid" foreign-key="fk_objecttranslation_periodid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
-    </set>
-
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
@@ -43,8 +43,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
-
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
@@ -124,11 +124,7 @@
     <set name="translations" table="programtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programid" foreign-key="fk_objecttranslation_programid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <!-- Access properties -->
@@ -146,9 +142,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramDataElement.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramDataElement.hbm.xml
@@ -19,11 +19,7 @@
     <set name="translations" table="programdataelementtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programdataelementid" foreign-key="fk_objecttranslation_programdataelementid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
     <many-to-one name="program" class="org.hisp.dhis.program.Program" column="programid"
@@ -33,9 +29,5 @@
       foreign-key="fk_programdataelement_dataelement" unique-key="programdataelement_unique_key" not-null="true" />
     
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicator.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicator.hbm.xml
@@ -57,11 +57,7 @@
     <set name="translations" table="programindicatortranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programindicatorid" foreign-key="fk_objecttranslation_programindicatorid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
     
     <!-- Access properties -->
@@ -83,9 +79,5 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicatorGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicatorGroup.hbm.xml
@@ -29,11 +29,7 @@
     <set name="translations" table="programindicatorgrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programindicatorgroupid" foreign-key="fk_objecttranslation_programindicatorgroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
 
@@ -57,10 +53,6 @@
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramMessage.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramMessage.hbm.xml
@@ -66,17 +66,9 @@
     <set name="translations" table="programmessagetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="id" foreign-key="fk_objecttranslation_programmessageid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStage.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStage.hbm.xml
@@ -89,17 +89,9 @@
     <set name="translations" table="programstagetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programstageid" foreign-key="fk_objecttranslation_programstageid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStageDataElement.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStageDataElement.hbm.xml
@@ -31,8 +31,4 @@
 
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
-
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStageSection.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStageSection.hbm.xml
@@ -39,17 +39,9 @@
     <set name="translations" table="programstagesectiontranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programstagesectionid" foreign-key="fk_objecttranslation_programstagesectionid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramValidation.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramValidation.hbm.xml
@@ -32,17 +32,9 @@
     <set name="translations" table="programvalidationtranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programvalidationid" foreign-key="fk_objecttranslation_programvalidationid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -38,17 +38,9 @@
     <set name="translations" table="programruletranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="programruleid" foreign-key="fk_objecttranslation_programruleid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipType.hbm.xml
@@ -25,17 +25,9 @@
     <set name="translations" table="relationshiptypetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="relationshiptypeid" foreign-key="fk_objecttranslation_relationshiptypeid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/report/hibernate/Report.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/report/hibernate/Report.hbm.xml
@@ -63,17 +63,9 @@
     <set name="translations" table="reporttranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="reportid" foreign-key="fk_objecttranslation_reportid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/reporttable/hibernate/ReportTable.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/reporttable/hibernate/ReportTable.hbm.xml
@@ -212,17 +212,9 @@
     <set name="translations" table="reporttabletranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="reporttableid" foreign-key="fk_objecttranslation_reporttableid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntity.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntity.hbm.xml
@@ -31,17 +31,9 @@
     <set name="translations" table="trackedentitytranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="trackedentityid" foreign-key="fk_objecttranslation_trackedentityid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
@@ -105,17 +105,9 @@
     <set name="translations" table="trackedentityattributetranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="trackedentityattributeid" foreign-key="fk_objecttranslation_trackedentityattributeid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttributeGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttributeGroup.hbm.xml
@@ -32,17 +32,9 @@
     <set name="translations" table="trackedentityattributegrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="trackedentityattributegroupid" foreign-key="fk_objecttranslation_trackedentityattributegroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityInstanceReminder.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityInstanceReminder.hbm.xml
@@ -33,17 +33,9 @@
     <set name="translations" table="trackedentityinstanceremindertranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="trackedentityinstancereminderid" foreign-key="fk_objecttranslation_trackedentityinstancereminderid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/translation/hibernate/ObjectTranslation.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/translation/hibernate/ObjectTranslation.hbm.xml
@@ -18,11 +18,6 @@
 
     <property name="value" column="value" type="text" not-null="true" />
 
-    <filter name="locale" condition="locale = :locale" />
-
   </class>
 
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserAuthorityGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserAuthorityGroup.hbm.xml
@@ -56,17 +56,9 @@
     <set name="translations" table="userroletranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="userroleid" foreign-key="fk_objecttranslation_userroleid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserGroup.hbm.xml
@@ -57,17 +57,9 @@
     <set name="translations" table="usergrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="usergroupid" foreign-key="fk_objecttranslation_usergroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationCriteria.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationCriteria.hbm.xml
@@ -29,17 +29,9 @@
     <set name="translations" table="validationcriteriatranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="validationcriteriaid" foreign-key="fk_objecttranslation_validationcriteriaid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRule.hbm.xml
@@ -68,17 +68,9 @@
     <set name="translations" table="validationruletranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="validationruleid" foreign-key="fk_objecttranslation_validationruleid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRuleGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRuleGroup.hbm.xml
@@ -50,17 +50,9 @@
     <set name="translations" table="validationrulegrouptranslations" cascade="delete-orphan">
       <cache usage="read-write" />
       <key column="validationrulegroupid" foreign-key="fk_objecttranslation_validationrulegroupid" />
-
-      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation">
-        <column name="objecttranslationid" unique="true" />
-        <filter name="locale" condition="locale = :locale" />
-      </many-to-many>
+      <many-to-many class="org.hisp.dhis.translation.ObjectTranslation" column="objecttranslationid" unique="true" />
     </set>
 
   </class>
-
-  <filter-def name="locale">
-    <filter-param name="locale" type="string" />
-  </filter-def>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CachingMap.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CachingMap.java
@@ -1,7 +1,5 @@
 package org.hisp.dhis.commons.collection;
 
-import java.util.Collection;
-
 /*
  * Copyright (c) 2004-2016, University of Oslo
  * All rights reserved.
@@ -33,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
+import java.util.Collection;
 
 /**
  * Map which allows storing a {@link java.util.concurrent.Callable}
@@ -97,6 +96,24 @@ public class CachingMap<K, V>
         }
         
         return value;
+    }
+
+    /**
+     * Returns the cached value if available or executes the Callable and returns
+     * the value, which is also cached. If the value produced, the defualt value
+     * will be returned. Will not attempt to fetch values for null keys, to 
+     * avoid potentially expensive and pointless operations.
+     *
+     * @param key the key.
+     * @param callable the Callable.
+     * @param defaultValue the default value.
+     * @return the return value of the Callable, either from cache or immediate execution.
+     */
+    public V get( K key, Callable<V> callable, V defaultValue )
+    {
+        V value = get( key, callable );
+        
+        return value != null ? value : defaultValue;
     }
     
     /**

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.hibernate.exception.CreateAccessDeniedException;
@@ -60,7 +59,6 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserSettingKey;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -68,7 +66,6 @@ import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * @author Lars Helge Overland
@@ -159,15 +156,7 @@ public class HibernateGenericStore<T>
      */
     protected final Session getSession()
     {
-        Session session = sessionFactory.getCurrentSession();
-        Locale dbLocale = UserContext.getUserSetting( UserSettingKey.DB_LOCALE, Locale.class );
-
-        if ( dbLocale != null )
-        {
-            session.enableFilter( "locale" ).setParameter( "locale", dbLocale.toString() );
-        }
-
-        return session;
+        return sessionFactory.getCurrentSession();
     }
 
     /**


### PR DESCRIPTION
Translations. Removed Hibernate filter and instead loading all translations into java objects. Loading all translations into object cache map, and uses the map for subsequent lookups to increase the cache hit ratio.