### PR TITLE
Provision to specify remoteObjectPort for ehcache 2.29

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -64,6 +64,7 @@ public enum ConfigurationKey
     CLUSTER_HOSTNAME( "cluster.hostname", "", false ),
     CLUSTER_MEMBERS( "cluster.members", "", false ),
     CLUSTER_CACHE_PORT( "cluster.cache.port", "4001", false ),
+    CLUSTER_CACHE_REMOTE_OBJECT_PORT( "cluster.cache.remote.object.port", "0", false ),
     CACHE_PROVIDER( "cache.provider", "ehcache", false ),
     CACHE_SERVERS( "cache.servers", "localhost:11211", false ),
     CACHE_TIME( "cache.time", "600", false ),

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
@@ -71,6 +71,7 @@ public class DefaultHibernateConfigurationProvider
     private static final String PROP_EHCACHE_PEER_PROVIDER_RIM_URLS = "ehcache.peer.provider.rmi.urls";
     private static final String PROP_EHCACHE_PEER_LISTENER_HOSTNAME = "ehcache.peer.listener.hostname";
     private static final String PROP_EHCACHE_PEER_LISTENER_PORT = "ehcache.peer.listener.port";
+    private static final String PROP_EHCACHE_PEER_LISTENER_REMOTE_OBJECT_PORT = "ehcache.peer.listener.remote.object.port";
     private static final String FILENAME_EHCACHE_REPLICATION = "/ehcache-replication.xml";
 
     private static final String PROP_MEMCACHED_CONNECTION_FACTORY = "hibernate.memcached.connectionFactory";
@@ -338,7 +339,7 @@ public class DefaultHibernateConfigurationProvider
     {
         String instanceHost = configurationProvider.getProperty( ConfigurationKey.CLUSTER_HOSTNAME );
         String instancePort = configurationProvider.getProperty( ConfigurationKey.CLUSTER_CACHE_PORT );
-        
+        String remoteObjectPort = configurationProvider.getProperty( ConfigurationKey.CLUSTER_CACHE_REMOTE_OBJECT_PORT );
         String clusterMembers = configurationProvider.getProperty( ConfigurationKey.CLUSTER_MEMBERS );
         
         //Split using comma delimiter along with possible spaces in between.
@@ -369,8 +370,9 @@ public class DefaultHibernateConfigurationProvider
         System.setProperty( PROP_EHCACHE_PEER_LISTENER_HOSTNAME, instanceHost );
         System.setProperty( PROP_EHCACHE_PEER_LISTENER_PORT, instancePort );
         System.setProperty( PROP_EHCACHE_PEER_PROVIDER_RIM_URLS, rmiUrls );
+        System.setProperty( PROP_EHCACHE_PEER_LISTENER_REMOTE_OBJECT_PORT, remoteObjectPort );
 
-        log.info( "Ehcache config properties: " + instanceHost + ", " + instancePort + ", " + rmiUrls );
+        log.info( "Ehcache config properties: " + instanceHost + ", " + instancePort + ", " + rmiUrls + ", " + remoteObjectPort  );
     }
     
     /**

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache-replication.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache-replication.xml
@@ -27,6 +27,6 @@
     properties="peerDiscovery=manual,rmiUrls=${ehcache.peer.provider.rmi.urls}" />
   
   <cacheManagerPeerListenerFactory class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
-    properties="hostName=${ehcache.peer.listener.hostname},port=${ehcache.peer.listener.port},socketTimeoutMillis=2000" />
+    properties="hostName=${ehcache.peer.listener.hostname},port=${ehcache.peer.listener.port},remoteObjectPort=${ehcache.peer.listener.remote.object.port},socketTimeoutMillis=2000" />
     
 </ehcache>


### PR DESCRIPTION
Added new config property to specify the remoteObjectPort for ehcache rmi peer listener factory.