### PR TITLE
[DHIS2-4503] Fix bug query events with OptionSet filter

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -617,26 +618,46 @@ public class JdbcEventStore
         for ( QueryItem item : params.getDataElementsAndFilters() )
         {
             final String col = statementBuilder.columnQuote( item.getItemId() );
+            final String optCol = item.getItemId() + "opt";
 
             if ( !joinedColumns.contains( col ) )
             {
-                sql += (item.hasFilter() ? "inner" : "left") + " join trackedentitydatavalue as " + col + " " + "on " + col
+                final String joinClause = item.hasFilter() ? "inner join" : "left join";
+
+                sql += joinClause + " " + "trackedentitydatavalue as " + col + " " + "on " + col
                     + ".programstageinstanceid = psi.programstageinstanceid " + "and " + col + ".dataelementid = "
                     + item.getItem().getId() + " ";
+
+                if ( item.hasOptionSet() && item.hasFilter() )
+                {
+                    sql += joinClause + " " + "optionvalue as " + optCol + " on lower(" + optCol + ".code) = " + "lower(" + col + ".value) and " + optCol + ".optionsetid = " + item.getOptionSet().getId() + " ";
+                }
 
                 joinedColumns.add( col );
             }
 
-            for ( QueryFilter filter : item.getFilters() )
+            if ( item.hasFilter() )
             {
-                final String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
+                for ( QueryFilter filter : item.getFilters() )
+                {
+                    final String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
 
-                final String queryCol = item.isNumeric() ? " CAST( " + (col + ".value AS NUMERIC)")
-                    : "lower(" + col + ".value)";
+                    final String queryCol = item.isNumeric() ? " CAST( " + (col + ".value AS NUMERIC)")
+                        : "lower(" + col + ".value)";
 
-                sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
-                    + StringUtils.lowerCase( StringUtils.isNumeric( encodedFilter ) ? encodedFilter :
-                    filter.getSqlFilter( encodedFilter ) ) + " ";
+                    if ( !item.hasOptionSet() || QueryOperator.IN.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
+                    {
+                        sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
+                            + StringUtils.lowerCase( StringUtils.isNumeric( encodedFilter ) ? encodedFilter :
+                            filter.getSqlFilter( encodedFilter ) ) + " ";
+                    }
+                    else
+                    {
+                        sql += "and lower(" + optCol + ".name)" + " " + filter.getSqlOperator() + " "
+                            + StringUtils.lowerCase( StringUtils.isNumeric( encodedFilter ) ? encodedFilter :
+                            filter.getSqlFilter( encodedFilter ) ) + " ";
+                    }
+                }
             }
         }
 
@@ -773,6 +794,7 @@ public class JdbcEventStore
         for ( QueryItem item : params.getDataElementsAndFilters() )
         {
             final String col = statementBuilder.columnQuote( item.getItemId() );
+            final String optCol = item.getItemId() + "opt";
 
             if ( !joinedColumns.contains( col ) )
             {
@@ -781,6 +803,11 @@ public class JdbcEventStore
                 sql += joinClause + " " + "trackedentitydatavalue as " + col + " " + "on " + col
                     + ".programstageinstanceid = psi.programstageinstanceid " + "and " + col + ".dataelementid = "
                     + item.getItem().getId() + " ";
+
+                if ( item.hasOptionSet() && item.hasFilter() )
+                {
+                    sql += joinClause + " " + "optionvalue as " + optCol + " on lower(" + optCol + ".code) = " + "lower(" + col + ".value) and " + optCol + ".optionsetid = " + item.getOptionSet().getId() + " ";
+                }
 
                 joinedColumns.add( col );
             }
@@ -794,8 +821,17 @@ public class JdbcEventStore
                     final String queryCol = item.isNumeric() ? " CAST( " + (col + ".value AS NUMERIC)")
                         : "lower(" + col + ".value)";
 
-                    sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
-                        + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
+                    if ( !item.hasOptionSet() || QueryOperator.IN.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
+                    {
+                        sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
+                            + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
+                    }
+                    else
+                    {
+                        sql += "and lower( " + optCol + ".name)" + " " + filter.getSqlOperator() + " "
+                            + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-4503

When querying data values on the /events endpoint, you can sort and filter data values normally, except for option sets, where the user will filter based on the name of the options, and the underlying filter in the database will compare the data value based on option code... not name.
API request : 

http://localhost:8080/api/events?filter=K6uUAvq500H:like:exposure&program=eBAyeGv0exc&orgUnit=DiszpKrYNg8&pageSize=15&page=1&order=eventDate:desc&totalPages=true

SQL query : 
 ```
select * from (select psi.programstageinstanceid as psi_id, psi.uid as psi_uid, psi.code as psi_code, psi.status as psi_status, psi.executiondate as psi_executiondate, psi.duedate as psi_duedate, psi.completedby as psi_completedby, psi.storedby as psi_storedby, psi.created as psi_created, psi.lastupdated as psi_lastupdated, psi.completeddate as psi_completeddate, psi.deleted as psi_deleted, ST_AsText( psi.geometry ) as psi_geometry, coc.categoryoptioncomboid AS coc_categoryoptioncomboid, coc.code AS coc_categoryoptioncombocode, coc.uid AS coc_categoryoptioncombouid, cocco.categoryoptionid AS cocco_categoryoptionid, deco.uid AS deco_uid, deco.publicaccess AS deco_publicaccess, decoa.uga_access AS uga_access, decoa.ua_access AS ua_access, cocount.option_size AS option_size, lower("K6uUAvq500H".value) as "K6uUAvq500H", pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, p.uid as p_uid, p.code as p_code, psi.duedate as psi_duedate, psi.completedby as psi_completedby, psi.storedby as psi_storedby, coc.categoryoptioncomboid AS coc_categoryoptioncomboid, coc.code AS coc_categoryoptioncombocode, coc.uid AS coc_categoryoptioncombouid, cocco.categoryoptionid AS cocco_categoryoptionid, deco.uid AS deco_uid, pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, p.uid as p_uid, p.code as p_code, p.type as p_type, ps.uid as ps_uid, ps.code as ps_code, ou.uid as ou_uid, ou.code as ou_code, ou.name as ou_name, tei.trackedentityinstanceid as tei_id, tei.uid as tei_uid, teiou.uid as tei_ou, teiou.name as tei_ou_name, tei.created as tei_created, tei.inactive as tei_inactive from programstageinstance psi inner join programinstance pi on pi.programinstanceid=psi.programinstanceid inner join program p on p.programid=pi.programid inner join programstage ps on ps.programstageid=psi.programstageid 
 	inner join categoryoptioncombo coc on coc.categoryoptioncomboid=psi.attributeoptioncomboid
 	 inner join categoryoptioncombos_categoryoptions cocco on psi.attributeoptioncomboid=cocco.categoryoptioncomboid 
 	 inner join dataelementcategoryoption deco on cocco.categoryoptionid=deco.categoryoptionid left join trackedentityinstance tei on tei.trackedentityinstanceid=pi.trackedentityinstanceid
 	  left join organisationunit ou on (psi.organisationunitid=ou.organisationunitid) 
 	  left join organisationunit teiou on (tei.organisationunitid=teiou.organisationunitid) 
 	  inner join trackedentitydatavalue as "K6uUAvq500H" on "K6uUAvq500H".programstageinstanceid = psi.programstageinstanceid and "K6uUAvq500H".dataelementid = 3000010 
 	  inner join optionvalue as K6uUAvq500Hopt on lower(K6uUAvq500Hopt.code) = lower("K6uUAvq500H".value) and K6uUAvq500Hopt.optionsetid = 3150104 
 	  and lower(K6uUAvq500Hopt.name) like '%exposure%'  
 	  left join ( select categoryoptioncomboid, count(categoryoptioncomboid) as option_size from categoryoptioncombos_categoryoptions group by categoryoptioncomboid) as cocount on coc.categoryoptioncomboid = cocount.categoryoptioncomboid left join (select deco.categoryoptionid as deco_id, deco.uid as deco_uid, deco.publicaccess AS deco_publicaccess, couga.usergroupaccessid as uga_id, coua.useraccessid as ua_id, uga.access as uga_access, uga.usergroupid AS usrgrp_id, ua.access as ua_access, ua.userid as usr_id from dataelementcategoryoption deco left join dataelementcategoryoptionusergroupaccesses couga on deco.categoryoptionid = couga.categoryoptionid left join dataelementcategoryoptionuseraccesses coua on deco.categoryoptionid = coua.categoryoptionid left join usergroupaccess uga on couga.usergroupaccessid = uga.usergroupaccessid left join useraccess ua on coua.useraccessid = ua.useraccessid  where ua.userid=1151265 or uga.usergroupid in (909662, 909233, 909316, 909745, 224024, 1149573, 1150851, 1153245, 239554, 910022, 908970, 909150, 909579, 909842, 909925, 909067)  ) as decoa on cocco.categoryoptionid = decoa.deco_id where p.programid = 1150221 and psi.organisationunitid in (559) and psi.deleted is false and (p.uid in ('eBAyeGv0exc', 'IpHINAT79UW', 'ur1Edk5Oe2n', 'VBqh0ynB2wv', 'uy2gU8kT1jF', 'lxAQ7Zs9VYR', 'fDd25txQckK', 'WSGAb5XwJ3Y', 'kla3mAPgvCH', 'q04UBOqq3rp')) and (ps.uid in ('aNLq9ZYoy9W', 'bbKtnxRZKEP', 'pSllsjpfLH2', 'ZzYYXq4fJie', 'jdRD35YwbRH', 'edqlbukwRfQ', 'ZkbAXlQUYJG', 'oRySG82BKE6', 'Zj7UnCAulEk', 'grIfo3oOf4Y', 'PFDfvmGpsR3', 'eaDHS084uMp', 'lST1OZ5BDJ2', 'EPEcjy3FWmI', 'dBwrot7S420', 'PUZaKR0Jh2k', 'A03MvHHogjR', 'WZbXY0S00lP', 'Xgk8Wvl0jHr', 'pTo4uMt3xur')) order by psi_executiondate desc  limit 15 offset 0 ) as event left join (select pdv.programstageinstanceid as pdv_id, pdv.created as pdv_created, pdv.lastupdated as pdv_lastupdated, pdv.value as pdv_value, pdv.storedby as pdv_storedby, pdv.providedelsewhere as pdv_providedelsewhere, de.uid as de_uid, de.code as de_code from trackedentitydatavalue pdv inner join dataelement de on pdv.dataelementid = de.dataelementid ) as dv on event.psi_id=dv.pdv_id left join (select psic.programstageinstanceid as psic_id, psinote.trackedentitycommentid as psinote_id, psinote.commenttext as psinote_value, psinote.created as psinote_storeddate, psinote.creator as psinote_storedby, psinote.uid as psinote_uid from programstageinstancecomments psic inner join trackedentitycomment psinote on psic.trackedentitycommentid=psinote.trackedentitycommentid ) as cm on event.psi_id=cm.psic_id 
 order by psi_executiondate desc 
```