### PR TITLE
Fixes for lookForDate in SmsUtils.java

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SmsUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SmsUtils.java
@@ -101,7 +101,14 @@ public class SmsUtils
         }
 
         Date date = null;
-        String dateString = message.trim().split( " " )[0];
+        String[] messageSplit = message.trim().split( " " );
+        // The first element in the split is the sms command. If there are only two elements
+        // in the split assume the 2nd is data values, not date.
+        if ( messageSplit.length <= 2 )
+        {
+            return null;
+        }
+        String dateString = messageSplit[1];
         SimpleDateFormat format = new SimpleDateFormat( "ddMM" );
 
         try
@@ -112,7 +119,7 @@ public class SmsUtils
             int year = Calendar.getInstance().get( Calendar.YEAR );
             int month = Calendar.getInstance().get( Calendar.MONTH );
 
-            if ( cal.get( Calendar.MONTH ) < month )
+            if ( cal.get( Calendar.MONTH ) <= month )
             {
                 cal.set( Calendar.YEAR, year );
             }


### PR DESCRIPTION
This fixes two issues:

1. The check of the given month against the current month when deciding year didn't allow for the months being equal.
2. On the split of the message on space, it was taking the first element, which would be the sms command, not the date.