### PR TITLE
fix send notification for event report and event chart

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -232,11 +232,11 @@ public class DefaultInterpretationService
                 + interpretation.getUid();
             break;
         case EVENT_REPORT:
-            link += "/dhis-web-event-reports/index.html?id=" + interpretation.getChart().getUid() + "&interpretationid="
+            link += "/dhis-web-event-reports/index.html?id=" + interpretation.getEventReport().getUid() + "&interpretationid="
                 + interpretation.getUid();
             break;
         case EVENT_CHART:
-            link += "/dhis-web-event-visualizer/index.html?id=" + interpretation.getChart().getUid()
+            link += "/dhis-web-event-visualizer/index.html?id=" + interpretation.getEventChart().getUid()
                 + "&interpretationid=" + interpretation.getUid();
             break;
         default:


### PR DESCRIPTION
When a user is mentioned in any analytic tool a notification is sent immediately. This was failing for event report and event chart