### PR TITLE
Added ou request param to /interpretations/chart/{chartId}

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -113,7 +113,8 @@ public class InterpretationController
     @RequestMapping( value = "/chart/{uid}", method = RequestMethod.POST, consumes = { "text/html", "text/plain" } )
     public void writeChartInterpretation(
         @PathVariable( "uid" ) String uid,
-        @RequestBody String text, 
+        @RequestParam( value = "ou", required = false ) String orgUnitUid,
+        @RequestBody String text,
         HttpServletResponse response, HttpServletRequest request ) throws WebMessageException
     {
         Chart chart = idObjectManager.get( Chart.class, uid );
@@ -125,14 +126,21 @@ public class InterpretationController
 
         User user = currentUserService.getCurrentUser();
 
-        // ---------------------------------------------------------------------
-        // When chart has user org unit, store current user org unit with
-        // interpretation so chart will refer to the original org unit later
-        // ---------------------------------------------------------------------
+        OrganisationUnit orgUnit = null;
 
-        OrganisationUnit unit = chart.hasUserOrgUnit() && user.hasOrganisationUnit() ? user.getOrganisationUnit() : null;
+        if ( orgUnitUid != null )
+        {
+            orgUnit = idObjectManager.get( OrganisationUnit.class, orgUnitUid );
 
-        createIntepretation( new Interpretation( chart, unit, text ), request, response );
+            if ( orgUnit == null )
+            {
+                throw new WebMessageException( WebMessageUtils.conflict( "Organisation unit does not exist or is not accessible: " + orgUnitUid ) );
+            }
+        } else {
+            orgUnit = chart.hasUserOrgUnit() && user.hasOrganisationUnit() ? user.getOrganisationUnit() : null;
+        }
+
+        createIntepretation( new Interpretation( chart, orgUnit, text ), request, response );
     }
 
     @RequestMapping( value = "/map/{uid}", method = RequestMethod.POST, consumes = { "text/html", "text/plain" } )


### PR DESCRIPTION
We are able to create interpretation for charts and reports but, we are not able to add the organisationUnit to the interpretation for chart (/api/interpretation/chart/{chartId}) unlike the interpretation for report (/api/interpretation/reportTable/{reportId}) which accepts a request param ‘ou’. In order to provide this functionality to interpretation for chart API, we have added a non mandatory request param ‘ou’ which will accept the organisation unit similar to interpretation for report API. As mentioned, this is not a mandatory param, if it is not provided, it will fallback to the existing functionality.
