### PR TITLE
[DHIS2-4045] [WIP] 2.29 Fix issue update catOptionCombo transaction rollback

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryManager.java
@@ -33,6 +33,7 @@ package org.hisp.dhis.category;
 import com.google.common.collect.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.dataelement.DataElementCategoryCombo;
 import org.hisp.dhis.dataelement.DataElementCategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElementCategoryService;
@@ -64,6 +65,7 @@ public class DefaultCategoryManager
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( noRollbackFor = DeleteNotAllowedException.class )
     public void addAndPruneOptionCombos( DataElementCategoryCombo categoryCombo )
     {
         if ( categoryCombo == null || !categoryCombo.isValid() )


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-4045
This is an attempt  to fix the tx rollback issue when updating catOptionCombo. It's not guarantee that this will solve the issue, but it also won't do any harm to current functions.

Currently the issues only happens on play 2.29 and 2.30, can't reproduce on local and play 2.31
Below is the error log on play 2.29 server

`* WARN  2018-07-09 04:53:03,580 Could not delete category option combo: {"class":"class org.hisp.dhis.dataelement.DataElementCategoryOptionCombo", "id":"359663", "uid":"YEmiuCcgNQI", "code":"COC_359663", "categoryCombo":{"class":"class org.hisp.dhis.dataelement.DataElementCategoryCombo", "id":"359659", "uid":"m2jTvAj5kkm", "code":"BIRTHS", "name":"Births", "created":"2011-12-24 12:24:25.203", "lastUpdated":"2016-04-18 16:04:34.745" }, "categoryOptions":[{"class":"class org.hisp.dhis.dataelement.DataElementCategoryOption", "hashCode":"1844240452", "id":"359612", "uid":"TXGfLxZlInA", "code":"SECHN", "name":"SECHN", "shortName":"SECHN", "description":"null", "created":"2011-12-24 12:24:24.149", "lastUpdated":"2011-12-24 12:24:24.149" }, {"class":"class org.hisp.dhis.dataelement.DataElementCategoryOption", "hashCode":"1070434135", "id":"167629", "uid":"Fp4gVHbRvEV", "code":"AT_PHU", "name":"At PHU", "shortName":"At PHU", "description":"null", "created":"2011-12-24 12:24:24.149", "lastUpdated":"2011-12-24 12:24:24.149" }]} (DefaultCategoryManager.java [http-nio-8029-exec-1])
org.springframework.transaction.UnexpectedRollbackException: Transaction rolled back because it has been marked as rollback-only
        at org.springframework.transaction.support.AbstractPlatformTransactionManager.commit(AbstractPlatformTransactionManager.java:724)
        at org.springframework.transaction.interceptor.TransactionAspectSupport.commitTransactionAfterReturning(TransactionAspectSupport.java:518)
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:292)
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
        at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
        at com.sun.proxy.$Proxy191.addAndPruneAllOptionCombos(Unknown Source)`