### PR TITLE
Fix collection merge issue for metadata import.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.system.util.ReflectionUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -57,7 +58,6 @@ public class DefaultMergeService implements MergeService
         T source = mergeParams.getSource();
         T target = mergeParams.getTarget();
 
-
         Schema schema = schemaService.getDynamicSchema( source.getClass() );
 
         for ( Property property : schema.getProperties() )
@@ -75,8 +75,8 @@ public class DefaultMergeService implements MergeService
 
             if ( property.isCollection() )
             {
-                Collection sourceObject = ReflectionUtils.invokeMethod( source, property.getGetterMethod() );
-                Collection targetObject = ReflectionUtils.invokeMethod( target, property.getGetterMethod() );
+                Collection<T> sourceObject = ReflectionUtils.invokeMethod( source, property.getGetterMethod() );
+                Collection<T> targetObject = ReflectionUtils.invokeMethod( target, property.getGetterMethod() );
 
                 if ( sourceObject == null )
                 {
@@ -88,8 +88,20 @@ public class DefaultMergeService implements MergeService
                     targetObject = ReflectionUtils.newCollectionInstance( property.getKlass() );
                 }
 
-                targetObject.clear();
-                targetObject.addAll( sourceObject );
+                if ( mergeParams.getMergeMode().isMerge() )
+                {
+                    Collection<T> merged = ReflectionUtils.newCollectionInstance( property.getKlass() );
+                    merged.addAll( targetObject );
+                    merged.addAll( sourceObject.stream().filter( o -> !merged.contains( o ) ).collect( Collectors.toList() ) );
+
+                    targetObject.clear();
+                    targetObject.addAll( merged );
+                }
+                else
+                {
+                    targetObject.clear();
+                    targetObject.addAll( sourceObject );
+                }
 
                 ReflectionUtils.invokeMethod( target, property.getSetterMethod(), targetObject );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/CsvMetadataImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/CsvMetadataImportTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.metadata;
  */
 
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.csv.CsvImportClass;
@@ -36,11 +37,13 @@ import org.hisp.dhis.dxf2.csv.CsvImportService;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.schema.SchemaService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,4 +125,109 @@ public class CsvMetadataImportTest
         assertEquals( 3, optionSets.get( 2 ).getOptions().size() );
         assertEquals( 3, optionSets.get( 3 ).getOptions().size() );
     }
+
+    @Test
+    public void testOptionSetMerge() throws IOException
+    {
+        // Import 1 OptionSet with 3 Options
+        input = new ClassPathResource( "metadata/optionSet_add.csv" ).getInputStream();
+
+        Metadata metadata = csvImportService.fromCsv( input, CsvImportClass.OPTION_SET );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+
+        ImportReport importReport = importService.importMetadata( params );
+
+        assertEquals( 4, importReport.getStats().getCreated() );
+
+        // Send payload with 2 new Options
+        input = new ClassPathResource( "metadata/optionSet_update.csv" ).getInputStream();
+
+        metadata = csvImportService.fromCsv( input, CsvImportClass.OPTION_SET );
+
+        params = new MetadataImportParams();
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+        params.setMergeMode( MergeMode.MERGE );
+
+        importReport = importService.importMetadata( params );
+
+        assertEquals( 2, importReport.getStats().getCreated() );
+
+        OptionSet optionSet = optionService.getOptionSetByCode( "COLOR" );
+
+        // Total 5 options added
+        assertEquals( 5, optionSet.getOptions().size() );
+    }
+
+    @Test
+    public void testOptionSetMergeDuplicate() throws IOException
+    {
+        // Import 1 OptionSet with 3 Options
+        input = new ClassPathResource( "metadata/optionSet_add.csv" ).getInputStream();
+
+        Metadata metadata = csvImportService.fromCsv( input, CsvImportClass.OPTION_SET );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+
+        ImportReport importReport = importService.importMetadata( params );
+
+        assertEquals( 4, importReport.getStats().getCreated() );
+
+        // Send payload with 5 Options, 2 new and 3 old from above
+        input = new ClassPathResource( "metadata/optionSet_update_duplicate.csv" ).getInputStream();
+
+        metadata = csvImportService.fromCsv( input, CsvImportClass.OPTION_SET );
+
+        params = new MetadataImportParams();
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+        params.setIdentifier( PreheatIdentifier.CODE );
+        params.setMergeMode( MergeMode.MERGE );
+
+        importReport = importService.importMetadata( params );
+
+        // Only 2 new Options are added
+        assertEquals( 2, importReport.getStats().getCreated() );
+
+        OptionSet optionSet = optionService.getOptionSetByCode( "COLOR" );
+
+        // Total 5 Options added
+        assertEquals( 5, optionSet.getOptions().size() );
+    }
+
+    @Test
+    public void testOptionSetReplace() throws IOException
+    {
+        // Import 1 OptionSet with 3 Options
+        input = new ClassPathResource( "metadata/optionSet_add.csv" ).getInputStream();
+
+        Metadata metadata = csvImportService.fromCsv( input, CsvImportClass.OPTION_SET );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+
+        ImportReport importReport = importService.importMetadata( params );
+
+        assertEquals( 4, importReport.getStats().getCreated() );
+
+        // Send payload with 2 new Options
+        input = new ClassPathResource( "metadata/optionSet_update.csv" ).getInputStream();
+
+        metadata = csvImportService.fromCsv( input, CsvImportClass.OPTION_SET );
+
+        params = new MetadataImportParams();
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+
+        importReport = importService.importMetadata( params );
+
+        assertEquals( 2, importReport.getStats().getCreated() );
+
+        OptionSet optionSet = optionService.getOptionSetByCode( "COLOR" );
+
+        // 3 old Options are replaced by 2 new added Options
+        assertEquals( 2, optionSet.getOptions().size() );
+    }
+
+
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/metadata/optionSet_add.csv
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/metadata/optionSet_add.csv
@@ -1,0 +1,4 @@
+name,uid,code,optionname,optionuid,optioncode
+"Color","kp8zS9cSnbR","COLOR","Blue",,"BLUE"
+"Color","kp8zS9cSnbR","COLOR","Green",,"GREEN"
+"Color","kp8zS9cSnbR","COLOR","Yellow",,"YELLOW"

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/metadata/optionSet_update.csv
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/metadata/optionSet_update.csv
@@ -1,0 +1,3 @@
+name,uid,code,optionname,optionuid,optioncode
+"Color","kp8zS9cSnbR","COLOR","Red",,"RED"
+"Color","kp8zS9cSnbR","COLOR","White",,"WHITE"

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/metadata/optionSet_update_duplicate.csv
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/metadata/optionSet_update_duplicate.csv
@@ -1,0 +1,6 @@
+name,uid,code,optionname,optionuid,optioncode
+"Color","kp8zS9cSnbR","COLOR","Blue",,"BLUE"
+"Color","kp8zS9cSnbR","COLOR","Green",,"GREEN"
+"Color","kp8zS9cSnbR","COLOR","Yellow",,"YELLOW"
+"Color","kp8zS9cSnbR","COLOR","Red",,"RED"
+"Color","kp8zS9cSnbR","COLOR","White",,"WHITE"


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1322

Currently, In DedaultMergeService, target collection is always cleared and add all from sourceObject.
This patch add a merge function for collection depends on the merge mode
- If mergeMode.isMerge() : merge distinct source to target collection
- If mergeMode.isReplace() : clear target and replace by source collection