### PR TITLE
Ensure build revision is always 7 characters

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -275,7 +275,7 @@
                   <mkdir dir="${project.build.outputDirectory}" />
                   <exec executable="git" outputproperty="revision" failifexecutionfails="false">
                     <arg value="rev-parse" />
-                    <arg value="--short" />
+                    <arg value="--short=7" />
                     <arg value="HEAD" />
                   </exec>
                   <echo file="${project.build.outputDirectory}/build.properties"


### PR DESCRIPTION
Newer versions of Git 2.x change the length returned by `git rev-parse --short HEAD` from 7 characters to 8. This ensures the current behavior of 7 characters remains the same if the underlying tools are upgraded.