### PR TITLE
Make use of dhis2.baseUrl for common javascript libs

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.sharing.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.sharing.js
@@ -29,9 +29,11 @@
 
 dhis2.util.namespace( 'dhis2.sharing' );
 
+dhis2.sharing.baseUrl =  dhis2.baseUrl ? dhis2.baseUrl : "..";
+
 function loadSharingSettings(type, uid) {
   return $.ajax( {
-    url: '../api/sharing',
+    url: dhis2.sharing.baseUrl + '/api/sharing' ,
     data: {
       type: type,
       id: uid
@@ -42,7 +44,7 @@ function loadSharingSettings(type, uid) {
 
 function saveSharingSettings(type, uid, data) {
   return $.ajax( {
-    url: '../api/sharing?type=' + type + '&id=' + uid,
+    url: dhis2.sharing.baseUrl + '/api/sharing?type=' + type + '&id=' + uid,
     type: 'POST',
     dataType: 'text',
     contentType: 'application/json; charset=UTF-8',
@@ -242,7 +244,7 @@ function showSharingDialog(type, uid) {
     $( '#sharingSearch' ).autocomplete( {
       source: function(request, response) {
         $.ajax( {
-          url: '../api/sharing/search',
+          url: dhis2.sharing.baseUrl + '/api/sharing/search',
           dataType: 'json',
           data: {
             key: request.term,

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/oust/oust.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/oust/oust.js
@@ -9,6 +9,8 @@ var selectionTree = new SelectionTree();
 var selectionTreePath = '../dhis-web-commons/oust/';
 var selectedOrganisationUnit = new Array();
 var selectedOrganisationUnitUid = new Array();
+var dhis2 = dhis2 || {};
+var dhis2BaseUrl = dhis2.baseUrl ? dhis2.baseUrl : "..";
 
 // -----------------------------------------------------------------------------
 // Selection
@@ -342,7 +344,7 @@ function SelectionTree()
     function getToggleExpand()
     {
         var imgTag = getToggleImage();
-        imgTag.src = '../images/colapse.png';
+        imgTag.src = dhis2BaseUrl + '/images/colapse.png';
         imgTag.alt = '[+]';
         return imgTag;
     }
@@ -350,7 +352,7 @@ function SelectionTree()
     function getToggleCollapse()
     {
         var imgTag = getToggleImage();
-        imgTag.src = '../images/expand.png';
+        imgTag.src = dhis2BaseUrl + '/images/expand.png';
         imgTag.alt = '[-]';
         return imgTag;
     }
@@ -358,7 +360,7 @@ function SelectionTree()
 	function getToggleBlank()
 	{
 		var imgTag = getToggleImage();
-		imgTag.src = '../images/transparent.gif';
+		imgTag.src = dhis2BaseUrl + '/images/transparent.gif';
 		imgTag.width = '9';
         imgTag.height = '9';
 		imgTag.alt = '';


### PR DESCRIPTION
Make use of baseUrl variable in common javascript libraries 
This is for supporting convert the old core dashboard app to external one,  where it uses those common javascript libs under url path 'api/aps/..'