### PR TITLE
Add csv and gml import functions for MetadataImportController

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/DefaultGmlImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/DefaultGmlImportService.java
@@ -35,10 +35,22 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.xerces.impl.io.MalformedByteSequenceException;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.dxf2.metadata.Metadata;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportService;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
+import org.hisp.dhis.dxf2.webmessage.responses.ImportReportWebMessageResponse;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.Status;
+import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -125,8 +137,10 @@ public class DefaultGmlImportService
 
     @Transactional
     @Override
-    public void importGml( InputStream inputStream, MetadataImportParams importParams )
+    public ImportReport importGml( InputStream inputStream, MetadataImportParams importParams )
     {
+        ImportReport importReport = new ImportReport();
+
         if ( !importParams.getImportStrategy().isUpdate() )
         {
             importParams.setImportStrategy( ImportStrategy.UPDATE );
@@ -138,15 +152,30 @@ public class DefaultGmlImportService
         if ( preProcessed.isSuccess && preProcessed.metaData != null )
         {
             importParams.addMetadata( schemaService.getMetadataSchemas(), preProcessed.metaData );
-            importService.importMetadata( importParams );
+            importReport = importService.importMetadata( importParams );
         }
         else
         {
             Throwable throwable = preProcessed.throwable;
 
             notifier.notify( importParams.getId(), NotificationLevel.ERROR, createNotifierErrorMessage( throwable ), false );
+
+            importReport.setStatus( Status.ERROR );
+
+            ObjectReport objectReport = new ObjectReport( getClass(),  0 );
+
+            objectReport.addErrorReport( new ErrorReport( getClass(), new ErrorMessage( ErrorCode.E7010, createNotifierErrorMessage( throwable ) ) ) );
+
+            TypeReport typeReport = new TypeReport( getClass() );
+
+            typeReport.addObjectReport( objectReport );
+
+            importReport.addTypeReport( typeReport );
+
             log.error( "GML import failed: ", throwable );
         }
+
+        return importReport;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/GmlImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/GmlImportService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.gml;
  */
 
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 
 import java.io.InputStream;
 
@@ -42,11 +43,10 @@ public interface GmlImportService
 {
     /**
      * Import the geospatial data from a GML document.
-     *
-     * @param inputStream   the GML document.
-     * @param userUid       the UID of the user performing the import.
+     *  @param userUid       the UID of the user performing the import.
      * @param importOptions the ImportOptions. ImportStrategy is always overridden to UPDATE.
      * @param taskId        the TaskId of the import process.
+     * @param inputStream   the GML document.
      */
-    void importGml( InputStream inputStream, MetadataImportParams importParams );
+    ImportReport importGml( InputStream inputStream, MetadataImportParams importParams );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.metadata;
 
 import com.google.api.client.util.Lists;
 import com.google.common.base.Enums;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -62,7 +63,6 @@ import org.hisp.dhis.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
 import java.util.List;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataImportParams.java
@@ -35,6 +35,7 @@ import com.google.common.base.MoreObjects;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MergeMode;
+import org.hisp.dhis.dxf2.csv.CsvImportClass;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
@@ -128,6 +129,11 @@ public class MetadataImportParams
      * Name of file that was used for import (if available).
      */
     private String filename;
+
+    /**
+     * Metadata Class name for importing using CSV
+     */
+    private CsvImportClass csvImportClass;
 
     /**
      * Job id to use for threaded imports.
@@ -328,6 +334,18 @@ public class MetadataImportParams
     {
         this.filename = filename;
         return this;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public CsvImportClass getCsvImportClass()
+    {
+        return this.csvImportClass;
+    }
+
+    public void setCsvImportClass( CsvImportClass csvImportClass )
+    {
+        this.csvImportClass = csvImportClass;
     }
 
     public JobConfiguration getId()


### PR DESCRIPTION
This is to add back the csv and gml metadata import api. Before it was in MetadataImportAction, which is removed together with import/export struts module.

