### PR TITLE
Fixed Events API response inconsistency issue when paginated

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -469,6 +469,8 @@ public class JdbcEventStore
 
         sql += getEventSelectQuery( params, organisationUnits );
 
+        sql += getOrderQuery( params.getOrders() );
+
         sql += getEventPagingQuery( params );
 
         sql += ") as event left join (";


### PR DESCRIPTION
In the Events query, LIMIT and ORDER BY are used when paginated. Because of applying the LIMIT on a inner query and ORDER BY on the entire outer query, the inner part of the query is working as if there is no order and is giving inconsistent results.
To fix this, we have also added an ORDER BY clause to the inner query where LIMIT is applied.

Please let us know if anything else needs to be done.