### PR TITLE
[DHIS2-4045] [DRC-29] Fix bug can't run update catOptionCombo in Data Admin app.

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryManager.java
@@ -1,0 +1,51 @@
+package org.hisp.dhis.category;
+
+/*
+ *
+ *  Copyright (c) 2004-2018, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @author Viet Nguyen <viet@dhis2.org>
+ */
+public interface CategoryManager
+{
+    /**
+     * Generates the complete set of category option combos for the given
+     * category combo. Removes obsolete category option combos.
+     *
+     * @param categoryCombo the CategoryCombo.
+     */
+    void addAndPruneOptionCombos( CategoryCombo categoryCombo );
+
+    /**
+     * Generates the complete set of category option combos for all category
+     * combos.
+     */
+    void addAndPruneAllOptionCombos();
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
@@ -427,20 +427,6 @@ public interface CategoryService
     void updateOptionCombos( CategoryCombo categoryCombo );
 
     /**
-     * Generates the complete set of category option combos for the given
-     * category combo. Removes obsolete category option combos.
-     *
-     * @param categoryCombo the CategoryCombo.
-     */
-    void addAndPruneOptionCombos( CategoryCombo categoryCombo );
-
-    /**
-     * Generates the complete set of category option combos for all category
-     * combos.
-     */
-    void addAndPruneAllOptionCombos();
-
-    /**
      * Returns the category option combo with the given uid. Respects access control
      * by only returning objects which all category options are accessible.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryManager.java
@@ -1,0 +1,132 @@
+package org.hisp.dhis.category;
+
+/*
+ *
+ *  Copyright (c) 2004-2018, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import com.google.common.collect.Sets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Viet Nguyen <viet@dhis2.org>
+ */
+@Transactional
+public class DefaultCategoryManager
+    implements CategoryManager
+{
+    // -------------------------------------------------------------------------
+    // Dependencies
+    // -------------------------------------------------------------------------
+
+    private static final Log log = LogFactory.getLog( DefaultCategoryManager.class );
+
+    @Autowired
+    private CategoryService categoryService;
+
+    // -------------------------------------------------------------------------
+    // CategoryOptionCombo
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void addAndPruneOptionCombos( CategoryCombo categoryCombo )
+    {
+        if ( categoryCombo == null || !categoryCombo.isValid() )
+        {
+            log.warn( "Category combo is null or invalid, could not update option combos: " + categoryCombo );
+            return;
+        }
+
+        List<CategoryOptionCombo> generatedOptionCombos = categoryCombo.generateOptionCombosList();
+        Set<CategoryOptionCombo> persistedOptionCombos = Sets.newHashSet( categoryCombo.getOptionCombos() );
+
+        boolean modified = false;
+
+        for ( CategoryOptionCombo optionCombo : generatedOptionCombos )
+        {
+            if ( !persistedOptionCombos.contains( optionCombo ) )
+            {
+                categoryCombo.getOptionCombos().add( optionCombo );
+                categoryService.addCategoryOptionCombo( optionCombo );
+
+                log.info( "Added missing category option combo: " + optionCombo + " for category combo: " + categoryCombo.getName() );
+                modified = true;
+            }
+        }
+
+        Iterator<CategoryOptionCombo> iterator = persistedOptionCombos.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            CategoryOptionCombo optionCombo = iterator.next();
+
+            if ( !generatedOptionCombos.contains( optionCombo ) )
+            {
+                try
+                {
+                    categoryService.deleteCategoryOptionCombo( optionCombo );
+                }
+                catch ( Exception ex )
+                {
+                    log.warn( "Could not delete category option combo: " + optionCombo );
+                    continue;
+                }
+
+                iterator.remove();
+                categoryCombo.getOptionCombos().remove( optionCombo );
+                categoryService.deleteCategoryOptionCombo( optionCombo );
+
+                log.info( "Deleted obsolete category option combo: " + optionCombo + " for category combo: " + categoryCombo.getName() );
+                modified = true;
+            }
+        }
+
+        if ( modified )
+        {
+            categoryService.updateCategoryCombo( categoryCombo );
+        }
+    }
+
+    @Override
+    public void addAndPruneAllOptionCombos()
+    {
+        List<CategoryCombo> categoryCombos = categoryService.getAllCategoryCombos();
+
+        for ( CategoryCombo categoryCombo : categoryCombos )
+        {
+            addAndPruneOptionCombos( categoryCombo );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
@@ -60,7 +60,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -605,75 +604,7 @@ public class DefaultCategoryService
         }
     }
 
-    @Override
-    public void addAndPruneOptionCombos( CategoryCombo categoryCombo )
-    {
-        if ( categoryCombo == null || !categoryCombo.isValid() )
-        {
-            log.warn( "Category combo is null or invalid, could not update option combos: " + categoryCombo );
-            return;
-        }
 
-        List<CategoryOptionCombo> generatedOptionCombos = categoryCombo.generateOptionCombosList();
-        Set<CategoryOptionCombo> persistedOptionCombos = Sets.newHashSet( categoryCombo.getOptionCombos() );
-
-        boolean modified = false;
-
-        for ( CategoryOptionCombo optionCombo : generatedOptionCombos )
-        {
-            if ( !persistedOptionCombos.contains( optionCombo ) )
-            {
-                categoryCombo.getOptionCombos().add( optionCombo );
-                addCategoryOptionCombo( optionCombo );
-
-                log.info( "Added missing category option combo: " + optionCombo + " for category combo: " + categoryCombo.getName() );
-                modified = true;
-            }
-        }
-
-        Iterator<CategoryOptionCombo> iterator = persistedOptionCombos.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            CategoryOptionCombo optionCombo = iterator.next();
-
-            if ( !generatedOptionCombos.contains( optionCombo ) )
-            {
-                try
-                {
-                    idObjectManager.delete( optionCombo );
-                }
-                catch ( Exception ex )
-                {
-                    log.warn( "Could not delete category option combo: " + optionCombo );
-                    continue;
-                }
-
-                iterator.remove();
-                categoryCombo.getOptionCombos().remove( optionCombo );
-                deleteCategoryOptionCombo( optionCombo );
-
-                log.info( "Deleted obsolete category option combo: " + optionCombo + " for category combo: " + categoryCombo.getName() );
-                modified = true;
-            }
-        }
-
-        if ( modified )
-        {
-            updateCategoryCombo( categoryCombo );
-        }
-    }
-
-    @Override
-    public void addAndPruneAllOptionCombos()
-    {
-        List<CategoryCombo> categoryCombos = getAllCategoryCombos();
-
-        for ( CategoryCombo categoryCombo : categoryCombos )
-        {
-            addAndPruneOptionCombos( categoryCombo );
-        }
-    }
 
     @Override
     public CategoryOptionCombo getCategoryOptionComboAcl( IdentifiableProperty property, String id )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
@@ -139,7 +139,7 @@ public class DefaultCategoryService
     {
         this.aclService = aclService;
     }
-        
+
     // -------------------------------------------------------------------------
     // Category
     // -------------------------------------------------------------------------
@@ -641,7 +641,7 @@ public class DefaultCategoryService
             {
                 try
                 {
-                    deleteCategoryOptionCombo( optionCombo );
+                    idObjectManager.delete( optionCombo );
                 }
                 catch ( Exception ex )
                 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionItemDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionItemDeletionHandler.java
@@ -1,0 +1,72 @@
+package org.hisp.dhis.dimension;
+
+/*
+ *
+ *  Copyright (c) 2004-2018, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.DataDimensionItem;
+import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * @author Viet Nguyen <viet@dhis2.org>
+ */
+public class DataDimensionItemDeletionHandler
+    extends DeletionHandler
+{
+    // -------------------------------------------------------------------------
+    // Dependencies
+    // -------------------------------------------------------------------------
+
+    private JdbcTemplate jdbcTemplate;
+
+    public void setJdbcTemplate( JdbcTemplate jdbcTemplate )
+    {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    // -------------------------------------------------------------------------
+    // DeletionHandler implementation
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected String getClassName()
+    {
+        return DataDimensionItem.class.getSimpleName();
+    }
+
+    @Override
+    public String allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
+    {
+        String sql = "SELECT COUNT(*) FROM datadimensionitem where dataelementoperand_categoryoptioncomboid=" + optionCombo.getId();
+
+        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? null : ERROR;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -1658,6 +1658,10 @@
     <property name="jdbcTemplate" ref="jdbcTemplate" />
   </bean>
 
+  <bean id="org.hisp.dhis.dimension.DataDimensionItemDeletionHandler" class="org.hisp.dhis.dimension.DataDimensionItemDeletionHandler">
+    <property name="jdbcTemplate" ref="jdbcTemplate" />
+  </bean>
+
   <bean id="org.hisp.dhis.dataset.DataInputPeriodDeletionHandler" class="org.hisp.dhis.dataset.DataInputPeriodDeletionHandler">
     <property name="jdbcTemplate" ref="jdbcTemplate" />
   </bean>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -904,6 +904,8 @@
 
   <bean id="validationNotificationMessageRenderer" class="org.hisp.dhis.notification.ValidationNotificationMessageRenderer" />
 
+  <bean id="org.hisp.dhis.category.CategoryManager" class="org.hisp.dhis.category.DefaultCategoryManager"/>
+
   <bean id="org.hisp.dhis.category.CategoryService" class="org.hisp.dhis.dataelement.DefaultCategoryService">
     <property name="categoryStore" ref="org.hisp.dhis.category.CategoryStore" />
     <property name="categoryOptionStore" ref="org.hisp.dhis.category.CategoryOptionStore" />

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -33,19 +33,20 @@ import org.hisp.dhis.DhisTest;
 import org.hisp.dhis.IntegrationTest;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsService;
-import org.hisp.dhis.mock.MockAnalyticsService;
+import org.hisp.dhis.category.CategoryManager;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElementDomain;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.expression.Expression;
 import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.mock.MockAnalyticsService;
 import org.hisp.dhis.mock.MockCurrentUserService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
@@ -151,6 +152,9 @@ public class EventPredictionServiceTest
 
     @Autowired
     private CurrentUserService currentUserService;
+
+    @Autowired
+    private CategoryManager categoryManager;
 
     private CategoryOptionCombo defaultCombo;
 
@@ -295,7 +299,7 @@ public class EventPredictionServiceTest
         programStageInstanceService.addProgramStageInstance( stageInstanceA );
         programStageInstanceService.addProgramStageInstance( stageInstanceB );
 
-        categoryService.addAndPruneAllOptionCombos();
+        categoryManager.addAndPruneAllOptionCombos();
 
         Expression expressionA = new Expression( EXPRESSION_A, "ProgramTrackedEntityAttribute" );
         Expression expressionD = new Expression( EXPRESSION_D, "ProgramDataElement" );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/EventValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/EventValidationServiceTest.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.DhisTest;
 import org.hisp.dhis.IntegrationTest;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsService;
+import org.hisp.dhis.category.CategoryManager;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
@@ -127,6 +128,9 @@ public class EventValidationServiceTest
 
     @Autowired
     private ValidationRuleService validationRuleService;
+
+    @Autowired
+    private CategoryManager categoryManager;
 
     private CategoryOptionCombo defaultCombo;
 
@@ -233,7 +237,7 @@ public class EventValidationServiceTest
         programStageInstanceService.addProgramStageInstance( stageInstanceA );
         programStageInstanceService.addProgramStageInstance( stageInstanceB );
 
-        categoryService.addAndPruneAllOptionCombos();
+        categoryManager.addAndPruneAllOptionCombos();
 
         Expression expressionA = new Expression( EXPRESSION_A, "ProgramTrackedEntityAttribute" );
         Expression expressionD = new Expression( EXPRESSION_D, "ProgramDataElement" );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.analytics.AnalyticsTableService;
 import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.cache.HibernateCacheManager;
+import org.hisp.dhis.category.CategoryManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -103,6 +104,9 @@ public class MaintenanceController
 
     @Autowired
     private List<AnalyticsTableService> analyticsTableService;
+
+    @Autowired
+    private CategoryManager categoryManager;
 
     @Autowired
     private AppManager appManager;
@@ -208,7 +212,7 @@ public class MaintenanceController
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCategoryOptionCombos()
     {
-        categoryService.addAndPruneAllOptionCombos();
+        categoryManager.addAndPruneAllOptionCombos();
     }
 
     @RequestMapping( value = { "/cacheClear", "/cache" }, method = { RequestMethod.PUT, RequestMethod.POST } )


### PR DESCRIPTION
- Add DataDimensionItemDeletionHandler as below error is thrown.
- Created CategoryManager so the method deleteCategoryOptionCombo() will be called by CategoryService proxy, thus the DeletionHandlers can be triggered by Spring AOP.


ERROR 2018-07-03 21:22:38,084 ERROR: update or delete on table "categoryoptioncombo" violates foreign key constraint "fk_datadimensionitem_dataelementoperand_categoryoptioncomboid" on table "datadimensionitem"