### PR TITLE
Hibernate query cache configuration update

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -1,12 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ehcache>
 
-  <defaultCache maxElementsInMemory="800000" eternal="false" timeToIdleSeconds="360" timeToLiveSeconds="720"
-    overflowToDisk="false" diskPersistent="false" />
+  <!-- Default cache -->
+  
+  <!-- 
+    Ensure that default cache has less frequent expiration than query cache
+    to avoid individual select queries per entity.
+  -->
+
+  <defaultCache
+    maxElementsInMemory="800000" 
+    eternal="false" 
+    timeToIdleSeconds="7200" 
+    timeToLiveSeconds="7200"
+    overflowToDisk="false" 
+    diskPersistent="false" />
 
   <!-- Hibernate query cache -->
 
-  <cache name="org.hibernate.cache.internal.StandardQueryCache" maxElementsInMemory="250000" />
+  <cache name="org.hibernate.cache.internal.StandardQueryCache"
+    maxElementsInMemory="800000" 
+    eternal="false" 
+    timeToIdleSeconds="3600" 
+    timeToLiveSeconds="3600"
+    overflowToDisk="false" 
+    diskPersistent="false" />
 
-  <cache name="org.hibernate.cache.spi.UpdateTimestampsCache" maxElementsInMemory="2000" />
+  <cache name="org.hibernate.cache.spi.UpdateTimestampsCache" 
+    maxElementsInMemory="5000" />
 </ehcache>

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -11,8 +11,8 @@
   <defaultCache
     maxElementsInMemory="800000" 
     eternal="false" 
-    timeToIdleSeconds="7200" 
-    timeToLiveSeconds="7200"
+    timeToIdleSeconds="21600" 
+    timeToLiveSeconds="21600"
     overflowToDisk="false" 
     diskPersistent="false" />
 
@@ -21,8 +21,8 @@
   <cache name="org.hibernate.cache.internal.StandardQueryCache"
     maxElementsInMemory="800000" 
     eternal="false" 
-    timeToIdleSeconds="3600" 
-    timeToLiveSeconds="3600"
+    timeToIdleSeconds="10800" 
+    timeToLiveSeconds="10800"
     overflowToDisk="false" 
     diskPersistent="false" />
 


### PR DESCRIPTION
Ensure that default cache is expired less frequently than query cache to avoid single-entity queries.