### PR TITLE
Added sortOrder to Options and ProgramTrackedEntityAttribute

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/Option.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/Option.java
@@ -32,8 +32,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.MergeMode;
+import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Property;
 
@@ -45,6 +49,7 @@ public class Option
     extends BaseIdentifiableObject
 {
     private OptionSet optionSet;
+    private Integer sortOrder;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -62,6 +67,14 @@ public class Option
         this.code = code;
     }
 
+    public Option( String name, String code,Integer sortOrder )
+    {
+        this();
+        this.name = name;
+        this.code = code;
+        this.sortOrder = sortOrder;
+    }
+    
     // -------------------------------------------------------------------------
     // Logic
     // -------------------------------------------------------------------------
@@ -104,5 +117,38 @@ public class Option
     {
         this.optionSet = optionSet;
     }
+    
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getSortOrder()
+    {
+        return sortOrder;
+    }
 
+    public void setSortOrder( Integer sortOrder )
+    {
+        this.sortOrder = sortOrder;
+    }
+    
+    @Override
+    public void mergeWith( IdentifiableObject other, MergeMode mergeMode )
+    {
+        super.mergeWith( other, mergeMode );
+
+        if ( other.getClass().isInstance( this ) )
+        {
+            Option programStageDataElement = (Option) other;
+
+            if ( mergeMode.isReplace() )
+            {
+            	optionSet = programStageDataElement.getOptionSet();
+                sortOrder = programStageDataElement.getSortOrder();
+            }
+            else if ( mergeMode.isMerge() )
+            {
+                optionSet = programStageDataElement.getOptionSet() == null ? optionSet : programStageDataElement.getOptionSet();
+                sortOrder = programStageDataElement.getSortOrder() == null ? sortOrder : programStageDataElement.getSortOrder();
+            }
+        }
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttribute.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -57,6 +58,8 @@ public class ProgramTrackedEntityAttribute
     private TrackedEntityAttribute attribute;
 
     private boolean displayInList;
+    
+    private Integer sortOrder;
 
     private Boolean mandatory;
 
@@ -83,6 +86,15 @@ public class ProgramTrackedEntityAttribute
         this( program, attribute );
         this.displayInList = displayInList;
         this.mandatory = mandatory;
+    }
+    
+    public ProgramTrackedEntityAttribute( Program program, TrackedEntityAttribute attribute, boolean displayInList,
+            Boolean mandatory, Integer sortOrder )
+    {
+        this( program, attribute );
+        this.displayInList = displayInList;
+        this.mandatory = mandatory;
+        this.sortOrder = sortOrder;
     }
 
     public ProgramTrackedEntityAttribute( Program program, TrackedEntityAttribute attribute, boolean displayInList,
@@ -232,6 +244,18 @@ public class ProgramTrackedEntityAttribute
     {
         this.allowFutureDate = allowFutureDate;
     }
+    
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getSortOrder()
+    {
+        return sortOrder;
+    }
+
+    public void setSortOrder( Integer sortOrder )
+    {
+        this.sortOrder = sortOrder;
+    }
 
     @Override
     public void mergeWith( IdentifiableObject other, MergeMode mergeMode )
@@ -246,6 +270,7 @@ public class ProgramTrackedEntityAttribute
             if ( mergeMode.isReplace() )
             {
                 program = programTrackedEntityAttribute.getProgram();
+                sortOrder = programTrackedEntityAttribute.getSortOrder();
                 attribute = programTrackedEntityAttribute.getAttribute();
                 mandatory = programTrackedEntityAttribute.isMandatory();
                 allowFutureDate = programTrackedEntityAttribute.getAllowFutureDate();
@@ -253,6 +278,7 @@ public class ProgramTrackedEntityAttribute
             else if ( mergeMode.isMerge() )
             {
                 program = programTrackedEntityAttribute.getProgram() == null ? program : programTrackedEntityAttribute.getProgram();
+                sortOrder = programTrackedEntityAttribute.getSortOrder() == null ? sortOrder : programTrackedEntityAttribute.getSortOrder();
                 attribute = programTrackedEntityAttribute.getAttribute() == null ? attribute : programTrackedEntityAttribute.getAttribute();
                 mandatory = programTrackedEntityAttribute.isMandatory() == null ? mandatory : programTrackedEntityAttribute.isMandatory();
                 allowFutureDate = programTrackedEntityAttribute.getAllowFutureDate() == null ? allowFutureDate : programTrackedEntityAttribute.getAllowFutureDate();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
@@ -19,7 +19,8 @@
     <property name="name" column="name" not-null="true" length="230" />
     <property name="created" type="timestamp" not-null="true" />
     <property name="lastUpdated" type="timestamp" not-null="true"/>
-
+    <property name="sortOrder" column="sort_order" />
+    
     <many-to-one name="optionSet" class="org.hisp.dhis.option.OptionSet" column="optionsetid" />
 
     <!-- Dynamic attribute values -->

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramTrackedEntityAttribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramTrackedEntityAttribute.hbm.xml
@@ -22,6 +22,8 @@
     <property name="displayInList" column="displayinlist" />
 
     <property name="mandatory" column="mandatory" />
+    
+    <property name="sortOrder" column="sort_order" />
 
     <property name="allowFutureDate" column="allowFutureDate" />
 


### PR DESCRIPTION
Added sortOrder, as they are needed when exporting and importing the metadata objects.

(cherry picked from commit 0e835088ca801da7b71f7166c9ad0b6cd76741d5)