### PR TITLE
Add api for returning CsvImportClass enum in MetadataImportController.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportController.java
@@ -50,13 +50,17 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.METADATA_IMPORT;
@@ -169,6 +173,12 @@ public class MetadataImportController
             ImportReport importReport = metadataImportService.importMetadata( params );
             renderService.toXml( response.getOutputStream(), importReport );
         }
+    }
+
+    @GetMapping( "/csvImportClasses" )
+    public @ResponseBody List<CsvImportClass> getCsvImportClasses()
+    {
+        return  Arrays.asList( CsvImportClass.values() );
     }
 
     private void startAsync( MetadataImportParams params, HttpServletRequest request, HttpServletResponse response )


### PR DESCRIPTION
This is for new reactjs import/export app, to return the list of supported Metadata classes that can be imported using CSV format. 

Below is the response 

[
    "ORGANISATION_UNIT_GROUP_MEMBERSHIP",
    "DATA_ELEMENT_GROUP_MEMBERSHIP",
    "INDICATOR_GROUP_MEMBERSHIP",
    "DATA_ELEMENT",
    "DATA_ELEMENT_GROUP",
    "CATEGORY_OPTION",
    "CATEGORY_OPTION_GROUP",
    "ORGANISATION_UNIT",
    "ORGANISATION_UNIT_GROUP",
    "VALIDATION_RULE",
    "OPTION_SET",
    "TRANSLATION"
]