### PR TITLE
[DHIS2-5562] Fix bug weekly dataset report failed in Report app.

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
@@ -40,6 +40,7 @@ import java.text.DateFormatSymbols;
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.WeekFields;
@@ -231,7 +232,7 @@ public class I18nFormat
         if ( periodType instanceof WeeklyAbstractPeriodType ) // Use ISO dates due to potential week confusion
         {
             DateTime dateTime = new DateTime( period.getStartDate() );
-            LocalDate date = period.getStartDate().toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+            LocalDate date = Instant.ofEpochMilli( period.getStartDate().getTime() ).atZone( ZoneId.systemDefault() ).toLocalDate();
             WeekFields weekFields = WeekFields.of( PeriodType.MAP_WEEK_TYPE.get( periodType.getName() ), 4 );
 
             String year = String.valueOf( date.get( weekFields.weekBasedYear() ) );


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-5562

period.getStartDate().toInstant() throw java.lang.UnsupportedOperationException() if the date doesn't include time or it's a java.sql.Date class

This need to be backported 