### PR TITLE
Bump maintenance-app to use the 2.30-SNAPSHOT

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -43,7 +43,7 @@
                 <artifactItem>
                   <groupId>org.hisp.dhis</groupId>
                   <artifactId>dhis-app-maintenance</artifactId>
-                  <version>2.29-SNAPSHOT</version>
+                  <version>2.30-SNAPSHOT</version>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/${project.artifactId}/dhis-web-maintenance</outputDirectory>
                   <includes>**/*.*</includes>


### PR DESCRIPTION
DHIS2 master should use this artifact:

https://oss.sonatype.org/content/repositories/snapshots/org/hisp/dhis/dhis-app-maintenance/2.30-SNAPSHOT/