### PR TITLE
metadata sync log refactoring

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
@@ -108,16 +108,6 @@ public class DefaultMetadataSyncService
         throws MetadataSyncServiceException, DhisVersionMismatchException
     {
         MetadataVersion version = getMetadataVersion( syncParams );
-        boolean isVersionExists = metadataVersionService.getVersionByName( version.getName() ) != null;
-
-        if ( isVersionExists )
-        {
-            MetadataSyncSummary metadataSyncSummary = new MetadataSyncSummary();
-            metadataSyncSummary.setMetadataVersion( version );
-            metadataSyncSummary.setImportReport( null );
-
-            return metadataSyncSummary;
-        }
 
         setMetadataImportMode( syncParams, version );
         String metadataVersionSnapshot = getMetadataVersionSnapshot( version );
@@ -133,6 +123,13 @@ public class DefaultMetadataSyncService
         log.info( "Metadata Sync Summary: " + metadataSyncSummary );
 
         return metadataSyncSummary;
+    }
+
+    @Override
+    public boolean isSyncRequired ( MetadataSyncParams syncParams )
+    {
+        MetadataVersion version = getMetadataVersion( syncParams );
+        return ( metadataVersionService.getVersionByName( version.getName() ) == null );
     }
 
     private void saveMetadataVersionSnapshotLocally( MetadataVersion version, String metadataVersionSnapshot )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessor.java
@@ -86,6 +86,13 @@ public class MetadataSyncPostProcessor
         return false;
     }
 
+    public void handleVersionAlreadyExists ( MetadataRetryContext retryContext, MetadataVersion dataVersion )
+    {
+        retryContext.updateRetryContext( MetadataSyncTask.METADATA_SYNC, "Version already exists in system and hence stopping the sync", dataVersion, null );
+        sendFailureMailToAdmin( retryContext );
+        log.info( "Aborting Metadata sync. Version already exists in system and hence stopping the sync. Check mail and logs for more details." );
+    }
+
     private void handleImportFailedContext( MetadataSyncSummary metadataSyncSummary, MetadataRetryContext retryContext, MetadataVersion dataVersion )
     {
         retryContext.updateRetryContext( MetadataSyncTask.METADATA_SYNC, "Import of metadata objects was unsuccessful", dataVersion, metadataSyncSummary );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.metadata.sync;
  */
 
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
+import org.hisp.dhis.metadata.version.MetadataVersion;
 
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,13 @@ public interface MetadataSyncService
      */
     MetadataSyncParams getParamsFromMap( Map<String, List<String>> parameters );
 
+    /**
+     * Checks whether metadata sync needs to be be done or not.
+     * If version already exists in system it does do the sync
+     * @param syncParams
+     * @return
+     */
+    public boolean isSyncRequired ( MetadataSyncParams syncParams );
     /**
      * Does the actual metadata sync logic. Calls the underlying importer to import the relevant
      * MetadataVersion snapshot downloaded from the remote server.

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTask.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/tasks/MetadataSyncTask.java
@@ -130,11 +130,18 @@ public class MetadataSyncTask
         {
             for ( MetadataVersion dataVersion : metadataVersionList )
             {
-                MetadataSyncSummary metadataSyncSummary = handleMetadataSync( context, dataVersion );
+                MetadataSyncParams syncParams = new MetadataSyncParams( new MetadataImportParams(), dataVersion );
+                boolean isSyncRequired = metadataSyncService.isSyncRequired(syncParams);
+                MetadataSyncSummary metadataSyncSummary = null;
 
-                if ( metadataSyncSummary.getImportReport() == null && metadataSyncSummary.getMetadataVersion() != null )
+                if ( isSyncRequired )
                 {
-                    log.error( metadataSyncSummary.getMetadataVersion().getName() + " already exists in system and hence stopping the sync." );
+                    metadataSyncSummary = handleMetadataSync( context, dataVersion );
+                }
+                else
+                {
+                    metadataSyncPostProcessor.handleVersionAlreadyExists( context, dataVersion );
+                    break;
                 }
 
                 boolean abortStatus = metadataSyncPostProcessor.handleSyncNotificationsAndAbortStatus( metadataSyncSummary, context, dataVersion );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
@@ -89,11 +89,15 @@ public class MetadataSyncController
 
             try
             {
-                metadataSyncSummary = metadataSyncService.doMetadataSync( syncParams );
+                boolean isSyncRequired = metadataSyncService.isSyncRequired(syncParams);
 
-                if ( metadataSyncSummary.getImportReport() == null && metadataSyncSummary.getMetadataVersion() != null )
+                if( isSyncRequired )
                 {
-                    throw new MetadataSyncServiceException( metadataSyncSummary.getMetadataVersion().getName() + " already exists in system and hence not starting the sync." );
+                    metadataSyncSummary = metadataSyncService.doMetadataSync( syncParams );
+                }
+                else
+                {
+                    throw new MetadataSyncServiceException( "Version already exists in system and hence not starting the sync." );
                 }
             }
             catch ( MetadataSyncServiceException serviceException )


### PR DESCRIPTION
Hi Morten,

These are minor changes as part of stopping metadata sync when version already exists in system. We have changed the logic to verify this scenario.

Thanks