### PR TITLE
Thread safe metadata sync changes

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
@@ -99,7 +99,7 @@ public class DefaultMetadataSyncService
     }
 
     @Override
-    public MetadataSyncSummary doMetadataSync( MetadataSyncParams syncParams )
+    public synchronized MetadataSyncSummary doMetadataSync( MetadataSyncParams syncParams )
         throws MetadataSyncServiceException
     {
         MetadataVersion version = getMetadataVersion( syncParams );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTask.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTask.java
@@ -111,7 +111,7 @@ public class MetadataSyncTask
         }
     }
 
-    public void runSyncTask( MetadataRetryContext context ) throws MetadataSyncServiceException
+    public synchronized void runSyncTask( MetadataRetryContext context ) throws MetadataSyncServiceException
     {
         metadataSyncPreProcessor.setUp( context );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
@@ -191,7 +191,7 @@ public class DefaultMetadataVersionService
      * 3. Creating the actual MetadataVersion entry.
      */
     @Override
-    public boolean saveVersion( VersionType versionType )
+    public synchronized boolean saveVersion( VersionType versionType )
     {
         MetadataVersion currentVersion = getCurrentVersion();
         String versionName = MetadataVersionNameGenerator.getNextVersionName( currentVersion );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegate.java
@@ -148,7 +148,7 @@ public class MetadataVersionDelegate
         return null;
     }
 
-    public void addNewMetadataVersion( MetadataVersion version )
+    public synchronized void addNewMetadataVersion( MetadataVersion version )
     {
         version.setImportDate( new Date() );
         boolean isVersionExists = metadataVersionService.getVersionByName( version.getName() ) != null;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/resources/META-INF/dhis/beans.xml
@@ -72,11 +72,11 @@
 
   <bean id="org.hisp.dhis.dxf2.synch.SynchronizationManager" class="org.hisp.dhis.dxf2.synch.DefaultSynchronizationManager" />
 
-  <bean id="org.hisp.dhis.metadata.version.MetadataVersionService" class="org.hisp.dhis.dxf2.metadata.version.DefaultMetadataVersionService" scope="prototype" />
+  <bean id="org.hisp.dhis.metadata.version.MetadataVersionService" class="org.hisp.dhis.dxf2.metadata.version.DefaultMetadataVersionService"/>
 
   <bean id="dataSynchTask" class="org.hisp.dhis.dxf2.synch.DataSynchronizationTask" scope="prototype" />
 
-  <bean id="org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService" class="org.hisp.dhis.dxf2.metadata.sync.DefaultMetadataSyncService" scope="prototype" />
+  <bean id="org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService" class="org.hisp.dhis.dxf2.metadata.sync.DefaultMetadataSyncService"/>
 
   <bean id="metadataSyncTask" class="org.hisp.dhis.dxf2.metadata.tasks.MetadataSyncTask" scope="prototype" />
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -45,7 +45,7 @@ public interface SchedulingManager
     String TASK_ANALYTICS_LAST_3_YEARS = "analyticsLast3YearsTask";
     String TASK_MONITORING_LAST_DAY = "monitoringLastDayTask";
     String TASK_DATA_SYNCH = "dataSynchTask";
-    String TASK_META_DATA_SYNC = "metaDataSyncTask";
+    String TASK_META_DATA_SYNC = "metadataSyncTask";
     String TASK_SEND_SCHEDULED_SMS_NOW = "sendScheduledMessageTaskNow";
     String TASK_SCHEDULED_PROGRAM_NOTIFICATIONS = "scheduledProgramNotificationsTask";
     

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
@@ -65,34 +65,36 @@ public class MetadataSyncController
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
     @RequestMapping( method = RequestMethod.GET )
-    public synchronized @ResponseBody MetadataSyncSummary metadataSync() throws MetadataSyncException, BadRequestException
+    public @ResponseBody MetadataSyncSummary metadataSync() throws MetadataSyncException, BadRequestException
     {
         MetadataSyncParams syncParams;
         MetadataSyncSummary metadataSyncSummary;
 
-        try
+        synchronized( metadataSyncService )
         {
-            syncParams = metadataSyncService.getParamsFromMap( contextService.getParameterValuesMap() );
-        }
-        catch ( RemoteServerUnavailableException exception )
-        {
-            throw new MetadataSyncException( exception.getMessage(), exception );
+            try
+            {
+                syncParams = metadataSyncService.getParamsFromMap( contextService.getParameterValuesMap() );
+            }
+            catch ( RemoteServerUnavailableException exception )
+            {
+                throw new MetadataSyncException( exception.getMessage(), exception );
 
-        }
-        catch ( MetadataSyncServiceException serviceException )
-        {
-            throw new BadRequestException( "Error in parsing inputParams " + serviceException.getMessage(), serviceException );
-        }
+            }
+            catch ( MetadataSyncServiceException serviceException )
+            {
+                throw new BadRequestException( "Error in parsing inputParams " + serviceException.getMessage(), serviceException );
+            }
 
-        try
-        {
-            metadataSyncSummary = metadataSyncService.doMetadataSync( syncParams );
+            try
+            {
+                metadataSyncSummary = metadataSyncService.doMetadataSync( syncParams );
+            }
+            catch ( MetadataSyncServiceException serviceException )
+            {
+                throw new MetadataSyncException( "Exception occurred while doing metadata sync " + serviceException.getMessage() );
+            }
         }
-        catch ( MetadataSyncServiceException serviceException )
-        {
-            throw new MetadataSyncException( "Exception occurred while doing metadata sync " + serviceException.getMessage() );
-        }
-
         return metadataSyncSummary;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
@@ -65,7 +65,7 @@ public class MetadataSyncController
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
     @RequestMapping( method = RequestMethod.GET )
-    public @ResponseBody MetadataSyncSummary metadataSync() throws MetadataSyncException, BadRequestException
+    public synchronized @ResponseBody MetadataSyncSummary metadataSync() throws MetadataSyncException, BadRequestException
     {
         MetadataSyncParams syncParams;
         MetadataSyncSummary metadataSyncSummary;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -221,7 +221,7 @@ public class MetadataVersionController
     //Creates version in versioning table, exports the metadata and saves the snapshot in datastore
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
     @RequestMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT + "/create", method = RequestMethod.POST, produces = ContextUtils.CONTENT_TYPE_JSON )
-    public @ResponseBody MetadataVersion createSystemVersion( @RequestParam( value = "type", required = true ) VersionType versionType ) throws MetadataVersionException
+    public synchronized @ResponseBody MetadataVersion createSystemVersion( @RequestParam( value = "type", required = true ) VersionType versionType ) throws MetadataVersionException
     {
         MetadataVersion versionToReturn = null;
         boolean enabled = isMetadataVersioningEnabled();

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/struts.xml
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/struts.xml
@@ -308,7 +308,7 @@
       <param name="requiredAuthorities">F_SCHEDULING_ADMIN</param>
     </action>
 
-    <action name="executeMetaDataSyncTask" class="org.hisp.dhis.dataadmin.action.scheduling.ScheduleTasksAction">
+    <action name="executeMetadataSyncTask" class="org.hisp.dhis.dataadmin.action.scheduling.ScheduleTasksAction">
       <result name="success" type="velocity">/main.vm</result>
       <param name="page">/dhis-web-maintenance-dataadmin/viewScheduledTasks.vm</param>
       <param name="menu">/dhis-web-maintenance-dataadmin/menu.vm</param>

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/struts.xml
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/resources/struts.xml
@@ -314,7 +314,7 @@
       <param name="menu">/dhis-web-maintenance-dataadmin/menu.vm</param>
       <param name="javascripts">javascript/scheduling.js</param>
       <param name="executeNow">true</param>
-      <param name="taskKey">metaDataSyncTask</param>
+      <param name="taskKey">metadataSyncTask</param>
       <param name="requiredAuthorities">F_SCHEDULING_ADMIN</param>
     </action>
 

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/webapp/dhis-web-maintenance-dataadmin/viewScheduledTasks.vm
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-dataadmin/src/main/webapp/dhis-web-maintenance-dataadmin/viewScheduledTasks.vm
@@ -192,7 +192,7 @@
 
 </form>
 
-<form id="metadataSyncNowForm" method="post" action="executeMetaDataSyncTask.action"></form>
+<form id="metadataSyncNowForm" method="post" action="executeMetadataSyncTask.action"></form>
 
 <input type="hidden" id="currentRunningTaskStatus" name="currentRunningTaskStatus" type="hidden"
     #if ( ${currentRunningTaskStatus} == "task_already_running" )


### PR DESCRIPTION
Hi

We are from ThoughtWorks. This is regarding the metadata sync solution. Till now the create api and sync api will fail if concurrent threads are requested at single point of time. We have made the critical blocks synchronized so that no thread will fail in such case.

Thanks