### PR TITLE
Fix DataSet Locked notification in DataEntry.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1775,7 +1775,7 @@ function insertDataValues( json )
     		if ( dhis2.de.validateOrgUnitOpening( organisationUnits[dhis2.de.getCurrentOrganisationUnit()], period ) )
     		{
     			dhis2.de.lockForm();
-    	        setHeaderMessage( i18n_orgunit_is_closed );
+            setHeaderDelayMessage( i18n_orgunit_is_closed );
     	        return;
     		}
     	}
@@ -1798,14 +1798,11 @@ function insertDataValues( json )
     	if ( orgUnitClosed )
 		{
     		dhis2.de.lockForm();
-	        setHeaderMessage( i18n_orgunit_is_closed );
+	        setHeaderDelayMessage( i18n_orgunit_is_closed );
 	        return;
 		}
 
     }
-    
-    //Hide i18n_orgunit_is_closed message
-    hideHeaderMessage();
     
     $.safeEach( json.dataValues, function( i, value )
     {


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-2199

The hideHeaderMessage() for i18n_orgunit_is_closed is also hiding data set locked message.
So use setHeaderDelayMessage instead, it will auto hide after few seconds.

TODO: backport to 2.28
