### PR TITLE
remove postfix index.action from dhis-web-importexport

### DIFF
--- a/dhis-2/dhis-web/dhis-web-importexport/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-importexport/src/main/webapp/WEB-INF/web.xml
@@ -20,7 +20,7 @@
     <async-supported>true</async-supported>
     <init-param>
       <param-name>redirectPath</param-name>
-      <param-value>dhis-web-importexport/index.action</param-value>
+      <param-value>dhis-web-importexport/</param-value>
     </init-param>
   </filter>
   <filter>


### PR DESCRIPTION
App uses _index.html_ for all inner app urls.