### PR TITLE
Fixed PushAnalysis upgrade from 2.28 to 2.29+

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysis.java
@@ -72,7 +72,7 @@ public class PushAnalysis
 
     private boolean enabled;
 
-    private int schedulingDayOfFrequency;
+    private Integer schedulingDayOfFrequency;
 
     private SchedulingFrequency schedulingFrequency;
 
@@ -162,12 +162,12 @@ public class PushAnalysis
         this.schedulingFrequency = schedulingFrequency;
     }
 
-    public int getSchedulingDayOfFrequency()
+    public Integer getSchedulingDayOfFrequency()
     {
         return schedulingDayOfFrequency;
     }
 
-    public void setSchedulingDayOfFrequency( int schedulingDayOfFrequency )
+    public void setSchedulingDayOfFrequency( Integer schedulingDayOfFrequency )
     {
         this.schedulingDayOfFrequency = schedulingDayOfFrequency;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysisService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysisService.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.User;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author Stian Sandvold
@@ -44,6 +45,12 @@ public interface PushAnalysisService
      * @return PushAnalysis
      */
     PushAnalysis getByUid( String uid );
+
+    /**
+     * Returns all PushAnalysis
+     * @return List of PushAnalysis
+     */
+    List<PushAnalysis> getAll();
 
     /**
      * Returns a String, consisting of HTML representing the PushAnalysis report.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerUpgrade.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerUpgrade.java
@@ -28,12 +28,7 @@ package org.hisp.dhis.startup;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.transaction.Transactional;
-
+import com.google.api.client.util.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.ListMap;
@@ -47,7 +42,10 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.startup.AbstractStartupRoutine;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.google.api.client.util.Sets;
+import javax.transaction.Transactional;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hisp.dhis.scheduling.JobType.*;
 
@@ -153,7 +151,7 @@ public class SchedulerUpgrade
             pushAnalysisService
                 .getAll()
                 .forEach( ( pa ) -> {
-                    String cron;
+                    String cron = "";
 
                     switch ( pa.getSchedulingFrequency() )
                     {
@@ -167,12 +165,15 @@ public class SchedulerUpgrade
                         cron = "0 0 4 " + pa.getSchedulingDayOfFrequency() + " */1 *";
                         break;
                     default:
-                        cron = "";
                         break;
                     }
 
-                    jobConfigurationService.addJobConfiguration( new JobConfiguration( "PushAnalysis: " + pa.getUid(), PUSH_ANALYSIS, cron,
-                        new PushAnalysisJobParameters( pa.getUid() ), true, pa.getEnabled() ) );
+                    if( !cron.isEmpty() )
+                    {
+                        jobConfigurationService.addJobConfiguration(
+                            new JobConfiguration( "PushAnalysis: " + pa.getUid(), PUSH_ANALYSIS, cron,
+                                new PushAnalysisJobParameters( pa.getUid() ), true, pa.getEnabled() ) );
+                    }
                 } );
 
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerUpgrade.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerUpgrade.java
@@ -28,14 +28,6 @@ package org.hisp.dhis.startup;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.scheduling.JobType.ANALYTICS_TABLE;
-import static org.hisp.dhis.scheduling.JobType.DATA_SYNC;
-import static org.hisp.dhis.scheduling.JobType.META_DATA_SYNC;
-import static org.hisp.dhis.scheduling.JobType.MONITORING;
-import static org.hisp.dhis.scheduling.JobType.PROGRAM_NOTIFICATIONS;
-import static org.hisp.dhis.scheduling.JobType.RESOURCE_TABLE;
-import static org.hisp.dhis.scheduling.JobType.SEND_SCHEDULED_MESSAGE;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,15 +37,19 @@ import javax.transaction.Transactional;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.ListMap;
+import org.hisp.dhis.pushanalysis.PushAnalysisService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobStatus;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
+import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.startup.AbstractStartupRoutine;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.api.client.util.Sets;
+
+import static org.hisp.dhis.scheduling.JobType.*;
 
 /**
  * Handles porting from the old scheduler to the new.
@@ -68,6 +64,9 @@ public class SchedulerUpgrade
 
     @Autowired
     private SystemSettingManager systemSettingManager;
+
+    @Autowired
+    private PushAnalysisService pushAnalysisService;
 
     private JobConfigurationService jobConfigurationService;
 
@@ -150,6 +149,32 @@ public class SchedulerUpgrade
                     log.error( "Could not map job type '" + jobType + "' with cron '" + cron + "'" );
                 }
             } ) );
+
+            pushAnalysisService
+                .getAll()
+                .forEach( ( pa ) -> {
+                    String cron;
+
+                    switch ( pa.getSchedulingFrequency() )
+                    {
+                    case DAILY:
+                        cron = "0 0 4 */1 * *";
+                        break;
+                    case WEEKLY:
+                        cron = "0 0 4 * * " + ( pa.getSchedulingDayOfFrequency() % 7 );
+                        break;
+                    case MONTHLY:
+                        cron = "0 0 4 " + pa.getSchedulingDayOfFrequency() + " */1 *";
+                        break;
+                    default:
+                        cron = "";
+                        break;
+                    }
+
+                    jobConfigurationService.addJobConfiguration( new JobConfiguration( "PushAnalysis: " + pa.getUid(), PUSH_ANALYSIS, cron,
+                        new PushAnalysisJobParameters( pa.getUid() ), true, pa.getEnabled() ) );
+                } );
+
 
             ListMap<String, String> emptySystemSetting = new ListMap<>();
             emptySystemSetting.putValue( "ported", "" );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -80,6 +80,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -140,6 +141,12 @@ public class DefaultPushAnalysisService
     public PushAnalysis getByUid( String uid )
     {
         return pushAnalysisStore.getByUid( uid );
+    }
+
+    @Override
+    public List<PushAnalysis> getAll()
+    {
+        return pushAnalysisStore.getAll();
     }
 
     @Override


### PR DESCRIPTION
Changed int to Integer to account for null-values (This property is not easily removed, but is not used after 2.29) for schedulingdayoffrequence

Re-added code for migrating PushAnalysis jobs to new scheduler.
