### PR TITLE
Fix regularAccessVoting bean not taking effect in security.xml

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -208,6 +208,14 @@
 
   <bean id="authenticatedVoter" class="org.springframework.security.access.vote.AuthenticatedVoter" />
 
+  <bean id="authenticatedVoting" class="org.springframework.security.access.vote.UnanimousBased">
+    <constructor-arg name="decisionVoters">
+      <list>
+        <ref bean="authenticatedVoter" />
+      </list>
+    </constructor-arg>
+  </bean>
+
   <bean id="methodSecurityExpressionHandler" class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
     <property name="defaultRolePrefix" value="" />
   </bean>
@@ -225,10 +233,12 @@
   <bean id="accessDecisionManager" class="org.hisp.dhis.security.vote.LogicalOrAccessDecisionManager">
     <property name="accessDecisionManagers">
       <list>
+        <ref bean="authenticatedVoting" />
         <ref bean="adminAccessDecisionVoting" />
-        <ref bean="regularAccessDecisionVoting" />
         <ref bean="webAccessDecisionVoting" />
         <ref bean="externalAccessDecisionVoting" />
+        <ref bean="actionAccessVoting" />
+        <ref bean="moduleAccessVoting" />
       </list>
     </property>
   </bean>
@@ -261,12 +271,19 @@
     </constructor-arg>
   </bean>
 
-  <bean id="regularAccessDecisionVoting" class="org.springframework.security.access.vote.UnanimousBased">
+
+  <bean id="actionAccessVoting" class="org.springframework.security.access.vote.UnanimousBased">
     <constructor-arg name="decisionVoters">
       <list>
         <ref bean="actionAccessVoter" />
+      </list>
+    </constructor-arg>
+  </bean>
+
+  <bean id="moduleAccessVoting" class="org.springframework.security.access.vote.UnanimousBased">
+    <constructor-arg name="decisionVoters">
+      <list>
         <ref bean="moduleAccessVoter" />
-        <ref bean="authenticatedVoter" />
       </list>
     </constructor-arg>
   </bean>


### PR DESCRIPTION
Not sure why but the below config  is not taking effect. All Access Voters in the list are not used for oauth2 authentication. Hence the result is always "Access denied"

```

<bean id="regularAccessDecisionVoting" class="org.springframework.security.access.vote.UnanimousBased">
    <constructor-arg name="decisionVoters">
      <list>
        <ref bean="actionAccessVoter" />
        <ref bean="moduleAccessVoter" />
        <ref bean="authenticatedVoter" />
      </list>
    </constructor-arg>
  </bean>
```

It works when I divide each AccessVoter into different AccessManager beans



Below is the result after the change
```

viet:~$ curl -X POST -H "Accept: application/json" -u test:c61535b8e-b6e2-6b49-6aa9-54a75cb9170 "http://localhost:8080/uaa/oauth/token?username=admin&password=district&grant_type=password" -v
*   Trying ::1...
* Connected to localhost (::1) port 8080 (#0)
* Server auth using Basic with user 'test'
> POST /uaa/oauth/token?username=admin&password=district&grant_type=password HTTP/1.1
> Host: localhost:8080
> Authorization: Basic dGVzdDpjNjE1MzViOGUtYjZlMi02YjQ5LTZhYTktNTRhNzVjYjkxNzA=
> User-Agent: curl/7.43.0
> Accept: application/json
>
< HTTP/1.1 200 OK
< Date: Mon, 17 Jul 2017 08:32:10 GMT
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-XSS-Protection: 1; mode=block
< X-Frame-Options: DENY
< X-Content-Type-Options: nosniff
< Content-Type: application/json;charset=UTF-8
< Transfer-Encoding: chunked
< Server: Jetty(9.3.13.v20161014)
<
* Connection #0 to host localhost left intact
{"access_token":"20cbbefd-e0dc-4b72-bfc9-463fd83e61a8","token_type":"bearer","refresh_token":"9e0878fc-5e7e-4f74-9191-23a937cfce1c","expires_in":42107,"scope":"ALL"}
```