### PR TITLE
Revert "Metadata sync now"

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
@@ -201,17 +201,10 @@ public class DefaultSchedulingManager
     public void executeTask( String taskKey )
     {
         Runnable task = tasks.get( taskKey );
-
-        if ( task != null && !isTaskInProgress( taskKey ) )
+        
+        if (task != null)
         {
-            scheduler.executeTask( taskKey, task );
+            scheduler.executeTask( task );
         }
     }
-
-    @Override
-    public boolean isTaskInProgress(String taskKey)
-    {
-        return ScheduledTaskStatus.RUNNING == scheduler.getCurrentTaskStatus( taskKey );
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -59,7 +59,7 @@ public interface SchedulingManager
      * Execute the Task.
      */
     void executeTask(String taskKey);
-
+    
     /**
      * Schedules the given tasks. The task map will replace the currently scheduled
      * tasks.
@@ -89,11 +89,5 @@ public interface SchedulingManager
     /**
      * Gets the task status.
      */
-    ScheduledTaskStatus getTaskStatus();
-
-    /**
-     *
-     * Returns the status of the currently executing task.
-     */
-    boolean isTaskInProgress(String taskKey);
+    ScheduledTaskStatus getTaskStatus();   
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/scheduling/Scheduler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/scheduling/Scheduler.java
@@ -55,15 +55,6 @@ public interface Scheduler
     void executeTask( Runnable task );
 
     /**
-     * Execute the given task immediately. The task can be referenced
-     * again through the given task key if the current task is not completed. A task cannot be scheduled if another
-     * task with the same key is already scheduled.
-     *
-     * @task the task to execute.
-     */
-    void executeTask( String taskKey, Runnable task );
-
-    /**
      * Execute the given task immediately and return a ListenableFuture.
      *
      * @param callable the task to execute.
@@ -117,13 +108,4 @@ public interface Scheduler
      * @return the task status.
      */
     ScheduledTaskStatus getTaskStatus( String key );
-
-    /**
-     * Gets the status for the current task with the given key.
-     *
-     * @param key the task key.
-     * @return the task status.
-     */
-    ScheduledTaskStatus getCurrentTaskStatus( String key );
-
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/scheduling/SpringScheduler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/scheduling/SpringScheduler.java
@@ -52,8 +52,6 @@ public class SpringScheduler
 
     private Map<String, ScheduledFuture<?>> futures = new HashMap<>();
 
-    private Map<String, ListenableFuture<?>> currentTasks = new HashMap<>();
-
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -80,13 +78,6 @@ public class SpringScheduler
     public void executeTask( Runnable task )
     {
         taskExecutor.execute( task );
-    }
-
-    @Override
-    public void executeTask( String taskKey, Runnable task )
-    {
-        ListenableFuture<?> future = taskExecutor.submitListenable( task );
-        currentTasks.put( taskKey, future );
     }
 
     @Override
@@ -183,28 +174,4 @@ public class SpringScheduler
             return ScheduledTaskStatus.RUNNING;
         }
     }
-
-    @Override
-    public ScheduledTaskStatus getCurrentTaskStatus( String key )
-    {
-        ListenableFuture<?> future = currentTasks.get( key );
-
-        if ( future == null )
-        {
-            return ScheduledTaskStatus.NOT_STARTED;
-        }
-        else if ( future.isCancelled() )
-        {
-            return ScheduledTaskStatus.STOPPED;
-        }
-        else if ( future.isDone() )
-        {
-            return ScheduledTaskStatus.DONE;
-        }
-        else
-        {
-            return ScheduledTaskStatus.RUNNING;
-        }
-    }
-
 }

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/java/org/hisp/dhis/dataadmin/action/scheduling/ScheduleTasksAction.java
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/java/org/hisp/dhis/dataadmin/action/scheduling/ScheduleTasksAction.java
@@ -71,8 +71,6 @@ public class ScheduleTasksAction
     private static final String STRATEGY_LAST_3_YEARS_DAILY = "last3YearsDaily";
     private static final String STRATEGY_ENABLED = "enabled";
     private static final String STRATEGY_EVERY_MIDNIGHT = "everyMidNight";
-    private static final String TASK_STARTED = "task_started";
-    private static final String TASK_ALREADY_RUNNING = "task_already_running";
 
     private static final Log log = LogFactory.getLog( ScheduleTasksAction.class );
 
@@ -287,13 +285,6 @@ public class ScheduleTasksAction
         return lastDataStatisticSuccess;
     }
 
-    private String metadataSyncStatus;
-    public String getMetadataSyncStatus(){ return metadataSyncStatus; }
-    public void setMetadataSyncStatus(String metadataSyncStatus )
-    {
-        this.metadataSyncStatus = metadataSyncStatus;
-    }
-
     // -------------------------------------------------------------------------
     // Action implementation
     // -------------------------------------------------------------------------
@@ -303,16 +294,9 @@ public class ScheduleTasksAction
     {
         if ( executeNow )
         {
-            if(schedulingManager.isTaskInProgress( TASK_META_DATA_SYNC ))
-            {
-                metadataSyncStatus = TASK_ALREADY_RUNNING;
-            }
-            else
-            {
-                schedulingManager.executeTask( TASK_META_DATA_SYNC );
-                metadataSyncStatus = TASK_STARTED;
-            }
+            schedulingManager.executeTask( taskKey );
 
+            return SUCCESS;
         }
 
         if ( schedule )
@@ -460,6 +444,7 @@ public class ScheduleTasksAction
 
         status = schedulingManager.getTaskStatus();
         running = ScheduledTaskStatus.RUNNING.equals( status );
+
         levels = organisationUnitService.getOrganisationUnitLevels();
 
         lastResourceTableSuccess = (Date) systemSettingManager.getSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE );

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/org/hisp/dhis/dataadmin/i18n_module.properties
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/org/hisp/dhis/dataadmin/i18n_module.properties
@@ -398,5 +398,3 @@ invalid_category_combos=Invalid category combinations
 legend_set=Legend Set
 reload_apps=Reload apps
 program_indicator=Program Indicator
-metadata_sync_in_progress=Metadata Synchronization is in progress
-metadata_sync_has_started=Metadata Synchronization is started

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/struts.xml
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/struts.xml
@@ -310,7 +310,7 @@
 
 
     <action name="executeMetaDataSyncTask" class="org.hisp.dhis.dataadmin.action.scheduling.ScheduleTasksAction">
-      <result name="success" type="velocity">/main.vm</result>
+      <result name="success" type="redirect">viewScheduledTasks.action</result>
       <param name="page">/dhis-web-maintenance-dataadmin/viewScheduledTasks.vm</param>
       <param name="menu">/dhis-web-maintenance-dataadmin/menu.vm</param>
       <param name="javascripts">javascript/scheduling.js</param>

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/webapp/dhis-web-maintenance-dataadmin/javascript/scheduling.js
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/webapp/dhis-web-maintenance-dataadmin/javascript/scheduling.js
@@ -1,10 +1,5 @@
 $(document).ready(function () {
 
-    if($('#metadataSyncStatus').val())
-    {
-        alert($('#metadataSyncStatus').val());
-    }
-
     if ($('#isRunning').val() == 'true') 
     {
         $('.scheduling').attr('disabled', 'disabled');
@@ -191,10 +186,17 @@ $(document).ready(function () {
         defaultScheduler();
     });
 
-    $("#submitSyncNow").unbind("click").click(function (e)
+    $("#submitSyncSchedule").unbind("click").click(function (e)
     {
         e.stopPropagation();
-        $("#metadataSyncNowForm").submit();
+        var button = this;
+        $(button).attr("disabled", "disabled");
+        $.post('executeMetaDataSyncTask.action', {
+            executeNow: true,
+            taskKey: "metadataSyncTask"
+        }, function (json) {
+            $(button).removeAttr("disabled");
+        });
     });
 
 });

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/webapp/dhis-web-maintenance-dataadmin/viewScheduledTasks.vm
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/webapp/dhis-web-maintenance-dataadmin/viewScheduledTasks.vm
@@ -97,7 +97,6 @@
             <option value="disabled">$i18n.getString( "disabled" )</option>
             <option value="enabled"#if( $metadataSyncStrategy && $metadataSyncStrategy == "enabled" ) selected="selected"#end>$i18n.getString( "enabled" )</option>
         </select>
-      <input id="submitSyncNow" type="button" style="width:140px" value="$i18n.getString( 'Sync Now' )"/>
     </div>
 
     <div id="scheduler" class="setting settingIndent schedulerWrapper scheduling">
@@ -156,6 +155,10 @@
             </div>
         </div>
         <input type="text" id="metadataSyncCron" name="metadataSyncCron" class="scheduling" value="${metadataSyncCron}" hidden>
+
+        <div class="syncStartButton">
+            <input id="submitSyncSchedule" type="button" style="width:140px" value="$i18n.getString( 'Sync Now' )"/>
+        </div>
     </div>
 
 <!-- SMS -->
@@ -188,12 +191,5 @@
 </div>
 
 </form>
-<form id="metadataSyncNowForm" method="post" action="executeMetaDataSyncTask.action">
-    <input type="hidden" id="metadataSyncStatus" name="metadataSyncStatus" type="hidden"
-    #if ( ${metadataSyncStatus} ==  'task_already_running')
-           value="$i18n.getString( 'metadata_sync_in_progress' )"
-    #elseif ( ${metadataSyncStatus} == "task_started" )
-           value="$i18n.getString( 'metadata_sync_has_started' )"
-    #end
-</form>
+
 <span id="info">$i18n.getString( "scheduling_is" ) $!i18n.getString( $!status.key )</span>


### PR DESCRIPTION
Reverts dhis2/dhis2-core#154
The reverted merge breaks the executeTask action for all other tasks by overriding and always running metadata sync. Should use executeTask.action?<metadata-sync-key> instead. Also, the code quality is just not good enough (please follow our basic Java conventions).