### PR TITLE
Update Mobile API 2.9

### DIFF
--- a/dhis-2/dhis-services/dhis-service-mobile/src/main/java/org/hisp/dhis/api/mobile/model/DataElement.java
+++ b/dhis-2/dhis-services/dhis-service-mobile/src/main/java/org/hisp/dhis/api/mobile/model/DataElement.java
@@ -94,7 +94,7 @@ public class DataElement
         {
             this.setType( TYPE_EMAIL );
         }
-        else if ( type == ValueType.INTEGER || type == ValueType.NUMBER )
+        else if ( type.isNumeric() )
         {
             this.setType( TYPE_NUMBER );
         }
@@ -220,6 +220,10 @@ public class DataElement
     {
         dout.writeInt( this.getId() );
         dout.writeUTF( this.getName() );
+		//For backwards compatibility with legacy mobile clients
+		if (this.getType().equals(TYPE_NUMBER)) {
+			this.setType("int");
+		}
         dout.writeUTF( this.getType() );
         dout.writeBoolean( this.isCompulsory() );
 


### PR DESCRIPTION
1. Utilize the core ValueType.isNumeric() to detect if the data elemnt is numeric. This will ensure that numbers are not entered as free text on the J2ME client. 

2. Conditionally change the string that represent number type from "number" to "int" for DataElement serialize method on version 2.9 . Newer mobile client that can due with "number" will not be affected by this change.