### PR TITLE
[DHIS2-3612] Handle appropriate error message for DE metadata read check.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueController.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.util.ValidationUtils;
@@ -137,6 +138,9 @@ public class DataValueController
     @Autowired
     private AggregateAccessManager accessManager;
 
+    @Autowired
+    private AclService aclService;
+
     // ---------------------------------------------------------------------
     // POST
     // ---------------------------------------------------------------------
@@ -162,12 +166,13 @@ public class DataValueController
         boolean strictOrgUnits = (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS );
         boolean requireCategoryOptionCombo = (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_REQUIRE_CATEGORY_OPTION_COMBO );
         FileResourceRetentionStrategy retentionStrategy = (FileResourceRetentionStrategy) systemSettingManager.getSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY );
+        User currentUser = currentUserService.getCurrentUser();
 
         // ---------------------------------------------------------------------
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = getAndValidateDataElement( de );
+        DataElement dataElement = getAndValidateDataElement( currentUser, de );
 
         CategoryOptionCombo categoryOptionCombo = getAndValidateCategoryOptionCombo( co, requireCategoryOptionCombo );
 
@@ -184,8 +189,6 @@ public class DataValueController
         validateAttributeOptionComboWithOrgUnitAndPeriod( attributeOptionCombo, organisationUnit, period );
 
         String valueValid = ValidationUtils.dataValueIsValid( value, dataElement );
-
-        User currentUser = currentUserService.getCurrentUser();
 
         if ( valueValid != null )
         {
@@ -384,7 +387,7 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = getAndValidateDataElement( de );
+        DataElement dataElement = getAndValidateDataElement( currentUserService.getCurrentUser(), de );
 
         CategoryOptionCombo categoryOptionCombo = getAndValidateCategoryOptionCombo( co, false );
 
@@ -447,7 +450,9 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = getAndValidateDataElement( de );
+        User currentUser = currentUserService.getCurrentUser();
+
+        DataElement dataElement = getAndValidateDataElement( currentUser, de );
 
         CategoryOptionCombo categoryOptionCombo = getAndValidateCategoryOptionCombo( co, false );
 
@@ -471,8 +476,6 @@ public class DataValueController
         // ---------------------------------------------------------------------
         // Data Sharing check
         // ---------------------------------------------------------------------
-
-        User currentUser = currentUserService.getCurrentUser();
 
         List<String> errors = accessManager.canRead( currentUser, dataValue );
 
@@ -506,7 +509,7 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = getAndValidateDataElement( de );
+        DataElement dataElement = getAndValidateDataElement( currentUserService.getCurrentUser(), de );
 
         if ( !dataElement.isFileType() )
         {
@@ -619,14 +622,18 @@ public class DataValueController
     // Supportive methods
     // ---------------------------------------------------------------------
 
-    private DataElement getAndValidateDataElement( String de )
+    private DataElement getAndValidateDataElement( User user, String de )
         throws WebMessageException
     {
-        DataElement dataElement = idObjectManager.get( DataElement.class, de );
+        DataElement dataElement = idObjectManager.getNoAcl( DataElement.class, de );
 
         if ( dataElement == null )
         {
             throw new WebMessageException( WebMessageUtils.conflict( "Illegal data element identifier: " + de ) );
+        }
+        else if ( !aclService.canRead( user, dataElement ) )
+        {
+            throw new WebMessageException( WebMessageUtils.conflict( "User does not have metadata read access for DataElement: " + de ) );
         }
 
         return dataElement;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -189,7 +189,8 @@ public class SystemSettingController
 
         for ( String key : settings.keySet() )
         {
-            systemSettingManager.saveSystemSetting( key, (Serializable) settings.get( key ) );
+            Serializable valueObject = SettingKey.getAsRealClass( key, settings.get( key ).toString() );
+            systemSettingManager.saveSystemSetting( key, valueObject );
         }
 
         webMessageService.send( WebMessageUtils.ok( "System settings imported" ), response, request );


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-3612

Currently getByUid() return null if user doesn't have read access for a DE, hence it return object doesn't exists message.

=> Need to check if object exists first, then check for read access and throw appropriate error message.