### PR TITLE
chore(messaging-app): use master-branch for dhis2-core v2.31

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -18,7 +18,7 @@
   "https://github.com/d2-ci/maintenance-app#v31",
   "https://github.com/d2-ci/maps-app#v31",
   "https://github.com/d2-ci/menu-management-app#v31",
-  "https://github.com/d2-ci/messaging-app#v31",
+  "https://github.com/d2-ci/messaging-app#master",
   "https://github.com/d2-ci/pivot-tables-app#v31",
   "https://github.com/d2-ci/scheduler-app#v31",
   "https://github.com/d2-ci/settings-app#v31",


### PR DESCRIPTION
See explanation given for v2.30: https://github.com/dhis2/dhis2-core/pull/2789#issue-246996173
This PR is the same but for v2.31.