### PR TITLE
Fix to handle uid collisions across different entities during the entity create/update

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -599,7 +599,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
             webMessage.setHttpStatus( HttpStatus.CREATED );
             response.setHeader( ContextUtils.HEADER_LOCATION, location );
-            T entity = manager.get( objectReport.getUid() );
+            T entity = manager.get( getEntityClass(), objectReport.getUid() );
             postCreateEntity( entity );
         }
         else
@@ -642,7 +642,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
             webMessage.setHttpStatus( HttpStatus.CREATED );
             response.setHeader( ContextUtils.HEADER_LOCATION, location );
-            T entity = manager.get( objectReport.getUid() );
+            T entity = manager.get( getEntityClass(), objectReport.getUid() );
             postCreateEntity( entity );
         }
         else
@@ -705,7 +705,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         if ( importReport.getStatus() == Status.OK )
         {
-            T entity = manager.get( pvUid );
+            T entity = manager.get( getEntityClass(), pvUid );
             postUpdateEntity( entity );
         }
         else
@@ -749,7 +749,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         if ( importReport.getStatus() == Status.OK )
         {
-            T entity = manager.get( pvUid );
+            T entity = manager.get( getEntityClass(), pvUid );
             postUpdateEntity( entity );
         }
         else


### PR DESCRIPTION
Hi team,
We are unable to update/create some entities (`organisationUnits`, `CategoryCombos`) with matching uid's of other entities. For example If I have a `category` with uid '`abcedfghijk`' in DHIS and If I try to create/update a organisationUnit with same uid, it's throwing following error.
```
{
  "httpStatus": "Internal Server Error",
  "httpStatusCode": 500,
  "status": "ERROR",
  "message": "org.hisp.dhis.dataelement.DataElementCategory cannot be cast to org.hisp.dhis.organisationunit.OrganisationUnit"
}
```
If at all there was a uid collisions for existing entities in DHIS, then we are not able to edit those entities at all. This fix will identify entity store first and try find the object inside that store instead of searching in all entity stores.
