### PR TITLE
[DHIS2-4796] Fix bug cannot query CompleteDataSetRegistration with children=true

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -72,7 +72,8 @@ public class HibernatePeriodStore
         Query<Period> typedQuery = getQuery( query )
             .setParameter( "startDate", startDate )
             .setParameter( "endDate", endDate )
-            .setParameter( "periodType", periodType.getId() );
+            .setParameter( "periodType", reloadPeriodType( periodType ).getId() );
+
         return getSingleResult( typedQuery );
     }
 
@@ -163,7 +164,7 @@ public class HibernatePeriodStore
         }
 
         Period storedPeriod = getPeriod( period.getStartDate(), period.getEndDate(), period.getPeriodType() );
-        
+
         return storedPeriod != null ? storedPeriod.copyTransientProperties( period ) : null;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/JdbcCompleteDataSetRegistrationExchangeStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/JdbcCompleteDataSetRegistrationExchangeStore.java
@@ -198,8 +198,8 @@ public class JdbcCompleteDataSetRegistrationExchangeStore
             String clause = " AND ( ";
 
             clause += params.getOrganisationUnits().stream()
-                .map( OrganisationUnit::getPath )
-                .collect( Collectors.joining( " ", "ou.path LIKE '", "%' OR" ) );
+                .map( o -> " ou.path LIKE '" + o.getPath() + "%' OR " )
+                .collect( Collectors.joining() );
 
             return TextUtils.removeLastOr( clause ) + " ) ";
         }


### PR DESCRIPTION
Fix minor issue with `Collectors.joining( " ", "ou.path LIKE '", "%' OR" )` which only add suffix (%) to the end of the final string.
Need to backport down to 2.29 

https://jira.dhis2.org/browse/DHIS2-4796