### PR TITLE
Persist validation rule violations

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodService.java
@@ -264,6 +264,16 @@ public interface PeriodService
      * @return a PeriodHierarchy instance.
      */
     PeriodHierarchy getPeriodHierarchy( Collection<Period> periods );
+
+    /**
+     * Returns how many days into period date is.
+     * If date is before period.startDate, returns 0
+     * If date is after period.endDate, return last day of period
+     * @param period
+     * @param date
+     * @return
+     */
+    int getDayInPeriod( Period period, Date date );
     
     // -------------------------------------------------------------------------
     // PeriodType

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResult.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResult.java
@@ -76,6 +76,15 @@ public class ValidationResult
      */
     private Double rightsideValue;
 
+    /**
+     * This property is a reference to which data was used to generate the result.
+     * For rules comparing fixed periods, this dayInPeriod only indicates when in a period the validation was done
+     * For rules comparing sliding windows, this will indicate where the end-position of the sliding window was
+     * during the validation (IE: the window will span over the days:
+     * (period.startDate + dayInPeriod - period.daysInPeriod) to (period.startDate + dayInPeriod)
+     */
+    private int dayInPeriod;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------     
@@ -86,7 +95,7 @@ public class ValidationResult
 
     public ValidationResult( ValidationRule validationRule, Period period, 
         OrganisationUnit organisationUnit, DataElementCategoryOptionCombo attributeOptionCombo, 
-        Double leftsideValue, Double rightsideValue )
+        Double leftsideValue, Double rightsideValue, int dayInPeriod )
     {
         this.validationRule = validationRule;
         this.period = period;
@@ -94,6 +103,7 @@ public class ValidationResult
         this.attributeOptionCombo = attributeOptionCombo;
         this.leftsideValue = leftsideValue;
         this.rightsideValue = rightsideValue;
+        this.dayInPeriod = dayInPeriod;
     }
 
     // -------------------------------------------------------------------------
@@ -405,5 +415,15 @@ public class ValidationResult
     public void setRightsideValue( Double rightsideValue )
     {
         this.rightsideValue = rightsideValue;
+    }
+
+    public int getDayInPeriod()
+    {
+        return dayInPeriod;
+    }
+
+    public void setDayInPeriod( int dayInPeriod )
+    {
+        this.dayInPeriod = dayInPeriod;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResult.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResult.java
@@ -50,6 +50,9 @@ import java.io.Serializable;
 public class ValidationResult
     implements Serializable, Comparable<ValidationResult>
 {
+
+    private int id;
+
     /**
      * Determines if a de-serialized file is compatible with this class.
      */
@@ -63,8 +66,14 @@ public class ValidationResult
 
     private DataElementCategoryOptionCombo attributeOptionCombo;
 
+    /**
+     * The leftsideValue at the time of the violation
+     */
     private Double leftsideValue;
 
+    /**
+     * The rightsideValue at the time of the violation
+     */
     private Double rightsideValue;
 
     // -------------------------------------------------------------------------
@@ -311,6 +320,16 @@ public class ValidationResult
     // -------------------------------------------------------------------------
     // Set and get methods
     // -------------------------------------------------------------------------     
+
+    public int getId()
+    {
+        return id;
+    }
+
+    public void setId( int id )
+    {
+        this.id = id;
+    }
 
     @JsonProperty
     @JsonSerialize( as = BaseIdentifiableObject.class )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
@@ -1,0 +1,58 @@
+package org.hisp.dhis.validation;
+/*
+ * Copyright (c) 2004-2017, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * @author Stian Sandvold
+ */
+public interface ValidationResultService
+{
+
+    /**
+     * Saves a set of ValidationResults in a bulk action
+     * @param validationResults
+     */
+    void saveValidationResults( Collection<ValidationResult> validationResults );
+
+    /**
+     * Checks if a validation rule exists for the combination of validation rule, period and organisation unit.
+     * @param validationRule
+     * @param period
+     * @param organisationUnit
+     * @return All matching ValidationResults, or an empty set if none exists.
+     */
+    Map<String, ValidationResult> validationResultExists( ValidationRule validationRule, Period period, OrganisationUnit organisationUnit );
+
+
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
@@ -27,32 +27,16 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
-
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * @author Stian Sandvold
  */
 public interface ValidationResultService
 {
-
     /**
      * Saves a set of ValidationResults in a bulk action
      * @param validationResults
      */
     void saveValidationResults( Collection<ValidationResult> validationResults );
-
-    /**
-     * Checks if a validation rule exists for the combination of validation rule, period and organisation unit.
-     * @param validationRule
-     * @param period
-     * @param organisationUnit
-     * @return All matching ValidationResults, or an empty set if none exists.
-     */
-    Map<String, ValidationResult> validationResultExists( ValidationRule validationRule, Period period, OrganisationUnit organisationUnit );
-
-
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.validation;
  */
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author Stian Sandvold
@@ -39,4 +40,16 @@ public interface ValidationResultService
      * @param validationResults
      */
     void saveValidationResults( Collection<ValidationResult> validationResults );
+
+    /**
+     * Returns a list of all existing ValidationResults
+     * @return
+     */
+    List<ValidationResult> getAllValidationResults();
+
+    /**
+     * Deletes the validationResult
+     * @param validationResult
+     */
+    void deleteValidationResult( ValidationResult validationResult );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultStore.java
@@ -27,53 +27,12 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.jdbc.batchhandler.ValidationResultBatchHandler;
-import org.hisp.quick.BatchHandler;
-import org.hisp.quick.BatchHandlerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.List;
+import org.hisp.dhis.common.GenericStore;
 
 /**
  * @author Stian Sandvold
  */
-public class DefaultValidationResultService
-    implements ValidationResultService
+public interface ValidationResultStore
+    extends GenericStore<ValidationResult>
 {
-    @Autowired
-    private ValidationResultStore validationResultStore;
-
-    @Autowired
-    private BatchHandlerFactory batchHandlerFactory;
-
-    @Override
-    @Transactional
-    public void saveValidationResults( Collection<ValidationResult> validationResults )
-    {
-        BatchHandler<ValidationResult> validationResultBatchHandler = batchHandlerFactory
-            .createBatchHandler( ValidationResultBatchHandler.class ).init();
-
-        validationResults.forEach( validationResult ->
-        {
-            if ( !validationResultBatchHandler.objectExists( validationResult ) )
-            {
-                validationResultBatchHandler.addObject( validationResult );
-            }
-        } );
-
-        validationResultBatchHandler.flush();
-    }
-
-    public List<ValidationResult> getAllValidationResults()
-    {
-        return validationResultStore.getAll();
-    }
-
-    @Override
-    public void deleteValidationResult( ValidationResult validationResult )
-    {
-        validationResultStore.delete( validationResult );
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -298,18 +298,7 @@ public class DefaultPeriodService
     {
         int days = (int) TimeUnit.DAYS.convert( date.getTime() - period.getStartDate().getTime(), TimeUnit.MILLISECONDS );
 
-        if ( days < 0 )
-        {
-            return 0;
-        }
-        else if ( days >= period.getDaysInPeriod() )
-        {
-            return period.getDaysInPeriod();
-        }
-        else
-        {
-            return days;
-        }
+        return Math.min( Math.max( 0, days ), period.getDaysInPeriod() );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -28,20 +28,14 @@ package org.hisp.dhis.period;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.system.util.DateUtils;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
 
 /**
  * @author Kristian Nordal
@@ -297,6 +291,25 @@ public class DefaultPeriodService
         }
         
         return hierarchy;
+    }
+
+    @Override
+    public int getDayInPeriod( Period period, Date date )
+    {
+        int days = (int) TimeUnit.DAYS.convert( date.getTime() - period.getStartDate().getTime(), TimeUnit.MILLISECONDS );
+
+        if ( days < 0 )
+        {
+            return 0;
+        }
+        else if ( days >= period.getDaysInPeriod() )
+        {
+            return period.getDaysInPeriod();
+        }
+        else
+        {
+            return days;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
@@ -1,0 +1,114 @@
+package org.hisp.dhis.validation;
+/*
+ * Copyright (c) 2004-2017, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.dataelement.DataElementCategoryService;
+import org.hisp.dhis.jdbc.batchhandler.ValidationResultBatchHandler;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.quick.BatchHandler;
+import org.hisp.quick.BatchHandlerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Stian Sandvold
+ */
+public class DefaultValidationResultService
+    implements ValidationResultService
+{
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private BatchHandlerFactory batchHandlerFactory;
+
+    @Autowired
+    private DataElementCategoryService categoryService;
+
+    @Override
+    @Transactional
+    public void saveValidationResults( Collection<ValidationResult> validationResults )
+    {
+        BatchHandler<ValidationResult> validationResultBatchHandler = batchHandlerFactory
+            .createBatchHandler( ValidationResultBatchHandler.class ).init();
+
+        validationResults.forEach( validationResult ->
+        {
+            if ( !validationResultBatchHandler.objectExists( validationResult ) )
+            {
+                validationResultBatchHandler.addObject( validationResult );
+            }
+        } );
+
+        validationResultBatchHandler.flush();
+    }
+
+    @Override
+    public Map<String, ValidationResult> validationResultExists( ValidationRule validationRule,
+        Period period,
+        OrganisationUnit organisationUnit )
+    {
+        Map<String, ValidationResult> result = new HashMap<>();
+
+        String sql = "" +
+            "SELECT attributeoptioncomboid, leftsidevalue, rightsidevalue, dayinperiod " +
+            "FROM validationresult R " +
+            "WHERE R.validationresultid IN ( " +
+            "SELECT validationresultid " +
+            "FROM validationresult R2 " +
+            "WHERE R2.validationruleid = " + validationRule.getId() +
+            "AND R2.periodid = " + period.getId() +
+            "AND R2.organisationunitid = " + organisationUnit.getId() +
+            "AND R2.attributeoptioncomboid = R.attributeoptioncomboid " +
+            "ORDER BY R2.dayinperiod DESC " +
+            "LIMIT 1" +
+            ")";
+
+        jdbcTemplate.queryForList( sql ).forEach( row ->
+        {
+            ValidationResult validationResult = new ValidationResult();
+            validationResult.setLeftsideValue( (double) row.get( "leftsidevalue" ) );
+            validationResult.setRightsideValue( (double) row.get( "rightsidevalue" ) );
+            validationResult.setDayInPeriod( (int) row.get( "dayinperiod" ) );
+
+            result.put(
+                categoryService.getDataElementCategoryOptionCombo( (int) row.get( "attributeoptioncomboid" ) ).getUid(),
+                validationResult
+            );
+        } );
+
+        return result;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
@@ -27,19 +27,13 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.dataelement.DataElementCategoryService;
 import org.hisp.dhis.jdbc.batchhandler.ValidationResultBatchHandler;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
 import org.hisp.quick.BatchHandler;
 import org.hisp.quick.BatchHandlerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Stian Sandvold
@@ -47,15 +41,8 @@ import java.util.Map;
 public class DefaultValidationResultService
     implements ValidationResultService
 {
-
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
-
     @Autowired
     private BatchHandlerFactory batchHandlerFactory;
-
-    @Autowired
-    private DataElementCategoryService categoryService;
 
     @Override
     @Transactional
@@ -73,42 +60,5 @@ public class DefaultValidationResultService
         } );
 
         validationResultBatchHandler.flush();
-    }
-
-    @Override
-    public Map<String, ValidationResult> validationResultExists( ValidationRule validationRule,
-        Period period,
-        OrganisationUnit organisationUnit )
-    {
-        Map<String, ValidationResult> result = new HashMap<>();
-
-        String sql = "" +
-            "SELECT attributeoptioncomboid, leftsidevalue, rightsidevalue, dayinperiod " +
-            "FROM validationresult R " +
-            "WHERE R.validationresultid IN ( " +
-            "SELECT validationresultid " +
-            "FROM validationresult R2 " +
-            "WHERE R2.validationruleid = " + validationRule.getId() +
-            "AND R2.periodid = " + period.getId() +
-            "AND R2.organisationunitid = " + organisationUnit.getId() +
-            "AND R2.attributeoptioncomboid = R.attributeoptioncomboid " +
-            "ORDER BY R2.dayinperiod DESC " +
-            "LIMIT 1" +
-            ")";
-
-        jdbcTemplate.queryForList( sql ).forEach( row ->
-        {
-            ValidationResult validationResult = new ValidationResult();
-            validationResult.setLeftsideValue( (double) row.get( "leftsidevalue" ) );
-            validationResult.setRightsideValue( (double) row.get( "rightsidevalue" ) );
-            validationResult.setDayInPeriod( (int) row.get( "dayinperiod" ) );
-
-            result.put(
-                categoryService.getDataElementCategoryOptionCombo( (int) row.get( "attributeoptioncomboid" ) ).getUid(),
-                validationResult
-            );
-        } );
-
-        return result;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/ValidationResultDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/ValidationResultDeletionHandler.java
@@ -27,53 +27,53 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.jdbc.batchhandler.ValidationResultBatchHandler;
-import org.hisp.quick.BatchHandler;
-import org.hisp.quick.BatchHandlerFactory;
+import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.List;
 
 /**
  * @author Stian Sandvold
  */
-public class DefaultValidationResultService
-    implements ValidationResultService
+public class ValidationResultDeletionHandler
+    extends DeletionHandler
 {
-    @Autowired
-    private ValidationResultStore validationResultStore;
 
     @Autowired
-    private BatchHandlerFactory batchHandlerFactory;
+    private
+    ValidationResultService validationResultService;
 
     @Override
-    @Transactional
-    public void saveValidationResults( Collection<ValidationResult> validationResults )
+    public String getClassName()
     {
-        BatchHandler<ValidationResult> validationResultBatchHandler = batchHandlerFactory
-            .createBatchHandler( ValidationResultBatchHandler.class ).init();
+        return ValidationResult.class.getSimpleName();
+    }
 
-        validationResults.forEach( validationResult ->
+    @Override
+    public void deleteValidationRule( ValidationRule validationRule )
+    {
+        System.out.println(" HERE !");
+        validationResultService.getAllValidationResults().forEach( validationResult ->
         {
-            if ( !validationResultBatchHandler.objectExists( validationResult ) )
+            if ( validationResult.getValidationRule().equals( validationRule ) )
             {
-                validationResultBatchHandler.addObject( validationResult );
+                validationResultService.deleteValidationResult( validationResult );
             }
         } );
-
-        validationResultBatchHandler.flush();
-    }
-
-    public List<ValidationResult> getAllValidationResults()
-    {
-        return validationResultStore.getAll();
     }
 
     @Override
-    public void deleteValidationResult( ValidationResult validationResult )
+    public String allowDeleteValidationRule( ValidationRule validationRule )
     {
-        validationResultStore.delete( validationResult );
+
+        System.out.println(" HERE 2 !");
+        for ( ValidationResult validationResult : validationResultService.getAllValidationResults() )
+        {
+            if ( validationResult.getValidationRule().equals( validationRule ) )
+            {
+                return ERROR;
+            }
+        }
+
+        return null;
     }
+
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/ValidationResultDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/ValidationResultDeletionHandler.java
@@ -27,6 +27,9 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.dataelement.DataElementCategoryOptionCombo;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -50,7 +53,6 @@ public class ValidationResultDeletionHandler
     @Override
     public void deleteValidationRule( ValidationRule validationRule )
     {
-        System.out.println(" HERE !");
         validationResultService.getAllValidationResults().forEach( validationResult ->
         {
             if ( validationResult.getValidationRule().equals( validationRule ) )
@@ -61,10 +63,44 @@ public class ValidationResultDeletionHandler
     }
 
     @Override
+    public void deletePeriod( Period period )
+    {
+        validationResultService.getAllValidationResults().forEach( validationResult ->
+        {
+            if ( validationResult.getPeriod().equals( period ) )
+            {
+                validationResultService.deleteValidationResult( validationResult );
+            }
+        } );
+    }
+
+    @Override
+    public void deleteOrganisationUnit( OrganisationUnit organisationUnit )
+    {
+        validationResultService.getAllValidationResults().forEach( validationResult ->
+        {
+            if ( validationResult.getOrganisationUnit().equals( organisationUnit ) )
+            {
+                validationResultService.deleteValidationResult( validationResult );
+            }
+        } );
+    }
+
+    @Override
+    public void deleteDataElementCategoryOptionCombo( DataElementCategoryOptionCombo dataElementCategoryOptionCombo )
+    {
+        validationResultService.getAllValidationResults().forEach( validationResult ->
+        {
+            if ( validationResult.getAttributeOptionCombo().equals( dataElementCategoryOptionCombo ) )
+            {
+                validationResultService.deleteValidationResult( validationResult );
+            }
+        } );
+    }
+
+    @Override
     public String allowDeleteValidationRule( ValidationRule validationRule )
     {
-
-        System.out.println(" HERE 2 !");
         for ( ValidationResult validationResult : validationResultService.getAllValidationResults() )
         {
             if ( validationResult.getValidationRule().equals( validationRule ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.validation;
+package org.hisp.dhis.validation.hibernate;
 /*
  * Copyright (c) 2004-2017, University of Oslo
  * All rights reserved.
@@ -27,53 +27,15 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.jdbc.batchhandler.ValidationResultBatchHandler;
-import org.hisp.quick.BatchHandler;
-import org.hisp.quick.BatchHandlerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.List;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.validation.ValidationResult;
+import org.hisp.dhis.validation.ValidationResultStore;
 
 /**
  * @author Stian Sandvold
  */
-public class DefaultValidationResultService
-    implements ValidationResultService
+public class HibernateValidationResultStore
+    extends HibernateGenericStore<ValidationResult>
+    implements ValidationResultStore
 {
-    @Autowired
-    private ValidationResultStore validationResultStore;
-
-    @Autowired
-    private BatchHandlerFactory batchHandlerFactory;
-
-    @Override
-    @Transactional
-    public void saveValidationResults( Collection<ValidationResult> validationResults )
-    {
-        BatchHandler<ValidationResult> validationResultBatchHandler = batchHandlerFactory
-            .createBatchHandler( ValidationResultBatchHandler.class ).init();
-
-        validationResults.forEach( validationResult ->
-        {
-            if ( !validationResultBatchHandler.objectExists( validationResult ) )
-            {
-                validationResultBatchHandler.addObject( validationResult );
-            }
-        } );
-
-        validationResultBatchHandler.flush();
-    }
-
-    public List<ValidationResult> getAllValidationResults()
-    {
-        return validationResultStore.getAll();
-    }
-
-    @Override
-    public void deleteValidationResult( ValidationResult validationResult )
-    {
-        validationResultStore.delete( validationResult );
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -269,6 +269,12 @@
     <property name="cacheable" value="true" />
   </bean>
 
+  <bean id="org.hisp.dhis.validation.ValidationResultStore" class="org.hisp.dhis.validation.hibernate.HibernateValidationResultStore">
+    <property name="clazz" value="org.hisp.dhis.validation.ValidationResult" />
+    <property name="sessionFactory" ref="sessionFactory" />
+    <property name="cacheable" value="true" />
+  </bean>
+
   <bean id="org.hisp.dhis.validation.notification.ValidationNotificationTemplateStore"
     class="org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore">
     <property name="clazz" value="org.hisp.dhis.validation.notification.ValidationNotificationTemplate" />
@@ -1753,6 +1759,8 @@
   <bean id="org.hisp.dhis.validation.ValidationRuleDeletionHandler" class="org.hisp.dhis.validation.ValidationRuleDeletionHandler">
     <property name="validationRuleService" ref="org.hisp.dhis.validation.ValidationRuleService" />
   </bean>
+
+  <bean id="org.hisp.dhis.validation.ValidationResultDeletionHandler" class="org.hisp.dhis.validation.ValidationResultDeletionHandler" />
 
   <bean id="org.hisp.dhis.validation.ValidationRuleGroupDeletionHandler"
     class="org.hisp.dhis.validation.ValidationRuleGroupDeletionHandler" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -925,6 +925,8 @@
     <property name="expressionService" ref="org.hisp.dhis.expression.ExpressionService" />
   </bean>
 
+  <bean id="org.hisp.dhis.validation.ValidationResultService" class="org.hisp.dhis.validation.DefaultValidationResultService" />
+
   <bean id="validationNotificationMessageRenderer" class="org.hisp.dhis.notification.ValidationNotificationMessageRenderer" />
 
   <bean id="org.hisp.dhis.validation.notification.ValidationNotificationService"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationResult.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationResult.hbm.xml
@@ -11,21 +11,25 @@
             <generator class="native"/>
         </id>
 
-        <many-to-one name="validationRule" class="org.hisp.dhis.validation.ValidationRule" column="validationrule"
-                     foreign-key="fk_validationresult_validationruleid"/>
-
-        <many-to-one name="period" class="org.hisp.dhis.period.Period" column="period"
-                     foreign-key="fk_validationresult_period"/>
-
-        <many-to-one name="attributeOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
-                     column="attributeoptioncombo" foreign-key="fk_validationresult_attributeoptioncomboid"/>
-
-        <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit"
-                     column="organisationunit" foreign-key="fk_validationresult_organisationunitid"/>
-
         <property name="leftsideValue"/>
 
         <property name="rightsideValue"/>
+
+        <properties name="unique-group" unique="true">
+
+            <many-to-one name="validationRule" class="org.hisp.dhis.validation.ValidationRule" column="validationrule"
+                         foreign-key="fk_validationresult_validationruleid"/>
+
+            <many-to-one name="period" class="org.hisp.dhis.period.Period" column="period"
+                         foreign-key="fk_validationresult_period"/>
+
+            <many-to-one name="attributeOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
+                         column="attributeoptioncombo" foreign-key="fk_validationresult_attributeoptioncomboid"/>
+
+            <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit"
+                         column="organisationunit" foreign-key="fk_validationresult_organisationunitid"/>
+
+        </properties>
 
     </class>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationResult.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationResult.hbm.xml
@@ -17,17 +17,19 @@
 
         <properties name="unique-group" unique="true">
 
-            <many-to-one name="validationRule" class="org.hisp.dhis.validation.ValidationRule" column="validationrule"
+            <many-to-one name="validationRule" class="org.hisp.dhis.validation.ValidationRule" column="validationruleid"
                          foreign-key="fk_validationresult_validationruleid"/>
 
-            <many-to-one name="period" class="org.hisp.dhis.period.Period" column="period"
+            <many-to-one name="period" class="org.hisp.dhis.period.Period" column="periodid"
                          foreign-key="fk_validationresult_period"/>
 
-            <many-to-one name="attributeOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
-                         column="attributeoptioncombo" foreign-key="fk_validationresult_attributeoptioncomboid"/>
-
             <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit"
-                         column="organisationunit" foreign-key="fk_validationresult_organisationunitid"/>
+                         column="organisationunitid" foreign-key="fk_validationresult_organisationunitid"/>
+
+            <many-to-one name="attributeOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
+                         column="attributeoptioncomboid" foreign-key="fk_validationresult_attributeoptioncomboid"/>
+
+            <property name="dayInPeriod" column="dayInPeriod" />
 
         </properties>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationResult.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationResult.hbm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd"
+        >
+
+<hibernate-mapping>
+    <class name="org.hisp.dhis.validation.ValidationResult" table="validationresult">
+
+        <id name="id" column="validationresultid">
+            <generator class="native"/>
+        </id>
+
+        <many-to-one name="validationRule" class="org.hisp.dhis.validation.ValidationRule" column="validationrule"
+                     foreign-key="fk_validationresult_validationruleid"/>
+
+        <many-to-one name="period" class="org.hisp.dhis.period.Period" column="period"
+                     foreign-key="fk_validationresult_period"/>
+
+        <many-to-one name="attributeOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
+                     column="attributeoptioncombo" foreign-key="fk_validationresult_attributeoptioncomboid"/>
+
+        <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit"
+                     column="organisationunit" foreign-key="fk_validationresult_organisationunitid"/>
+
+        <property name="leftsideValue"/>
+
+        <property name="rightsideValue"/>
+
+    </class>
+
+</hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -38,6 +38,8 @@ import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.notification.NotificationMessage;
 import org.hisp.dhis.notification.ValidationNotificationMessageRenderer;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.QuarterlyPeriodType;
 import org.hisp.dhis.user.User;
@@ -50,21 +52,15 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anySetOf;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for the business logic implemented in ValidationNotificationService.
@@ -95,6 +91,9 @@ public class ValidationNotificationServiceTest
 
     @InjectMocks
     private DefaultValidationNotificationService service;
+
+    @Autowired
+    private PeriodService periodService;
 
     private List<MockMessage> sentMessages;
 
@@ -167,25 +166,29 @@ public class ValidationNotificationServiceTest
 
     private ValidationResult createValidationResult( OrganisationUnit ou, ValidationRule rule )
     {
+        Period p = createPeriod( "2017Q1" );
         return new ValidationResult(
             rule,
-            createPeriod( "2017Q1" ),
+            p,
             ou,
             catOptCombo,
             RandomUtils.nextDouble( 10, 1000 ),
-            RandomUtils.nextDouble( 10, 1000 )
+            RandomUtils.nextDouble( 10, 1000 ),
+            periodService.getDayInPeriod( p, new Date() )
         );
     }
 
     private ValidationResult createValidationResultA()
     {
+        Period p = createPeriod( "2017Q1" );
         return new ValidationResult(
             valRuleA,
-            createPeriod( "2017Q1" ),
+            p,
             orgUnitA,
             catOptCombo,
             RandomUtils.nextDouble( 10, 1000 ),
-            RandomUtils.nextDouble( 10, 1000 )
+            RandomUtils.nextDouble( 10, 1000 ),
+            periodService.getDayInPeriod( p, new Date() )
         );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -165,29 +165,29 @@ public class ValidationNotificationServiceTest
 
     private ValidationResult createValidationResult( OrganisationUnit ou, ValidationRule rule )
     {
-        Period p = createPeriod( "2017Q1" );
+        Period period = createPeriod( "2017Q1" );
         return new ValidationResult(
             rule,
-            p,
+            period,
             ou,
             catOptCombo,
             RandomUtils.nextDouble( 10, 1000 ),
             RandomUtils.nextDouble( 10, 1000 ),
-            periodService.getDayInPeriod( p, new Date() )
+            periodService.getDayInPeriod( period, new Date() )
         );
     }
 
     private ValidationResult createValidationResultA()
     {
-        Period p = createPeriod( "2017Q1" );
+        Period period = createPeriod( "2017Q1" );
         return new ValidationResult(
             valRuleA,
-            p,
+            period,
             orgUnitA,
             catOptCombo,
             RandomUtils.nextDouble( 10, 1000 ),
             RandomUtils.nextDouble( 10, 1000 ),
-            periodService.getDayInPeriod( p, new Date() )
+            periodService.getDayInPeriod( period, new Date() )
         );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -38,8 +38,8 @@ import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.notification.NotificationMessage;
 import org.hisp.dhis.notification.ValidationNotificationMessageRenderer;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.DefaultPeriodService;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.QuarterlyPeriodType;
 import org.hisp.dhis.user.User;
@@ -52,7 +52,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -92,8 +91,8 @@ public class ValidationNotificationServiceTest
     @InjectMocks
     private DefaultValidationNotificationService service;
 
-    @Autowired
-    private PeriodService periodService;
+    @InjectMocks
+    private DefaultPeriodService periodService;
 
     private List<MockMessage> sentMessages;
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -117,6 +117,9 @@ public class ValidationServiceTest
     private Period periodA;
     private Period periodB;
 
+    private int dayInPeriodA;
+    private int dayInPeriodB;
+
     private OrganisationUnit sourceA;
     private OrganisationUnit sourceB;
     private OrganisationUnit sourceC;
@@ -210,6 +213,9 @@ public class ValidationServiceTest
 
         periodA = createPeriod( periodTypeMonthly, getDate( 2000, 3, 1 ), getDate( 2000, 3, 31 ) );
         periodB = createPeriod( periodTypeMonthly, getDate( 2000, 4, 1 ), getDate( 2000, 4, 30 ) );
+
+        dayInPeriodA = periodService.getDayInPeriod( periodA, new Date() );
+        dayInPeriodB = periodService.getDayInPeriod( periodB, new Date() );
 
         dataSetWeekly = createDataSet( 'W', periodTypeWeekly );
         dataSetMonthly = createDataSet( 'M', periodTypeMonthly );
@@ -379,15 +385,15 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
 
-        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleB, periodB, sourceA, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleB, periodA, sourceB, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleB, periodB, sourceB, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleB, periodB, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( validationRuleB, periodA, sourceB, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleB, periodB, sourceB, defaultCombo, -1.0, 4.0, dayInPeriodB ) );
 
         for ( ValidationResult result : results )
         {
@@ -437,10 +443,10 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
 
         for ( ValidationResult result : results )
         {
@@ -469,8 +475,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
 
         for ( ValidationResult result : results )
         {
@@ -503,7 +509,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> results = validationService.validate( dataSetMonthly, periodA, sourceA, null );
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 0.0, 1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 0.0, 1.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -520,7 +526,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> results = validationService.validate( dataSetMonthly, periodA, sourceA, null );
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 1.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 1.0, 0.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -558,7 +564,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 0.0, 1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 0.0, 1.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -575,7 +581,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 1.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 1.0, 0.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -606,7 +612,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -626,7 +632,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -646,7 +652,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -667,8 +673,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, dayInPeriodA ) );
 
         assertEquals( 2, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -720,7 +726,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, dayInPeriodA ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -774,8 +780,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
 
         for ( ValidationResult result : results )
         {
@@ -793,10 +799,10 @@ public class ValidationServiceTest
 
         reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboBC, 3.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
-        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboBC, 3.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboBC, 3.0, 2.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboBC, 3.0, 2.0, dayInPeriodA ) );
 
         for ( ValidationResult result : results )
         {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -28,32 +28,8 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static org.hisp.dhis.expression.Expression.SEPARATOR;
-import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
-import static org.hisp.dhis.expression.Operator.compulsory_pair;
-import static org.hisp.dhis.expression.Operator.equal_to;
-import static org.hisp.dhis.expression.Operator.exclusive_pair;
-import static org.hisp.dhis.expression.Operator.greater_than;
-import static org.hisp.dhis.expression.Operator.less_than;
-import static org.hisp.dhis.expression.Operator.less_than_or_equal_to;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.hisp.dhis.DhisTest;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementCategory;
-import org.hisp.dhis.dataelement.DataElementCategoryCombo;
-import org.hisp.dhis.dataelement.DataElementCategoryOption;
-import org.hisp.dhis.dataelement.DataElementCategoryOptionCombo;
-import org.hisp.dhis.dataelement.DataElementCategoryService;
-import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dataelement.*;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.datavalue.DataValueService;
@@ -62,15 +38,19 @@ import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.mock.MockCurrentUserService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.period.MonthlyPeriodType;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.period.WeeklyPeriodType;
-import org.hisp.dhis.period.YearlyPeriodType;
+import org.hisp.dhis.period.*;
 import org.hisp.dhis.system.util.MathUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.*;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static org.hisp.dhis.expression.Expression.SEPARATOR;
+import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
+import static org.hisp.dhis.expression.Operator.*;
 
 /**
  * @author Jim Grace
@@ -101,6 +81,9 @@ public class ValidationServiceTest
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
+
+    @Autowired
+    private PeriodService periodService;
 
     private DataElement dataElementA;
     private DataElement dataElementB;
@@ -396,15 +379,15 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0 ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
 
-        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0 ) );
-        reference.add( new ValidationResult( validationRuleB, periodB, sourceA, defaultCombo, -1.0, 4.0 ) );
-        reference.add( new ValidationResult( validationRuleB, periodA, sourceB, defaultCombo, -1.0, 4.0 ) );
-        reference.add( new ValidationResult( validationRuleB, periodB, sourceB, defaultCombo, -1.0, 4.0 ) );
+        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleB, periodB, sourceA, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleB, periodA, sourceB, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleB, periodB, sourceB, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
 
         for ( ValidationResult result : results )
         {
@@ -454,10 +437,10 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0 ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodB, new Date() ) ) );
 
         for ( ValidationResult result : results )
         {
@@ -486,8 +469,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0 ) );
-        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0 ) );
+        reference.add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         for ( ValidationResult result : results )
         {
@@ -520,7 +503,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> results = validationService.validate( dataSetMonthly, periodA, sourceA, null );
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 0.0, 1.0 ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 0.0, 1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -537,7 +520,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> results = validationService.validate( dataSetMonthly, periodA, sourceA, null );
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 1.0, 0.0 ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 1.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -575,7 +558,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 0.0, 1.0 ) );
+        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 0.0, 1.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -592,7 +575,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 1.0, 0.0 ) );
+        reference.add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 1.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -623,7 +606,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0 ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -643,7 +626,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0 ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -663,7 +646,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0 ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -684,8 +667,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0 ) );
-        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0 ) );
+        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 2, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -737,7 +720,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0 ) );
+        reference.add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         assertEquals( 1, results.size() );
         assertEquals( orderedList( reference ), orderedList( results ) );
@@ -791,8 +774,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0 ) );
-        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0 ) );
+        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         for ( ValidationResult result : results )
         {
@@ -810,10 +793,10 @@ public class ValidationServiceTest
 
         reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0 ) );
-        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0 ) );
-        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboBC, 3.0, 2.0 ) );
-        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboBC, 3.0, 2.0 ) );
+        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboBC, 3.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
+        reference.add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboBC, 3.0, 2.0, periodService.getDayInPeriod( periodA, new Date() ) ) );
 
         for ( ValidationResult result : results )
         {

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
@@ -28,14 +28,14 @@ package org.hisp.dhis.dbms;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.List;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
 
 /**
  * @author Lars Helge Overland
@@ -189,7 +189,9 @@ public class HibernateDbmsManager
         emptyTable( "validationrulegroupmembers" );
         emptyTable( "validationrulegroup" );
         emptyTable( "validationrulegroupusergroupaccesses" );
-        
+
+        emptyTable( "validationresult" );
+
         emptyTable( "validationrule" );
         emptyTable( "validationruleusergroupaccesses" );
 

--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/batchhandler/ValidationResultBatchHandler.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/batchhandler/ValidationResultBatchHandler.java
@@ -1,0 +1,137 @@
+package org.hisp.dhis.jdbc.batchhandler;
+/*
+ * Copyright (c) 2004-2017, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.validation.ValidationResult;
+import org.hisp.quick.JdbcConfiguration;
+import org.hisp.quick.batchhandler.AbstractBatchHandler;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * @author Stian Sandvold
+ */
+public class ValidationResultBatchHandler
+    extends AbstractBatchHandler<ValidationResult>
+{
+    public ValidationResultBatchHandler( JdbcConfiguration configuration )
+    {
+        super( configuration );
+    }
+
+    @Override
+    public String getTableName()
+    {
+        return "validationresult";
+    }
+
+    @Override
+    public String getAutoIncrementColumn()
+    {
+        return "validationresultid";
+    }
+
+    @Override
+    public boolean isInclusiveUniqueColumns()
+    {
+        return true;
+    }
+
+    @Override
+    public List<String> getIdentifierColumns()
+    {
+        return getStringList( "validationresultid" );
+    }
+
+    @Override
+    public List<Object> getIdentifierValues( ValidationResult validationResult )
+    {
+        return getObjectList( validationResult.getId() );
+    }
+
+    @Override
+    public List<String> getUniqueColumns()
+    {
+        return getStringList(
+            "validationruleid",
+            "periodid",
+            "organisationunitid",
+            "attributeoptioncomboid",
+            "dayinperiod"
+        );
+    }
+
+    @Override
+    public List<Object> getUniqueValues( ValidationResult validationResult )
+    {
+        return getObjectList(
+            validationResult.getValidationRule().getId(),
+            validationResult.getPeriod().getId(),
+            validationResult.getOrganisationUnit().getId(),
+            validationResult.getAttributeOptionCombo().getId(),
+            validationResult.getDayInPeriod()
+        );
+    }
+
+    @Override
+    public List<String> getColumns()
+    {
+        return getStringList(
+            "leftsidevalue",
+            "rightsidevalue",
+            "validationruleid",
+            "periodid",
+            "organisationunitid",
+            "attributeoptioncomboid",
+            "dayinperiod"
+        );
+    }
+
+    @Override
+    public List<Object> getValues( ValidationResult validationResult )
+    {
+        return getObjectList(
+            validationResult.getLeftsideValue(),
+            validationResult.getRightsideValue(),
+            validationResult.getValidationRule().getId(),
+            validationResult.getPeriod().getId(),
+            validationResult.getOrganisationUnit().getId(),
+            validationResult.getAttributeOptionCombo().getId(),
+            validationResult.getDayInPeriod()
+        );
+    }
+
+    @Override
+    public ValidationResult mapRow( ResultSet resultSet )
+        throws SQLException
+    {
+        return null;
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionHandler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionHandler.java
@@ -114,6 +114,7 @@ import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserSetting;
 import org.hisp.dhis.validation.ValidationCriteria;
+import org.hisp.dhis.validation.ValidationResult;
 import org.hisp.dhis.validation.ValidationRule;
 import org.hisp.dhis.validation.ValidationRuleGroup;
 import org.hisp.dhis.validation.notification.ValidationNotificationTemplate;
@@ -374,6 +375,11 @@ public abstract class DeletionHandler
     }
 
     public String allowDeleteValidationRule( ValidationRule validationRule )
+    {
+        return null;
+    }
+
+    public String allowDeleteValidationResult( ValidationResult validationResult )
     {
         return null;
     }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -114,14 +114,4 @@ public class ValidationController
 
         return summary;
     }
-
-    @RequestMapping( value = "/run/scheduled", method = RequestMethod.GET )
-    public @ResponseBody String scheduledValidation(
-        HttpServletResponse response
-    )
-    {
-        validationService.scheduledRun();
-
-        return "OK";
-    }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -114,4 +114,14 @@ public class ValidationController
 
         return summary;
     }
+
+    @RequestMapping( value = "/run/scheduled", method = RequestMethod.GET )
+    public @ResponseBody String scheduledValidation(
+        HttpServletResponse response
+    )
+    {
+        validationService.scheduledRun();
+
+        return "OK";
+    }
 }


### PR DESCRIPTION
This _only_ adds the persisting of validations results, it does no change the way the validation rules are being analysed.

In addition a few notable changes to the validation result model:
- dayInPeriod: (int) represents when, relative to the period of the result, the analysis was done
- orgunit, period, rule, dayInPeriod and cat option combo is part of a unique constraint to the model.