### PR TITLE
Add matching event uid condition to events/query.json endpoint

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -733,6 +733,11 @@ public class JdbcEventStore
             }
         }
 
+        if ( params.getEvents() != null && !params.getEvents().isEmpty() && !params.hasFilters() )
+        {
+            sql += hlp.whereAnd() + " (psi.uid in (" + getQuotedCommaDelimitedString( params.getEvents() ) + ")) ";
+        }
+
         return sql;
     }
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1596

After this fix, the below query will return only one record with event uid = WtUDEw3resf

http://localhost:8080/api/26/events/query.json?orgUnit=DiszpKrYNg8&programStage=Zj7UnCAulEk&event=WtUDEw3resf&dataElement=qrur9Dvnyt5,fWIAEtYVEGk,K6uUAvq500H