### PR TITLE
Permissions issue - DHIS2-5408

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -407,7 +407,7 @@ public class DefaultEventAnalyticsService
     @Override
     public Grid getAggregatedEventData( EventQueryParams params )
     {
-        securityManager.decideAccess( params );
+        securityManager.decideAccessEventQuery( params );
 
         queryValidator.validate( params );
 
@@ -636,7 +636,7 @@ public class DefaultEventAnalyticsService
             .withStartEndDatesForPeriods()
             .build();
 
-        securityManager.decideAccess( params );
+        securityManager.decideAccessEventQuery( params );
 
         queryValidator.validate( params );
 
@@ -675,7 +675,7 @@ public class DefaultEventAnalyticsService
             .withStartEndDatesForPeriods()
             .build();
 
-        securityManager.decideAccess( params );
+        securityManager.decideAccessEventQuery( params );
 
         queryValidator.validate( params );
 


### PR DESCRIPTION
The user authority `AUTH_VIEW_EVENT_ANALYTICS` is:
- **CHECKED** for `/analytics/events/query` (in `DefaultEventAnalyticsService::getEvents` with `securityManager.decideAccessEventQuery`) 
- **NOT CHECKED** for `/analytics/events/cluster` (`DefaultEventAnalyticsService::getEventClusters`)
- **NOT CHECKED** for `/analytics/events/count` (`DefaultEventAnalyticsService::getRectangle`).
- **NOT CHECKED** for `/analytics/events/aggregate` (in `EventAnalyticsController::getAggregatedEventData`)

This permits an **unauthorized** user to view event analytics information with several /analytics/events endpoints, and to successfully add server-clustered events layers in the Maps app.

This will be back-ported to 2.31/2.30/2.29 as it exists in those releases as well.