### PR TITLE
[2.25] fix bug missing JacksonXMLProperty localName attribute for DataElement.categoryCombo

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -604,7 +604,7 @@ public class DataElement
 
     @JsonProperty( value = "categoryCombo" )
     @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "categoryCombo", namespace = DxfNamespaces.DXF_2_0 )
     public DataElementCategoryCombo getDataElementCategoryCombo()
     {
         return dataElementCategoryCombo;


### PR DESCRIPTION
fix bug missing JacksonXMLProperty localName attribute for dataElement.categoryCombo