### PR TITLE
Updated dependency check plugin version and added aggregate goal

### DIFF
--- a/dhis-2/build.sh
+++ b/dhis-2/build.sh
@@ -5,5 +5,6 @@
 
 mvn clean install -DskipTests=true
 mvn clean install -DskipTests=true -f dhis-web/pom.xml -U
+mvn dependency-check:aggregate
 
 

--- a/dhis-2/build.sh
+++ b/dhis-2/build.sh
@@ -5,6 +5,5 @@
 
 mvn clean install -DskipTests=true
 mvn clean install -DskipTests=true -f dhis-web/pom.xml -U
-mvn dependency-check:aggregate
 
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -107,6 +107,21 @@
           </formats>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>1.3.3</version>
+        <configuration>
+          <name>Dependency Check</name>
+        </configuration>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
     </plugins>
   </reporting>
 
@@ -297,7 +312,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.2.4</version>
+          <version>1.3.3</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
Hi,

We have run vulnerability checks on DHIS dependencies using the dependency-check maven plugin. This plugin wraps the OWASP Dependency Check utility which uses NIST’s National Vulnerability Database (NVD) to identify the vulnerable dependencies.
Changes in this PR: plugin version updated, aggregate goal added, command to run the plugin on every build.

Thanks
Aamer.