### PR TITLE
[2.24] Fix translations for ProgramStage and ProgramStageSection

### DIFF
--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-program/src/main/java/org/hisp/dhis/trackedentity/action/program/GetProgramAction.java
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-program/src/main/java/org/hisp/dhis/trackedentity/action/program/GetProgramAction.java
@@ -28,11 +28,10 @@ package org.hisp.dhis.trackedentity.action.program;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import com.opensymphony.xwork2.Action;
 import org.hisp.dhis.common.comparator.IdentifiableObjectNameComparator;
+import org.hisp.dhis.i18n.I18nService;
+import org.hisp.dhis.i18n.I18nUtils;
 import org.hisp.dhis.oust.manager.SelectionTreeManager;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
@@ -41,8 +40,11 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupService;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import com.opensymphony.xwork2.Action;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -82,6 +84,9 @@ public class GetProgramAction
     {
         this.periodService = periodService;
     }
+
+    @Autowired
+    private I18nService i18nService;
 
     // -------------------------------------------------------------------------
     // Input/Output
@@ -150,6 +155,8 @@ public class GetProgramAction
         periodTypes = periodService.getAllPeriodTypes();
 
         program = programService.getProgram( id );
+
+        I18nUtils.i18n( i18nService, program.getProgramStages() );
 
         selectionTreeManager.setSelectedOrganisationUnits( program.getOrganisationUnits() );
 

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-program/src/main/java/org/hisp/dhis/trackedentity/action/programstage/GetProgramStageSectionListAction.java
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-program/src/main/java/org/hisp/dhis/trackedentity/action/programstage/GetProgramStageSectionListAction.java
@@ -28,16 +28,18 @@ package org.hisp.dhis.trackedentity.action.programstage;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import com.opensymphony.xwork2.Action;
+import org.hisp.dhis.i18n.I18nService;
+import org.hisp.dhis.i18n.I18nUtils;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageSection;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.comparator.ProgramStageSectionSortOrderComparator;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import com.opensymphony.xwork2.Action;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Chau Thu Tran
@@ -56,6 +58,9 @@ public class GetProgramStageSectionListAction
     {
         this.programStageService = programStageService;
     }
+
+    @Autowired
+    private I18nService i18nService;
 
     // -------------------------------------------------------------------------
     // Input/Output
@@ -98,6 +103,8 @@ public class GetProgramStageSectionListAction
         programStage = programStageService.getProgramStage( id );
 
         sections = new ArrayList<>( programStage.getProgramStageSections() );
+
+        I18nUtils.i18n( i18nService, sections );
 
         Collections.sort( sections, new ProgramStageSectionSortOrderComparator() );
 


### PR DESCRIPTION
The old Struts actions GetProgramAction and GetProgramStageSectionListAction are missing i18nService translations for the return collections.

This fix apply to 2.24 only as from 2.25 I18nService is removed and replaced by new ObjectTranslation table.