### PR TITLE
[2.25] Backport fix to handle uid collisons across different entities during the entity create and update

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -595,7 +595,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             webMessage.setHttpStatus( HttpStatus.CREATED );
             response.setHeader( "Location", contextService.getApiPath() + getSchema().getRelativeApiEndpoint()
                 + "/" + objectReport.getUid() );
-            T entity = manager.get( objectReport.getUid() );
+            T entity = manager.get( getEntityClass(), objectReport.getUid() );
             postCreateEntity( entity );
         }
 
@@ -634,7 +634,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             response.setHeader( "Location", contextService.getApiPath() + getSchema().getRelativeApiEndpoint()
                 + "/" + objectReport.getUid() );
 
-            T entity = manager.get( objectReport.getUid() );
+            T entity = manager.get( getEntityClass(), objectReport.getUid() );
             postCreateEntity( entity );
         }
 
@@ -692,7 +692,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         if ( importReport.getStatus() == Status.OK )
         {
-            T entity = manager.get( pvUid );
+            T entity = manager.get( getEntityClass(), pvUid );
             postUpdateEntity( entity );
         }
 
@@ -732,7 +732,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         if ( importReport.getStatus() == Status.OK )
         {
-            T entity = manager.get( pvUid );
+            T entity = manager.get( getEntityClass(), pvUid );
             postUpdateEntity( entity );
         }
 


### PR DESCRIPTION
This is back-port fix for 2.25