### PR TITLE
2.29  Fix no session error in ProgramNotificationService

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationAsyncTask.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationAsyncTask.java
@@ -1,0 +1,74 @@
+package org.hisp.dhis.program.notification;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.dbms.DbmsUtils;
+import org.hisp.dhis.security.SecurityContextRunnable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Viet Nguyen <viet@dhis2.org>
+ */
+public class ProgramNotificationAsyncTask
+    extends SecurityContextRunnable
+{
+    @Autowired
+    private SessionFactory sessionFactory;
+
+    @Autowired
+    private ProgramNotificationService programNotificationService;
+
+    private Consumer<ProgramNotificationService> function;
+
+    @Override
+    public void call()
+    {
+        function.accept( programNotificationService );
+    }
+
+    @Override
+    public void before()
+    {
+        DbmsUtils.bindSessionToThread( sessionFactory );
+    }
+
+    @Override
+    public void after()
+    {
+        DbmsUtils.unbindSessionFromThread( sessionFactory );
+    }
+
+    public void setFunction( Consumer<ProgramNotificationService> function )
+    {
+        this.function = function;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationListener.java
@@ -38,40 +38,45 @@ import org.springframework.scheduling.annotation.Async;
 public class ProgramNotificationListener
 {
     @Autowired
-    private ProgramNotificationService programNotificationService;
+    private ProgramNotificationAsyncTask asyncTask;
 
     @EventListener( condition = "#event.eventType.name() == 'PROGRAM_ENROLLMENT'" )
     @Async
     public void onEnrollment( ProgramNotificationEvent event )
     {
-        programNotificationService.sendEnrollmentNotifications( event.getProgramInstance() );
+        asyncTask.setFunction( notificationService -> notificationService.sendEnrollmentNotifications( event.getProgramInstance() ) );
+        asyncTask.run();
     }
 
     @EventListener( condition = "#event.eventType.name() == 'PROGRAM_COMPLETION'" )
     @Async
     public void onCompletion( ProgramNotificationEvent event )
     {
-        programNotificationService.sendCompletionNotifications( event.getProgramInstance() );
+        asyncTask.setFunction( notificationService -> notificationService.sendCompletionNotifications( event.getProgramInstance() ) );
+        asyncTask.run();
     }
 
     @EventListener( condition = "#event.eventType.name() == 'PROGRAM_RULE_ENROLLMENT'" )
     @Async
     public void onProgramRuleEnrollment( ProgramNotificationEvent event )
     {
-        programNotificationService.sendProgramRuleTriggeredNotifications( event.getTemplate(), event.getProgramInstance() );
+        asyncTask.setFunction( notificationService -> notificationService.sendProgramRuleTriggeredNotifications( event.getTemplate(), event.getProgramInstance() ) );
+        asyncTask.run();
     }
 
     @EventListener( condition = "#event.eventType.name() == 'PROGRAM_STAGE_COMPLETION'" )
     @Async
     public void onEvent( ProgramNotificationEvent event )
     {
-        programNotificationService.sendCompletionNotifications( event.getProgramStageInstance() );
+        asyncTask.setFunction( notificationService -> notificationService.sendCompletionNotifications( event.getProgramStageInstance() ) );
+        asyncTask.run();
     }
 
     @EventListener( condition = "#event.eventType.name() == 'PROGRAM_RULE_EVENT'" )
     @Async
     public void onProgramRuleEvent( ProgramNotificationEvent event )
     {
-        programNotificationService.sendProgramRuleTriggeredNotifications( event.getTemplate(), event.getProgramStageInstance() );
+        asyncTask.setFunction( notificationService -> notificationService.sendProgramRuleTriggeredNotifications( event.getTemplate(), event.getProgramStageInstance() ) );
+        asyncTask.run();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -1466,6 +1466,8 @@
 
   <bean id="org.hisp.dhis.program.notification.ProgramNotificationListener" class="org.hisp.dhis.program.notification.ProgramNotificationListener" />
 
+  <bean id="org.hisp.dhis.program.notification.ProgramNotificationAsyncTask" class="org.hisp.dhis.program.notification.ProgramNotificationAsyncTask"  scope="prototype"/>
+
   <bean id="org.hisp.dhis.programrule.ProgramRuleVariableService" class="org.hisp.dhis.programrule.DefaultProgramRuleVariableService">
     <property name="programRuleVariableStore" ref="org.hisp.dhis.programrule.ProgramRuleVariableStore" />
   </bean>


### PR DESCRIPTION
Got this error when enroll for a program in Tracker Capture app in 2.29
`Unexpected error occurred invoking async method 'public void org.hisp.dhis.program.notification.ProgramNotificationListener.onEnrollment(org.hisp.dhis.program.notification.ProgramNotificationEvent)'. (SimpleAsyncUncaughtExceptionHandler.java [taskScheduler-16])
org.hibernate.LazyInitializationException: could not initialize proxy - no Session`

In ProgramNotificationListener, methods are marked with Async annotation, so it is required to implement runnable interface which can open/close session in a new thread. 
- Add ProgramNotificationAsyncTask
- Use TransactionTemplate in DefaultProgramNotificationService so methods called is executed in a spring transaction ( Transactional annotation doesn't work maybe because of the private methods. ) 

*** In 2.30 and 2.31, those methods are not marked with Async. Do we need to port this fix to those versions also ? 