### PR TITLE
Fix issue with unique AttributeValue across Attributes

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -419,6 +419,8 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         Criteria criteria = getSharingCriteria();
         criteria.createAlias( "attributeValues", "av" );
         criteria.add( Restrictions.eq( "av.value", value ) );
+        criteria.createAlias( "av.attribute", "att" );
+        criteria.add( Restrictions.eq( "att.id", attribute.getId() ) );
 
         return (T) criteria.uniqueResult();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
@@ -442,6 +442,50 @@ public class DataElementStoreTest
     }
 
     @Test
+    public void testUniqueAttributesWithSameValues()
+    {
+        Attribute attributeA = new Attribute( "ATTRIBUTEA", ValueType.TEXT );
+        attributeA.setDataElementAttribute( true );
+        attributeA.setUnique( true );
+        attributeService.addAttribute( attributeA );
+
+        Attribute attributeB = new Attribute( "ATTRIBUTEB", ValueType.TEXT );
+        attributeB.setDataElementAttribute( true );
+        attributeB.setUnique( true );
+        attributeService.addAttribute( attributeB );
+
+        Attribute attributeC = new Attribute( "ATTRIBUTEC", ValueType.TEXT );
+        attributeC.setDataElementAttribute( true );
+        attributeC.setUnique( true );
+        attributeService.addAttribute( attributeC );
+
+        DataElement dataElementA = createDataElement( 'A' );
+        DataElement dataElementB = createDataElement( 'B' );
+
+        dataElementStore.save( dataElementA );
+        dataElementStore.save( dataElementB );
+
+        AttributeValue attributeValueA = new AttributeValue( "VALUE", attributeA );
+        AttributeValue attributeValueB = new AttributeValue( "VALUE", attributeB );
+        AttributeValue attributeValueC = new AttributeValue( "VALUE", attributeC );
+
+        attributeService.addAttributeValue( dataElementA, attributeValueA );
+        attributeService.addAttributeValue( dataElementB, attributeValueB );
+        attributeService.addAttributeValue( dataElementB, attributeValueC );
+
+        dataElementStore.update( dataElementA );
+        dataElementStore.update( dataElementB );
+
+        assertNotNull( dataElementStore.getByUniqueAttributeValue( attributeA, "VALUE" ) );
+        assertNotNull( dataElementStore.getByUniqueAttributeValue( attributeB, "VALUE" ) );
+        assertNotNull( dataElementStore.getByUniqueAttributeValue( attributeC, "VALUE" ) );
+
+        assertEquals( "DataElementA", dataElementStore.getByUniqueAttributeValue( attributeA, "VALUE" ).getName() );
+        assertEquals( "DataElementB", dataElementStore.getByUniqueAttributeValue( attributeB, "VALUE" ).getName() );
+        assertEquals( "DataElementB", dataElementStore.getByUniqueAttributeValue( attributeC, "VALUE" ).getName() );
+    }
+
+    @Test
     public void testDataElementByNonUniqueAttributeValue() throws NonUniqueAttributeValueException
     {
         Attribute attribute = new Attribute( "cid", ValueType.TEXT );


### PR DESCRIPTION
If we have two unique attributes that have same value, getByUniqueAttributeValue() will throw error because it find 2 results.