### PR TITLE
Explicit open periods for data entry per data set

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -709,6 +709,28 @@ public class DataElement
         this.commentOptionSet = commentOptionSet;
     }
 
+    public boolean isPeriodInDataSetOpenPeriods( Period period )
+    {
+        if ( getDataSets().isEmpty() )
+        {
+            return true;
+        }
+
+        boolean result = false;
+
+        for ( DataSet dataSet : getDataSets() )
+        {
+            if ( dataSet.getOpenPeriods().contains( period ))
+            {
+                return true;
+            }
+
+            result = result || dataSet.getOpenPeriods().isEmpty();
+        }
+
+        return result;
+    }
+
     @Override
     public void mergeWith( IdentifiableObject other, MergeMode mergeMode )
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
@@ -36,18 +36,13 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-
 import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.adapter.JacksonPeriodDeserializer;
+import org.hisp.dhis.common.adapter.JacksonPeriodSerializer;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeDeserializer;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeSerializer;
 import org.hisp.dhis.dataapproval.DataApprovalWorkflow;
-import org.hisp.dhis.dataelement.CategoryOptionGroupSet;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementCategory;
-import org.hisp.dhis.dataelement.DataElementCategoryCombo;
-import org.hisp.dhis.dataelement.DataElementCategoryOption;
-import org.hisp.dhis.dataelement.DataElementCategoryOptionCombo;
-import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.*;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -85,7 +80,7 @@ public class DataSet
     /**
      * The openPeriods is a set of periods in which data sets are open for entry
      */
-    private Set<Period> openPeriods = new HashSet<>();
+    private Set<Period> openPeriods = new java.util.HashSet<>();
 
     /**
      * All DataElements associated with this DataSet.
@@ -543,7 +538,8 @@ public class DataSet
     }
 
     @JsonProperty
-    @JsonSerialize( contentAs = BaseDimensionalItemObject.class )
+    @JsonSerialize( contentUsing = JacksonPeriodSerializer.class )
+    @JsonDeserialize( contentUsing = JacksonPeriodDeserializer.class )
     @JacksonXmlElementWrapper( localName = "openPeriods", namespace = DxfNamespaces.DXF_2_0 )
     @JacksonXmlProperty( localName = "openPeriods", namespace = DxfNamespaces.DXF_2_0 )
     public Set<Period> getOpenPeriods()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
@@ -37,13 +37,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import org.hisp.dhis.common.BaseDataDimensionalItemObject;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DimensionItemType;
-import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.MergeMode;
-import org.hisp.dhis.common.VersionedObject;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeDeserializer;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeSerializer;
 import org.hisp.dhis.dataapproval.DataApprovalWorkflow;
@@ -87,6 +81,11 @@ public class DataSet
      * The PeriodType indicating the frequency that this DataSet should be used
      */
     private PeriodType periodType;
+
+    /**
+     * The openPeriods is a set of periods in which data sets are open for entry
+     */
+    private Set<Period> openPeriods = new HashSet<>();
 
     /**
      * All DataElements associated with this DataSet.
@@ -288,6 +287,11 @@ public class DataSet
 
         sources.clear();
         sources.addAll( updates );
+    }
+
+    public boolean addOpenPeriod( Period period )
+    {
+        return openPeriods.add( period );
     }
 
     public boolean addDataSetElement( DataSetElement element )
@@ -536,6 +540,20 @@ public class DataSet
     public void setPeriodType( PeriodType periodType )
     {
         this.periodType = periodType;
+    }
+
+    @JsonProperty
+    @JsonSerialize( contentAs = BaseDimensionalItemObject.class )
+    @JacksonXmlElementWrapper( localName = "openPeriods", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "openPeriods", namespace = DxfNamespaces.DXF_2_0 )
+    public Set<Period> getOpenPeriods()
+    {
+        return openPeriods;
+    }
+
+    public void setOpenPeriods( Set<Period> openPeriods )
+    {
+        this.openPeriods = openPeriods;
     }
 
     @JsonProperty
@@ -881,6 +899,9 @@ public class DataSet
                 startDate = dataSet.getStartDate() == null ? startDate : dataSet.getStartDate();
                 endDate = dataSet.getEndDate() == null ? endDate : dataSet.getEndDate();
             }
+
+            openPeriods.clear();
+            dataSet.getOpenPeriods().forEach( this::addOpenPeriod );
 
             removeAllDataSetElements();
             dataSet.getDataSetElements().forEach( this::addDataSetElement );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -33,9 +33,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import org.hisp.dhis.common.BaseDimensionalItemObject;
-import org.hisp.dhis.common.DimensionItemType;
-import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeDeserializer;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeSerializer;
 import org.hisp.dhis.schema.PropertyType;
@@ -395,5 +393,17 @@ public class Period
     public void setPeriodType( PeriodType periodType )
     {
         this.periodType = periodType;
+    }
+
+    @Override
+    public void mergeWith( IdentifiableObject object, MergeMode mergeMode )
+    {
+        Period period = (Period) object;
+
+        startDate = period.getStartDate();
+        endDate = period.getEndDate();
+        periodType = period.getPeriodType();
+        isoPeriod = period.getIsoDate();
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboNameResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboNameResourceTable.java
@@ -97,11 +97,12 @@ public class CategoryOptionComboNameResourceTable
                 Date latestStartDate = null;
                 Date earliestEndDate = null;
 
-                for( DataElementCategoryOption co : coc.getCategoryOptions() )
+                for ( DataElementCategoryOption co : coc.getCategoryOptions() )
                 {
                     latestStartDate = (latestStartDate == null || latestStartDate.before( co.getStartDate() ) ? co.getStartDate() : latestStartDate);
                     earliestEndDate = (earliestEndDate == null || earliestEndDate.after( co.getEndDate() ) ? co.getEndDate() : earliestEndDate);
                 }
+
                 values.add( latestStartDate );
                 values.add( earliestEndDate );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataSet.hbm.xml
@@ -24,6 +24,13 @@
     <many-to-one name="periodType" lazy="false" class="org.hisp.dhis.period.PeriodType" column="periodtypeid"
       not-null="true" foreign-key="fk_dataset_periodtypeid" />
 
+    <set name="openPeriods" table="datasetopenperiods">
+      <cache usage="read-write" />
+      <key column="datasetid" foreign-key="fk_datasetopenperiods_datasetid" />
+      <many-to-many class="org.hisp.dhis.period.Period" column="periodid"
+        foreign-key="fk_dataset_periodid" />
+    </set>
+
     <set name="dataSetElements" table="datasetelement" cascade="all-delete-orphan">
       <key column="datasetid" foreign-key="fk_datasetmembers_datasetid" />
       <one-to-many class="org.hisp.dhis.dataset.DataSetElement" />

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -658,6 +658,7 @@ public class DefaultDataValueSetService
         CachingMap<String, Optional<Set<String>>> dataElementOptionsMap = new CachingMap<>();
         CachingMap<String, Boolean> approvalMap = new CachingMap<>();
         CachingMap<String, Boolean> lowestApprovalLevelMap = new CachingMap<>();
+        CachingMap<String, Boolean> periodOpenForDataElement = new CachingMap<>();
 
         // ---------------------------------------------------------------------
         // Get meta-data maps
@@ -1024,6 +1025,12 @@ public class DefaultDataValueSetService
             {
                 summary.getConflicts().add( new ImportConflict( orgUnit.getUid(),
                     "Period: " + period.getIsoDate() + " is not within date range of data set: " + implicitDataSet.getUid() ) );
+                continue;
+            }
+
+            if( !periodOpenForDataElement.get(dataElement.getUid() + period.getIsoDate(), () -> dataElement.isPeriodInDataSetOpenPeriods( period ) ) )
+            {
+                summary.getConflicts().add( new ImportConflict( orgUnit.getUid(), "Period " + period.getName() + " does not conform to the open periods of associated data set(s)" ) );
                 continue;
             }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueController.java
@@ -221,6 +221,12 @@ public class DataValueController
         validateDataSetNotLocked( dataElement, period, organisationUnit, attributeOptionCombo );
 
         // ---------------------------------------------------------------------
+        // Period validation
+        // ---------------------------------------------------------------------
+
+        validatePeriodWithinDataSetOpenPeriods( dataElement, period );
+
+        // ---------------------------------------------------------------------
         // Assemble and save data value
         // ---------------------------------------------------------------------
 
@@ -354,6 +360,12 @@ public class DataValueController
         // ---------------------------------------------------------------------
 
         validateDataSetNotLocked( dataElement, period, organisationUnit, attributeOptionCombo );
+
+        // ---------------------------------------------------------------------
+        // Period validation
+        // ---------------------------------------------------------------------
+
+        validatePeriodWithinDataSetOpenPeriods( dataElement, period );
 
         // ---------------------------------------------------------------------
         // Delete data value
@@ -688,6 +700,15 @@ public class DataValueController
         if ( dataSetService.isLocked( dataElement, period, organisationUnit, attributeOptionCombo, null ) )
         {
             throw new WebMessageException( WebMessageUtils.conflict( "Data set is locked" ) );
+        }
+    }
+
+    private void validatePeriodWithinDataSetOpenPeriods( DataElement dataElement, Period period )
+        throws WebMessageException
+    {
+        if ( !dataElement.isPeriodInDataSetOpenPeriods( period ) )
+        {
+            throw new WebMessageException( WebMessageUtils.conflict( "Period reported is not open in data set" ) );
         }
     }
 }

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1309,6 +1309,11 @@ function displayPeriods()
 
     $.safeEach( periods, function( idx, item ) 
     {
+        console.log(dhis2.de.dataSets[dataSetId]);
+        if ( dhis2.de.dataSets[dataSetId].openPeriods.length > 0 )
+        {
+            console.log("Filter!");
+        }
         addOptionById( 'selectedPeriodId', item.iso, item.name );
         dhis2.de.periodChoices[ item.iso ] = item;
     } );

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1307,15 +1307,16 @@ function displayPeriods()
 
     dhis2.de.periodChoices = [];
 
+    dhis2.de.openPeriodsWhitelist = dhis2.de.dataSets[dataSetId].openPeriods.map(function(_period) { return _period.isoPeriod; });
+
     $.safeEach( periods, function( idx, item ) 
     {
-        console.log(dhis2.de.dataSets[dataSetId]);
-        if ( dhis2.de.dataSets[dataSetId].openPeriods.length > 0 )
+        console.log(dhis2.de.openPeriodsWhitelist, item.iso, dhis2.de.openPeriodsWhitelist.indexOf(item.iso) != -1 );
+        if ( dhis2.de.openPeriodsWhitelist.indexOf(item.iso) != -1 )
         {
-            console.log("Filter!");
+            addOptionById( 'selectedPeriodId', item.iso, item.name );
+            dhis2.de.periodChoices[ item.iso ] = item;
         }
-        addOptionById( 'selectedPeriodId', item.iso, item.name );
-        dhis2.de.periodChoices[ item.iso ] = item;
     } );
 }
 

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1311,8 +1311,7 @@ function displayPeriods()
 
     $.safeEach( periods, function( idx, item ) 
     {
-        console.log(dhis2.de.openPeriodsWhitelist, item.iso, dhis2.de.openPeriodsWhitelist.indexOf(item.iso) != -1 );
-        if ( dhis2.de.openPeriodsWhitelist.indexOf(item.iso) != -1 )
+        if ( dhis2.de.openPeriodsWhitelist.length == 0 || dhis2.de.openPeriodsWhitelist.indexOf(item.iso) != -1 )
         {
             addOptionById( 'selectedPeriodId', item.iso, item.name );
             dhis2.de.periodChoices[ item.iso ] = item;

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/responseMetaData.vm
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/responseMetaData.vm
@@ -42,6 +42,7 @@
 "endDate":"${dataSet.endDate}",
 #end
 "openFuturePeriods":${dataSet.openFuturePeriods},"fieldCombinationRequired":${dataSet.fieldCombinationRequired},
+"openPeriods":[#foreach( $period in $dataSet.openPeriods ) {"periodType":"${period.periodType.getName()}", "startDate":"${period.startDate}", "endDate":"${period.endDate}", "isoPeriod":"${period.getIsoDate()}"}#if( $foreach.hasNext ),#end #end],
 "validCompleteOnly":${dataSet.validCompleteOnly},"skipOffline":${dataSet.skipOffline}, "renderAsTabs":${dataSet.renderAsTabs}, "renderHorizontally":${dataSet.renderHorizontally}}#if( $velocityCount < $size ),#end
 #end },
 


### PR DESCRIPTION
Added new set of periods for dataSets, which includes which periods data can be entered. If one or more periods exists for a dataset, all data entry must be targeting one of these periods.

Updated Data Entry app to only show open Periods in the period dropdown, if there exists one or more periods.