### PR TITLE
Metadata versioning should not be enabled on application startup by default

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
@@ -73,6 +73,11 @@ public class MetadataSyncPreProcessor
     @Autowired
     private MetadataVersionDelegate metadataVersionDelegate;
 
+    public void setUp(MetadataRetryContext context)
+    {
+        systemSettingManager.saveSystemSetting( SettingKey.METADATAVERSION_ENABLED, true );
+    }
+
     public ImportSummary handleAggregateDataPush( MetadataRetryContext context )
     {
         log.debug( "Entering data push" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTask.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTask.java
@@ -41,8 +41,6 @@ import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.retry.support.RetryTemplate;
 
 import java.util.Date;
@@ -56,7 +54,7 @@ import java.util.List;
  * @author anilkumk
  */
 public class MetadataSyncTask
-    implements Runnable, ApplicationListener<ContextRefreshedEvent>
+    implements Runnable
 {
     private static final Log log = LogFactory.getLog( MetadataSyncTask.class );
 
@@ -88,19 +86,6 @@ public class MetadataSyncTask
     private MetadataRetryContext metadataRetryContext;
 
     @Override
-    public void onApplicationEvent( ContextRefreshedEvent contextRefreshedEvent )
-    {
-        try
-        {
-            systemSettingManager.saveSystemSetting( SettingKey.METADATAVERSION_ENABLED, true );
-        }
-        catch ( Exception e )
-        {
-            log.error( "Exception occurred while saving system setting 'keyVersionEnabled' " + e.getMessage(), e );
-        }
-    }
-
-    @Override
     public void run()
     {
         log.info( "Metadata Sync cron Job started" );
@@ -128,6 +113,7 @@ public class MetadataSyncTask
 
     public void runSyncTask( MetadataRetryContext context ) throws MetadataSyncServiceException
     {
+        metadataSyncPreProcessor.setUp( context );
 
         metadataSyncPreProcessor.handleAggregateDataPush( context );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTaskTest.java
@@ -46,7 +46,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.retry.support.RetryTemplate;
 
 import java.util.ArrayList;
@@ -106,14 +105,6 @@ public class MetadataSyncTaskTest
         metadataVersions.add( metadataVersion );
     }
 
-    @Test
-    public void testShouldSetMetadataVersionEnabledToTrue() throws Exception
-    {
-        metadataSyncTask.onApplicationEvent( mock( ContextRefreshedEvent.class ) );
-
-        verify( systemSettingManager ).saveSystemSetting( SettingKey.METADATAVERSION_ENABLED, true );
-    }
-
     // TODO: can we write more tests. This might cover a lot more tests.
     // TODO: don't test on how it happens. test for the result
     @Test
@@ -124,6 +115,7 @@ public class MetadataSyncTaskTest
         when( metadataSyncPreProcessor.handleMetadataVersionsList( metadataRetryContext, metadataVersion ) ).thenReturn( metadataVersions );
         metadataSyncTask.runSyncTask( metadataRetryContext );
 
+        verify (metadataSyncPreProcessor).setUp( metadataRetryContext );
         verify( metadataSyncPreProcessor ).handleAggregateDataPush( metadataRetryContext );
         verify( metadataSyncPreProcessor ).handleEventDataPush( metadataRetryContext );
         verify( metadataSyncPreProcessor ).handleCurrentMetadataVersion( metadataRetryContext );
@@ -141,6 +133,7 @@ public class MetadataSyncTaskTest
         doNothing().when( metadataRetryContext ).updateRetryContext( any( String.class ), any( String.class ), eq( metadataVersion ) );
         metadataSyncTask.runSyncTask( metadataRetryContext );
 
+        verify (metadataSyncPreProcessor).setUp( metadataRetryContext );
         verify( metadataSyncPreProcessor ).handleAggregateDataPush( metadataRetryContext );
         verify( metadataSyncPreProcessor ).handleEventDataPush( metadataRetryContext );
         verify( metadataSyncPreProcessor ).handleCurrentMetadataVersion( metadataRetryContext );
@@ -160,6 +153,7 @@ public class MetadataSyncTaskTest
         when( metadataSyncPostProcessor.handleSyncNotificationsAndAbortStatus( metadataSyncSummary, metadataRetryContext, metadataVersion ) ).thenReturn( true );
         metadataSyncTask.runSyncTask( metadataRetryContext );
 
+        verify (metadataSyncPreProcessor, times( 1 ) ).setUp( metadataRetryContext );
         verify( metadataSyncPreProcessor, times( 1 ) ).handleAggregateDataPush( metadataRetryContext );
         verify( metadataSyncPreProcessor, times( 1 ) ).handleEventDataPush( metadataRetryContext );
         verify( metadataSyncPreProcessor, times( 1 ) ).handleCurrentMetadataVersion( metadataRetryContext );


### PR DESCRIPTION
Hi

We are from ThoughtWorks. We recently contributed 'Metadata Synchronization' feature to DHIS. This PR is continuation of those changes. Before this PR, metadata versioning was enabled by default on application startup. After this changes, it will not be so. It will be enabled only if it is explicitly enabled from settings-app or if user clicks 'sync now' button in metadata synchronization.