### PR TITLE
Refactor: Support dates & comments in DataValueSMS

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -207,7 +207,7 @@ public class DataValueSMSListener
         if ( !StringUtils.isBlank( smsCommand.getSeparator() ) )
         {
             String x = "([^\\s|" + smsCommand.getSeparator().trim() + "]+)\\s*\\" + smsCommand.getSeparator().trim()
-                + "\\s*([\\w ]+)\\s*(\\" + smsCommand.getSeparator().trim() + "|$)*\\s*";
+                + "\\s*([-\\w\\s]+)\\s*(\\" + smsCommand.getSeparator().trim() + "|$)*\\s*";
             pattern = Pattern.compile( x );
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -214,8 +214,8 @@ public class DataValueSMSListener
         Matcher matcher = pattern.matcher( sms );
         while ( matcher.find() )
         {
-            String key = matcher.group( 1 );
-            String value = matcher.group( 2 );
+            String key = matcher.group( 1 ).trim();
+            String value = matcher.group( 2 ).trim();
 
             if ( !StringUtils.isEmpty( key ) && !StringUtils.isEmpty( value ) )
             {


### PR DESCRIPTION
Dates sent in through the DataValueSMS would get stripped out because they had a hypen (-). For example: 2016-11-29, only the 2016 would make it through, and then be rejected as an unacceptable value. Also, with comments only the first word would make it through and the rest would get stripped out. For example: "Oh my awesome comment", only the "Oh" will get taken without "my awesome comment".