### PR TITLE
Add JRebel plugin setup to the maven 'dev' profile

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api/pom.xml
@@ -12,26 +12,32 @@
   <packaging>jar</packaging>
   <name>DHIS Web API</name>
 
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>jrebel-maven-plugin</artifactId>
+            <version>1.1.6</version>
+            <executions>
+              <execution>
+                <id>generate-rebel-xml</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <finalName>dhis-web-api</finalName>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.zeroturnaround</groupId>
-          <artifactId>jrebel-maven-plugin</artifactId>
-          <version>1.1.6</version>
-          <executions>
-            <execution>
-              <id>generate-rebel-xml</id>
-              <phase>process-resources</phase>
-              <goals>
-                <goal>generate</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <dependencies>

--- a/dhis-2/dhis-web/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api/pom.xml
@@ -12,30 +12,6 @@
   <packaging>jar</packaging>
   <name>DHIS Web API</name>
 
-  <profiles>
-    <profile>
-      <id>dev</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>jrebel-maven-plugin</artifactId>
-            <version>1.1.6</version>
-            <executions>
-              <execution>
-                <id>generate-rebel-xml</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <finalName>dhis-web-api</finalName>
   </build>

--- a/dhis-2/dhis-web/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api/pom.xml
@@ -14,6 +14,24 @@
 
   <build>
     <finalName>dhis-web-api</finalName>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.zeroturnaround</groupId>
+          <artifactId>jrebel-maven-plugin</artifactId>
+          <version>1.1.6</version>
+          <executions>
+            <execution>
+              <id>generate-rebel-xml</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencies>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -38,6 +38,31 @@
       <properties>
         <useWarCompression>false</useWarCompression>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-maven-plugin</artifactId>
+            <configuration>
+              <scanIntervalSeconds>0</scanIntervalSeconds>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>jrebel-maven-plugin</artifactId>
+            <version>1.1.6</version>
+            <executions>
+              <execution>
+                <id>generate-rebel-xml</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 
@@ -58,7 +83,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.8.v20160314</version>
+        <version>9.3.13.v20161014</version>
         <configuration>
           <systemProperties>
             <systemProperty>
@@ -69,22 +94,7 @@
           <webAppConfig>
             <contextPath>/</contextPath>
           </webAppConfig>
-          <scanIntervalSeconds>0</scanIntervalSeconds>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.zeroturnaround</groupId>
-        <artifactId>jrebel-maven-plugin</artifactId>
-        <version>1.1.6</version>
-        <executions>
-          <execution>
-            <id>generate-rebel-xml</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -69,11 +69,26 @@
           <webAppConfig>
             <contextPath>/</contextPath>
           </webAppConfig>
+          <scanIntervalSeconds>0</scanIntervalSeconds>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.zeroturnaround</groupId>
+        <artifactId>jrebel-maven-plugin</artifactId>
+        <version>1.1.6</version>
+        <executions>
+          <execution>
+            <id>generate-rebel-xml</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.hisp.dhis</groupId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -291,7 +291,25 @@
           </executions>
         </plugin>
 
+        <!-- JRebel -->
+
+        <plugin>
+          <groupId>org.zeroturnaround</groupId>
+          <artifactId>jrebel-maven-plugin</artifactId>
+          <version>1.1.6</version>
+          <executions>
+            <execution>
+              <id>generate-rebel-xml</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
       </plugins>
+
     </pluginManagement>
   </build>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -171,6 +171,22 @@
               <excludedGroups>org.hisp.dhis.IntegrationTest</excludedGroups>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>jrebel-maven-plugin</artifactId>
+            <version>1.1.6</version>
+            <executions>
+              <execution>
+                <configuration>
+                </configuration>
+                <id>generate-rebel-xml</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -286,23 +302,6 @@
             <execution>
               <goals>
                 <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
-        <!-- JRebel -->
-
-        <plugin>
-          <groupId>org.zeroturnaround</groupId>
-          <artifactId>jrebel-maven-plugin</artifactId>
-          <version>1.1.6</version>
-          <executions>
-            <execution>
-              <id>generate-rebel-xml</id>
-              <phase>process-resources</phase>
-              <goals>
-                <goal>generate</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
Generates necessary `rebel.xml` files under `target` when build is invoked using the `-Pdev` flag. Enables deploying the application with JRebel hotdeploy using mvn:jetty-*. (Requires JRebel to be installed and configured on the system).