### PR TITLE
Fixed Enrollments API pagination issue - Missing paging information in response when paginated

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -71,7 +71,7 @@ public class HibernateProgramInstanceStore
     @Override
     public int countProgramInstances( ProgramInstanceQueryParams params )
     {
-        String hql = buildProgramInstanceHql( params );
+        String hql = buildProgramInstanceCountHql( params );
         
         Query query = getQuery( hql );
 
@@ -93,6 +93,11 @@ public class HibernateProgramInstanceStore
         }
 
         return query.list();
+    }
+
+    private String buildProgramInstanceCountHql( ProgramInstanceQueryParams params )
+    {
+        return buildProgramInstanceHql( params ).replaceFirst( "from ProgramInstance pi", "select count(distinct uid) from ProgramInstance pi" );
     }
 
     private String buildProgramInstanceHql( ProgramInstanceQueryParams params )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Lists;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
 import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
@@ -139,11 +140,11 @@ public class EnrollmentController
 
         List<Enrollment> enrollments;
 
-        if ( enrollment == null )
-        {
-            ProgramInstanceQueryParams params = programInstanceService.getFromUrl( orgUnits, ouMode, lastUpdated, program, programStatus, programStartDate,
+        ProgramInstanceQueryParams params = programInstanceService.getFromUrl( orgUnits, ouMode, lastUpdated, program, programStatus, programStartDate,
                 programEndDate, trackedEntity, trackedEntityInstance, followUp, page, pageSize, totalPages, skipPaging );
 
+        if ( enrollment == null )
+        {
             enrollments = new ArrayList<>( enrollmentService.getEnrollments(
                 programInstanceService.getProgramInstances( params ) ) );
         }
@@ -154,6 +155,14 @@ public class EnrollmentController
         }
 
         RootNode rootNode = NodeUtils.createMetadata();
+
+        if ( params.isPaging() && params.isTotalPages() )
+        {
+            int count = programInstanceService.countProgramInstances( params );
+            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            rootNode.addChild( NodeUtils.createPager( pager ) );
+        }
+
         rootNode.addChild( fieldFilterService.filter( Enrollment.class, enrollments, fields ) );
 
         return rootNode;


### PR DESCRIPTION
As a part of this pull request, we have added pager params to the Enrollments API response when paginated. We have done following things to do this:
1. Used the countProgramInstances method to get the count of all enrollments matching the given params.
2. Fixed countProgramInstances in HibernateProgramInstanceStore: Corrected the query to get the count of programInstances.

This pull request fixes [this bug](https://jira.dhis2.org/browse/DHIS2-2476) 

If you are okay with this fix, we can send the pull requests to fix the issue in 2.27 and later versions. Please let us know if anything else needs to be done.

Thanks,
Jhansi