### PR TITLE
[DHIS2-4045] Fix bug TransactionRollback when deleting COC.

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
@@ -30,12 +30,14 @@ package org.hisp.dhis.category;
  *
  */
 
+import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.hierarchy.HierarchyViolationException;
 import org.hisp.dhis.user.UserCredentials;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -337,6 +339,8 @@ public interface CategoryService
      *                                       to delete.
      */
     void deleteCategoryOptionCombo( CategoryOptionCombo dataElementCategoryOptionCombo );
+
+    void deleteCategoryOptionComboNoRollback( CategoryOptionCombo categoryOptionCombo );
 
     /**
      * Retrieves the CategoryOptionCombo with the given identifier.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryManager.java
@@ -33,6 +33,7 @@ package org.hisp.dhis.category;
 import com.google.common.collect.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,9 +97,9 @@ public class DefaultCategoryManager
             {
                 try
                 {
-                    categoryService.deleteCategoryOptionCombo( optionCombo );
+                    categoryService.deleteCategoryOptionComboNoRollback( optionCombo );
                 }
-                catch ( Exception ex )
+                catch ( DeleteNotAllowedException ex )
                 {
                     log.warn( "Could not delete category option combo: " + optionCombo );
                     continue;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dataelement;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.category.Category;
@@ -47,6 +46,7 @@ import org.hisp.dhis.category.CategoryOptionStore;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.category.CategoryStore;
 import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.dataset.DataSet;
@@ -430,6 +430,13 @@ public class DefaultCategoryService
     public void deleteCategoryOptionCombo( CategoryOptionCombo dataElementCategoryOptionCombo )
     {
         categoryOptionComboStore.delete( dataElementCategoryOptionCombo );
+    }
+
+    @Override
+    @Transactional( noRollbackFor = DeleteNotAllowedException.class )
+    public void deleteCategoryOptionComboNoRollback( CategoryOptionCombo categoryOptionCombo )
+    {
+        categoryOptionComboStore.delete( categoryOptionCombo );
     }
 
     @Override


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-4045

Current DeletionHandler aspect throws DeleteNotAllowedException, this will cause spring to mark the current transaction as `rollback-only` as below.

One solution is to tell spring to ignore this specific exception and not to rollback the transaction using the annotation `@Transactional( noRollbackFor = DeleteNotAllowedException.class )`, and this must be put at the delete service method where the exception is thrown.

This fix is only applied for the function in Data Admin App -> Maintenance -> Update Category Option Combinations

` WARN  2018-11-19 13:02:16,897 Could not delete category option combo: {"class":"class org.hisp.dhis.category.CategoryOptionCombo", "id":"359663", "uid":"YEmiuCcgNQI", "code":"COC_359663", "categoryCombo":{"class":"class org.hisp.dhis.category.CategoryCombo", "id":"359659", "uid":"m2jTvAj5kkm", "code":"BIRTHS", "name":"Births", "created":"2011-12-24 12:24:25.203", "lastUpdated":"2016-04-18 16:04:34.745" }, "categoryOptions":[{"class":"class 
org.hisp.dhis.category.CategoryOption", "hashCode":"1844240452", "id":"359612", "uid":"TXGfLxZlInA", "code":"SECHN", "name":"SECHN", "shortName":"SECHN", "description":"null", "created":"2011-12-24 12:24:24.149", "lastUpdated":"2011-12-24 12:24:24.149" }, {"class":"class org.hisp.dhis.category.CategoryOption", "hashCode":"1070434135", "id":"167629", "uid":"Fp4gVHbRvEV", "code":"AT_PHU", "name":"At PHU", "shortName":"At PHU", "description":"null", "created":"2011-12-24 12:24:24.149", "lastUpdated":"2011-12-24 12:24:24.149" }]} (DefaultCategoryManager.java [qtp819790006-86])`

`org.springframework.transaction.UnexpectedRollbackException: Transaction rolled back because it has been marked as rollback-only
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.commit(AbstractPlatformTransactionManager.java:728)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.commitTransactionAfterReturning(TransactionAspectSupport.java:518)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:292)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
	at com.sun.proxy.$Proxy230.addAndPruneAllOptionCombos(Unknown Source)
	at org.hisp.dhis.webapi.controller.MaintenanceController.updateCategoryOptionCombos(MaintenanceController.java:222)
	at org.hisp.dhis.webapi.controller.MaintenanceController.performMaintenance(MaintenanceController.java:391)
	at org.hisp.dhis.webapi.controller.MaintenanceController$$FastClassBySpringCGLIB$$a0db5fcb.invoke(<generated>)`