### PR TITLE
[DHIS2-4953] Fix bug block failed login attempts with basic authentication.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/security.xml
@@ -29,7 +29,7 @@
     <property name="password" ref="ldapManagerPassword" />
   </bean>
 
-  <bean id="ldapAuthenticationProvider" class="org.springframework.security.ldap.authentication.LdapAuthenticationProvider">
+  <bean id="ldapAuthenticationProvider" class="org.hisp.dhis.security.ldap.authentication.CustomLdapAuthenticationProvider">
     <constructor-arg>
       <bean class="org.hisp.dhis.security.ldap.authentication.DhisBindAuthenticator">
         <constructor-arg ref="contextSource" />

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/AuthenticationListener.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/AuthenticationListener.java
@@ -72,6 +72,8 @@ public class AuthenticationListener
 
             log.info( String.format( "Login attempt failed for remote IP: %s", authDetails.getIp() ) );
         }
+
+        securityService.registerFailedLogin( auth.getName() );
     }
 
     @EventListener

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -101,6 +101,8 @@
     <constructor-arg name="loginFormUrl" value="/dhis-web-commons/security/login.action" />
   </bean>
 
+  <bean id="basicAuthenticationEntryPoint" class="org.hisp.dhis.security.BasicAuthenticationEntryPoint"/>
+
   <sec:http access-decision-manager-ref="accessDecisionManager" realm="DHIS2" disable-url-rewriting="true" use-expressions="true"
     authentication-manager-ref="authenticationManager" entry-point-ref="http401LoginUrlAuthenticationEntryPoint">
     <sec:openid-login user-service-ref="userDetailsService" default-target-url="/" always-use-default-target="false"
@@ -125,7 +127,7 @@
 
     <sec:csrf disabled="true" />
 
-    <sec:http-basic />
+    <sec:http-basic entry-point-ref="basicAuthenticationEntryPoint" />
     <sec:logout logout-url="/dhis-web-commons-security/logout.action" logout-success-url="/" />
     <sec:intercept-url pattern="/dhis-web-commons/i18nJavaScript.action" access="permitAll()" />
     <sec:intercept-url pattern="/dhis-web-commons/security/**" access="permitAll()" />


### PR DESCRIPTION
- Add BasicAuthenticationEntryPoint for return auth failed message in json format ( currently returning html ) 
- Add CustomLdapAuthenticationProvider to check for Ldap Configuration in DHIS2 before delegating authentication process to LdapAuthenticationProvider. 

https://jira.dhis2.org/browse/DHIS2-4953