### PR TITLE
Fixes issues with transcations and validation during sync job. - DHIS2-3080

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
@@ -106,13 +106,14 @@ public interface TrackedEntityInstanceService
     Grid getTrackedEntityInstancesGrid( TrackedEntityInstanceQueryParams params );
 
     /**
-     * Returns a list with tracked entity instance values based on the given
-     * TrackedEntityInstanceQueryParams.
+     * Returns a list with tracked entity instance values based on the given TrackedEntityInstanceQueryParams.
      *
-     * @param params the TrackedEntityInstanceQueryParams.
+     * @param params               the TrackedEntityInstanceQueryParams.
+     * @param skipAccessValidation If true, access validation is skippes. Should be set to true only for internal
+     *                             tasks (e.g. currently used by synchronization job)
      * @return List of TEIs matching the params
      */
-    List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params );
+    List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation );
 
     int getTrackedEntityInstanceCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation, boolean skipSearchScopeValidation );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -125,7 +125,7 @@ public class DefaultTrackedEntityInstanceService
     // -------------------------------------------------------------------------
 
     @Override
-    public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params )
+    public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation )
     {
         if ( params.isOrQuery() && !params.hasAttributes() && !params.hasProgram() )
         {
@@ -135,7 +135,11 @@ public class DefaultTrackedEntityInstanceService
         }
 
         decideAccess( params );
-        validate( params );
+        //AccessValidation should be skipped only and only if it is internal service that runs the task (for example sync job)
+        if ( !skipAccessValidation )
+        {
+            validate( params );
+        }
 
         params.setUser( currentUserService.getCurrentUser() );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -74,6 +74,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -149,10 +150,11 @@ public abstract class AbstractTrackedEntityInstanceService
     // READ
     // -------------------------------------------------------------------------
 
+    @Transactional
     @Override
-    public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams, TrackedEntityInstanceParams params )
+    public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams, TrackedEntityInstanceParams params, boolean skipAccessValidation )
     {
-        List<org.hisp.dhis.trackedentity.TrackedEntityInstance> daoTEIs = teiService.getTrackedEntityInstances( queryParams );
+        List<org.hisp.dhis.trackedentity.TrackedEntityInstance> daoTEIs = teiService.getTrackedEntityInstances( queryParams, skipAccessValidation );
 
         List<TrackedEntityInstance> dtoTEIItems = new ArrayList<>();
         User user = currentUserService.getCurrentUser();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
@@ -50,7 +50,7 @@ public interface TrackedEntityInstanceService
     // READ
     // -------------------------------------------------------------------------
 
-    List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams, TrackedEntityInstanceParams params );
+    List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams, TrackedEntityInstanceParams params, boolean skipAccessValidation );
 
     int getTrackedEntityInstanceCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation, boolean skipSearchScopeValidation );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/ProgramDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/ProgramDataSynchronizationJob.java
@@ -87,6 +87,7 @@ public class ProgramDataSynchronizationJob extends AbstractJob
         try
         {
             trackerSync.syncTrackerProgramData();
+            notifier.notify( jobConfiguration, "Tracker programs data sync successful" );
         }
         catch ( Exception e )
         {
@@ -94,8 +95,6 @@ public class ProgramDataSynchronizationJob extends AbstractJob
             notifier.notify( jobConfiguration, "TrackerPrograms data sync failed: " + e.getMessage() );
             messageService.sendSystemErrorNotification( "TrackerProgram data sync failed", e );
         }
-
-        notifier.notify( jobConfiguration, "Event and Tracker programs data sync successful" );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/ProgramDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/ProgramDataSynchronizationJob.java
@@ -75,17 +75,6 @@ public class ProgramDataSynchronizationJob extends AbstractJob
     {
         try
         {
-            eventSync.syncEventProgramData();
-        }
-        catch ( Exception e )
-        {
-            log.error( "EventPrograms data sync failed.", e );
-            notifier.notify( jobConfiguration, "Event sync failed: " + e.getMessage() );
-            messageService.sendSystemErrorNotification( "Event sync failed", e );
-        }
-
-        try
-        {
             trackerSync.syncTrackerProgramData();
             notifier.notify( jobConfiguration, "Tracker programs data sync successful" );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
@@ -169,7 +169,7 @@ public class SyncUtils
         {
             for ( ImportSummary summary : summaries.getImportSummaries() )
             {
-                if ( !checkSummaryStatus( summary, originalTopSummaries, endpoint ) )
+                if ( !checkSummaryStatus( summary, summaries, originalTopSummaries, endpoint ) )
                 {
                     return false;
                 }
@@ -202,14 +202,15 @@ public class SyncUtils
      *
      * @param summary      ImportSummary that are checked for error/warning
      * @param topSummaries References to the ImportSummaries from top level of the graph (Used to create proper log message)
+     * @param summaries    References to the ImportSummaries 1 level above (Used to create proper log message)
      * @param endpoint     Specifies against which endpoint the request was run
      * @return true if everything is OK, false otherwise
      */
-    private static boolean checkSummaryStatus( ImportSummary summary, ImportSummaries topSummaries, SyncEndpoint endpoint )
+    private static boolean checkSummaryStatus( ImportSummary summary, ImportSummaries summaries, ImportSummaries topSummaries, SyncEndpoint endpoint )
     {
         if ( summary.getStatus() == ImportStatus.ERROR || summary.getStatus() == ImportStatus.WARNING )
         {
-            log.error( "Sync against endpoint: " + endpoint.name() + " failed: " + topSummaries );
+            log.error( "Sync against endpoint: " + endpoint.name() + " failed: ImportSummaries: " + summaries + " |########| Top ImportSummaries: " + topSummaries );
             return false;
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstances;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -112,7 +113,7 @@ public class TrackerSynchronization
         {
             queryParams.setPage( i );
 
-            List<TrackedEntityInstance> dtoTeis = teiService.getTrackedEntityInstances( queryParams, params );
+            List<TrackedEntityInstance> dtoTeis = teiService.getTrackedEntityInstances( queryParams, params, true );
             filterOutNonSynchronizableAttributes( dtoTeis );
             log.info( String.format( "Syncing page %d, page size is: %d", i, trackerSyncPageSize ) );
 
@@ -147,11 +148,14 @@ public class TrackerSynchronization
 
     private boolean sendTrackerSyncRequest( List<TrackedEntityInstance> dtoTeis, String username, String password )
     {
+        TrackedEntityInstances teis = new TrackedEntityInstances();
+        teis.setTrackedEntityInstances( dtoTeis );
+
         final RequestCallback requestCallback = request ->
         {
             request.getHeaders().setContentType( MediaType.APPLICATION_JSON );
             request.getHeaders().add( SyncUtils.HEADER_AUTHORIZATION, CodecUtils.getBasicAuthString( username, password ) );
-            renderService.toJson( request.getBody(), dtoTeis );
+            renderService.toJson( request.getBody(), teis );
         };
 
         return SyncUtils.sendSyncRequest( systemSettingManager, restTemplate, requestCallback, SyncEndpoint.TEIS_ENDPOINT );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -204,7 +204,7 @@ public class TrackedEntityInstanceController
         if ( trackedEntityInstance == null )
         {
             trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
-                getTrackedEntityInstanceParams( fields ) );
+                getTrackedEntityInstanceParams( fields ), false );
         }
         else
         {


### PR DESCRIPTION
Adds logic to skip validation if it is a sync job that runs the query. Also broadens transaction over multiple methods so LazyInitializationException is avoided.

Removes event sync until issues with it are solved.

Adds more info into log message about success/failure of sync so the eventual issue can be investigated faster.