### PR TITLE
Update completeness message to include dataset attribute

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/completeness_message.vm
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/completeness_message.vm
@@ -1,1 +1,1 @@
-The form '$!{object.dataSet.name}' was registered as complete for period $!{object.periodName} and organisation unit '$!{object.source.name}'.
+The form '$!{object.dataSet.name}' was registered as complete for period $!{object.periodName}, with attribute(s): '$!{object.AttributeOptionCombo.name}' and organisation unit '$!{object.source.name}'.


### PR DESCRIPTION
When dataset attributes are used the completeness message sent to users/admins of the data entry is not very useful. Adding category option combo name will solve this. Could perhaps be improved by making the attribute show only in datasets that are not with the default cat. option combo. I've only built and tested this on 2.23. I'm not sure if the recent changes in 2.25 impacts this issue.