### PR TITLE
(2.31) Remove "-SNAPSHOT" from version strings

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-api</artifactId>

--- a/dhis-2/dhis-services/dhis-service-acl/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-acl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-acl</artifactId>

--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-administration</artifactId>

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-analytics</artifactId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-service-core</artifactId>

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-service-dxf2</artifactId>

--- a/dhis-2/dhis-services/dhis-service-logging/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-logging/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-service-logging</artifactId>

--- a/dhis-2/dhis-services/dhis-service-mobile/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-mobile/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-service-mobile</artifactId>

--- a/dhis-2/dhis-services/dhis-service-node/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-node/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-node</artifactId>

--- a/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-program-rule</artifactId>

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-reporting</artifactId>

--- a/dhis-2/dhis-services/dhis-service-schema/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-schema</artifactId>

--- a/dhis-2/dhis-services/dhis-service-setting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-setting/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-setting</artifactId>

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-service-validation</artifactId>

--- a/dhis-2/dhis-services/pom.xml
+++ b/dhis-2/dhis-services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-services</artifactId>

--- a/dhis-2/dhis-support/dhis-support-commons/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-commons/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>dhis-support</artifactId>
     <groupId>org.hisp.dhis</groupId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-commons</artifactId>

--- a/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-db-migration</artifactId>

--- a/dhis-2/dhis-support/dhis-support-external/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-external/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-external</artifactId>

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-hibernate</artifactId>

--- a/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-support-jdbc</artifactId>

--- a/dhis-2/dhis-support/dhis-support-kafka/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-kafka/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-kafka</artifactId>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-system</artifactId>

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support-test</artifactId>

--- a/dhis-2/dhis-support/pom.xml
+++ b/dhis-2/dhis-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-support</artifactId>

--- a/dhis-2/dhis-web/dhis-web-api-mobile/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api-mobile/pom.xml
@@ -5,7 +5,7 @@
    <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-web-api-mobile</artifactId>

--- a/dhis-2/dhis-web/dhis-web-api-test/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-web-api-test</artifactId>

--- a/dhis-2/dhis-web/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-web-api</artifactId>

--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hisp.dhis</groupId>
         <artifactId>dhis-web</artifactId>
-		<version>2.31-SNAPSHOT</version>
+		<version>2.31</version>
     </parent>
 
     <artifactId>dhis-web-apps</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons-resources/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-web-commons-resources</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-web-commons</artifactId>

--- a/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-web-dataentry</artifactId>

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-mobile/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-mobile/pom.xml
@@ -5,7 +5,7 @@
    <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web-maintenance</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>  
 
   <artifactId>dhis-web-maintenance-mobile</artifactId>

--- a/dhis-2/dhis-web/dhis-web-maintenance/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-maintenance/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-web-maintenance</artifactId>

--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-web-portal</artifactId>

--- a/dhis-2/dhis-web/dhis-web-reporting/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-reporting/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   
   <artifactId>dhis-web-reporting</artifactId>

--- a/dhis-2/dhis-web/dhis-web-uaa/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-uaa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
 
   <artifactId>dhis-web-uaa</artifactId>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.31-SNAPSHOT</version>
+    <version>2.31</version>
   </parent>
   <artifactId>dhis-web</artifactId>
   <packaging>pom</packaging>

--- a/dhis-2/pom-full.xml
+++ b/dhis-2/pom-full.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.hisp.dhis</groupId>
 		<artifactId>dhis</artifactId>
-		<version>2.31-SNAPSHOT</version>
+		<version>2.31</version>
 		<relativePath>.</relativePath>		
 	</parent>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.hisp.dhis</groupId>
   <artifactId>dhis</artifactId>
-  <version>2.31-SNAPSHOT</version>
+  <version>2.31</version>
   <packaging>pom</packaging>
   <name>DHIS 2</name>
   <url>http://dhis2.org</url>


### PR DESCRIPTION
Change "2.31-SNAPSHOT" to "2.31" since 2.31 has been released.