### PR TITLE
 Improves/fixes the logic for deletion of items - DHIS2-3080 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -687,13 +687,10 @@ public abstract class AbstractEnrollmentService
 
     private ImportSummary deleteEnrollment( String uid, Enrollment enrollment, ImportOptions importOptions )
     {
+        ImportSummary importSummary = new ImportSummary();
         importOptions = updateImportOptions( importOptions );
 
-        String descMsg = "Deletion of enrollment " + uid + " was successful";
-        ImportSummary importSummary = null;
-
         boolean existsEnrollment = programInstanceService.programInstanceExists( uid );
-        boolean existsEnrollmentIncludingDeleted = programInstanceService.programInstanceExistsIncludingDeleted( uid );
 
         if ( existsEnrollment )
         {
@@ -701,7 +698,7 @@ public abstract class AbstractEnrollmentService
 
             if ( enrollment != null )
             {
-                importSummary = new ImportSummary( uid );
+                importSummary.setReference( uid );
                 importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
             }
 
@@ -712,25 +709,29 @@ public abstract class AbstractEnrollmentService
             if ( !notDeletedProgramStageInstances.isEmpty() && importOptions.getUser() != null &&
                 !importOptions.getUser().isAuthorized( Authorities.F_ENROLLMENT_CASCADE_DELETE.getAuthority() ) )
             {
-                descMsg = "The enrollment to be deleted has associated events. Deletion requires special authority: " + i18nManager.getI18n().getString( Authorities.F_ENROLLMENT_CASCADE_DELETE.getAuthority() );
-                return new ImportSummary( ImportStatus.ERROR, descMsg ).incrementIgnored();
+                importSummary.setStatus( ImportStatus.ERROR );
+                importSummary.setReference( uid );
+                String descMsg = "The enrollment to be deleted has associated events. Deletion requires special authority: " + i18nManager.getI18n().getString( Authorities.F_ENROLLMENT_CASCADE_DELETE.getAuthority() );
+                importSummary.setDescription( descMsg );
+
+                return importSummary.incrementIgnored();
             }
 
             programInstanceService.deleteProgramInstance( programInstance );
             teiService.updateTrackedEntityInstance( programInstance.getEntityInstance() );
-        }
 
-        if ( existsEnrollment || existsEnrollmentIncludingDeleted )
-        {
-            if ( importSummary == null )
-            {
-                importSummary = new ImportSummary( ImportStatus.SUCCESS, descMsg );
-            }
+            importSummary.setStatus( ImportStatus.SUCCESS );
+            importSummary.setDescription( "Deletion of enrollment " + uid + " was successful" );
 
             return importSummary.incrementDeleted();
         }
-
-        return new ImportSummary( ImportStatus.ERROR, "ID " + uid + " does not point to a valid enrollment" ).incrementIgnored();
+        else
+        {
+            //If I am here, it means that the item is either already deleted or it is not present in the system at all.
+            importSummary.setStatus( ImportStatus.SUCCESS );
+            importSummary.setDescription( "Enrollment with UID " + uid + " is not present in the system. Therefore, there is nothing to delete." );
+            return importSummary.incrementIgnored();
+        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -1304,6 +1304,7 @@ public abstract class AbstractEventService
         }
         else
         {
+            //If I am here, it means that the item is either already deleted or it is not present in the system at all.
             return new ImportSummary( ImportStatus.SUCCESS, "Event with UID " + uid + " is not present in the system. Therefore, there is nothing to delete." ).incrementIgnored();
         }
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -899,7 +899,7 @@ public abstract class AbstractEventService
         }
 
         if ( attributeOptionCombo != null && !userCredentials.isSuper() && !aclService.canDataRead( user, attributeOptionCombo ) )
-        {            
+        {
             throw new IllegalQueryException( "User has no access to attribute category option combo: " + attributeOptionCombo.getUid() );
         }
 
@@ -1288,8 +1288,6 @@ public abstract class AbstractEventService
         // as for update? Currently, no check is present at all.
 
         boolean existsEvent = programStageInstanceService.programStageInstanceExists( uid );
-        boolean existsEventIncludingDeleted = programStageInstanceService
-            .programStageInstanceExistsIncludingDeleted( uid );
 
         if ( existsEvent )
         {
@@ -1301,14 +1299,13 @@ public abstract class AbstractEventService
             {
                 entityInstanceService.updateTrackedEntityInstance( programStageInstance.getProgramInstance().getEntityInstance() );
             }
-        }
 
-        if ( existsEvent || existsEventIncludingDeleted )
-        {
             return new ImportSummary( ImportStatus.SUCCESS, "Deletion of event " + uid + " was successful" ).incrementDeleted();
         }
-
-        return new ImportSummary( ImportStatus.ERROR, "ID " + uid + " does not point to a valid event." ).incrementIgnored();
+        else
+        {
+            return new ImportSummary( ImportStatus.SUCCESS, "Event with UID " + uid + " is not present in the system. Therefore, there is nothing to delete." ).incrementIgnored();
+        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -522,12 +522,10 @@ public abstract class AbstractTrackedEntityInstanceService
 
     private ImportSummary deleteTrackedEntityInstance( String uid, TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions )
     {
-        String descMsg = "Deletion of tracked entity instance " + uid + " was successful";
-        ImportSummary importSummary = null;
+        ImportSummary importSummary = new ImportSummary();
         importOptions = updateImportOptions( importOptions );
 
         boolean existsTei = teiService.trackedEntityInstanceExists( uid );
-        boolean existsTeiIncludingDeleted = teiService.trackedEntityInstanceExistsIncludingDeleted( uid );
 
         if ( existsTei )
         {
@@ -535,7 +533,7 @@ public abstract class AbstractTrackedEntityInstanceService
 
             if ( dtoEntityInstance != null )
             {
-                importSummary = new ImportSummary( uid );
+                importSummary.setReference( uid );
                 importSummary.setEnrollments( handleEnrollments( dtoEntityInstance, daoEntityInstance, importOptions ) );
             }
 
@@ -546,24 +544,27 @@ public abstract class AbstractTrackedEntityInstanceService
             if ( !notDeletedProgramInstances.isEmpty() && importOptions.getUser() != null &&
                 !importOptions.getUser().isAuthorized( Authorities.F_TEI_CASCADE_DELETE.getAuthority() ) )
             {
-                descMsg = "The " + daoEntityInstance.getTrackedEntityType().getName() + " to be deleted has associated enrollments. Deletion requires special authority: " + i18nManager.getI18n().getString( Authorities.F_TEI_CASCADE_DELETE.getAuthority() );
-                return new ImportSummary( ImportStatus.ERROR, descMsg ).incrementIgnored();
+                importSummary.setStatus( ImportStatus.ERROR );
+                importSummary.setReference( uid );
+                String descMsg = "The " + daoEntityInstance.getTrackedEntityType().getName() + " to be deleted has associated enrollments. Deletion requires special authority: " + i18nManager.getI18n().getString( Authorities.F_TEI_CASCADE_DELETE.getAuthority() );
+                importSummary.setDescription( descMsg );
+
+                return importSummary.incrementIgnored();
             }
 
             teiService.deleteTrackedEntityInstance( daoEntityInstance );
-        }
 
-        if ( existsTei || existsTeiIncludingDeleted )
-        {
-            if ( importSummary == null )
-            {
-                importSummary = new ImportSummary( ImportStatus.SUCCESS, descMsg );
-            }
-
+            importSummary.setStatus( ImportStatus.SUCCESS );
+            importSummary.setDescription( "Deletion of tracked entity instance " + uid + " was successful" );
             return importSummary.incrementDeleted();
         }
-
-        return new ImportSummary( ImportStatus.ERROR, "ID " + uid + " does not point to a valid tracked entity instance" ).incrementIgnored();
+        else
+        {
+            //If I am here, it means that the item is either already deleted or it is not present in the system at all.
+            importSummary.setStatus( ImportStatus.SUCCESS );
+            importSummary.setDescription( "Tracked entity instance with UID " + uid + " is not present in the system. Therefore, there is nothing to delete." );
+            return importSummary.incrementIgnored();
+        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -587,6 +587,8 @@ public abstract class AbstractTrackedEntityInstanceService
             counter++;
         }
 
+        clearSession();
+
         return importSummaries;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstance.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstance.java
@@ -304,6 +304,7 @@ public class TrackedEntityInstance
             ", relationships=" + relationships +
             ", attributes=" + attributes +
             ", inactive=" + inactive +
+            ", deleted=" + deleted +
             '}';
     }
 }


### PR DESCRIPTION
Improves the logic how the SUCCESS/ERROR ImportSummaries are generated. Improves info/error messages.

Improves toString method (adds info about delete property)

Fixes the bug with not clearing the session when there are too few items in the collection.