### PR TITLE
Add data-administration-app to bundle

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/package.json
+++ b/dhis-2/dhis-web/dhis-web-apps/package.json
@@ -16,6 +16,7 @@
     "core-resource-app": "github:d2-ci/core-resource-app#master",
     "dashboard-app": "github:d2-ci/dashboards-app#2.29",
     "datastore-app": "github:d2-ci/datastore-app#v29",
+    "data-administration-app": "github:d2-ci/data-administration-app#v29",
     "event-capture-app": "github:d2-ci/event-capture-app#v29",
     "event-visualizer-app": "github:d2-ci/event-charts-app#v29",
     "event-reports-app": "github:d2-ci/event-reports-app#v29",


### PR DESCRIPTION
@larshelge there is some uncertainty if the data-administration-app should be bundled with 2.29 of dhis2. This PR adds it, but if it is not supposed to be in 2.29 this PR can be closed and the branch deleted.