### PR TITLE
Fix bug cannot download metadata with compression.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/view/CustomPathExtensionContentNegotiationStrategy.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/view/CustomPathExtensionContentNegotiationStrategy.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.accept.PathExtensionContentNegotiationStrategy;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.util.UriUtils;
 import org.springframework.web.util.UrlPathHelper;
 
 import javax.servlet.http.HttpServletRequest;
@@ -50,6 +49,10 @@ import java.util.Map;
 public class CustomPathExtensionContentNegotiationStrategy extends PathExtensionContentNegotiationStrategy
 {
     private static final UrlPathHelper URL_PATH_HELPER = new UrlPathHelper();
+
+    private static final char EXTENSION_SEPARATOR = '.';
+
+    private static final String FOLDER_SEPARATOR = "/";
 
     static
     {
@@ -72,8 +75,31 @@ public class CustomPathExtensionContentNegotiationStrategy extends PathExtension
         }
 
         String path = URL_PATH_HELPER.getLookupPathForRequest( servletRequest );
-        String extension = UriUtils.extractFileExtension( path );
+        String extension = getFilenameExtension( path );
 
         return !StringUtils.isBlank( extension ) ? extension.toLowerCase( Locale.ENGLISH ) : null;
+    }
+
+    private static String getFilenameExtension( String path )
+    {
+        if ( path == null )
+        {
+            return null;
+        }
+        int extIndex = path.indexOf( EXTENSION_SEPARATOR );
+
+        if ( extIndex == -1 )
+        {
+            return null;
+        }
+
+        int folderIndex = path.indexOf( FOLDER_SEPARATOR );
+
+        if ( folderIndex > extIndex )
+        {
+            return null;
+        }
+
+        return path.substring( extIndex + 1 );
     }
 }


### PR DESCRIPTION
Fix bug exporting metadata is ignoring the compression settings.

This is caused by UriUtils.extractFileExtension which only support one dot character, 
which will fail if the path is dataSet.json.zip  -> return value is "zip"

https://jira.dhis2.org/browse/D227TEST-32