### PR TITLE
[DHIS2-2589] skip sharing for exporter

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -210,7 +210,7 @@ public class DefaultMetadataExportService implements MetadataExportService
         for ( Class<? extends IdentifiableObject> klass : metadata.keySet() )
         {
             CollectionNode collectionNode = fieldFilterService.toCollectionNode( klass,
-                new FieldFilterParams( metadata.get( klass ), params.getFields( klass ), params.getDefaults() ) );
+                new FieldFilterParams( metadata.get( klass ), params.getFields( klass ), params.getDefaults(), params.getSkipSharing() ) );
 
             if ( !collectionNode.getChildren().isEmpty() )
             {
@@ -254,6 +254,12 @@ public class DefaultMetadataExportService implements MetadataExportService
         {
             params.setDefaultOrder( parameters.get( "order" ) );
             parameters.remove( "order" );
+        }
+
+        if ( parameters.containsKey( "skipSharing" ) )
+        {
+            params.setSkipSharing( Boolean.parseBoolean( parameters.get( "skipSharing" ).get( 0 ) ) );
+            parameters.remove( "skipSharing" );
         }
 
         for ( String parameterKey : parameters.keySet() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportParams.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.dxf2.metadata;
 import com.google.common.collect.Lists;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.fieldfilter.Defaults;
+import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.node.config.InclusionStrategy;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.user.User;
@@ -41,6 +42,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.hisp.dhis.commons.collection.CollectionUtils.addAllUnique;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -91,6 +94,11 @@ public class MetadataExportParams
      * Inclusion strategy to use. There are a few already defined inclusions in the Inclusions enum.
      */
     private InclusionStrategy inclusionStrategy = InclusionStrategy.Include.NON_NULL;
+
+    /**
+     * Indicates whether sharing properties should be included in the export.
+     */
+    private boolean skipSharing;
 
     public MetadataExportParams()
     {
@@ -146,9 +154,15 @@ public class MetadataExportParams
 
     public MetadataExportParams addFields( Class<? extends IdentifiableObject> klass, List<String> classFields )
     {
-        if ( !fields.containsKey( klass ) ) fields.put( klass, classFields );
+        if ( !fields.containsKey( klass ) )
+        {
+            fields.put( klass, classFields );
+        }
+        else
+        {
+            fields.get( klass ).addAll( classFields );
+        }
 
-        fields.get( klass ).addAll( classFields );
         return this;
     }
 
@@ -176,6 +190,7 @@ public class MetadataExportParams
     public void setDefaultFilter( List<String> filter )
     {
         this.defaultFilter = filter;
+
     }
 
     public List<String> getDefaultOrder()
@@ -206,5 +221,24 @@ public class MetadataExportParams
     public void setInclusionStrategy( InclusionStrategy inclusionStrategy )
     {
         this.inclusionStrategy = inclusionStrategy;
+    }
+
+    public void setSkipSharing( boolean skipSharing )
+    {
+        if ( skipSharing )
+        {
+            addAllUnique( defaultFields, FieldFilterService.SHARING_FIELDS );
+        }
+        else
+        {
+            defaultFields.removeAll( FieldFilterService.SHARING_FIELDS );
+        }
+
+        this.skipSharing = skipSharing;
+    }
+
+    public boolean getSkipSharing()
+    {
+        return this.skipSharing;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -58,11 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -153,6 +149,11 @@ public class DefaultFieldFilterService implements FieldFilterService
         collectionNode.setNamespace( rootSchema.getNamespace() );
 
         List<?> objects = params.getObjects();
+
+        if ( params.getSkipSharing() )
+        {
+            fields = Joiner.on( "," ).join( fieldParser.modifyFilter( params.getFields(),  SHARING_FIELDS ) );
+        }
 
         if ( params.getObjects().isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldParser.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldParser.java
@@ -31,7 +31,10 @@ package org.hisp.dhis.fieldfilter;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -87,6 +90,19 @@ public class DefaultFieldParser implements FieldParser
         }
 
         return fieldMap;
+    }
+
+    @Override
+    public List<String> modifyFilter( Collection<String> fields, Collection<String> excludeFields )
+    {
+        if ( fields == null )
+        {
+            fields = new LinkedList<String>();
+        }
+
+        return fields.stream()
+            .map( s -> s.replaceAll( "]", String.format( ",%s]", excludeFields.toString().replaceAll( "\\[|\\]", "" ) ) ) )
+            .collect( Collectors.toList() );
     }
 
     private String joinedWithPrefix( StringBuilder builder, List<String> prefixList )

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/FieldFilterParams.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/FieldFilterParams.java
@@ -51,6 +51,11 @@ public final class FieldFilterParams
      */
     private List<String> fields;
 
+    /**
+     * Filters out sharing fields if true
+     */
+    private boolean skipSharing;
+
     private Defaults defaults = Defaults.EXCLUDE;
 
     public FieldFilterParams( List<?> objects, List<String> fields )
@@ -64,6 +69,14 @@ public final class FieldFilterParams
         this.objects = objects;
         this.fields = fields;
         this.defaults = defaults;
+    }
+
+    public FieldFilterParams( List<?> objects, List<String> fields, Defaults defaults, boolean skipSharing )
+    {
+        this.objects = objects;
+        this.fields = fields;
+        this.defaults = defaults;
+        this.skipSharing = skipSharing;
     }
 
     public User getUser()
@@ -108,5 +121,15 @@ public final class FieldFilterParams
     {
         this.defaults = defaults;
         return this;
+    }
+
+    public boolean getSkipSharing()
+    {
+        return this.skipSharing;
+    }
+
+    public void setSkipSharing( boolean skipSharing )
+    {
+        this.skipSharing = skipSharing;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/FieldFilterService.java
@@ -31,11 +31,17 @@ package org.hisp.dhis.fieldfilter;
 import org.hisp.dhis.node.types.CollectionNode;
 import org.hisp.dhis.node.types.ComplexNode;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface FieldFilterService
 {
+    List<String> SHARING_FIELDS = Arrays.asList(
+        "!user", "!publicAccess", "!userGroupAccesses", "!userAccesses", "!externalAccess" );
+
     /**
      * Perform inclusion/exclusion on a list of objects.
      */

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/FieldParser.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/FieldParser.java
@@ -28,6 +28,9 @@ package org.hisp.dhis.fieldfilter;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
@@ -41,4 +44,13 @@ public interface FieldParser
      * @see org.hisp.dhis.fieldfilter.FieldMap
      */
     FieldMap parse( String filter );
+
+    /**
+     * Recursively add some field filtering to a field filter
+     *
+     * @param fieldFilter Field filter to modify
+     * @param excludeFields Fields to add to the field filter
+     * @return Modified field filter
+     */
+    List<String> modifyFilter( Collection<String> fieldFilter, Collection<String> excludeFields );
 }

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
@@ -109,4 +109,17 @@ public class CollectionUtils
     {
         return set != null ? set : new HashSet<>();
     }
+
+    /**
+     * Adds all items not already present in the target collection
+     *
+     * @param collection collection to add items to.
+     * @param items collection of items to add.
+     */
+    public static <E> void addAllUnique( Collection<E> collection, Collection<E> items )
+    {
+        items.stream()
+            .filter( item -> !collection.contains( item ) )
+            .forEach( item -> collection.add( item ) );
+    }
 }


### PR DESCRIPTION
The user wasn't cleared when calling MetadataExportService.getMetadata, but it seems to work fine in the api which uses getMetadataAsNode