### PR TITLE
chore(messaging-app): use master branch for dhis2-core v2.30

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -16,7 +16,7 @@
     "https://github.com/d2-ci/maintenance-app#v30",
     "https://github.com/d2-ci/maps-app#2.30",
     "https://github.com/d2-ci/menu-management-app#v30",
-    "https://github.com/d2-ci/messaging-app#v30",
+    "https://github.com/d2-ci/messaging-app#master",
     "https://github.com/d2-ci/pivot-tables-app#v30",
     "https://github.com/d2-ci/scheduler-app#v30",
     "https://github.com/d2-ci/settings-app#v30",


### PR DESCRIPTION
As discussed on Slack, we have introduced a "feature-toggling" mechanism in the messaging-app. This means all dhis2-core versions (starting 2.30, which is when the messaging-app was introduced) can run the master branch of the messaging-app. This will improve the maintainability of the app.

I've created a test case https://jira.dhis2.org/browse/DHIS2-5808 and Gintare has executed these tests in a staging environment (https://dhis2.vardevs.se/2.30).

So now we are ready to switch to master...

