### PR TITLE
[2.26] Fix in event reports page to display available items properly

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-event-reports/scripts/app.js
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-event-reports/scripts/app.js
@@ -4182,7 +4182,7 @@ Ext.onReady( function() {
                     }
                 });
 
-                //this.toggleProgramIndicators();
+                this.toggleProgramIndicators();
             },
             toggleProgramIndicators: function(type) {
                 type = type || ns.app.typeToolbar.getType();


### PR DESCRIPTION
On initial load of event reports page, both data elements and program indicators are listed on selection of program under aggregated values tab. This fix will filter program indicator on selection of program.