### PR TITLE
WIP - Explicitly set the target flyway version

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/META-INF/dhis/beans.xml
@@ -12,21 +12,16 @@
       class="org.flywaydb.core.api.configuration.ClassicConfiguration" depends-on="databaseInfoProvider">
       <property name="dataSource" ref="dataSource" />
       <property name="baselineOnMigrate" value="true" />
-      <property name="outOfOrder" ref="flywayOutOfOrder" />
       <property name="ignoreMissingMigrations" value="true" />
       <property name="ignoreFutureMigrations" value="false" />
       <property name="group" value="true" />
+      <property name="target" value="2.32.3" />
       <property name="locations">
         <bean class="org.flywaydb.core.api.Location">
           <constructor-arg index="0"
             value="org/hisp/dhis/db/migration" />
         </bean>
       </property>
-    </bean>
-
-    <bean id="flywayOutOfOrder"
-      class="org.hisp.dhis.external.conf.ConfigurationPropertyFactoryBean">
-      <constructor-arg value="FLYWAY_OUT_OF_ORDER_MIGRATION" />
     </bean>
 
     <bean id="flyway" class="org.flywaydb.core.Flyway" init-method="migrate">

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -87,7 +87,6 @@ public enum ConfigurationKey
     REDIS_PASSWORD( "redis.password", "", true ),
     REDIS_ENABLED( "redis.enabled", "false", false ),
     REDIS_USE_SSL( "redis.use.ssl", "false", false ),
-    FLYWAY_OUT_OF_ORDER_MIGRATION( "flyway.migrate_out_of_order", "false", false ),
     PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT( "tracker.temporary.ownership.timeout", "3", false ),
     LEADER_TIME_TO_LIVE( "leader.time.to.live.minutes", "2", false ),
     RABBITMQ_CONNECTION_TIMEOUT( "rabbitmq.connection-timeout", "60000", false ),


### PR DESCRIPTION
This enforces deliberate in-order migrations at merge-time (before any code is in the wild).  It also removes the out-of-order runtime configuration option.

I discussed the risk associated with shipping a runtime out-of-order database migration execution flag with Ameen some time back and wanted to share my proposed mitigation of the root cause.  Goals in short:

1. Developers should be able to work on non-dependent migration scripts in tandem without worrying about the order of merges affecting the resulting binary build.
2. Wherever possible we shouldn't introduce unsupported and undocumented functionality to shipped product to support development-stream workflows
3. Database upgrades should be deterministic based only on the [db_version, core_version] set of inputs.

The idea here is that the target version of a shipped binary should explicitly specify the target version of the flyway database migration.  This is nice in that it makes explicit the intended db version, rather than implying the version from a list of script filenames in different locations (sql and java).  It has the additional bennefit of enabling a PR to introduce a new migration script and bump the intended version by one notch and one notch only.  Any other migrations developed in parallel but merged later would receive a merge conflict at PR time and would need to increment the version of the migration to be applied (in the migration file and the target version).  This should require minimal effort but ensure out-of-order migrations are **never** required.

I haven't fully tested this, just opening the PR to get feedback from @ameenhere and the team.