### PR TITLE
[DHIS2-4480] 2.29 Fix lazy load issue for default coc cache.

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementCategoryOptionCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementCategoryOptionCombo.java
@@ -302,6 +302,15 @@ public class DataElementCategoryOptionCombo
         return earliestEndDate;
     }
 
+    public DataElementCategoryOptionCombo eagerLoadCollections()
+    {
+        getTranslations();
+        getAttributeValues();
+        getOrganisationUnits();
+        getCategoryOptions();
+        return this;
+    }
+
     // -------------------------------------------------------------------------
     // Getters and setters
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -1202,7 +1202,7 @@ public class DefaultIdentifiableObjectManager
             .put( DataElementCategory.class, DEFAULT_OBJECT_CACHE.get( DataElementCategory.class, key -> getByName( DataElementCategory.class, "default" ) ) )
             .put( DataElementCategoryCombo.class, DEFAULT_OBJECT_CACHE.get( DataElementCategoryCombo.class, key -> getByName( DataElementCategoryCombo.class, "default" ) ) )
             .put( DataElementCategoryOption.class, DEFAULT_OBJECT_CACHE.get( DataElementCategoryOption.class, key -> getByName( DataElementCategoryOption.class, "default" ) ) )
-            .put( DataElementCategoryOptionCombo.class, DEFAULT_OBJECT_CACHE.get( DataElementCategoryOptionCombo.class, key -> getByName( DataElementCategoryOptionCombo.class, "default" ) ) )
+            .put( DataElementCategoryOptionCombo.class, DEFAULT_OBJECT_CACHE.get( DataElementCategoryOptionCombo.class, key -> getByName( DataElementCategoryOptionCombo.class, "default" ).eagerLoadCollections() ) )
             .build();
     }
 


### PR DESCRIPTION
In method AbstractEventService.saveEvent(....) line 1341
All defaults object from the cache fail to load the lazy collections. This may due to the fact that this saveEvent method is a private method, and hence the @Transactional doesn't have effect, and session is lost. 
This is a quick fix for the issue 
https://jira.dhis2.org/browse/DHIS2-4480 as it's urgent.  We need to look for a better solution for this issue later

Below is screenshot in debug mode. 

![screen shot 2018-08-24 at 8 57 26 pm](https://user-images.githubusercontent.com/766102/44591029-d143d380-a7e6-11e8-95de-0d3b64c5fbff.png)
