### PR TITLE
Fixes bug with not skipping PSDEs that should be skipped - DHIS2-4280

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValue.java
@@ -72,6 +72,8 @@ public class TrackedEntityDataValue
 
     private transient String auditValue;
 
+    private transient boolean skipSynchronization = false;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -161,14 +163,6 @@ public class TrackedEntityDataValue
         return true;
     }
 
-    @Override
-    public String toString()
-    {
-        return "TrackedEntityDataValue{" + "dataElement=" + dataElement + ", programStageInstance=" + programStageInstance
-            + ", lastUpdated=" + lastUpdated + ", value='" + value + '\'' + ", providedElsewhere=" + providedElsewhere
-            + ", storedBy='" + storedBy + '\'' + '}';
-    }
-
     // -------------------------------------------------------------------------
     // Getters and setters
     // -------------------------------------------------------------------------
@@ -254,5 +248,29 @@ public class TrackedEntityDataValue
     public String getAuditValue()
     {
         return auditValue;
+    }
+
+    public Boolean isSkipSynchronization()
+    {
+        return skipSynchronization;
+    }
+
+    public void setSkipSynchronization( Boolean skipSynchronization )
+    {
+        this.skipSynchronization = skipSynchronization;
+    }
+
+    @Override public String toString()
+    {
+        return "TrackedEntityDataValue{" +
+            "dataElement=" + dataElement +
+            ", programStageInstance=" + programStageInstance.getUid() +
+            ", created=" + created +
+            ", lastUpdated=" + lastUpdated +
+            ", value='" + value + '\'' +
+            ", providedElsewhere=" + providedElsewhere +
+            ", storedBy='" + storedBy + '\'' +
+            ", skipSynchronization='" + skipSynchronization + '\'' +
+            '}';
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValue.java
@@ -72,8 +72,6 @@ public class TrackedEntityDataValue
 
     private transient String auditValue;
 
-    private transient boolean skipSynchronization = false;
-
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -250,16 +248,6 @@ public class TrackedEntityDataValue
         return auditValue;
     }
 
-    public Boolean isSkipSynchronization()
-    {
-        return skipSynchronization;
-    }
-
-    public void setSkipSynchronization( Boolean skipSynchronization )
-    {
-        this.skipSynchronization = skipSynchronization;
-    }
-
     @Override public String toString()
     {
         return "TrackedEntityDataValue{" +
@@ -270,7 +258,6 @@ public class TrackedEntityDataValue
             ", value='" + value + '\'' +
             ", providedElsewhere=" + providedElsewhere +
             ", storedBy='" + storedBy + '\'' +
-            ", skipSynchronization='" + skipSynchronization + '\'' +
             '}';
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueService.java
@@ -28,13 +28,13 @@ package org.hisp.dhis.trackedentitydatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -46,47 +46,54 @@ public interface TrackedEntityDataValueService
 
     /**
      * Adds an {@link TrackedEntityDataValue}
-     * 
+     *
      * @param dataValue The to TrackedEntityDataValue add.
      */
     void saveTrackedEntityDataValue( TrackedEntityDataValue dataValue );
 
     /**
      * Updates an {@link TrackedEntityDataValue}.
-     * 
+     *
      * @param dataValue the TrackedEntityDataValue to update.
      */
     void updateTrackedEntityDataValue( TrackedEntityDataValue dataValue );
 
     /**
      * Deletes a {@link TrackedEntityDataValue}.
-     * 
+     *
      * @param dataValue the TrackedEntityDataValue to delete.
      */
     void deleteTrackedEntityDataValue( TrackedEntityDataValue dataValue );
 
     /**
      * Deletes all {@link TrackedEntityDataValue} of {@link ProgramStageInstance}
-     * 
+     *
      * @param programStageInstance The {@link ProgramStageInstance}.
      */
     void deleteTrackedEntityDataValue( ProgramStageInstance programStageInstance );
 
     /**
      * Retrieve data values of a event
-     * 
+     *
      * @param programStageInstance ProgramStageInstance
-     * 
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> getTrackedEntityDataValues( ProgramStageInstance programStageInstance );
 
     /**
-     * Retrieve data values of a event with data elements specified
-     * 
+     * Retrieve data values of an event that should be synchronized by ProgramDataSynchronizationJob
+     * (so with skipsynchronization=false in programstagedataelement table)
+     *
      * @param programStageInstance ProgramStageInstance
-     * @param dataElement DataElement List
-     * 
+     * @return TrackedEntityDataValue list
+     */
+    List<TrackedEntityDataValue> getTrackedEntityDataValuesForSynchronization( ProgramStageInstance programStageInstance );
+
+    /**
+     * Retrieve data values of a event with data elements specified
+     *
+     * @param programStageInstance ProgramStageInstance
+     * @param dataElement          DataElement List
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> getTrackedEntityDataValues( ProgramStageInstance programStageInstance,
@@ -94,18 +101,16 @@ public interface TrackedEntityDataValueService
 
     /**
      * Retrieve data values of many events
-     * 
+     *
      * @param programStageInstances the collection of ProgramStageInstances
-     * 
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> getTrackedEntityDataValues( Collection<ProgramStageInstance> programStageInstances );
 
     /**
      * Retrieve data values of a data element
-     * 
+     *
      * @param dataElement DataElement
-     * 
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> getTrackedEntityDataValues( DataElement dataElement );
@@ -113,12 +118,11 @@ public interface TrackedEntityDataValueService
     /**
      * Retrieve data values of a instance on data elements specified from
      * a certain period
-     * 
-     * @param instance TrackedEntityInstance
+     *
+     * @param instance     TrackedEntityInstance
      * @param dataElements DataElement List
-     * @param after Optional date the instance should be on or after.
-     * @param before Optional date the instance should be on or before.
-     * 
+     * @param after        Optional date the instance should be on or after.
+     * @param before       Optional date the instance should be on or before.
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> getTrackedEntityDataValues( TrackedEntityInstance instance, Collection<DataElement> dataElements,
@@ -126,10 +130,9 @@ public interface TrackedEntityDataValueService
 
     /**
      * Retrieve a data value on an event and a data element
-     * 
+     *
      * @param programStageInstance ProgramStageInstance
-     * @param dataElement DataElement
-     * 
+     * @param dataElement          DataElement
      * @return TrackedEntityDataValue
      */
     TrackedEntityDataValue getTrackedEntityDataValue( ProgramStageInstance programStageInstance, DataElement dataElement );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueStore.java
@@ -28,14 +28,14 @@ package org.hisp.dhis.trackedentitydatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
 import org.hisp.dhis.common.GenericStore;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -47,33 +47,40 @@ public interface TrackedEntityDataValueStore
 
     /**
      * Adds an {@link TrackedEntityDataValue}
-     * 
+     *
      * @param dataValue The to TrackedEntityDataValue add.
      */
     void saveVoid( TrackedEntityDataValue dataValue );
 
     /**
      * Deletes a {@link TrackedEntityDataValue}.
-     * 
+     *
      * @param programStageInstance ProgramStageInstance.
      */
     int delete( ProgramStageInstance programStageInstance );
 
     /**
      * Retrieve data values of a event
-     * 
+     *
      * @param programStageInstance ProgramStageInstance
-     * 
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> get( ProgramStageInstance programStageInstance );
 
     /**
-     * Retrieve data values of a event with data elements specified
-     * 
+     * Retrieve data values of an event that are supposed to be synchronized in ProgramDataSynchronizationJob
+     * (so with skipsynchronization=false in programstagedataelement table)
+     *
      * @param programStageInstance ProgramStageInstance
-     * @param dataElements DataElement List
-     * 
+     * @return TrackedEntityDataValue list
+     */
+    List<TrackedEntityDataValue> getTrackedEntityDataValuesForSynchronization( ProgramStageInstance programStageInstance );
+
+    /**
+     * Retrieve data values of a event with data elements specified
+     *
+     * @param programStageInstance ProgramStageInstance
+     * @param dataElements         DataElement List
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> get( ProgramStageInstance programStageInstance,
@@ -81,18 +88,16 @@ public interface TrackedEntityDataValueStore
 
     /**
      * Retrieve data values of many events
-     * 
+     *
      * @param programStageInstances ProgramStageInstance
-     * 
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> get( Collection<ProgramStageInstance> programStageInstances );
 
     /**
      * Retrieve data values on a data element
-     * 
+     *
      * @param dataElement {@link DataElement}
-     * 
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> get( DataElement dataElement );
@@ -100,12 +105,11 @@ public interface TrackedEntityDataValueStore
     /**
      * Retrieve data values of a {@link TrackedEntityInstance} on a
      * {@link DataElement} list.
-     * 
-     * @param instance TrackedEntityInstance
+     *
+     * @param instance     TrackedEntityInstance
      * @param dataElements The data element list
-     * @param after Optional date the instance should be on or after.
-     * @param before Optional date the instance should be on or before.
-     * 
+     * @param after        Optional date the instance should be on or after.
+     * @param before       Optional date the instance should be on or before.
      * @return TrackedEntityDataValue list
      */
     List<TrackedEntityDataValue> get( TrackedEntityInstance instance, Collection<DataElement> dataElements,
@@ -113,10 +117,9 @@ public interface TrackedEntityDataValueStore
 
     /**
      * Retrieve a data value on an event and a data element
-     * 
+     *
      * @param programStageInstance ProgramStageInstance
-     * @param dataElement DataElement
-     * 
+     * @param dataElement          DataElement
      * @return TrackedEntityDataValue
      */
     TrackedEntityDataValue get( ProgramStageInstance programStageInstance, DataElement dataElement );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -187,7 +187,7 @@ public class HibernateTrackedEntityInstanceStore
 
             if ( !params.isIncludeDeleted() )
             {
-                hql += hlp.whereAnd() + "pi.deleted is false";
+                hql += hlp.whereAnd() + "pi.deleted is false ";
             }
 
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -116,6 +116,13 @@ public class HibernateTrackedEntityInstanceStore
     public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params )
     {
         String hql = buildTrackedEntityInstanceHql( params );
+
+        //If it is a sync job running a query, I need to adjust an HQL a bit, because I am adding 2 joins and don't want duplicates in results
+        if ( params.isSynchronizationQuery() )
+        {
+            hql = hql.replaceFirst( "select tei from", "select distinct tei from" );
+        }
+
         Query query = getQuery( hql );
 
         if ( params.isPaging() )
@@ -183,6 +190,16 @@ public class HibernateTrackedEntityInstanceStore
                 hql += hlp.whereAnd() + "pi.deleted is false";
             }
 
+        }
+
+        //If it is a sync job that runs the query, fetch only TEAVs that are supposed to be synchronized
+        if ( params.isSynchronizationQuery() )
+        {
+
+            hql += "left join tei.trackedEntityAttributeValues teav1 " +
+                "left join teav1.attribute as attr";
+
+            hql += hlp.whereAnd() + " attr.skipSynchronization = false";
         }
 
         if ( params.hasTrackedEntityType() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/DefaultTrackedEntityDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/DefaultTrackedEntityDataValueService.java
@@ -40,11 +40,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsValid;
-
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+
+import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsValid;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -170,6 +170,12 @@ public class DefaultTrackedEntityDataValueService
     public List<TrackedEntityDataValue> getTrackedEntityDataValues( ProgramStageInstance programStageInstance )
     {
         return dataValueStore.get( programStageInstance );
+    }
+
+    @Override
+    public List<TrackedEntityDataValue> getTrackedEntityDataValuesForSynchronization( ProgramStageInstance programStageInstance )
+    {
+        return dataValueStore.getTrackedEntityDataValuesForSynchronization( programStageInstance );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueStore.java
@@ -76,14 +76,21 @@ public class HibernateTrackedEntityDataValueStore
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public List<TrackedEntityDataValue> get( ProgramStageInstance programStageInstance )
+    {
+        return getCriteria( Restrictions.eq( "programStageInstance", programStageInstance ) ).list();
+    }
+
+    @Override
+    public List<TrackedEntityDataValue> getTrackedEntityDataValuesForSynchronization( ProgramStageInstance programStageInstance )
     {
         List<TrackedEntityDataValue> dataValues = new ArrayList<>();
 
-        String sql = "SELECT tedv.*, psde.skipsynchronization " +
-            "FROM trackedentitydatavalue tedv LEFT JOIN programstageinstance psi on tedv.programstageinstanceid = psi.programstageinstanceid " +
+        String sql = "SELECT tedv.* FROM trackedentitydatavalue tedv " +
+            "LEFT JOIN programstageinstance psi on tedv.programstageinstanceid = psi.programstageinstanceid " +
             "LEFT JOIN programstagedataelement psde ON tedv.dataelementid = psde.dataelementid AND psi.programstageid = psde.programstageid " +
-            "WHERE tedv.programstageinstanceid = " + programStageInstance.getId();
+            "WHERE tedv.programstageinstanceid = " + programStageInstance.getId() + " AND psde.skipsynchronization = false";
 
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
 
@@ -93,7 +100,6 @@ public class HibernateTrackedEntityDataValueStore
 
             tedv.setCreated( rowSet.getDate( "created" ) );
             tedv.setLastUpdated( rowSet.getDate( "lastupdated" ) );
-            tedv.setSkipSynchronization( rowSet.getBoolean( "skipsynchronization" ) );
             tedv.setProgramStageInstance( programStageInstance );
             tedv.setValue( rowSet.getString( "value" ) );
             tedv.setStoredBy( rowSet.getString( "storedby" ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueStore.java
@@ -81,8 +81,8 @@ public class HibernateTrackedEntityDataValueStore
         List<TrackedEntityDataValue> dataValues = new ArrayList<>();
 
         String sql = "SELECT tedv.*, psde.skipsynchronization " +
-            "FROM trackedentitydatavalue tedv JOIN programstageinstance psi on tedv.programstageinstanceid = psi.programstageinstanceid " +
-            "JOIN programstagedataelement psde ON tedv.dataelementid = psde.dataelementid AND psi.programstageid = psde.programstageid " +
+            "FROM trackedentitydatavalue tedv LEFT JOIN programstageinstance psi on tedv.programstageinstanceid = psi.programstageinstanceid " +
+            "LEFT JOIN programstagedataelement psde ON tedv.dataelementid = psde.dataelementid AND psi.programstageid = psde.programstageid " +
             "WHERE tedv.programstageinstanceid = " + programStageInstance.getId();
 
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueStore.java
@@ -28,20 +28,25 @@ package org.hisp.dhis.trackedentitydatavalue.hibernate;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.criterion.Restrictions;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementStore;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValue;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -50,12 +55,18 @@ public class HibernateTrackedEntityDataValueStore
     extends HibernateGenericStore<TrackedEntityDataValue>
     implements TrackedEntityDataValueStore
 {
+    @Autowired
+    DataElementStore dataElementStore;
+
+    @Resource( name = "readOnlyJdbcTemplate" )
+    private JdbcTemplate jdbcTemplate;
+
     @Override
     public void saveVoid( TrackedEntityDataValue dataValue )
     {
         sessionFactory.getCurrentSession().save( dataValue );
     }
-   
+
     @Override
     public int delete( ProgramStageInstance programStageInstance )
     {
@@ -65,10 +76,34 @@ public class HibernateTrackedEntityDataValueStore
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public List<TrackedEntityDataValue> get( ProgramStageInstance programStageInstance )
     {
-        return getCriteria( Restrictions.eq( "programStageInstance", programStageInstance ) ).list();
+        List<TrackedEntityDataValue> dataValues = new ArrayList<>();
+
+        String sql = "SELECT tedv.*, psde.skipsynchronization " +
+            "FROM trackedentitydatavalue tedv JOIN programstageinstance psi on tedv.programstageinstanceid = psi.programstageinstanceid " +
+            "JOIN programstagedataelement psde ON tedv.dataelementid = psde.dataelementid AND psi.programstageid = psde.programstageid " +
+            "WHERE tedv.programstageinstanceid = " + programStageInstance.getId();
+
+        SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
+
+        while ( rowSet.next() )
+        {
+            TrackedEntityDataValue tedv = new TrackedEntityDataValue();
+
+            tedv.setCreated( rowSet.getDate( "created" ) );
+            tedv.setLastUpdated( rowSet.getDate( "lastupdated" ) );
+            tedv.setSkipSynchronization( rowSet.getBoolean( "skipsynchronization" ) );
+            tedv.setProgramStageInstance( programStageInstance );
+            tedv.setValue( rowSet.getString( "value" ) );
+            tedv.setStoredBy( rowSet.getString( "storedby" ) );
+            tedv.setProvidedElsewhere( rowSet.getBoolean( "providedelsewhere" ) );
+            tedv.setDataElement( dataElementStore.get( rowSet.getInt( "dataelementid" ) ) );
+
+            dataValues.add( tedv );
+        }
+
+        return dataValues;
     }
 
     @Override
@@ -80,7 +115,7 @@ public class HibernateTrackedEntityDataValueStore
         {
             return new ArrayList<>();
         }
-        
+
         return getCriteria( Restrictions.in( "dataElement", dataElements ), Restrictions.eq( "programStageInstance", programStageInstance ) ).list();
     }
 
@@ -107,12 +142,12 @@ public class HibernateTrackedEntityDataValueStore
     @SuppressWarnings( "unchecked" )
     public List<TrackedEntityDataValue> get( TrackedEntityInstance entityInstance, Collection<DataElement> dataElements, Date startDate,
         Date endDate )
-     {
+    {
         if ( dataElements == null || dataElements.isEmpty() )
         {
             return new ArrayList<>();
         }
-        
+
         Criteria criteria = getCriteria();
         criteria.createAlias( "programStageInstance", "programStageInstance" );
         criteria.createAlias( "programStageInstance.programInstance", "programInstance" );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueServiceTest.java
@@ -28,17 +28,7 @@ package org.hisp.dhis.trackedentitydatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -58,12 +48,26 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Chau Thu Tran
  */
 public class TrackedEntityDataValueServiceTest
     extends DhisSpringTest
 {
+    @Autowired
+    private SessionFactory sessionFactory;
+
     @Autowired
     private TrackedEntityDataValueService dataValueService;
 
@@ -218,6 +222,9 @@ public class TrackedEntityDataValueServiceTest
         dataValueService.saveTrackedEntityDataValue( dataValueB );
         dataValueService.saveTrackedEntityDataValue( dataValueC );
         dataValueService.saveTrackedEntityDataValue( dataValueD );
+
+        sessionFactory.getCurrentSession().flush();
+        sessionFactory.getCurrentSession().clear();
 
         List<TrackedEntityDataValue> dataValues = dataValueService.getTrackedEntityDataValues( stageInstanceA );
         assertEquals( 2, dataValues.size() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueServiceTest.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.trackedentitydatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -65,9 +64,6 @@ import static org.junit.Assert.assertTrue;
 public class TrackedEntityDataValueServiceTest
     extends DhisSpringTest
 {
-    @Autowired
-    private SessionFactory sessionFactory;
-
     @Autowired
     private TrackedEntityDataValueService dataValueService;
 
@@ -222,9 +218,6 @@ public class TrackedEntityDataValueServiceTest
         dataValueService.saveTrackedEntityDataValue( dataValueB );
         dataValueService.saveTrackedEntityDataValue( dataValueC );
         dataValueService.saveTrackedEntityDataValue( dataValueD );
-
-        sessionFactory.getCurrentSession().flush();
-        sessionFactory.getCurrentSession().clear();
 
         List<TrackedEntityDataValue> dataValues = dataValueService.getTrackedEntityDataValues( stageInstanceA );
         assertEquals( 2, dataValues.size() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueStoreTest.java
@@ -28,16 +28,7 @@ package org.hisp.dhis.trackedentitydatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -57,12 +48,25 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Chau Thu Tran
  */
 public class TrackedEntityDataValueStoreTest
     extends DhisSpringTest
 {
+    @Autowired
+    private SessionFactory sessionFactory;
+
     @Autowired
     private TrackedEntityDataValueStore dataValueStore;
 
@@ -185,7 +189,11 @@ public class TrackedEntityDataValueStoreTest
         dataValueStore.saveVoid( dataValueC );
         dataValueStore.saveVoid( dataValueD );
 
+        sessionFactory.getCurrentSession().flush();
+        sessionFactory.getCurrentSession().clear();
+
         List<TrackedEntityDataValue> dataValues = dataValueStore.get( stageInstanceA );
+
         assertEquals( 2, dataValues.size() );
         assertTrue( dataValues.contains( dataValueA ) );
         assertTrue( dataValues.contains( dataValueB ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueStoreTest.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.trackedentitydatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -64,9 +63,6 @@ import static org.junit.Assert.assertTrue;
 public class TrackedEntityDataValueStoreTest
     extends DhisSpringTest
 {
-    @Autowired
-    private SessionFactory sessionFactory;
-
     @Autowired
     private TrackedEntityDataValueStore dataValueStore;
 
@@ -188,9 +184,6 @@ public class TrackedEntityDataValueStoreTest
         dataValueStore.saveVoid( dataValueB );
         dataValueStore.saveVoid( dataValueC );
         dataValueStore.saveVoid( dataValueD );
-
-        sessionFactory.getCurrentSession().flush();
-        sessionFactory.getCurrentSession().clear();
 
         List<TrackedEntityDataValue> dataValues = dataValueStore.get( stageInstanceA );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dxf2.events;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -45,8 +44,10 @@ public class TrackedEntityInstanceParams
     private boolean includeEnrollments;
 
     private boolean includeEvents;
-    
+
     private boolean includeProgramOwners;
+
+    private boolean includeDeleted = false;
 
     public TrackedEntityInstanceParams()
     {
@@ -58,7 +59,7 @@ public class TrackedEntityInstanceParams
         this.includeEnrollments = includeEnrollments;
         this.includeEvents = includeEvents;
     }
-    
+
     public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
         boolean includeProgramOwners )
     {
@@ -100,7 +101,7 @@ public class TrackedEntityInstanceParams
     {
         this.includeEvents = includeEvents;
     }
-    
+
     @JsonProperty
     public boolean isIncludeProgramOwners()
     {
@@ -112,13 +113,25 @@ public class TrackedEntityInstanceParams
         this.includeProgramOwners = includeProgramOwners;
     }
 
-    @Override
-    public String toString()
+    @JsonProperty
+    public boolean isIncludeDeleted()
     {
-        return MoreObjects.toStringHelper( this )
-            .add( "includeRelationships", includeRelationships )
-            .add( "includeEnrollments", includeEnrollments )
-            .add( "includeEvents", includeEvents )
-            .toString();
+        return includeDeleted;
+    }
+
+    public void setIncludeDeleted( boolean includeDeleted )
+    {
+        this.includeDeleted = includeDeleted;
+    }
+
+    @Override public String toString()
+    {
+        return "TrackedEntityInstanceParams{" +
+            "includeRelationships=" + includeRelationships +
+            ", includeEnrollments=" + includeEnrollments +
+            ", includeEvents=" + includeEvents +
+            ", includeProgramOwners=" + includeProgramOwners +
+            ", includeDeleted=" + includeDeleted +
+            '}';
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceParams.java
@@ -39,7 +39,7 @@ public class TrackedEntityInstanceParams
 
     public static final TrackedEntityInstanceParams FALSE = new TrackedEntityInstanceParams( false, false, false, false );
 
-    public static final TrackedEntityInstanceParams DATA_SYNCHRONIZATION = new TrackedEntityInstanceParams( true, true, true, true, true );
+    public static final TrackedEntityInstanceParams DATA_SYNCHRONIZATION = new TrackedEntityInstanceParams( true, true, true, true, true, true );
 
     private boolean includeRelationships;
 
@@ -50,6 +50,8 @@ public class TrackedEntityInstanceParams
     private boolean includeProgramOwners;
 
     private boolean includeDeleted = false;
+
+    private boolean dataSynchronizationQuery = false;
 
     public TrackedEntityInstanceParams()
     {
@@ -65,13 +67,14 @@ public class TrackedEntityInstanceParams
     }
 
     public TrackedEntityInstanceParams( boolean includeRelationships, boolean includeEnrollments, boolean includeEvents,
-        boolean includeProgramOwners, boolean includeDeleted )
+        boolean includeProgramOwners, boolean includeDeleted, boolean dataSynchronizationQuery )
     {
         this.includeRelationships = includeRelationships;
         this.includeEnrollments = includeEnrollments;
         this.includeEvents = includeEvents;
         this.includeProgramOwners = includeProgramOwners;
         this.includeDeleted = includeDeleted;
+        this.dataSynchronizationQuery = dataSynchronizationQuery;
     }
 
     @JsonProperty
@@ -129,6 +132,17 @@ public class TrackedEntityInstanceParams
         this.includeDeleted = includeDeleted;
     }
 
+    @JsonProperty
+    public boolean isDataSynchronizationQuery()
+    {
+        return dataSynchronizationQuery;
+    }
+
+    public void setDataSynchronizationQuery( boolean dataSynchronizationQuery )
+    {
+        this.dataSynchronizationQuery = dataSynchronizationQuery;
+    }
+
     @Override public String toString()
     {
         return "TrackedEntityInstanceParams{" +
@@ -137,6 +151,7 @@ public class TrackedEntityInstanceParams
             ", includeEvents=" + includeEvents +
             ", includeProgramOwners=" + includeProgramOwners +
             ", includeDeleted=" + includeDeleted +
+            ", dataSynchronizationQuery=" + dataSynchronizationQuery +
             '}';
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -340,7 +340,7 @@ public abstract class AbstractEnrollmentService
             {
                 if ( (params.isIncludeDeleted() || !programStageInstance.isDeleted()) && trackerAccessManager.canRead( user, programStageInstance ).isEmpty() )
                 {
-                    enrollment.getEvents().add( eventService.getEvent( programStageInstance ) );
+                    enrollment.getEvents().add( eventService.getEvent( programStageInstance, params.isDataSynchronizationQuery() ) );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -338,7 +338,7 @@ public abstract class AbstractEnrollmentService
         {
             for ( ProgramStageInstance programStageInstance : programInstance.getProgramStageInstances() )
             {
-                if ( !programStageInstance.isDeleted() && trackerAccessManager.canRead( user, programStageInstance ).isEmpty() )
+                if ( (params.isIncludeDeleted() || !programStageInstance.isDeleted()) && trackerAccessManager.canRead( user, programStageInstance ).isEmpty() )
                 {
                     enrollment.getEvents().add( eventService.getEvent( programStageInstance ) );
                 }
@@ -936,7 +936,7 @@ public abstract class AbstractEnrollmentService
 
     private boolean doValidationOfMandatoryAttributes( User user )
     {
-        return !( user != null && user.isAuthorized( Authorities.F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION.getAuthority() ) );
+        return user == null || !user.isAuthorized( Authorities.F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION.getAuthority() );
     }
 
     private List<ImportConflict> checkAttributes( Enrollment enrollment, ImportOptions importOptions )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -777,10 +777,7 @@ public abstract class AbstractEventService
             return null;
         }
 
-        programStageInstance = programStageInstanceService.getProgramStageInstance( programStageInstance.getUid() );
-
         Event event = new Event();
-
         event.setEvent( programStageInstance.getUid() );
 
         if ( programStageInstance.getProgramInstance().getEntityInstance() != null )
@@ -858,6 +855,7 @@ public abstract class AbstractEventService
             value.setValue( dataValue.getValue() );
             value.setProvidedElsewhere( dataValue.getProvidedElsewhere() );
             value.setStoredBy( dataValue.getStoredBy() );
+            value.setSkipSynchronization( dataValue.isSkipSynchronization() );
 
             event.getDataValues().add( value );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -772,6 +772,12 @@ public abstract class AbstractEventService
     @Override
     public Event getEvent( ProgramStageInstance programStageInstance )
     {
+        return getEvent( programStageInstance, false );
+    }
+
+    @Override
+    public Event getEvent( ProgramStageInstance programStageInstance, boolean isSynchronizationQuery )
+    {
         if ( programStageInstance == null )
         {
             return null;
@@ -837,7 +843,15 @@ public abstract class AbstractEventService
             event.setTrackedEntityInstance( programStageInstance.getProgramInstance().getEntityInstance().getUid() );
         }
 
-        Collection<TrackedEntityDataValue> dataValues = dataValueService.getTrackedEntityDataValues( programStageInstance );
+        Collection<TrackedEntityDataValue> dataValues;
+        if ( !isSynchronizationQuery )
+        {
+            dataValues = dataValueService.getTrackedEntityDataValues( programStageInstance );
+        }
+        else
+        {
+            dataValues = dataValueService.getTrackedEntityDataValuesForSynchronization( programStageInstance );
+        }
 
         for ( TrackedEntityDataValue dataValue : dataValues )
         {
@@ -855,7 +869,6 @@ public abstract class AbstractEventService
             value.setValue( dataValue.getValue() );
             value.setProvidedElsewhere( dataValue.getProvidedElsewhere() );
             value.setStoredBy( dataValue.getStoredBy() );
-            value.setSkipSynchronization( dataValue.isSkipSynchronization() );
 
             event.getDataValues().add( value );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
@@ -69,6 +69,8 @@ public interface EventService
 
     Event getEvent( ProgramStageInstance programStageInstance );
 
+    Event getEvent( ProgramStageInstance programStageInstance, boolean isSynchronizationQuery );
+
     List<Event> getEventsXml( InputStream inputStream ) throws IOException;
 
     List<Event> getEventsJson( InputStream inputStream ) throws IOException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -108,6 +108,7 @@ public class TrackerSynchronization
 
         queryParams.setPageSize( trackerSyncPageSize );
         TrackedEntityInstanceParams params = TrackedEntityInstanceParams.TRUE;
+        params.setIncludeDeleted( true );
         boolean syncResult = true;
 
         for ( int i = 1; i <= pages; i++ )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -115,7 +115,6 @@ public class TrackerSynchronization
             queryParams.setPage( i );
 
             List<TrackedEntityInstance> dtoTeis = teiService.getTrackedEntityInstances( queryParams, params, true );
-            filterOutAttributesMarkedWithSkipSynchronizationFlag( dtoTeis );
             log.info( String.format( "Syncing page %d, page size is: %d", i, trackerSyncPageSize ) );
 
             if ( log.isDebugEnabled() )
@@ -147,17 +146,6 @@ public class TrackerSynchronization
         return SynchronizationResult.newFailureResultWithMessage( "Tracker synchronization failed." );
     }
 
-    private void filterOutAttributesMarkedWithSkipSynchronizationFlag( List<TrackedEntityInstance> dtoTeis )
-    {
-        for ( TrackedEntityInstance tei : dtoTeis )
-        {
-            tei.setAttributes(
-                tei.getAttributes().stream()
-                    .filter( attr -> !attr.isSkipSynchronization() )
-                    .collect( Collectors.toList() )
-            );
-        }
-    }
 
     private boolean sendTrackerSyncRequest( List<TrackedEntityInstance> dtoTeis, String username, String password )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.dxf2.sync;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
+import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
+import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstances;
@@ -116,6 +118,7 @@ public class TrackerSynchronization
 
             List<TrackedEntityInstance> dtoTeis = teiService.getTrackedEntityInstances( queryParams, params, true );
             filterOutAttributesMarkedWithSkipSynchronizationFlag( dtoTeis );
+            filterOutDataValuesMarkedWithSkipSynchronizationFlag( dtoTeis );
             log.info( String.format( "Syncing page %d, page size is: %d", i, trackerSyncPageSize ) );
 
             if ( log.isDebugEnabled() )
@@ -156,6 +159,22 @@ public class TrackerSynchronization
                     .filter( attr -> !attr.isSkipSynchronization() )
                     .collect( Collectors.toList() )
             );
+        }
+    }
+
+    private void filterOutDataValuesMarkedWithSkipSynchronizationFlag( List<TrackedEntityInstance> dtoTeis )
+    {
+        for ( TrackedEntityInstance tei : dtoTeis )
+        {
+            for ( Enrollment enrollment : tei.getEnrollments() )
+            {
+                for ( Event event : enrollment.getEvents() )
+                {
+                    event.setDataValues( event.getDataValues().stream()
+                        .filter( dv -> !dv.isSkipSynchronization() )
+                        .collect( Collectors.toList() ) );
+                }
+            }
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -31,8 +31,6 @@ package org.hisp.dhis.dxf2.sync;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
-import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
-import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstances;
@@ -118,7 +116,6 @@ public class TrackerSynchronization
 
             List<TrackedEntityInstance> dtoTeis = teiService.getTrackedEntityInstances( queryParams, params, true );
             filterOutAttributesMarkedWithSkipSynchronizationFlag( dtoTeis );
-            filterOutDataValuesMarkedWithSkipSynchronizationFlag( dtoTeis );
             log.info( String.format( "Syncing page %d, page size is: %d", i, trackerSyncPageSize ) );
 
             if ( log.isDebugEnabled() )
@@ -159,22 +156,6 @@ public class TrackerSynchronization
                     .filter( attr -> !attr.isSkipSynchronization() )
                     .collect( Collectors.toList() )
             );
-        }
-    }
-
-    private void filterOutDataValuesMarkedWithSkipSynchronizationFlag( List<TrackedEntityInstance> dtoTeis )
-    {
-        for ( TrackedEntityInstance tei : dtoTeis )
-        {
-            for ( Enrollment enrollment : tei.getEnrollments() )
-            {
-                for ( Event event : enrollment.getEvents() )
-                {
-                    event.setDataValues( event.getDataValues().stream()
-                        .filter( dv -> !dv.isSkipSynchronization() )
-                        .collect( Collectors.toList() ) );
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Backport to 2.30 - Fixes bug with not skipping synchronization of PSDEs that are marked with Skip synchronization property and so should be skipped.

Removes SupressWarnings as it is not needed anymore