### PR TITLE
[Dhis2-4230] 2.29 Performance fix for api/trackedEntityInstances

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -203,6 +203,11 @@ public class TrackedEntityInstanceQueryParams
      */
     private List<String> orders;
 
+    /**
+     * All readable TrackedEntityAttribute of current User
+     */
+    private Set<TrackedEntityAttribute> readableAttributes = new HashSet<>();
+
     // -------------------------------------------------------------------------
     // Transient properties
     // -------------------------------------------------------------------------
@@ -939,5 +944,15 @@ public class TrackedEntityInstanceQueryParams
     public void setOrders( List<String> orders )
     {
         this.orders = orders;
+    }
+
+    public Set<TrackedEntityAttribute> getReadableAttributes()
+    {
+        return this.readableAttributes;
+    }
+
+    public void setReadableAttributes( Set<TrackedEntityAttribute> readableAttributes )
+    {
+        this.readableAttributes = readableAttributes;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -140,7 +140,7 @@ public class DefaultTrackedEntityInstanceService
             params.addAttributes( QueryItem.getQueryItems( attributes ) );
             params.addFiltersIfNotExist( QueryItem.getQueryItems( attributes ) );
         }
-        
+
         decideAccess( params );
         validate( params );
         
@@ -150,16 +150,16 @@ public class DefaultTrackedEntityInstanceService
         {
             params.setDefaultPaging();
         }
-        
-        Set<TrackedEntityAttribute> readableAttributes = attributeService.getAllUserReadableTrackedEntityAttributes();
-            
+
+        Set<TrackedEntityAttribute> readableAttributes = params.getReadableAttributes();
+
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceStore.getTrackedEntityInstances( params );
- 
+
         for( TrackedEntityInstance tei : trackedEntityInstances )
         {             
             tei.setTrackedEntityAttributeValues( tei.getTrackedEntityAttributeValues().stream().filter( av -> readableAttributes.contains( av.getAttribute() ) ).collect( Collectors.toSet() ) );
         }
-        
+
         return trackedEntityInstances;
         
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -200,7 +200,7 @@ public class HibernateTrackedEntityInstanceStore
 
             if ( params.hasProgramStatus() )
             {
-                hql += hlp.whereAnd() + "pi.status = " + params.getProgramStatus();
+                hql += hlp.whereAnd() + "pi.status = '" + params.getProgramStatus() + "'";
             }
 
             if ( params.hasFollowUp() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
@@ -32,12 +32,14 @@ import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.user.User;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -63,6 +65,27 @@ public interface TrackedEntityInstanceService
     TrackedEntityInstance getTrackedEntityInstance( org.hisp.dhis.trackedentity.TrackedEntityInstance entityInstance,
         TrackedEntityInstanceParams params );
 
+    /**
+     * @param entityInstance DAO TrackedEntityInstance
+     * @param params TrackedEntityInstanceParams
+     * @param user current User
+     * @return DTO TrackedEntityInstance
+     */
+    TrackedEntityInstance getTrackedEntityInstance( org.hisp.dhis.trackedentity.TrackedEntityInstance entityInstance,
+        TrackedEntityInstanceParams params, User user );
+
+    /**
+     *
+     * @param entityInstance DAO TrackedEntityInstance
+     * @param params TrackedEntityInstanceParams
+     * @param readableAttributes All readable TrackedEntityAttributes of current User
+     * @param user current User
+     * @return DTO TrackedEntityInstance
+     */
+    TrackedEntityInstance getTrackedEntityInstance( org.hisp.dhis.trackedentity.TrackedEntityInstance entityInstance,
+        TrackedEntityInstanceParams params, Set<TrackedEntityAttribute> readableAttributes, User user );
+
+
     // -------------------------------------------------------------------------
     // CREATE
     // -------------------------------------------------------------------------
@@ -70,9 +93,6 @@ public interface TrackedEntityInstanceService
     ImportSummaries addTrackedEntityInstanceXml( InputStream inputStream, ImportOptions importOptions ) throws IOException;
 
     ImportSummaries addTrackedEntityInstanceJson( InputStream inputStream, ImportOptions importOptions ) throws IOException;
-
-    TrackedEntityInstance getTrackedEntityInstance( org.hisp.dhis.trackedentity.TrackedEntityInstance entityInstance,
-        TrackedEntityInstanceParams params, User user );
 
     ImportSummaries addTrackedEntityInstances( List<TrackedEntityInstance> trackedEntityInstances, ImportOptions importOptions );
 


### PR DESCRIPTION
Move the below method call outside of the loop. 

Set<TrackedEntityAttribute> readableAttributes = trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes( user );

https://jira.dhis2.org/browse/DHIS2-4230

I will port this fix to other versions after it is reviewed and merged. 