### PR TITLE
More interpretations improvements

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/resources/org/hisp/dhis/dashboard/i18n_module.properties
+++ b/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/resources/org/hisp/dhis/dashboard/i18n_module.properties
@@ -60,6 +60,7 @@ click_to_view_in_gis=Click to view in GIS
 click_to_view_data_set_report=Click to view data set report
 share=Share
 write_your_interpretation=Write a comment, question or interpretation
+cannot_write_interpretation=You don't have permissions to add an interpretation
 share_your_interpretation_of=Share your interpretation of
 interpretation_was_shared=Interpretation was shared
 viewing=Viewing

--- a/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/dashboard.vm
+++ b/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/dashboard.vm
@@ -103,6 +103,12 @@ jQuery( document ).ready( function() {
     <input type="button" class="interpretationButton" value="$i18n.getString( 'share' )" onclick="dhis2.db.shareInterpretation()">
 </div>
 
+<div id="shareFormError">
+    <p>$i18n.getString( 'cannot_write_interpretation' )</p>
+    <a class="greyButtonLink" href="javascript:void(0);" onclick="dhis2.db.closeDialog(this)" 
+       style="margin-top: 1px">$i18n.getString( "close" )</a>
+</div>
+
 <div id="shareHelpForm">
     <ul>
         <li>$i18n.getString( "from" ) <a href="../dhis-web-pivot/index.html">$i18n.getString( "pivot_table" )</a>, $i18n.getString( "generate_pivot_table_click_share" )</li>

--- a/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/javascript/dashboard.js
+++ b/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/javascript/dashboard.js
@@ -95,7 +95,7 @@ dhis2.db.tmpl = {
     "<a href='javascript:dhis2.db.resizeItem( \"${itemId}\" )'>${i18n_resize}</a>|" +
     "<a href='javascript:dhis2.db.exploreChart( \"${id}\" )'>${i18n_explore}</a>|" +
     "<a href='javascript:dhis2.db.viewShareForm( \"${id}\", \"chart\", \"${name}\" )'>${i18n_share}</a>" +
-    "{{if interpretationCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"CHART\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>{{/if}}" +
+    "<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"CHART\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>" +
     "{{if interpretationLikeCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"CHART\" );return false;' title=\"${interpretationLikeCount} likes\"><i class=\"fa fa-thumbs-o-up\"></i>${interpretationLikeCount}</a>{{/if}}" +
     "<i class=\"fa fa-arrows dragIcon\" title=\"${i18n_click_and_drag_to_new_position}\"></i></div>" +
     "<div id='plugin-${itemId}' style='width:100%; height:" + dhis2.db.itemContentHeight + "px'></div>" +
@@ -107,7 +107,7 @@ dhis2.db.tmpl = {
     "<a href='javascript:dhis2.db.resizeItem( \"${itemId}\" )'>${i18n_resize}</a>|" +
     "<a href='javascript:dhis2.db.exploreEventChart( \"${id}\" )'>${i18n_explore}</a>|" +
     "<a href='javascript:dhis2.db.viewShareForm( \"${id}\", \"eventChart\", \"${name}\" )'>${i18n_share}</a>" +
-    "{{if interpretationCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"EVENT_CHART\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>{{/if}}" +
+    "<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"EVENT_CHART\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>" +
     "{{if interpretationLikeCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"EVENT_CHART\" );return false;' title=\"${interpretationLikeCount} likes\"><i class=\"fa fa-thumbs-o-up\"></i>${interpretationLikeCount}</a>{{/if}}" +
     "<i class=\"fa fa-arrows dragIcon\" title=\"${i18n_click_and_drag_to_new_position}\"></i></div>" +
     "<div id='plugin-${itemId}'></div>" +
@@ -118,7 +118,7 @@ dhis2.db.tmpl = {
     "<a href='javascript:dhis2.db.resizeItem( \"${itemId}\" )'>${i18n_resize}</a>|" +
     "<a href='javascript:dhis2.db.exploreMap( \"${id}\" )'>${i18n_explore}</a>|" +
     "<a href='javascript:dhis2.db.viewShareForm( \"${id}\", \"map\", \"${name}\" )'>${i18n_share}</a>" +
-    "{{if interpretationCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"MAP\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>{{/if}}" +
+    "<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"MAP\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>" +
     "{{if interpretationLikeCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"MAP\" );return false;' title=\"${interpretationLikeCount} likes\"><i class=\"fa fa-thumbs-o-up\"></i>${interpretationLikeCount}</a>{{/if}}" +
     "<i class=\"fa fa-arrows dragIcon\" title=\"${i18n_click_and_drag_to_new_position}\"></i></div>" +
     "<div id='plugin-${itemId}' style='width:100%; height:${height}px'></div>" +
@@ -129,7 +129,7 @@ dhis2.db.tmpl = {
     "<a href='javascript:dhis2.db.resizeItem( \"${itemId}\" )'>${i18n_resize}</a>|" +
     "<a href='javascript:dhis2.db.exploreReportTable( \"${id}\" )'>${i18n_explore}</a>|" +
     "<a href='javascript:dhis2.db.viewShareForm( \"${id}\", \"reportTable\", \"${name}\" )'>${i18n_share}</a>" +
-    "{{if interpretationCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"REPORT_TABLE\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>{{/if}}" +
+    "<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"REPORT_TABLE\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>" +
     "{{if interpretationLikeCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"REPORT_TABLE\" );return false;' title=\"${interpretationLikeCount} likes\"><i class=\"fa fa-thumbs-o-up\"></i>${interpretationLikeCount}</a>{{/if}}" +
     "<i class=\"fa fa-arrows dragIcon\" title=\"${i18n_click_and_drag_to_new_position}\"></i></div>" +
     "<div id='plugin-${itemId}'></div>" +
@@ -140,7 +140,7 @@ dhis2.db.tmpl = {
     "<a href='javascript:dhis2.db.resizeItem( \"${itemId}\", true )'>${i18n_resize}</a>|" +
     "<a href='javascript:dhis2.db.exploreEventReport( \"${id}\" )'>${i18n_explore}</a>|" +
     "<a href='javascript:dhis2.db.viewShareForm( \"${id}\", \"eventReport\", \"${name}\" )'>${i18n_share}</a>" +
-    "{{if interpretationCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"EVENT_REPORT\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>{{/if}}" +
+    "<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"EVENT_REPORT\" );return false;' title=\"${interpretationCount} interpretations\"><i class=\"fa fa-comments-o\"></i>${interpretationCount}</a>" +
     "{{if interpretationLikeCount > 0}}<a href='#' onclick='javascript:dhis2.db.viewInterpretationPopup( \"${itemId}\", \"${id}\", \"EVENT_REPORT\" );return false;' title=\"${interpretationLikeCount} likes\"><i class=\"fa fa-thumbs-o-up\"></i>${interpretationLikeCount}</a>{{/if}}" +
     "<i class=\"fa fa-arrows dragIcon\" title=\"${i18n_click_and_drag_to_new_position}\"></i></div>" +
     "<div id='plugin-${itemId}'></div>" +
@@ -183,6 +183,8 @@ dhis2.db.tmpl = {
 	"<div class='likeComment'><label>" +
 	"<div style='padding:5px 0;'><i class='fa fa-thumbs-o-up'></i><span style='color:#3162C5;'>${numberLikes} people</span> like this. <span style='color:#3162C5;'>${numberComments} people</span> commented.</div>" +
 	"</label></div></div></a>",
+
+    new_interpretation : "<div><a id='newInterpretation' href='javascript:dhis2.db.${exploreFunction}( \"${favoriteId}\", \"new\" )'>${i18n_share_interpretation}</a></div>",
 
     interpretationDashboardItem: "<div id='plugin-interpretation-${itemId}' style='width:100%; height:${height}px'></div>"
 };
@@ -1429,16 +1431,25 @@ dhis2.db.registerDashboardViewEvent = function () {
 //------------------------------------------------------------------------------
 
 dhis2.db.viewShareForm = function (id, type, name) {
-    dhis2.db.currentShareId = id;
-    dhis2.db.currentShareType = type;
+    $.ajax({
+        url: "../api/sharing?type=" + type + "&id=" + id,
+        complete: function (xhr) {
+            var userCanAddInterpretation = 
+                (xhr.status >= 200 && xhr.status <= 299) || xhr.status == 403;
+            var selector = userCanAddInterpretation ? "#shareForm" : "#shareFormError";
 
-    var title = i18n_share_your_interpretation_of + " " + name;
+            dhis2.db.currentShareId = id;
+            dhis2.db.currentShareType = type;
 
-    $("#shareForm").dialog({
-        modal: true,
-        width: 550,
-        resizable: false,
-        title: title
+            var title = i18n_share_your_interpretation_of + " " + name;
+
+            $(selector).dialog({
+                modal: true,
+                width: 550,
+                resizable: false,
+                title: title
+            });
+        }
     });
 }
 
@@ -1510,6 +1521,10 @@ dhis2.db.downloadImage = function () {
         url = url + "&attachment=true";
         window.location.href = url;
     }
+}
+
+dhis2.db.closeDialog = function (button) {
+    $(button).closest('.ui-dialog-content').dialog('close');
 }
 
 //------------------------------------------------------------------------------
@@ -1615,6 +1630,15 @@ dhis2.db.viewInterpretationPopup = function (itemId, id, type) {
 			});
 			dhis2.db.preOrAppend(interpretationContainer, interpretationContent, false);
 		}
+
+        if (data.interpretations.length == 0) {
+            var newInterpretationContent = $.tmpl(dhis2.db.tmpl.new_interpretation, {
+                "favoriteId": id,
+                "interpretationId": "new",
+                "exploreFunction": exploreFunction
+            });
+            interpretationContainer.append(newInterpretationContent);
+        }
 
         dhis2.db.currentShareId = id;
         dhis2.db.currentShareType = type;

--- a/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/style/dashboard.css
+++ b/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/style/dashboard.css
@@ -852,6 +852,12 @@ div#selectionTree
   text-decoration: none;
 }
 
+#interpretationPopup #newInterpretation {
+  display: block;
+  color: #3162C5;
+  margin-top: 5px;
+}
+
 #interpretationContainer{
   margin-bottom: 8px;
   margin-top: 10px;

--- a/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/style/dashboard.css
+++ b/dhis-2/dhis-web/dhis-web-dashboard-integration/src/main/webapp/dhis-web-dashboard-integration/style/dashboard.css
@@ -326,6 +326,10 @@
   display: none;
 }
 
+#shareFormError {
+  display: none;
+}
+
 #shareHelpForm
 {
   display: none;


### PR DESCRIPTION
This PR implements some minor features and bug fixing regarding interpretations on the dashboard:
- Always display interpretation icon close to "Share Interpretation" text on dashboard item header.
![screenshot from 2017-05-04 13 32 29](https://cloud.githubusercontent.com/assets/6850223/25703650/5089e760-30ce-11e7-8085-8fe5faa7ab54.png)

- When clicking on interpretation/comment icon, interpretation modal will be open as usual. However, if no interpretation is found a share interpretation icon is displayed. Share interpretation link will redirect to chart or pivot app with the share interpretation dialog opened.
![screenshot from 2017-05-04 13 33 45](https://cloud.githubusercontent.com/assets/6850223/25703657/558ecbd6-30ce-11e7-820d-23c4f7495f8c.png)

- If a user tries to share an interpretation for an object without permissions an error dialog will be displayed ('You don't have permissions to add an interpretation'). Before this PR, a cryptic 409 was displayed.

Not sure how to proceed about multilanguage. Please let us know if we should send a patch or create a PR or whatever...
Once approved we will migrate these features to 2.26 and trunk and create PRs.

Thank you!