### PR TITLE
Modify bulk dataApproval API to fallback to default attributeCategoryOptionCombo if not specified

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -765,13 +765,16 @@ public class DataApprovalController
             for ( Approval approval : approvals.getApprovals() )
             {
                 OrganisationUnit unit = organisationUnitService.getOrganisationUnit( approval.getOu() );
-                DataElementCategoryOptionCombo optionCombo = categoryService.getDataElementCategoryOptionCombo( approval.getAoc() );
+
+                DataElementCategoryOptionCombo attributeOptionCombo = approval.getAoc() != null ?
+                        categoryService.getDataElementCategoryOptionCombo(approval.getAoc()) :
+                        categoryService.getDefaultDataElementCategoryOptionCombo();
 
                 for ( Period period : periods )
                 {
-                    if ( dataSetOptionCombos != null && dataSetOptionCombos.contains( optionCombo ) )
+                    if ( dataSetOptionCombos != null && dataSetOptionCombos.contains( attributeOptionCombo ) )
                     {
-                        DataApproval dataApproval = new DataApproval( null, dataSet.getWorkflow(), period, unit, optionCombo, false, date, user );
+                        DataApproval dataApproval = new DataApproval( null, dataSet.getWorkflow(), period, unit, attributeOptionCombo, false, date, user );
                         set.add( dataApproval );
                     }
                 }


### PR DESCRIPTION
The bulk dataApproval API (`POST /api/dataApprovals/approvals`) currently requires the attributeCategoryOptionComboId to be specified for `aoc` within the payload. This pull request makes the `aoc` parameter optional and falls back to the "default" categoryOptionCombo. This behaviour is consistent with the individual dataApproval API (`POST /api/dataApprovals`) where there is no `aoc` parameter.
