### PR TITLE
Added JaCoCo for test coverage reporting

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -96,17 +96,6 @@
   <reporting>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <version>1.3.3</version>
@@ -144,9 +133,13 @@
                 </property>
               </systemProperties>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>-Xmx1024m</argLine>
+              <argLine>${argLine} -Xmx1024m</argLine>
               <excludedGroups>org.hisp.dhis.IntegrationTest</excludedGroups>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>
@@ -322,7 +315,30 @@
             </execution>
           </executions>
         </plugin>
-
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco.version}</version>
+          <configuration>
+            <destFile>${sonar.jacoco.reportPath}</destFile>
+            <dataFile>${sonar.jacoco.reportPath}</dataFile>
+            <append>true</append>
+          </configuration>
+          <executions>
+            <execution>
+              <id>default-prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
 
     </pluginManagement>
@@ -1175,6 +1191,7 @@
         <artifactId>jts-io</artifactId>
         <version>1.14.0</version>
       </dependency>
+      <!-- Test -->
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
@@ -1187,7 +1204,6 @@
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -1213,5 +1229,7 @@
     <geotools.version>18.0</geotools.version>
     <jasperreports.version>6.3.1</jasperreports.version>
     <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
+    <jacoco.version>0.8.2</jacoco.version>
+    <sonar.jacoco.reportPath>${rootDir}/../target/jacoco.exec</sonar.jacoco.reportPath>
   </properties>
 </project>


### PR DESCRIPTION
* Cobertura support has been deprecated by sonarqube some versions ago and the only supported code coverage tools is JaCoCo. 