### PR TITLE
JClouds 2.0.3

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.scheduling.SchedulingManager;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Hours;
-import org.joda.time.Seconds;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.concurrent.ListenableFuture;
 
@@ -100,8 +99,7 @@ public class DefaultFileResourceService
     @Transactional
     public FileResource getFileResource( String uid )
     {
-        // TODO ensureStorageStatus(..) is a temp fix. Should be removed.
-        return ensureStorageStatus( fileResourceStore.getByUid( uid ) );
+        return fileResourceStore.getByUid( uid );
     }
 
     @Override
@@ -120,14 +118,12 @@ public class DefaultFileResourceService
     }
 
     @Override
-    @Transactional
     public String saveFileResource( FileResource fileResource, File file )
     {
         return saveFileResourceInternal( fileResource, () -> fileResourceContentStore.saveFileResourceContent( fileResource, file ) );
     }
 
     @Override
-    @Transactional
     public String saveFileResource( FileResource fileResource, byte[] bytes )
     {
         return saveFileResourceInternal( fileResource, () -> fileResourceContentStore.saveFileResourceContent( fileResource, bytes ) );
@@ -194,6 +190,7 @@ public class DefaultFileResourceService
     {
         fileResource.setStorageStatus( FileResourceStorageStatus.PENDING );
         fileResourceStore.save( fileResource );
+        updateFileResource( fileResource );
 
         final ListenableFuture<String> saveContentTask = schedulingManager.executeJob( saveCallable );
 
@@ -202,45 +199,5 @@ public class DefaultFileResourceService
         saveContentTask.addCallback( uploadCallback.newInstance( uid ) );
 
         return uid;
-    }
-
-    /**
-     * TODO Temporary fix. Remove at some point.
-     *
-     * Ensures correctness of the storageStatus of this FileResource.
-     *
-     * If the status has been 'PENDING' for more than 1 second we check to see if the content may actually have been stored.
-     * If this is the case the status is corrected to STORED.
-     *
-     * This method is a TEMPORARY fix for the for now unsolved issue with a race occurring between the Hibernate object cache
-     * and the upload callback attempting to modify the FileResource object upon completion.
-     *
-     * Resolving that issue (likely by breaking the StorageStatus into a separate table) should make this method redundant.
-     */
-    private FileResource ensureStorageStatus( FileResource fileResource )
-    {
-        if ( fileResource != null && fileResource.getStorageStatus() == FileResourceStorageStatus.PENDING )
-        {
-            Duration pendingDuration = new Duration( new DateTime( fileResource.getLastUpdated() ), DateTime.now() );
-
-            if ( pendingDuration.isLongerThan( Seconds.seconds( 1 ).toStandardDuration() ) )
-            {
-                // Upload has been finished for 5+ seconds and is still PENDING.
-                // Check if content has actually been stored and correct to STORED if this is the case.
-
-                boolean contentIsStored = fileResourceContentStore.fileResourceContentExists( fileResource.getStorageKey() );
-
-                if ( contentIsStored )
-                {
-                    // We fix
-                    fileResource.setStorageStatus( FileResourceStorageStatus.STORED );
-                    fileResourceStore.update( fileResource );
-                    log.warn( "Corrected issue: FileResource '" + fileResource.getUid() +
-                        "' had storageStatus PENDING but content was actually stored." );
-                }
-            }
-        }
-
-        return fileResource;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/JCloudsFileResourceContentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/JCloudsFileResourceContentStore.java
@@ -230,7 +230,7 @@ public class JCloudsFileResourceContentStore
             return null;
         }
 
-        putBlob( blob );
+        blobStore.putBlob( config.container, blob );
 
         log.debug( String.format( "File resource saved with key: %s", fileResource.getStorageKey() ) );
 
@@ -247,7 +247,7 @@ public class JCloudsFileResourceContentStore
             return null;
         }
 
-        putBlob( blob );
+        blobStore.putBlob( config.container, blob );
 
         try
         {
@@ -316,33 +316,6 @@ public class JCloudsFileResourceContentStore
     private void deleteBlob( String key )
     {
         blobStore.removeBlob( config.container, key );
-    }
-
-    private String putBlob( Blob blob )
-    {
-        String etag = null;
-
-        try
-        {
-            etag = blobStore.putBlob( config.container, blob );
-        }
-        catch ( RuntimeException rte )
-        {
-            Throwable cause = rte.getCause();
-
-            if ( cause != null && cause instanceof UserPrincipalNotFoundException )
-            {
-                // Intentionally ignored exception which occurs with JClouds (< 2.0.0) on localized Windows.
-                // See https://issues.apache.org/jira/browse/JCLOUDS-1015
-                log.debug( "Ignored UserPrincipalNotFoundException. Workaround for 'JCLOUDS-1015'." );
-            }
-            else
-            {
-                throw rte;
-            }
-        }
-
-        return etag;
     }
 
     private Blob createBlob( FileResource fileResource, byte[] bytes )

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1149,7 +1149,7 @@
     <struts.version>2.3.32</struts.version>
     <hibernate.version>5.2.11.Final</hibernate.version>
     <hibernate-validator.version>4.3.2.Final</hibernate-validator.version>
-    <jclouds.version>1.9.3</jclouds.version>
+    <jclouds.version>2.0.3</jclouds.version>
     <!-- Keep in sync with Hibernate -->
     <javassist.version>3.20.0-GA</javassist.version>
     <!-- unit test dependencies-->


### PR DESCRIPTION
The callback would sometimes start executing before the transaction was done. Making file resource uploads non-transactional seems to have solved the problem.