### PR TITLE
Fixes bug with unintentional return of deleted events. - DHIS2-4276

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
@@ -39,6 +39,8 @@ public class TrackedEntityInstanceParams
 
     public static final TrackedEntityInstanceParams FALSE = new TrackedEntityInstanceParams( false, false, false, false );
 
+    public static final TrackedEntityInstanceParams DATA_SYNCHRONIZATION = new TrackedEntityInstanceParams( true, true, true, true, true );
+
     private boolean includeRelationships;
 
     private boolean includeEnrollments;
@@ -53,13 +55,6 @@ public class TrackedEntityInstanceParams
     {
     }
 
-    public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents )
-    {
-        this.includeRelationships = includeRelationships;
-        this.includeEnrollments = includeEnrollments;
-        this.includeEvents = includeEvents;
-    }
-
     public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
         boolean includeProgramOwners )
     {
@@ -67,6 +62,16 @@ public class TrackedEntityInstanceParams
         this.includeEnrollments = includeEnrollments;
         this.includeEvents = includeEvents;
         this.includeProgramOwners = includeProgramOwners;
+    }
+
+    public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
+        boolean includeProgramOwners, boolean includeDeleted )
+    {
+        this.includeRelationships = includeRelationships;
+        this.includeEnrollments = includeEnrollments;
+        this.includeEvents = includeEvents;
+        this.includeProgramOwners = includeProgramOwners;
+        this.includeDeleted = includeDeleted;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -107,8 +107,7 @@ public class TrackerSynchronization
         log.info( "Tracker sync job has " + pages + " pages to sync. With page size: " + trackerSyncPageSize );
 
         queryParams.setPageSize( trackerSyncPageSize );
-        TrackedEntityInstanceParams params = TrackedEntityInstanceParams.TRUE;
-        params.setIncludeDeleted( true );
+        TrackedEntityInstanceParams params = TrackedEntityInstanceParams.DATA_SYNCHRONIZATION;
         boolean syncResult = true;
 
         for ( int i = 1; i <= pages; i++ )


### PR DESCRIPTION
Fixing the problem with having wrong values in public static final field which lead to unexpected behavior (e.g. when sync job run first and then some request for the API came, the includeDeleted was set to true which was not planned)