### PR TITLE
[DHIS2-4928] Remove ping request for online status from aggregate data entry.

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.availability.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.availability.js
@@ -39,13 +39,13 @@ dhis2.availability._availableTimeoutHandler = -1;
  * when availability changes.
  *
  * @param onlineInterval How often to check for availability when online,
- *            default is 10000.
+ *            default is 15000.
  * @param offlineInterval How often to check for availability when offline,
- *            default is 1000.
+ *            default is 10000.
  */
 dhis2.availability.startAvailabilityCheck = function ( onlineInterval, offlineInterval ) {
   onlineInterval = onlineInterval ? onlineInterval : 15000;
-  offlineInterval = offlineInterval ? offlineInterval : 1000;
+  offlineInterval = offlineInterval ? offlineInterval : 10000;
 
   function _checkAvailability() {
     $.ajax({

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.js
@@ -444,6 +444,7 @@ function ValueSaver( de, pe, co, ds, value, fieldId, resultColor )
             $( document ).trigger( dhis2.de.event.dataValueSaved, [ dhis2.de.currentDataSetId, dataValue ] );
     		markValue( fieldId, resultColor );
     		setHeaderDelayMessage( i18n_offline_notification );
+            dhis2.availability.startAvailabilityCheck();
     	}
     }
 

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -2579,9 +2579,6 @@ function updateForms()
         .then(downloadRemoteForms)
         .then(dhis2.de.loadOptionSets)
         .done( function() {
-        	dhis2.availability.startAvailabilityCheck();
-            console.log( 'Started availability check' );
-
             setDisplayNamePreferences();
 
             selection.responseReceived();


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-4928

After this fix,  when user enters data 
 	- If session time out and server still online -> show login dialog on top of the screen and send ping request every 10s.

![screen shot 2018-12-19 at 2 02 07 pm](https://user-images.githubusercontent.com/766102/50330562-57bab880-052e-11e9-9132-9729011b00a9.png)


 	- If server offline -> show server offline message -> ping every 10s -> if server gone online -> show login dialog

![screen shot 2018-12-19 at 2 03 35 pm](https://user-images.githubusercontent.com/766102/50331666-13c9b280-0532-11e9-957d-c06c373eb229.png)

After user logging in, stop sending ping request. 

This can be backported