### PR TITLE
[Fix] Add suport for html interpretation/comments in mentions parsing

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -134,6 +134,12 @@
         <groupId>com.vividsolutions</groupId>
         <artifactId>jts-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.11.3</version>
+    </dependency>
+
   </dependencies>
 
   <properties>

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/MentionUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/MentionUtils.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
+import org.jsoup.Jsoup;
 
 public final class MentionUtils
 {
@@ -59,7 +60,8 @@ public final class MentionUtils
     public static Set<User> getMentionedUsers( String text, UserService userService )
     {
         Set<User> users = new HashSet<>();
-        Matcher matcher = Pattern.compile( "(?:\\s|^)@([\\w+._-]+)" ).matcher( text );
+        String plainText = Jsoup.parse( text ).text();
+        Matcher matcher = Pattern.compile( "(?:\\s|^)@([\\w+._-]+)" ).matcher( plainText );
         while ( matcher.find() )
         {
             String username = matcher.group( 1 );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/interpretation/InterpretationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/interpretation/InterpretationServiceTest.java
@@ -272,7 +272,7 @@ public class InterpretationServiceTest
         assertNotNull( interpretationA.getMentions() );
         assertEquals( 2, interpretationA.getMentions().size() );
         
-        InterpretationComment interpretationComment = interpretationService.addInterpretationComment( uid, "This interpretation is good @" +  userA.getUsername() + " @" + userB.getUsername());
+        InterpretationComment interpretationComment = interpretationService.addInterpretationComment( uid, "This interpretation with HTML is good <p>@" +  userA.getUsername() + "</p> <b>@" + userB.getUsername() + "</b>");
         assertNotNull( interpretationComment.getMentions() );
         assertEquals( 2, interpretationComment.getMentions().size() );
         
@@ -321,7 +321,7 @@ public class InterpretationServiceTest
         interpretationComment3 = interpretationService.addInterpretationComment( uid, "This interpretation has a fake mention @thisisnotauser");
         assertNotNull( interpretationComment3.getMentions() );
         assertEquals( 0, interpretationComment3.getMentions().size() );
-        
+
         interpretationA = interpretationService.getInterpretation( uid );
         assertNotNull( interpretationA.getComments() );
         assertEquals( 2, interpretationA.getComments().size() );


### PR DESCRIPTION
Required by https://jira.dhis2.org/browse/DHIS2-3422

Now that we have HTML in interpretations and comments, the extraction of mentions from the text should also use Jsoup (similar to https://github.com/dhis2/dhis2-core/pull/2019), otherwise HTML strings like `<p>@admin</p>` will not parse the mention correctly.

Note: There was an option to modify the regexp instead, something like `(?:\\W|\\s|^)@([\\w+._-]+)`, but using a parser seems cleaner.

https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/MentionUtils.java#L62