### PR TITLE
Fixes bug with unintentional return of deleted events. - DHIS2-4276

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
@@ -39,6 +39,8 @@ public class TrackedEntityInstanceParams
 
     public static final TrackedEntityInstanceParams FALSE = new TrackedEntityInstanceParams( false, false, false, false );
 
+    public static final TrackedEntityInstanceParams DATA_SYNCHRONIZATION = new TrackedEntityInstanceParams( true, true, true, true, true );
+
     private boolean includeRelationships;
 
     private boolean includeEnrollments;
@@ -53,13 +55,6 @@ public class TrackedEntityInstanceParams
     {
     }
 
-    public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents )
-    {
-        this.includeRelationships = includeRelationships;
-        this.includeEnrollments = includeEnrollments;
-        this.includeEvents = includeEvents;
-    }
-
     public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
         boolean includeProgramOwners )
     {
@@ -67,6 +62,16 @@ public class TrackedEntityInstanceParams
         this.includeEnrollments = includeEnrollments;
         this.includeEvents = includeEvents;
         this.includeProgramOwners = includeProgramOwners;
+    }
+
+    public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
+        boolean includeProgramOwners, boolean includeDeleted )
+    {
+        this.includeRelationships = includeRelationships;
+        this.includeEnrollments = includeEnrollments;
+        this.includeEvents = includeEvents;
+        this.includeProgramOwners = includeProgramOwners;
+        this.includeDeleted = includeDeleted;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dxf2.events;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -45,8 +44,10 @@ public class TrackedEntityInstanceParams
     private boolean includeEnrollments;
 
     private boolean includeEvents;
-    
+
     private boolean includeProgramOwners;
+
+    private boolean includeDeleted = false;
 
     public TrackedEntityInstanceParams()
     {
@@ -58,7 +59,7 @@ public class TrackedEntityInstanceParams
         this.includeEnrollments = includeEnrollments;
         this.includeEvents = includeEvents;
     }
-    
+
     public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
         boolean includeProgramOwners )
     {
@@ -100,7 +101,7 @@ public class TrackedEntityInstanceParams
     {
         this.includeEvents = includeEvents;
     }
-    
+
     @JsonProperty
     public boolean isIncludeProgramOwners()
     {
@@ -112,13 +113,25 @@ public class TrackedEntityInstanceParams
         this.includeProgramOwners = includeProgramOwners;
     }
 
-    @Override
-    public String toString()
+    @JsonProperty
+    public boolean isIncludeDeleted()
     {
-        return MoreObjects.toStringHelper( this )
-            .add( "includeRelationships", includeRelationships )
-            .add( "includeEnrollments", includeEnrollments )
-            .add( "includeEvents", includeEvents )
-            .toString();
+        return includeDeleted;
+    }
+
+    public void setIncludeDeleted( boolean includeDeleted )
+    {
+        this.includeDeleted = includeDeleted;
+    }
+
+    @Override public String toString()
+    {
+        return "TrackedEntityInstanceParams{" +
+            "includeRelationships=" + includeRelationships +
+            ", includeEnrollments=" + includeEnrollments +
+            ", includeEvents=" + includeEvents +
+            ", includeProgramOwners=" + includeProgramOwners +
+            ", includeDeleted=" + includeDeleted +
+            '}';
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -338,7 +338,7 @@ public abstract class AbstractEnrollmentService
         {
             for ( ProgramStageInstance programStageInstance : programInstance.getProgramStageInstances() )
             {
-                if ( !programStageInstance.isDeleted() && trackerAccessManager.canRead( user, programStageInstance ).isEmpty() )
+                if ( (params.isIncludeDeleted() || !programStageInstance.isDeleted()) && trackerAccessManager.canRead( user, programStageInstance ).isEmpty() )
                 {
                     enrollment.getEvents().add( eventService.getEvent( programStageInstance ) );
                 }
@@ -936,7 +936,7 @@ public abstract class AbstractEnrollmentService
 
     private boolean doValidationOfMandatoryAttributes( User user )
     {
-        return !( user != null && user.isAuthorized( Authorities.F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION.getAuthority() ) );
+        return user == null || !user.isAuthorized( Authorities.F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION.getAuthority() );
     }
 
     private List<ImportConflict> checkAttributes( Enrollment enrollment, ImportOptions importOptions )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -108,6 +108,7 @@ public class TrackerSynchronization
 
         queryParams.setPageSize( trackerSyncPageSize );
         TrackedEntityInstanceParams params = TrackedEntityInstanceParams.TRUE;
+        params.setIncludeDeleted( true );
         boolean syncResult = true;
 
         for ( int i = 1; i <= pages; i++ )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -107,8 +107,7 @@ public class TrackerSynchronization
         log.info( "Tracker sync job has " + pages + " pages to sync. With page size: " + trackerSyncPageSize );
 
         queryParams.setPageSize( trackerSyncPageSize );
-        TrackedEntityInstanceParams params = TrackedEntityInstanceParams.TRUE;
-        params.setIncludeDeleted( true );
+        TrackedEntityInstanceParams params = TrackedEntityInstanceParams.DATA_SYNCHRONIZATION;
         boolean syncResult = true;
 
         for ( int i = 1; i <= pages; i++ )


### PR DESCRIPTION
Backport to 2.30: Fixing the problem with having wrong values in public static final field which lead to unexpected behavior (e.g. when sync job run first and then some request for the API came, the includeDeleted was set to true which was not planned)