### PR TITLE
[DHIS2-1691] Fix bug cant save externalFileResource in PushAnalysisService.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -498,11 +498,13 @@ public class DefaultPushAnalysisService
     {
         ExternalFileResource externalFileResource = new ExternalFileResource();
 
-        externalFileResource.setFileResource( fileResource );
         externalFileResource.setExpires( null );
 
         fileResource.setAssigned( true );
-        schedulingManager.executeJob( () -> fileResourceService.saveFileResource( fileResource, bytes ) );
+
+        String fileResourceUid = fileResourceService.saveFileResource( fileResource, bytes );
+
+        externalFileResource.setFileResource( fileResourceService.getFileResource( fileResourceUid ) );
 
         return externalFileResourceService.saveExternalFileResource( externalFileResource );
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1691

The method fileResourceService.saveFileResource() has already run async, so we don't need another job async to wrap outside, that will lead to the error 

`Not-null property references a transient value - transient instance must be saved before current operation : org.hisp.dhis.fileresource.ExternalFileResource.fileResource -> org.hisp.dhis.fileresource.FileResource`
