### PR TITLE
Updated ValidationRunContext to include a initial set of existing results

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultService.java
@@ -27,6 +27,8 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.validation.comparator.ValidationResultQuery;
 
 import java.util.Collection;
@@ -78,4 +80,7 @@ public interface ValidationResultService
     List<ValidationResult> getValidationResults( ValidationResultQuery query );
 
     int countValidationResults( ValidationResultQuery query );
+
+    List<ValidationResult> getValidationResults( List<OrganisationUnit> orgUnits, Collection<ValidationRule> validationRules,
+        Collection<Period> periods );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationResultStore.java
@@ -29,8 +29,11 @@ package org.hisp.dhis.validation;
  */
 
 import org.hisp.dhis.common.GenericStore;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.validation.comparator.ValidationResultQuery;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -46,4 +49,7 @@ public interface ValidationResultStore
     List<ValidationResult> query( ValidationResultQuery query );
 
     int count( ValidationResultQuery query );
+
+    List<ValidationResult> getValidationResults( List<OrganisationUnit> orgUnits, Collection<ValidationRule> validationRules,
+        Collection<Period> periods );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.validation;
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.validation.comparator.ValidationResultQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Stian Sandvold
@@ -46,6 +48,9 @@ public class DefaultValidationResultService
 {
     @Autowired
     private ValidationResultStore validationResultStore;
+
+    @Autowired
+    private PeriodService periodService;
 
     @Override
     public void saveValidationResults( Collection<ValidationResult> validationResults )
@@ -98,6 +103,8 @@ public class DefaultValidationResultService
     public List<ValidationResult> getValidationResults( List<OrganisationUnit> orgUnits,
         Collection<ValidationRule> validationRules, Collection<Period> periods )
     {
-        return validationResultStore.getValidationResults( orgUnits, validationRules, periods);
+        Set<Period> persistedPeriods = periods.stream().map( period -> periodService.getPeriod( period.getIsoDate() ) )
+            .collect( Collectors.toSet() );
+        return validationResultStore.getValidationResults( orgUnits, validationRules, persistedPeriods );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/DefaultValidationResultService.java
@@ -27,6 +27,8 @@ package org.hisp.dhis.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.validation.comparator.ValidationResultQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,5 +92,12 @@ public class DefaultValidationResultService
     public int countValidationResults( ValidationResultQuery query )
     {
         return validationResultStore.count( query );
+    }
+
+    @Override
+    public List<ValidationResult> getValidationResults( List<OrganisationUnit> orgUnits,
+        Collection<ValidationRule> validationRules, Collection<Period> periods )
+    {
+        return validationResultStore.getValidationResults( orgUnits, validationRules, periods);
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
@@ -39,11 +39,14 @@ import org.hisp.dhis.dataelement.CategoryOptionGroupSet;
 import org.hisp.dhis.dataelement.DataElementCategory;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.validation.ValidationResult;
 import org.hisp.dhis.validation.ValidationResultStore;
+import org.hisp.dhis.validation.ValidationRule;
 import org.hisp.dhis.validation.comparator.ValidationResultQuery;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -94,6 +97,19 @@ public class HibernateValidationResultStore
         Query hibernateQuery = getQuery( "from ValidationResult vr" + getRestrictions( "where" ) );
 
         return hibernateQuery.list().size();
+    }
+
+    @Override
+    public List<ValidationResult> getValidationResults( List<OrganisationUnit> orgUnits,
+        Collection<ValidationRule> validationRules, Collection<Period> periods )
+    {
+        Query query = getQuery( "from ValidationResult vr where vr.organisationUnit in :orgUnits and validationRule in :validationRules and vr.period in :periods " );
+
+        query.setParameter( "orgUnits", orgUnits );
+        query.setParameter( "validationRules", validationRules );
+        query.setParameter( "periods", periods );
+
+        return query.list();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -126,7 +126,7 @@ public class DataValidationTask
         {
             for ( PeriodTypeExtended periodTypeX : context.getPeriodTypeExtendedMap().values() )
             {
-                log.trace("Validation PeriodType " + periodTypeX.getPeriodType().getName() );
+                log.trace( "Validation PeriodType " + periodTypeX.getPeriodType().getName() );
 
                 Set<ValidationRuleExtended> ruleXs = getRulesBySourceAndPeriodType( orgUnit, periodTypeX );
 
@@ -159,7 +159,7 @@ public class DataValidationTask
                         {
                             ValidationRule rule = ruleX.getRule();
 
-                            log.trace("Validation rule " + rule.getUid() + " " + rule.getName() );
+                            log.trace( "Validation rule " + rule.getUid() + " " + rule.getName() );
 
                             Map<String, Double> leftSideValues;
 
@@ -190,7 +190,14 @@ public class DataValidationTask
 
                             for ( String optionCombo : attributeOptionCombos )
                             {
-                                log.trace("Validation attributeOptionCombo " + optionCombo );
+                                // Skipping any results we already know
+                                if ( context.skipValidationOfTuple( orgUnit, rule, period, optionCombo,
+                                    periodService.getDayInPeriod( period, new Date() ) ) )
+                                {
+                                    continue;
+                                }
+
+                                log.trace( "Validation attributeOptionCombo " + optionCombo );
 
                                 Double leftSide = leftSideValues.get( optionCombo );
                                 Double rightSide = rightSideValues.get( optionCombo );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -123,6 +123,9 @@ public class DefaultValidationService
     @Autowired
     private ApplicationContext applicationContext;
 
+    @Autowired
+    private ValidationResultService validationResultService;
+
     private CurrentUserService currentUserService;
 
     public void setCurrentUserService( CurrentUserService currentUserService )
@@ -327,7 +330,8 @@ public class DefaultValidationService
             .withPeriodTypeExtendedMap( periodTypeExtendedMap )
             .withOrgUnits( orgUnits )
             .withEventItems( getEventItems( dimensionItemMap ) )
-            .withConstantMap( constantService.getConstantMap() );
+            .withConstantMap( constantService.getConstantMap() )
+            .withInitialResults( validationResultService.getValidationResults(orgUnits, validationRules, periods) );
 
         if ( currentUser != null )
         {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
@@ -29,16 +29,15 @@ package org.hisp.dhis.validation;
 
 import org.apache.commons.lang3.Validate;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.MapMapMap;
 import org.hisp.dhis.dataelement.CategoryOptionGroup;
 import org.hisp.dhis.dataelement.DataElementCategoryOption;
 import org.hisp.dhis.dataelement.DataElementCategoryOptionCombo;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -74,6 +73,8 @@ public class ValidationRunContext
     private boolean sendNotifications = false;
 
     private boolean persistResults = false;
+
+    private MapMapMap<OrganisationUnit, ValidationRule, Period, List<ValidationResult>> initialValidationResults = new MapMapMap<>();
 
     public ValidationRunContext()
     {
@@ -139,6 +140,34 @@ public class ValidationRunContext
         return persistResults;
     }
 
+    public Queue<ValidationResult> getValidationResults()
+    {
+        return validationResults;
+    }
+
+    public boolean skipValidationOfTuple( OrganisationUnit organisationUnit, ValidationRule validationRule,
+        Period period, String attributeOptionCombo, int dayInPeriod )
+    {
+
+        List<ValidationResult> validationResultList = initialValidationResults
+            .getValue( organisationUnit, validationRule, period );
+
+        if ( validationResultList != null )
+        {
+            for ( ValidationResult vr : validationResultList )
+            {
+                if ( vr.getAttributeOptionCombo().getUid().equals( attributeOptionCombo ) &&
+                    vr.getDayInPeriod() == dayInPeriod )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }
+
     // -------------------------------------------------------------------------
     // Builder
     // -------------------------------------------------------------------------
@@ -146,11 +175,6 @@ public class ValidationRunContext
     public static Builder newBuilder()
     {
         return new Builder();
-    }
-
-    public Queue<ValidationResult> getValidationResults()
-    {
-        return validationResults;
     }
 
     public boolean isAnalysisComplete()
@@ -258,6 +282,29 @@ public class ValidationRunContext
         public Builder withPersistResults( boolean persistResults )
         {
             this.context.persistResults = persistResults;
+            return this;
+        }
+
+        public Builder withInitialResults( Collection<ValidationResult> results )
+        {
+            this.context.validationResults.addAll( results );
+
+            results.forEach( validationResult -> {
+                List<ValidationResult> res = context.initialValidationResults
+                    .getValue( validationResult.getOrganisationUnit(), validationResult.getValidationRule(),
+                        validationResult.getPeriod() );
+                if ( res == null )
+                {
+                    res = new ArrayList();
+                }
+
+                res.add( validationResult );
+
+                context.initialValidationResults
+                    .putEntry( validationResult.getOrganisationUnit(), validationResult.getValidationRule(),
+                        validationResult.getPeriod(), res );
+            } );
+
             return this;
         }
     }


### PR DESCRIPTION
ValidationRunContextBuilder now has a withInitialResults method for allowing DataValidationTask to skip validating existing results.

The final result of a DataValidation will still include old(skipped) and new violations.