### PR TITLE
Fix bug userCredential.getName() to get value from userinfo 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -397,7 +397,7 @@ public class UserCredentials
     @Override
     public String getName()
     {
-        return user != null ? user.getName() : username;
+        return userInfo!= null ? userInfo.getName() : username;
     }
 
     /**


### PR DESCRIPTION
The attribute user is the one who created current user.. Maybe we should change this property name to "createdBy"
https://jira.dhis2.org/browse/DHIS2-1644