### PR TITLE
Fix bug auditTrails in dataEntry app show incorrect values.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/GetHistoryAction.java
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/GetHistoryAction.java
@@ -259,6 +259,8 @@ public class GetHistoryAction
 
         DataElementCategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo( cc, cp, false );
 
+        dataElementHistory = historyRetriever.getHistory( dataElement, categoryOptionCombo, attributeOptionCombo, organisationUnit, period, HISTORY_LENGTH );
+
         dataValueAudits = dataValueAuditService.getDataValueAudits( Lists.newArrayList( dataElement ), Lists.newArrayList( period ),
             Lists.newArrayList( organisationUnit ), categoryOptionCombo, attributeOptionCombo, null );
 
@@ -270,8 +272,6 @@ public class GetHistoryAction
             storedBy = credentials != null ? credentials.getName() : dataValue.getStoredBy();
         }
 
-        dataElementHistory = historyRetriever.getHistory( dataElement, categoryOptionCombo, attributeOptionCombo, organisationUnit, period, HISTORY_LENGTH );
-        
         historyInvalid = dataElementHistory == null;
 
         minMaxInvalid = !dataElement.getValueType().isNumeric();


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-456

If user selects a period that does not exist in database, the method dataValueAuditService.getDataValueAudits() will query audit data with period = null.

While in method historyRetriever.getHistory(), it will force-add a non-existed period. 

So reorder those method calls will fix this issue.
