### PR TITLE
Bug-fix: UserSettings stored as String not actual class

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
@@ -134,7 +134,7 @@ public class UserSettingController
             throw new WebMessageException( WebMessageUtils.conflict( "You need to specify a new value" ) );
         }
 
-        userSettingService.saveUserSetting( userSettingKey, newValue, user );
+        userSettingService.saveUserSetting( userSettingKey, UserSettingKey.getAsRealClass( key, newValue ), user );
 
         return WebMessageUtils.ok( "User setting saved" );
     }


### PR DESCRIPTION
Fixed a bug where userSettings would be saved as String not their appropriate class when using the api.