### PR TITLE
[DHIS2-3871] Minor fix for ValidateUser error message E3003.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -587,7 +587,7 @@ public class DefaultUserService
         {
             if ( !currentUser.getUserCredentials().canIssueUserRole( ur, canGrantOwnUserAuthorityGroups ) )
             {
-                errors.add( new ErrorReport( UserAuthorityGroup.class, ErrorCode.E3003, currentUser, ur ) );
+                errors.add( new ErrorReport( UserAuthorityGroup.class, ErrorCode.E3003, currentUser.getUsername(), ur.getName() ) );
             }
         } );
 


### PR DESCRIPTION
After the fix the error msg will look like below 

{"importParams":{"userOverrideMode":"NONE","importMode":"COMMIT","identifier":"UID","preheatMode":"REFERENCE","importStrategy":"UPDATE","atomicMode":"ALL","mergeMode":"REPLACE","flushMode":"AUTO","skipSharing":false,"skipValidation":false,"username":"testInter"},"status":"ERROR","stats":{"created":0,"updated":0,"deleted":0,"ignored":1,"total":1},"typeReports":[{"klass":"org.hisp.dhis.user.User","stats":{"created":0,"updated":0,"deleted":0,"ignored":1,"total":1},"objectReports":[{"klass":"org.hisp.dhis.user.User","index":0,"uid":"VjfCB52lPd1","errorReports":[{"message":"User `testInter` is not allowed to grant users access to user role `System administrator (ALL)`.","mainKlass":"org.hisp.dhis.user.UserAuthorityGroup","errorCode":"E3003"},{"message":"User `testInter` is not allowed to grant users access to user role `User manager`.","mainKlass":"org.hisp.dhis.user.UserAuthorityGroup","errorCode":"E3003"}]}]}]}