### PR TITLE
Minor fix for custom app authority name.

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -46,7 +46,7 @@ public class App
      */
     private static final long serialVersionUID = -6638197841892194228L;
 
-    public static final String SEE_APP_AUTHORITY_PREFIX = "M_See_";
+    public static final String SEE_APP_AUTHORITY_PREFIX = "M_";
 
     /**
      * Required.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/TableAlteror.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/TableAlteror.java
@@ -717,7 +717,7 @@ public class TableAlteror
 
         executeSql( "UPDATE userroleauthorities SET authority='M_dhis-web-data-administration' WHERE authority='M_dhis-web-maintenance-dataadmin'" );
 
-        executeSql( "UPDATE userroleauthorities SET authority = 'M_' ||  replace(regexp_replace(authority, '[^a-zA-Z0-9\\s]', ''), ' ', '_') WHERE authority like 'See%'" );
+        executeSql( "UPDATE userroleauthorities SET authority = 'M_' ||  replace(regexp_replace(replace(authority, 'See ', '' ), '[^a-zA-Z0-9 ]', ''), ' ', '_') WHERE authority like 'See%'" );
 
         // remove unused authorities
         executeSql( "DELETE FROM userroleauthorities WHERE authority='F_CONCEPT_UPDATE'" );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/commons/action/GetSystemAuthoritiesAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/commons/action/GetSystemAuthoritiesAction.java
@@ -115,7 +115,7 @@ public class GetSystemAuthoritiesAction
         // Custom App doesn't have translation for See App authority
         if ( auth.startsWith( App.SEE_APP_AUTHORITY_PREFIX ) )
         {
-            return auth.replace( "M_", "" ).replaceAll( "_", " " );
+            return auth.replace( App.SEE_APP_AUTHORITY_PREFIX, "" ).replaceAll( "_", " " ) + " app";
         }
         else
         {


### PR DESCRIPTION
Currently the custom app authority looks like this

{
"id": "M_See_Custom_Js_Css",
"name": "See Custom Js Css"
}

we need to remove the "See " part from both the id and the name, and then add a " app" suffix to the name (edited) so that it becomes


{
"id": "M_Custom_Js_Css",
"name": "Custom Js Css app"
}