### PR TITLE
for queries with root-junction OR, skip criteria engine (#1646)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -64,6 +64,14 @@ public class DefaultQueryPlanner implements QueryPlanner
     @Override
     public QueryPlan planQuery( Query query, boolean persistedOnly )
     {
+        if ( Junction.Type.OR == query.getRootJunctionType() && !persistedOnly )
+        {
+            return new QueryPlan(
+                Query.from( query.getSchema() ).setPlannedQuery( true ),
+                Query.from( query ).setPlannedQuery( true )
+            );
+        }
+
         Query npQuery = Query.from( query ).setPlannedQuery( true );
         Query pQuery = getQuery( npQuery, persistedOnly )
             .setUser( query.getUser() ).setPlannedQuery( true );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -601,6 +601,29 @@ public class QueryServiceTest
         assertEquals( 1, objects.size() );
     }
 
+    @Test
+    public void testMixedQSRootJunction1()
+    {
+        Query query = Query.from( schemaService.getDynamicSchema( DataElementGroup.class ), Junction.Type.OR );
+        query.add( Restrictions.eq( "id", "abcdefghijA" ) );
+        query.add( Restrictions.eq( "dataElements.id", "deabcdefghA" ) );
+        query.add( Restrictions.eq( "dataElements.id", "deabcdefghD" ) );
+
+        List<? extends IdentifiableObject> objects = queryService.query( query );
+        assertEquals( 2, objects.size() );
+    }
+
+    @Test
+    public void testMixedQSRootJunction2()
+    {
+        Query query = Query.from( schemaService.getDynamicSchema( DataElementGroup.class ), Junction.Type.OR );
+        query.add( Restrictions.eq( "id", "abcdefghijA" ) );
+        query.add( Restrictions.eq( "dataElements.id", "does-not-exist" ) );
+
+        List<? extends IdentifiableObject> objects = queryService.query( query );
+        assertEquals( 1, objects.size() );
+    }
+
     private boolean collectionContainsUid( Collection<? extends IdentifiableObject> collection, String uid )
     {
         for ( IdentifiableObject identifiableObject : collection )


### PR DESCRIPTION
* for queries with root-junction OR, skip criteria engine

* minor fix for persistedOnly queries