### PR TITLE
Ehcache remote object port patch 2.28

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -60,6 +60,7 @@ public enum ConfigurationKey
     META_DATA_SYNC_RETRY_TIME_FREQUENCY_MILLISEC( "metadata.sync.retry.time.frequency.millisec", "30000", false ),
     CLUSTER_INSTANCE_HOSTNAME( "cluster.instance0.hostname", "", false ),
     CLUSTER_INSTANCE_CACHE_PORT( "cluster.instance0.cache.port", "4001", false ),
+    CLUSTER_INSTANCE_CACHE_REMOTE_OBJECT_PORT( "cluster.instance0.cache.remote.object.port", "0", false ),
     CACHE_PROVIDER( "cache.provider", "ehcache", false ),
     CACHE_SERVERS( "cache.servers", "localhost:11211", false ),
     CACHE_TIME( "cache.time", "600", false ),

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
@@ -70,6 +70,7 @@ public class DefaultHibernateConfigurationProvider
     private static final String PROP_EHCACHE_PEER_PROVIDER_RIM_URLS = "ehcache.peer.provider.rmi.urls";
     private static final String PROP_EHCACHE_PEER_LISTENER_HOSTNAME = "ehcache.peer.listener.hostname";
     private static final String PROP_EHCACHE_PEER_LISTENER_PORT = "ehcache.peer.listener.port";
+    private static final String PROP_EHCACHE_PEER_LISTENER_REMOTE_OBJECT_PORT = "ehcache.peer.listener.remote.object.port";
     private static final String FORMAT_CLUSTER_INSTANCE_HOSTNAME = "cluster.instance%d.hostname";
     private static final String FORMAT_CLUSTER_INSTANCE_CACHE_PORT = "cluster.instance%d.cache.port";
     private static final String FILENAME_EHCACHE_REPLICATION = "/ehcache-replication.xml";
@@ -340,6 +341,7 @@ public class DefaultHibernateConfigurationProvider
     {
         String instanceHost = configurationProvider.getProperty( ConfigurationKey.CLUSTER_INSTANCE_HOSTNAME );
         String instancePort = configurationProvider.getProperty( ConfigurationKey.CLUSTER_INSTANCE_CACHE_PORT );
+        String remoteObjectPort = configurationProvider.getProperty( ConfigurationKey.CLUSTER_INSTANCE_CACHE_REMOTE_OBJECT_PORT );
         
         Properties dhisProps = configurationProvider.getProperties();
         
@@ -375,8 +377,9 @@ public class DefaultHibernateConfigurationProvider
         System.setProperty( PROP_EHCACHE_PEER_LISTENER_HOSTNAME, instanceHost );
         System.setProperty( PROP_EHCACHE_PEER_LISTENER_PORT, instancePort );
         System.setProperty( PROP_EHCACHE_PEER_PROVIDER_RIM_URLS, rmiUrls );
+        System.setProperty( PROP_EHCACHE_PEER_LISTENER_REMOTE_OBJECT_PORT, remoteObjectPort );
 
-        log.info( "Ehcache config properties: " + instanceHost + ", " + instancePort + ", " + rmiUrls );
+        log.info( "Ehcache config properties: " + instanceHost + ", " + instancePort + ", " + rmiUrls + ", " + remoteObjectPort  );
     }
     
     /**

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache-replication.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache-replication.xml
@@ -27,6 +27,6 @@
     properties="peerDiscovery=manual,rmiUrls=${ehcache.peer.provider.rmi.urls}" />
   
   <cacheManagerPeerListenerFactory class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
-    properties="hostName=${ehcache.peer.listener.hostname},port=${ehcache.peer.listener.port},socketTimeoutMillis=2000" />
+    properties="hostName=${ehcache.peer.listener.hostname},port=${ehcache.peer.listener.port},remoteObjectPort=${ehcache.peer.listener.remote.object.port},socketTimeoutMillis=2000" />
     
 </ehcache>

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-caches.txt
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-caches.txt
@@ -7,15 +7,12 @@ org.hisp.dhis.period.PeriodType
 org.hisp.dhis.validation.ValidationRuleGroup
 org.hisp.dhis.document.Document
 org.hisp.dhis.eventchart.EventChart
-org.hisp.dhis.scheduling.JobConfiguration
 org.hisp.dhis.indicator.IndicatorGroup
 org.hisp.dhis.user.UserSetting
-org.hisp.dhis.program.AnalyticsPeriodBoundary
 org.hisp.dhis.organisationunit.OrganisationUnitGroup
 org.hisp.dhis.user.UserGroup
 org.hisp.dhis.dataelement.DataElementCategoryOption
 org.hisp.dhis.dataelement.DataElementGroupSetDimension
-org.hisp.dhis.trackedentity.TrackedEntityType
 org.hisp.dhis.legend.Legend
 org.hisp.dhis.report.Report
 org.hisp.dhis.dataset.DataSet
@@ -29,12 +26,12 @@ org.hisp.dhis.indicator.Indicator
 org.hisp.dhis.indicator.IndicatorType
 org.hisp.dhis.dataelement.DataElementGroupSet
 org.hisp.dhis.dataelement.CategoryOptionGroupSet
-org.hisp.dhis.trackedentityfilter.TrackedEntityInstanceFilter
 org.hisp.dhis.color.Color
 org.hisp.dhis.dataelement.CategoryOptionGroup
 org.hisp.dhis.organisationunit.OrganisationUnitGroupSet
 org.hisp.dhis.user.UserGroupAccess
 org.hisp.dhis.option.OptionSet
+org.hisp.dhis.trackedentity.TrackedEntity
 org.hisp.dhis.dataelement.CategoryOptionGroupSetDimension
 org.hisp.dhis.keyjsonvalue.KeyJsonValue
 org.hisp.dhis.expression.Expression
@@ -74,7 +71,6 @@ org.hisp.dhis.programrule.ProgramRuleVariable
 org.hisp.dhis.setting.SystemSetting
 org.hisp.dhis.programrule.ProgramRuleAction
 org.hisp.dhis.program.Program
-org.hisp.dhis.program.ProgramSection
 org.hisp.dhis.dataelement.DataElement
 org.hisp.dhis.reporttable.ReportTable
 org.hisp.dhis.relationship.RelationshipType
@@ -91,7 +87,6 @@ org.hisp.dhis.dashboard.Dashboard
 org.hisp.dhis.program.ProgramStageSection
 org.hisp.dhis.organisationunit.OrganisationUnit
 org.hisp.dhis.option.Option
-org.hisp.dhis.analytics.AnalyticsTableHook
 org.hisp.dhis.dataapproval.DataApprovalAudit
 org.hisp.dhis.organisationunit.OrganisationUnitGroupSet.userGroupAccesses
 org.hisp.dhis.option.OptionSet.options
@@ -137,7 +132,6 @@ org.hisp.dhis.dataelement.DataElementCategoryOptionCombo.categoryOptions
 org.hisp.dhis.dataelement.DataElementCategoryOptionCombo.attributeValues
 org.hisp.dhis.dataelement.DataElementGroupSet.translations
 org.hisp.dhis.organisationunit.OrganisationUnit.groups
-org.hisp.dhis.trackedentity.TrackedEntityType.userGroupAccesses
 org.hisp.dhis.dataelement.DataElementGroup.translations
 org.hisp.dhis.organisationunit.OrganisationUnitGroup.userGroupAccesses
 org.hisp.dhis.dataelement.CategoryDimension.items
@@ -183,7 +177,6 @@ org.hisp.dhis.mapping.MapView.organisationUnitLevels
 org.hisp.dhis.dataelement.DataElementGroupSetDimension.items
 org.hisp.dhis.dataelement.DataElementGroup.members
 org.hisp.dhis.organisationunit.OrganisationUnitGroupSet.attributeValues
-org.hisp.dhis.program.ProgramSection.translations
 org.hisp.dhis.dataelement.CategoryOptionGroupSet.members
 org.hisp.dhis.attribute.Attribute.userGroupAccesses
 org.hisp.dhis.reporttable.ReportTable.dataElementGroupSetDimensions
@@ -281,12 +274,10 @@ org.hisp.dhis.indicator.Indicator.groups
 org.hisp.dhis.mapping.Map.mapViews
 org.hisp.dhis.indicator.IndicatorGroup.translations
 org.hisp.dhis.dataset.DataSet.attributeValues
-org.hisp.dhis.trackedentity.TrackedEntityType.userAccesses
 org.hisp.dhis.program.ProgramIndicator.translations
 org.hisp.dhis.trackedentity.TrackedEntityAttribute.legendSets
 org.hisp.dhis.validation.ValidationRuleGroup.userAccesses
 org.hisp.dhis.user.User.organisationUnits
-org.hisp.dhis.program.ProgramStage.userGroupAccesses
 org.hisp.dhis.program.ProgramStage.translations
 org.hisp.dhis.program.ProgramStageSection.translations
 org.hisp.dhis.organisationunit.OrganisationUnit.users
@@ -304,6 +295,7 @@ org.hisp.dhis.legend.Legend.translations
 org.hisp.dhis.dataset.DataSet.sections
 org.hisp.dhis.reporttable.ReportTable.categoryDimensions
 org.hisp.dhis.dataelement.CategoryOptionGroup.userGroupAccesses
+org.hisp.dhis.trackedentity.TrackedEntity.attributeValues
 org.hisp.dhis.eventchart.EventChart.userAccesses
 org.hisp.dhis.dataelement.DataElementCategoryCombo.userAccesses
 org.hisp.dhis.mapping.MapView.organisationUnits
@@ -316,7 +308,6 @@ org.hisp.dhis.security.oauth2.OAuth2Client.grantTypes
 org.hisp.dhis.constant.Constant.attributeValues
 org.hisp.dhis.program.message.ProgramMessage.translations
 org.hisp.dhis.program.ProgramIndicator.userAccesses
-org.hisp.dhis.trackedentity.TrackedEntityType.translations
 org.hisp.dhis.dataset.Section.translations
 org.hisp.dhis.eventreport.EventReport.organisationUnitLevels
 org.hisp.dhis.dataelement.CategoryOptionGroup.translations
@@ -352,14 +343,13 @@ org.hisp.dhis.program.ProgramTrackedEntityAttribute.groups
 org.hisp.dhis.dataelement.DataElementCategoryOption.translations
 org.hisp.dhis.dataset.DataSet.userGroupAccesses
 org.hisp.dhis.dataelement.DataElementGroup.userAccesses
+org.hisp.dhis.trackedentity.TrackedEntity.translations
 org.hisp.dhis.legend.LegendSet.legends
 org.hisp.dhis.dataelement.DataElementCategoryOption.categories
 org.hisp.dhis.trackedentity.TrackedEntityAttribute.translations
-org.hisp.dhis.trackedentity.TrackedEntityType.attributeValues
 org.hisp.dhis.reporttable.ReportTable.rowDimensions
 org.hisp.dhis.chart.Chart.categoryDimensions
 org.hisp.dhis.legend.LegendSet.userAccesses
-org.hisp.dhis.program.ProgramIndicator.analyticsPeriodBoundaries
 org.hisp.dhis.eventchart.EventChart.periods
 org.hisp.dhis.reporttable.ReportTable.translations
 org.hisp.dhis.dataset.DataSet.dataInputPeriods
@@ -382,7 +372,6 @@ org.hisp.dhis.dataset.DataSet.sources
 org.hisp.dhis.organisationunit.OrganisationUnitGroupSet.userAccesses
 org.hisp.dhis.chart.Chart.translations
 org.hisp.dhis.pushanalysis.PushAnalysis.recipientUserGroups
-org.hisp.dhis.program.ProgramStage.userAccesses
 org.hisp.dhis.option.OptionGroupSet.userGroupAccesses
 org.hisp.dhis.organisationunit.OrganisationUnitGroupSet.organisationUnitGroups
 org.hisp.dhis.dataelement.DataElementCategoryCombo.translations


### PR DESCRIPTION
Added new config property to specify the remoteObjectPort for ehcache rmi peer listener factory. Updated cache names to reflect all entitites and collection cache in 2.28