### PR TITLE
Fix FileResourceRetentionStrategy enum casting error

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -252,6 +252,10 @@ public enum SettingKey
             {
                 return AnalyticsFinancialYearStartKey.valueOf( value );
             }
+            else if ( FileResourceRetentionStrategy.class.isAssignableFrom( settingClazz ) )
+            {
+                return FileResourceRetentionStrategy.valueOf( value );
+            }
 
             //TODO handle Dates
         }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1843

Test issue https://jira.dhis2.org/browse/DHIS2-3073

Issue: FileResourceRetentionStrategy SystemSetting value is saved in String, but getting as Enum value.
This fix doesn't solve the issue for existing value, need to save the setting again.