### PR TITLE
PushAnalysis exception assign null to primitive type int

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysis.java
@@ -72,7 +72,7 @@ public class PushAnalysis
 
     private boolean enabled;
 
-    private int schedulingDayOfFrequency;
+    private Integer schedulingDayOfFrequency;
 
     private SchedulingFrequency schedulingFrequency;
 
@@ -162,12 +162,13 @@ public class PushAnalysis
         this.schedulingFrequency = schedulingFrequency;
     }
 
-    public int getSchedulingDayOfFrequency()
+    // Deprecated since 2.29
+    public Integer getSchedulingDayOfFrequency()
     {
         return schedulingDayOfFrequency;
     }
 
-    public void setSchedulingDayOfFrequency( int schedulingDayOfFrequency )
+    public void setSchedulingDayOfFrequency( Integer schedulingDayOfFrequency )
     {
         this.schedulingDayOfFrequency = schedulingDayOfFrequency;
     }


### PR DESCRIPTION
The property "schedulingdayoffrequency" is no longer used, but can not easily be removed. To solve this issue, the type of this property was changed from int to Integer to allow null values should they appear.