### PR TITLE
[DHIS2-3891] Send notifications to subscribers on new interpretation, comment and like

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/InterpretationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/InterpretationService.java
@@ -50,6 +50,8 @@ public interface InterpretationService
 
     void updateInterpretation( Interpretation interpretation );
 
+    void updateInterpretationText( Interpretation interpretation, String text );
+
     void deleteInterpretation( Interpretation interpretation );
 
     List<Interpretation> getInterpretations();
@@ -60,8 +62,8 @@ public interface InterpretationService
 
     InterpretationComment addInterpretationComment( String uid, String text );
 
-    void sendNotifications( Interpretation interpretation, InterpretationComment comment, Set<User> users );
-    
+    void updateComment( Interpretation interpretation, InterpretationComment comment );
+
     void updateSharingForMentions( Interpretation interpretation, Set<User> users );
 
     void updateCurrentUserLastChecked();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/NotificationType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/NotificationType.java
@@ -1,0 +1,38 @@
+package org.hisp.dhis.interpretation;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public enum NotificationType
+{
+        INTERPRETATION_CREATE,
+        INTERPRETATION_UPDATE,
+        INTERPRETATION_LIKE,
+        COMMENT_CREATE,
+        COMMENT_UPDATE
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/message/MessageService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/message/MessageService.java
@@ -49,6 +49,8 @@ public interface MessageService
 
     MessageConversationParams.Builder createSystemMessage( String subject, String text );
 
+    MessageConversationParams.Builder createSystemMessage( Collection<User> user, String subject, String text );
+
     MessageConversationParams.Builder createValidationResultMessage( Collection<User> users, String subject, String text );
 
     int sendMessage( MessageConversationParams params );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -79,6 +79,14 @@ public interface UserService
     User getUser( String uid );
 
     /**
+     * Retrieves a collection of User with the given unique identifiers.
+     *
+     * @param uids the identifiers of the collection of Users to retrieve.
+     * @return the User.
+     */
+    List<User> getUsers( Collection<String> uids );
+
+    /**
      * Returns a List of all Users.
      *
      * @return a Collection of Users.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/DefaultMessageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/DefaultMessageService.java
@@ -158,6 +158,13 @@ public class DefaultMessageService
     }
 
     @Override
+    public MessageConversationParams.Builder createSystemMessage( Collection<User> recipients, String subject, String text )
+    {
+        return new MessageConversationParams.Builder( recipients, null, subject, text,
+            MessageType.SYSTEM );
+    }
+
+    @Override
     public MessageConversationParams.Builder createValidationResultMessage( Collection<User> receivers, String subject,
         String text )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -170,6 +170,12 @@ public class DefaultUserService
     }
 
     @Override
+    public List<User> getUsers( Collection<String> uids )
+    {
+        return userStore.getByUid( uids );
+    }
+
+    @Override
     public List<User> getAllUsersBetweenByName( String name, int first, int max )
     {
         UserQueryParams params = new UserQueryParams();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -1589,3 +1589,12 @@ comment_mention_notification=You were mentioned in the following comment
 interpretation_mention_notification=You were mentioned in the following interpretation
 go_to=Go to
 mentioned_you_in_dhis2=mentioned you in DHIS 2
+
+#-- Subscriber notifications -----------------------------------------------------------------#
+notification_user=User
+notification_object_subscribed=of an object you are subscribed to
+notification_interpretation_create=created an interpretation
+notification_interpretation_update=updated an interpretation
+notification_interpretation_like=liked an interpretation
+notification_comment_create=created an interpretation comment
+notification_comment_update=updated an interpretation comment

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -90,6 +90,11 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-external</artifactId>
     </dependency>
+    <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.11.3</version>
+    </dependency>
     
   </dependencies>
   <properties>

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -91,9 +91,9 @@
       <artifactId>dhis-support-external</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>1.11.3</version>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.11.3</version>
     </dependency>
     
   </dependencies>

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -292,10 +292,10 @@ public class DefaultInterpretationService
 
         String fullBody = String.join( "\n\n", Arrays.asList(
             String.format( "%s: %s", subject, interpretableName ),
-            getInterpretationLink( interpretation ),
-            Jsoup.parse( details ).text()
+            Jsoup.parse( details ).text(),
+            String.format( "%s %s", i18n.getString( "go_to" ), getInterpretationLink( interpretation ) )
         ) );
-
+        
         return messageService.createSystemMessage( users, subject, fullBody ).build();
     }
 
@@ -308,9 +308,10 @@ public class DefaultInterpretationService
             SubscribableObject object = (SubscribableObject) interpretableObject;
             Set<User> subscribers = new HashSet<>( userService.getUsers( object.getSubscribers() ) );
             subscribers.remove( currentUserService.getCurrentUser() );
-            MessageConversationParams message =
-                getNotificationMessage( subscribers, interpretation, comment, notificationType );
-            messageService.sendMessage( message );
+            if ( !subscribers.isEmpty() ){
+                MessageConversationParams message = getNotificationMessage( subscribers, interpretation, comment, notificationType );
+                messageService.sendMessage( message );
+            }
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -30,15 +30,20 @@ package org.hisp.dhis.interpretation.impl;
 
 import org.hisp.dhis.chart.Chart;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.SubscribableObject;
 import org.hisp.dhis.interpretation.Interpretation;
 import org.hisp.dhis.interpretation.InterpretationComment;
 import org.hisp.dhis.interpretation.InterpretationService;
 import org.hisp.dhis.interpretation.InterpretationStore;
 import org.hisp.dhis.interpretation.MentionUtils;
 import org.hisp.dhis.mapping.Map;
+import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.reporttable.ReportTable;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -48,9 +53,12 @@ import org.hisp.dhis.user.UserAccess;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
+import org.jsoup.Jsoup;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -123,6 +131,18 @@ public class DefaultInterpretationService
         this.i18nManager = i18nManager;
     }
 
+    private enum NotificationType
+    {
+        INTERPRETATION_CREATE,
+        INTERPRETATION_UPDATE,
+        INTERPRETATION_LIKE,
+        COMMENT_CREATE,
+        COMMENT_UPDATE
+    }
+
+    @Autowired
+    private SchemaService schemaService;
+
     // -------------------------------------------------------------------------
     // InterpretationService implementation
     // -------------------------------------------------------------------------
@@ -133,7 +153,7 @@ public class DefaultInterpretationService
         User user = currentUserService.getCurrentUser();
         
         Set<User> users = new HashSet<>();
-        
+
         if ( interpretation != null )
         {
             if ( user != null )
@@ -152,8 +172,9 @@ public class DefaultInterpretationService
         }
 
         interpretationStore.save( interpretation );
+        notifySubscribers( interpretation, null, NotificationType.INTERPRETATION_CREATE );
 
-        sendNotifications( interpretation, null, users );
+        sendMentionNotifications( interpretation, null, users );
 
         return interpretation.getId();
     }
@@ -171,15 +192,32 @@ public class DefaultInterpretationService
     }
 
     @Override
+    public void updateComment( Interpretation interpretation, InterpretationComment comment )
+    {
+        Set<User> users = MentionUtils.getMentionedUsers( comment.getText(), userService );
+        comment.setMentionsFromUsers( users );
+        updateSharingForMentions( interpretation, users );
+        interpretationStore.update( interpretation );
+        notifySubscribers( interpretation, comment, NotificationType.COMMENT_UPDATE );
+        sendMentionNotifications( interpretation, comment, users );
+    }
+
+    @Override
     public void updateInterpretation( Interpretation interpretation )
     {
-        Set<User> users = MentionUtils.getMentionedUsers( interpretation.getText(), userService );
-        
-        interpretation.setMentionsFromUsers( users );
         interpretationStore.update( interpretation );
+    }
+
+    @Override
+    public void updateInterpretationText( Interpretation interpretation, String text )
+    {
+        interpretation.setText( text );
+        updateInterpretation( interpretation );
+        notifySubscribers( interpretation, null, NotificationType.INTERPRETATION_UPDATE );
+        Set<User> users = MentionUtils.getMentionedUsers( interpretation.getText(), userService );
+        interpretation.setMentionsFromUsers( users );
         updateSharingForMentions( interpretation, users );
-        
-        sendNotifications( interpretation, null, users );
+        sendMentionNotifications( interpretation, null, users );
     }
 
     @Override
@@ -206,53 +244,95 @@ public class DefaultInterpretationService
         return interpretationStore.getAllOrderedLastUpdated( first, max );
     }
 
-    @Override
-    public void sendNotifications( Interpretation interpretation, InterpretationComment comment, Set<User> users )
+    private MessageConversationParams getNotificationMessage(
+        Set<User> users,
+        Interpretation interpretation,
+        InterpretationComment comment,
+        NotificationType notificationType
+    )
+    {
+        I18n i18n = i18nManager.getI18n();
+        String currentUsername = currentUserService.getCurrentUser().getUsername();
+        String interpretableName = interpretation.getObject().getName();
+        String actionString;
+        String details;
+
+        switch ( notificationType )
+        {
+            case INTERPRETATION_CREATE:
+                actionString = i18n.getString( "notification_interpretation_create" );
+                details = interpretation.getText();
+                break;
+            case INTERPRETATION_UPDATE:
+                actionString = i18n.getString( "notification_interpretation_update" );
+                details = interpretation.getText();
+                break;
+            case INTERPRETATION_LIKE:
+                actionString = i18n.getString( "notification_interpretation_like" );
+                details = "";
+                break;
+            case COMMENT_CREATE:
+                actionString = i18n.getString( "notification_comment_create" );
+                details = comment.getText();
+                break;
+            case COMMENT_UPDATE:
+                actionString = i18n.getString( "notification_comment_update" );
+                details = comment.getText();
+                break;
+            default:
+                throw new RuntimeException( "Unknown notification type: " + notificationType );
+        }
+
+        String subject = String.join( " ", Arrays.asList(
+            i18n.getString( "notification_user" ),
+            currentUsername,
+            actionString,
+            i18n.getString( "notification_object_subscribed" )
+        ) );
+
+        String fullBody = String.join( "\n\n", Arrays.asList(
+            String.format( "%s: %s", subject, interpretableName ),
+            getInterpretationLink( interpretation ),
+            Jsoup.parse( details ).text()
+        ) );
+
+        return messageService.createSystemMessage( users, subject, fullBody ).build();
+    }
+
+    private void notifySubscribers( Interpretation interpretation, InterpretationComment comment, NotificationType notificationType )
+    {
+        IdentifiableObject interpretableObject = interpretation.getObject();
+        Schema interpretableObjectSchema = schemaService.getDynamicSchema( interpretableObject.getClass() );
+
+        if ( interpretableObjectSchema.isSubscribable() ) {
+            SubscribableObject object = (SubscribableObject) interpretableObject;
+            Set<User> subscribers = new HashSet<>( userService.getUsers( object.getSubscribers() ) );
+            subscribers.remove( currentUserService.getCurrentUser() );
+            MessageConversationParams message =
+                getNotificationMessage( subscribers, interpretation, comment, notificationType );
+            messageService.sendMessage( message );
+        }
+    }
+
+    private void sendMentionNotifications( Interpretation interpretation, InterpretationComment comment, Set<User> users )
     {
         if ( interpretation == null || users.isEmpty() )
         {
             return;
         }
-        String link = systemSettingManager.getInstanceBaseUrl();
-
-        switch ( interpretation.getType() )
-        {
-        case MAP:
-            link += "/dhis-web-mapping/index.html?id=" + interpretation.getMap().getUid() + "&interpretationid="
-                + interpretation.getUid();
-            break;
-        case REPORT_TABLE:
-            link += "/dhis-web-pivot/index.html?id=" + interpretation.getReportTable().getUid() + "&interpretationid="
-                + interpretation.getUid();
-            break;
-        case CHART:
-            link += "/dhis-web-visualizer/index.html?id=" + interpretation.getChart().getUid() + "&interpretationid="
-                + interpretation.getUid();
-            break;
-        case EVENT_REPORT:
-            link += "/dhis-web-event-reports/index.html?id=" + interpretation.getEventReport().getUid() + "&interpretationid="
-                + interpretation.getUid();
-            break;
-        case EVENT_CHART:
-            link += "/dhis-web-event-visualizer/index.html?id=" + interpretation.getEventChart().getUid()
-                + "&interpretationid=" + interpretation.getUid();
-            break;
-        default:
-            break;
-        }
-
+        String link = getInterpretationLink( interpretation );
         StringBuilder messageContent;
         I18n i18n = i18nManager.getI18n();
 
         if ( comment != null )
         {
             messageContent = new StringBuilder( i18n.getString( "comment_mention_notification" ) ).append( ":" )
-                .append( "\n\n" ).append( comment.getText() );
+                .append( "\n\n" ).append( Jsoup.parse( comment.getText() ).text() );
         }
         else
         {
             messageContent = new StringBuilder( i18n.getString( "interpretation_mention_notification" ) ).append( ":" )
-                .append( "\n\n" ).append( interpretation.getText() );
+                .append( "\n\n" ).append( Jsoup.parse( interpretation.getText() ).text() );
 
         }
         messageContent.append( "\n\n" ).append( i18n.getString( "go_to" ) ).append( " " ).append( link );
@@ -262,6 +342,38 @@ public class DefaultInterpretationService
             .append( i18n.getString( "mentioned_you_in_dhis2" ) );
         messageService.sendMessage( messageService
             .createPrivateMessage( users, subjectContent.toString(), messageContent.toString(), "Meta" ).build() );
+    }
+
+    private String getInterpretationLink( Interpretation interpretation ) {
+        String path;
+
+        switch ( interpretation.getType() )
+        {
+        case MAP:
+            path = "/dhis-web-mapping/index.html?id=" + interpretation.getMap().getUid() + "&interpretationid="
+                + interpretation.getUid();
+            break;
+        case REPORT_TABLE:
+            path = "/dhis-web-pivot/index.html?id=" + interpretation.getReportTable().getUid() + "&interpretationid="
+                + interpretation.getUid();
+            break;
+        case CHART:
+            path = "/dhis-web-visualizer/index.html?id=" + interpretation.getChart().getUid() + "&interpretationid="
+                + interpretation.getUid();
+            break;
+        case EVENT_REPORT:
+            path = "/dhis-web-event-reports/index.html?id=" + interpretation.getEventReport().getUid() + "&interpretationid="
+                + interpretation.getUid();
+            break;
+        case EVENT_CHART:
+            path = "/dhis-web-event-visualizer/index.html?id=" + interpretation.getEventChart().getUid()
+                + "&interpretationid=" + interpretation.getUid();
+            break;
+        default:
+            path = "";
+            break;
+        }
+        return systemSettingManager.getInstanceBaseUrl() + path;
     }
 
     @Override
@@ -298,7 +410,8 @@ public class DefaultInterpretationService
         interpretation.addComment( comment );
         interpretationStore.update( interpretation );
 
-        sendNotifications( interpretation, comment, users );
+        notifySubscribers( interpretation, comment, NotificationType.COMMENT_CREATE );
+        sendMentionNotifications( interpretation, comment, users );
 
         return comment;
     }
@@ -349,7 +462,10 @@ public class DefaultInterpretationService
             return false;
         }
 
-        return interpretation.like( user );
+        boolean userLike = interpretation.like( user );
+        notifySubscribers( interpretation, null, NotificationType.INTERPRETATION_LIKE );
+
+        return userLike;
     }
 
     @Transactional( isolation = Isolation.REPEATABLE_READ )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -127,13 +127,13 @@ public class DefaultInterpretationService
 
     private I18nManager i18nManager;
 
+    @Autowired
+    private SchemaService schemaService;
+
     public void setI18nManager( I18nManager i18nManager )
     {
         this.i18nManager = i18nManager;
     }
-
-    @Autowired
-    private SchemaService schemaService;
 
     // -------------------------------------------------------------------------
     // InterpretationService implementation
@@ -272,7 +272,7 @@ public class DefaultInterpretationService
                 details = comment.getText();
                 break;
             default:
-                throw new RuntimeException( "Unknown notification type: " + notificationType );
+                throw new IllegalArgumentException( "Unknown notification type: " + notificationType );
         }
 
         String subject = String.join( " ", Arrays.asList(

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.interpretation.InterpretationComment;
 import org.hisp.dhis.interpretation.InterpretationService;
 import org.hisp.dhis.interpretation.InterpretationStore;
 import org.hisp.dhis.interpretation.MentionUtils;
+import org.hisp.dhis.interpretation.NotificationType;
 import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageService;
@@ -129,15 +130,6 @@ public class DefaultInterpretationService
     public void setI18nManager( I18nManager i18nManager )
     {
         this.i18nManager = i18nManager;
-    }
-
-    private enum NotificationType
-    {
-        INTERPRETATION_CREATE,
-        INTERPRETATION_UPDATE,
-        INTERPRETATION_LIKE,
-        COMMENT_CREATE,
-        COMMENT_UPDATE
     }
 
     @Autowired

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -75,6 +75,8 @@ public class DefaultInterpretationService
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
+    @Autowired
+    private SchemaService schemaService;
 
     private InterpretationStore interpretationStore;
 
@@ -126,9 +128,6 @@ public class DefaultInterpretationService
     }
 
     private I18nManager i18nManager;
-
-    @Autowired
-    private SchemaService schemaService;
 
     public void setI18nManager( I18nManager i18nManager )
     {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -296,7 +296,8 @@ public class DefaultInterpretationService
         IdentifiableObject interpretableObject = interpretation.getObject();
         Schema interpretableObjectSchema = schemaService.getDynamicSchema( interpretableObject.getClass() );
 
-        if ( interpretableObjectSchema.isSubscribable() ) {
+        if ( interpretableObjectSchema.isSubscribable() )
+        {
             SubscribableObject object = (SubscribableObject) interpretableObject;
             Set<User> subscribers = new HashSet<>( userService.getUsers( object.getSubscribers() ) );
             subscribers.remove( currentUserService.getCurrentUser() );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/interpretation/InterpretationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/interpretation/InterpretationServiceTest.java
@@ -239,8 +239,23 @@ public class InterpretationServiceTest
     }
 
     @Test
+    public void testUpdateComment()
+    {
+        interpretationService.saveInterpretation( interpretationA );
+        String uid = interpretationA.getUid();
+        assertNotNull( uid );
+
+        InterpretationComment comment = interpretationService.addInterpretationComment( uid, "This interpretation is good" );
+        comment.setText( "Comment with Mentions @" + userA.getUsername() + " @" + userB.getUsername() );
+
+        interpretationService.updateComment( interpretationA, comment );
+        assertEquals( 2, comment.getMentions().size() );
+    }
+
+    @Test
     public void testMentions()
     {
+        String text;
         // Testing with mentions 
         interpretationA = new Interpretation( chartA, null, "Interpration of chart A with Mentions @" + userA.getUsername() );
         interpretationService.saveInterpretation( interpretationA );
@@ -250,8 +265,8 @@ public class InterpretationServiceTest
         assertNotNull( interpretationA.getMentions() );
         assertEquals( 1, interpretationA.getMentions().size() );
         
-        interpretationA.setText( "Interpretation of chart A with Mentions @" + userA.getUsername() + " @" + userB.getUsername() );
-        interpretationService.updateInterpretation( interpretationA );
+        text = "Interpretation of chart A with Mentions @" + userA.getUsername() + " @" + userB.getUsername();
+        interpretationService.updateInterpretationText( interpretationA, text );
         uid = interpretationA.getUid();
         assertNotNull( uid );
         assertNotNull( interpretationA.getMentions() );
@@ -285,15 +300,15 @@ public class InterpretationServiceTest
         assertNotNull( interpretationB.getMentions() );
         assertEquals( 0, interpretationB.getMentions().size() );
         
-        interpretationB.setText( "Interpration of chart B with fake mention @thisisnotauser" );
-        interpretationService.updateInterpretation( interpretationB );
+        text = "Interpration of chart B with fake mention @thisisnotauser";
+        interpretationService.updateInterpretationText( interpretationB, text );
         uid = interpretationB.getUid();
         assertNotNull( uid );
         assertNotNull( interpretationB.getMentions() );
         assertEquals( 0, interpretationB.getMentions().size() );
         
-        interpretationB.setText( "Interpration of chart B with 3 mentions @" +  userA.getUsername() + " @" + userB.getUsername() + " @" + userC.getUsername() );
-        interpretationService.updateInterpretation( interpretationB );
+        text = "Interpration of chart B with 3 mentions @" +  userA.getUsername() + " @" + userB.getUsername() + " @" + userC.getUsername();
+        interpretationService.updateInterpretationText( interpretationB, text );
         uid = interpretationB.getUid();
         assertNotNull( uid );
         assertNotNull( interpretationB.getMentions() );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
@@ -77,6 +77,12 @@ public class MockUserService implements UserService
     }
 
     @Override
+    public List<User> getUsers( Collection<String> uid )
+    {
+        return this.users;
+    }
+
+    @Override
     public List<User> getAllUsers()
     {
         return null;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.interpretation.InterpretationComment;
 import org.hisp.dhis.interpretation.InterpretationService;
 import org.hisp.dhis.interpretation.MentionUtils;
 import org.hisp.dhis.mapping.Map;
+import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
@@ -74,7 +75,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -93,6 +93,9 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private MessageService messageService;
 
     @Override
     @SuppressWarnings( "unchecked" )
@@ -326,9 +329,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
             throw new AccessDeniedException( "You are not allowed to update this interpretation." );
         }
 
-        interpretation.setText( text );
-
-        interpretationService.updateInterpretation( interpretation );
+        interpretationService.updateInterpretationText( interpretation, text );
     }
 
     @Override
@@ -399,12 +400,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
                 }
 
                 comment.setText( content );
-                Set<User> users = MentionUtils.getMentionedUsers( content, userService );
-                comment.setMentionsFromUsers( users );
-                interpretationService.updateSharingForMentions( interpretation, users );
-                
-                interpretationService.updateInterpretation( interpretation );
-                interpretationService.sendNotifications( interpretation, comment, users );
+                interpretationService.updateComment( interpretation, comment );
 
             }
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.interpretation.InterpretationComment;
 import org.hisp.dhis.interpretation.InterpretationService;
 import org.hisp.dhis.interpretation.MentionUtils;
 import org.hisp.dhis.mapping.Map;
-import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
@@ -93,9 +92,6 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     
     @Autowired
     private UserService userService;
-
-    @Autowired
-    private MessageService messageService;
 
     @Override
     @SuppressWarnings( "unchecked" )


### PR DESCRIPTION
If a user is subscribed to an analytical object, send a system notification message for any new interpretation, comment and like. Notifications are not sent to the current user (to avoid self-notifications)

This work has been done by @tokland and myself as part of this Jira issue https://jira.dhis2.org/browse/DHIS2-3891