### PR TITLE
Fix update versionObject issue while importing metadata

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/VersionedObjectObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/VersionedObjectObjectBundleHook.java
@@ -52,8 +52,11 @@ public class VersionedObjectObjectBundleHook extends AbstractObjectBundleHook
     {
         if ( VersionedObject.class.isInstance( object ) )
         {
-            VersionedObject versionedObject = (VersionedObject) object;
-            versionedObject.increaseVersion();
+            VersionedObject versionObj = (VersionedObject) object;
+            int persistedVersion = ( ( VersionedObject ) persistedObject ).getVersion();
+
+            versionObj.setVersion( persistedVersion > versionObj.getVersion() ? persistedVersion :
+                persistedVersion < versionObj.getVersion() ? versionObj.getVersion() : versionObj.increaseVersion() );
         }
     }
 
@@ -70,7 +73,7 @@ public class VersionedObjectObjectBundleHook extends AbstractObjectBundleHook
         {
             versionedObject = ((Option) persistedObject).getOptionSet();
         }
-        
+
         if ( versionedObject != null )
         {
             versionedObject.increaseVersion();


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-2747
The issue if data type of version is int, so if payload doesn't include it, the default value = 0 instead of null, so version is updated to 1.

This will add condition to check and only increase version properly.

