### PR TITLE
Return json repsonse on authenticationFailure requests.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/CustomBasicAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/CustomBasicAuthenticationEntryPoint.java
@@ -1,0 +1,61 @@
+package org.hisp.dhis.security;
+
+/*
+ *
+ *  Copyright (c) 2004-2017, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
+import org.hisp.dhis.render.RenderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Viet Nguyen <viet@dhis2.org>
+ */
+public class CustomBasicAuthenticationEntryPoint extends BasicAuthenticationEntryPoint
+{
+    @Autowired
+    private RenderService renderService;
+
+    @Override
+    public void commence( HttpServletRequest request, HttpServletResponse response, AuthenticationException authException ) throws IOException, ServletException
+    {
+        response.addHeader("WWW-Authenticate", "Basic realm=\"" + getRealmName() + "\"");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType( MediaType.APPLICATION_JSON_UTF8_VALUE );
+        renderService.toJson( response.getOutputStream(), WebMessageUtils.unathorized( "Unauthorized" ) );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/Http401LoginUrlAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/Http401LoginUrlAuthenticationEntryPoint.java
@@ -56,7 +56,7 @@ public class Http401LoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticat
     @Override
     public void commence( HttpServletRequest request, HttpServletResponse response, AuthenticationException authException ) throws IOException, ServletException
     {
-        if ( "XMLHttpRequest".equals( request.getHeader( "X-Requested-With" ) ) )
+        if ( "XMLHttpRequest".equals( request.getHeader( "X-Requested-With" ) ) || isApiRequest( request ) )
         {
             response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
             response.setContentType( MediaType.APPLICATION_JSON_UTF8_VALUE );
@@ -65,5 +65,10 @@ public class Http401LoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticat
         }
 
         super.commence( request, response, authException );
+    }
+
+    private boolean isApiRequest( HttpServletRequest request )
+    {
+        return request.getRequestURI().matches( ".*/api/.*" ) ?  true : false;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -95,9 +95,17 @@
   </sec:http>
   -->
 
+  <!-- Custom Entry Point -->
+
   <bean id="http401LoginUrlAuthenticationEntryPoint" class="org.hisp.dhis.security.Http401LoginUrlAuthenticationEntryPoint">
     <constructor-arg name="loginFormUrl" value="/dhis-web-commons/security/login.action" />
   </bean>
+
+  <bean id="basicAuthenticationEntryPoint" class="org.hisp.dhis.security.CustomBasicAuthenticationEntryPoint">
+    <property name="realmName" value="dhis2" />
+  </bean>
+
+  <!-- Security configurations -->
 
   <sec:http access-decision-manager-ref="accessDecisionManager" realm="DHIS2" disable-url-rewriting="true" use-expressions="true"
     authentication-manager-ref="authenticationManager" entry-point-ref="http401LoginUrlAuthenticationEntryPoint">
@@ -123,7 +131,7 @@
 
     <sec:csrf disabled="true" />
 
-    <sec:http-basic entry-point-ref="http401LoginUrlAuthenticationEntryPoint" />
+    <sec:http-basic entry-point-ref="basicAuthenticationEntryPoint" />
     <sec:logout logout-url="/dhis-web-commons-security/logout.action" logout-success-url="/" />
     <sec:intercept-url pattern="/dhis-web-commons/i18nJavaScript.action" access="permitAll()" />
     <sec:intercept-url pattern="/dhis-web-commons/security/**" access="permitAll()" />
@@ -191,6 +199,8 @@
   <!-- Security : Listener -->
 
   <bean id="loggerListener" class="org.springframework.security.authentication.event.LoggerListener" />
+
+  <bean id="authenticationListener" class="org.hisp.dhis.security.AuthenticationListener"/>
 
   <!-- Security : AccessProvider -->
 
@@ -439,6 +449,6 @@
 
   <bean id="appsSystemAuthoritiesProvider" class="org.hisp.dhis.security.authority.AppsSystemAuthoritiesProvider" />
 
-  <bean id="authenticationListener" class="org.hisp.dhis.security.AuthenticationListener"/>
+
 
 </beans>


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1829

This patch do the following : 

1) Currently, for /api/* endpoints,  unAuthorized requests will be redirected to login page. Which make it difficult for js client to handle the repsonse.

This patch will allow ajax requests ( without "X-Requested-With" ) to check for json repsonse and ask user to relog if needed.
However, for users who access api resources using web browser, they have to manually go to login page when seeing the json repsonse.

`{
    "httpStatus": "Unauthorized",
    "httpStatusCode": 401,
    "status": "ERROR",
    "message": "Unauthorized"
}`

2) For Basic Auth authenticationFailure requests, currently DHIS2 returns a HTML page as below

`<!doctype html><html lang="en"><head><title>HTTP Status 401 – Unauthorized</title><style type="text/css">h1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} h2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} h3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} body {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} b {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} p {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;} a {color:black;} a.name {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 401 – Unauthorized</h1><hr class="line" /><p><b>Type</b> Status Report</p><p><b>Message</b> Bad credentials</p><p><b>Description</b> The request has not been applied because it lacks valid authentication credentials for the target resource.</p><hr class="line" /><h3>Apache Tomcat/8.5.24</h3></body></html>`

 This patch will make it return a json response as below 

`{
    "httpStatus": "Unauthorized",
    "httpStatusCode": 401,
    "status": "ERROR",
    "message": "Unauthorized"
}`


