### PR TITLE
Remove index.html from url since dashboard uses hash routing now [DHIS2-3668]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/about/menuDashboard.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/about/menuDashboard.vm
@@ -7,7 +7,7 @@
 <h2>$i18n.getString( "dashboard" )&nbsp;</h2>
 
 <ul>
-    <li><a href="../dhis-web-dashboard/index.html">$i18n.getString( "dashboard" )&nbsp;</a></li>
+    <li><a href="../dhis-web-dashboard/">$i18n.getString( "dashboard" )&nbsp;</a></li>
     <li><a href="../dhis-web-user-profile/#/profile">$i18n.getString( "profile" )&nbsp;</a></li>
     <li><a href="../dhis-web-messaging/message.action">$i18n.getString( "messages" )&nbsp;</a></li>
     <li><a href="../dhis-web-messaging/interpretation.action">$i18n.getString( "interpretations" )&nbsp;</a></li>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
@@ -66,7 +66,7 @@ public class RedirectAction
         String startModule = (String) systemSettingManager.getSystemSetting( SettingKey.START_MODULE );
 
         String contextPath = (String) ContextUtils.getContextPath( ServletActionContext.getRequest() );
-        
+
         if ( startModule != null && !startModule.trim().isEmpty() )
         {
             if ( startModule.startsWith( "app:" ) )
@@ -89,7 +89,7 @@ public class RedirectAction
             }
         }
 
-        redirectUrl = "../dhis-web-dashboard/index.html";
+        redirectUrl = "../dhis-web-dashboard/";
 
         return SUCCESS;
     }


### PR DESCRIPTION
The dashboard now uses client-side routing using a hash. Therefore, it is no longer useful, and is in fact ugly, to include index.html in the url