### PR TITLE
Fix in event reports to load data elements properly on program select

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-event-reports/scripts/app.js
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-event-reports/scripts/app.js
@@ -4182,7 +4182,7 @@ Ext.onReady( function() {
                     }
                 });
 
-                //this.toggleProgramIndicators();
+                this.toggleProgramIndicators();
             },
             toggleProgramIndicators: function(type) {
                 type = type || ns.app.typeToolbar.getType();


### PR DESCRIPTION
In event reports page, both data elements and program indicators are listed on program select for aggregated values. This fix will filter program indicator on program select for aggregated values.