### PR TITLE
Changed some tests to use Mockito instead of Spring ctx

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -59,12 +59,7 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.translation.TranslationProperty;
 import org.joda.time.DateTime;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hisp.dhis.dataset.DataSet.NO_EXPIRY;
@@ -223,7 +218,7 @@ public class DataElement
         return ImmutableSet.<CategoryCombo>builder()
             .addAll( dataSetElements.stream()
                 .filter( DataSetElement::hasCategoryCombo )
-                .map( dse -> dse.getCategoryCombo() )
+                .map(DataSetElement::getCategoryCombo)
                 .collect( Collectors.toSet() ) )
             .add( categoryCombo ).build();
     }
@@ -254,8 +249,8 @@ public class DataElement
     public Set<CategoryOptionCombo> getCategoryOptionCombos()
     {
         return getCategoryCombos().stream()
-            .map( c -> c.getOptionCombos() )
-            .flatMap( c -> c.stream() )
+            .map(CategoryCombo::getOptionCombos)
+            .flatMap(Collection::stream)
             .collect( Collectors.toSet() );
     }
 
@@ -295,7 +290,7 @@ public class DataElement
     public DataSet getDataSet()
     {
         List<DataSet> list = new ArrayList<>( getDataSets() );
-        Collections.sort( list, DataSetFrequencyComparator.INSTANCE );
+        list.sort(DataSetFrequencyComparator.INSTANCE);
         return !list.isEmpty() ? list.get( 0 ) : null;
     }
 
@@ -307,7 +302,7 @@ public class DataElement
     public DataSet getApprovalDataSet()
     {
         List<DataSet> list = new ArrayList<>( getDataSets() );
-        Collections.sort( list, DataSetApprovalFrequencyComparator.INSTANCE );
+        list.sort(DataSetApprovalFrequencyComparator.INSTANCE);
         return !list.isEmpty() ? list.get( 0 ) : null;
     }
 
@@ -319,7 +314,7 @@ public class DataElement
     public Set<DataSet> getDataSets()
     {
         return ImmutableSet.copyOf( dataSetElements.stream().map( DataSetElement::getDataSet ).filter(
-            dataSet -> dataSet != null ).collect( Collectors.toSet() ) );
+                Objects::nonNull).collect( Collectors.toSet() ) );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
@@ -450,7 +450,9 @@ public class DataSet
      */
     public Set<DataElement> getDataElements()
     {
-        return ImmutableSet.copyOf( dataSetElements.stream().map( e -> e.getDataElement() ).collect( Collectors.toSet() ) );
+        return ImmutableSet.copyOf(
+                dataSetElements.stream().map(DataSetElement::getDataElement).collect( Collectors.toSet() )
+        );
     }
 
     public Set<DataElement> getDataElementsInSections()

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseDimensionalObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseDimensionalObjectTest.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.*;
 
 import java.util.stream.Collectors;
 
-import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.legend.Legend;
@@ -51,9 +50,9 @@ import com.google.common.collect.Sets;
 public class BaseDimensionalObjectTest
 {
     @Test
+    @SuppressWarnings("unchecked")
     public void verifyInstanceCloneObject()
     {
-
         BaseDimensionalObject target = new BaseDimensionalObject( "test-dimension" );
         target.setUid( "uid-999999" );
         target.setDimensionType( DimensionType.DATA_X );
@@ -79,12 +78,12 @@ public class BaseDimensionalObjectTest
         assertThat( cloned.getItems(), hasSize( 2 ) );
         assertThat( cloned.getItems(),
             IsIterableContainingInAnyOrder.containsInAnyOrder(
-                allOf( hasProperty( "name", Matchers.is( target.getItems().get( 0 ).getName() ) ),
-                    hasProperty( "uid", Matchers.is( target.getItems().get( 0 ).getUid() ) ),
-                    hasProperty( "code", Matchers.is( target.getItems().get( 0 ).getCode() ) ) ),
-                allOf( hasProperty( "name", Matchers.is( target.getItems().get( 1 ).getName() ) ),
-                    hasProperty( "uid", Matchers.is( target.getItems().get( 1 ).getUid() ) ),
-                    hasProperty( "code", Matchers.is( target.getItems().get( 1 ).getCode() ) ) ) ) );
+                allOf( hasProperty( "name", is( target.getItems().get( 0 ).getName() ) ),
+                       hasProperty( "uid",  is( target.getItems().get( 0 ).getUid() ) ),
+                       hasProperty( "code", is( target.getItems().get( 0 ).getCode() ) ) ),
+                allOf( hasProperty( "name", is( target.getItems().get( 1 ).getName() ) ),
+                       hasProperty( "uid",  is( target.getItems().get( 1 ).getUid() ) ),
+                       hasProperty( "code", is( target.getItems().get( 1 ).getCode() ) ) ) ) );
         assertThat( cloned.getFilter(), is( target.getFilter() ) );
         assertThat( cloned.getLegendSet().getName(), is( "legend-name" ) );
         assertThat( cloned.getLegendSet().getSymbolizer(), is( "symbolizer-test" ) );

--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -40,7 +40,16 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -28,12 +28,18 @@ package org.hisp.dhis.dataintegrity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.commons.collection.ListUtils.getDuplicates;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hisp.dhis.common.ListMap;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.ListMap;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataelement.DataElementGroupSet;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -48,11 +54,7 @@ import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.indicator.IndicatorGroupSet;
 import org.hisp.dhis.indicator.IndicatorService;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.organisationunit.*;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
@@ -64,20 +66,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.commons.collection.ListUtils.getDuplicates;
 
 /**
  * @author Lars Helge Overland
@@ -94,85 +82,64 @@ public class DefaultDataIntegrityService
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @Autowired
     private I18nManager i18nManager;
 
     private DataElementService dataElementService;
 
-    public void setDataElementService( DataElementService dataElementService )
-    {
-        this.dataElementService = dataElementService;
-    }
-
     private IndicatorService indicatorService;
-
-    public void setIndicatorService( IndicatorService indicatorService )
-    {
-        this.indicatorService = indicatorService;
-    }
 
     private DataSetService dataSetService;
 
-    public void setDataSetService( DataSetService dataSetService )
-    {
-        this.dataSetService = dataSetService;
-    }
-
     private OrganisationUnitService organisationUnitService;
-
-    public void setOrganisationUnitService( OrganisationUnitService organisationUnitService )
-    {
-        this.organisationUnitService = organisationUnitService;
-    }
 
     private OrganisationUnitGroupService organisationUnitGroupService;
 
-    public void setOrganisationUnitGroupService( OrganisationUnitGroupService organisationUnitGroupService )
-    {
-        this.organisationUnitGroupService = organisationUnitGroupService;
-    }
-
     private ValidationRuleService validationRuleService;
-
-    public void setValidationRuleService( ValidationRuleService validationRuleService )
-    {
-        this.validationRuleService = validationRuleService;
-    }
 
     private ExpressionService expressionService;
 
-    public void setExpressionService( ExpressionService expressionService )
-    {
-        this.expressionService = expressionService;
-    }
-
     private DataEntryFormService dataEntryFormService;
-
-    public void setDataEntryFormService( DataEntryFormService dataEntryFormService )
-    {
-        this.dataEntryFormService = dataEntryFormService;
-    }
 
     private CategoryService categoryService;
 
-    public void setCategoryService( CategoryService categoryService )
-    {
-        this.categoryService = categoryService;
-    }
-
     private PeriodService periodService;
-
-    public void setPeriodService( PeriodService periodService )
-    {
-        this.periodService = periodService;
-    }
 
     private ProgramIndicatorService programIndicatorService;
 
-    public void setProgramIndicatorService( ProgramIndicatorService programIndicatorService )
+    @Autowired
+    public DefaultDataIntegrityService( I18nManager i18nManager, DataElementService dataElementService,
+        IndicatorService indicatorService, DataSetService dataSetService,
+        OrganisationUnitService organisationUnitService, OrganisationUnitGroupService organisationUnitGroupService,
+        ValidationRuleService validationRuleService, ExpressionService expressionService,
+        DataEntryFormService dataEntryFormService, CategoryService categoryService, PeriodService periodService,
+        ProgramIndicatorService programIndicatorService )
     {
+        checkNotNull(i18nManager);
+        checkNotNull(dataElementService);
+        checkNotNull(indicatorService);
+        checkNotNull(dataSetService);
+        checkNotNull(organisationUnitService);
+        checkNotNull(organisationUnitGroupService);
+        checkNotNull(validationRuleService);
+        checkNotNull(dataEntryFormService);
+        checkNotNull(categoryService);
+        checkNotNull(periodService);
+        checkNotNull(programIndicatorService);
+
+        this.i18nManager = i18nManager;
+        this.dataElementService = dataElementService;
+        this.indicatorService = indicatorService;
+        this.dataSetService = dataSetService;
+        this.organisationUnitService = organisationUnitService;
+        this.organisationUnitGroupService = organisationUnitGroupService;
+        this.validationRuleService = validationRuleService;
+        this.expressionService = expressionService;
+        this.dataEntryFormService = dataEntryFormService;
+        this.categoryService = categoryService;
+        this.periodService = periodService;
         this.programIndicatorService = programIndicatorService;
     }
+
     // -------------------------------------------------------------------------
     // DataIntegrityService implementation
     // -------------------------------------------------------------------------
@@ -458,7 +425,7 @@ public class DefaultDataIntegrityService
 
         Set<OrganisationUnit> visited = new HashSet<>();
 
-        OrganisationUnit parent = null;
+        OrganisationUnit parent;
 
         for ( OrganisationUnit unit : organisationUnits )
         {
@@ -653,11 +620,11 @@ public class DefaultDataIntegrityService
     @Override
     public Map<ProgramIndicator, String> getInvalidProgramIndicatorExpressions()
     {
-        Map<ProgramIndicator, String> invalidExpressions = new HashMap<>();
+        Map<ProgramIndicator, String> invalidExpressions;
 
         invalidExpressions = programIndicatorService.getAllProgramIndicators().stream()
             .filter( pi -> ! ProgramIndicator.VALID.equals( programIndicatorService.expressionIsValid( pi.getExpression() ) ) )
-            .collect( Collectors.toMap( pi -> pi, pi -> pi.getExpression() ) );
+            .collect( Collectors.toMap( pi -> pi, ProgramIndicator::getExpression) );
 
         return invalidExpressions;
     }
@@ -665,11 +632,11 @@ public class DefaultDataIntegrityService
     @Override
     public Map<ProgramIndicator, String> getInvalidProgramIndicatorFilters()
     {
-        Map<ProgramIndicator, String> invalidFilters = new HashMap<>();
+        Map<ProgramIndicator, String> invalidFilters;
 
         invalidFilters = programIndicatorService.getAllProgramIndicators().stream()
-            .filter( pi -> ( ! ( pi.hasFilter() ? ProgramIndicator.VALID.equals( programIndicatorService.filterIsValid( pi.getFilter() ) ) : true ) ) )
-            .collect( Collectors.toMap( pi -> pi, pi -> pi.getFilter() ) );
+            .filter( pi -> ( ! (!pi.hasFilter() || ProgramIndicator.VALID.equals(programIndicatorService.filterIsValid(pi.getFilter()))) ) )
+            .collect( Collectors.toMap( pi -> pi, ProgramIndicator::getFilter) );
 
         return invalidFilters;
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/META-INF/dhis/beans.xml
@@ -28,17 +28,18 @@
   <!-- Data integrity -->
 
   <bean id="org.hisp.dhis.dataintegrity.DataIntegrityService" class="org.hisp.dhis.dataintegrity.DefaultDataIntegrityService">
-    <property name="dataElementService" ref="org.hisp.dhis.dataelement.DataElementService" />
-    <property name="indicatorService" ref="org.hisp.dhis.indicator.IndicatorService" />
-    <property name="dataSetService" ref="org.hisp.dhis.dataset.DataSetService" />
-    <property name="organisationUnitService" ref="org.hisp.dhis.organisationunit.OrganisationUnitService" />
-    <property name="organisationUnitGroupService" ref="org.hisp.dhis.organisationunit.OrganisationUnitGroupService" />
-    <property name="validationRuleService" ref="org.hisp.dhis.validation.ValidationRuleService" />
-    <property name="expressionService" ref="org.hisp.dhis.expression.ExpressionService" />
-	<property name="dataEntryFormService" ref="org.hisp.dhis.dataentryform.DataEntryFormService" />
-	<property name="categoryService" ref="org.hisp.dhis.category.CategoryService" />
-	<property name="periodService" ref="org.hisp.dhis.period.PeriodService" />
-    <property name="programIndicatorService" ref="org.hisp.dhis.program.ProgramIndicatorService" />
+    <constructor-arg index="0" ref="org.hisp.dhis.i18n.I18nManager"/>
+    <constructor-arg index="1" ref="org.hisp.dhis.dataelement.DataElementService"/>
+    <constructor-arg index="2" ref="org.hisp.dhis.indicator.IndicatorService"/>
+    <constructor-arg index="3" ref="org.hisp.dhis.dataset.DataSetService"/>
+    <constructor-arg index="4" ref="org.hisp.dhis.organisationunit.OrganisationUnitService"/>
+    <constructor-arg index="5" ref="org.hisp.dhis.organisationunit.OrganisationUnitGroupService"/>
+    <constructor-arg index="6" ref="org.hisp.dhis.validation.ValidationRuleService"/>
+    <constructor-arg index="7" ref="org.hisp.dhis.expression.ExpressionService"/>
+    <constructor-arg index="8" ref="org.hisp.dhis.dataentryform.DataEntryFormService"/>
+    <constructor-arg index="9" ref="org.hisp.dhis.category.CategoryService"/>
+    <constructor-arg index="10" ref="org.hisp.dhis.period.PeriodService"/>
+    <constructor-arg index="11" ref="org.hisp.dhis.program.ProgramIndicatorService"/>
   </bean>
   
   <!-- Maintenance -->

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -28,19 +28,30 @@ package org.hisp.dhis.dataintegrity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.collect.Lists.newArrayList;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.hamcrest.Matchers.*;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import org.hisp.dhis.DhisSpringTest;
+import com.google.common.collect.Lists;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dataentryform.DataEntryFormService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.indicator.IndicatorService;
@@ -50,71 +61,114 @@ import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.MonthlyPeriodType;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.QuarterlyPeriodType;
+import org.hisp.dhis.program.ProgramIndicatorService;
+import org.hisp.dhis.validation.ValidationRuleService;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * @author Lars Helge Overland
  * @version $Id$
  */
 public class DataIntegrityServiceTest
-    extends DhisSpringTest
 {
-    @Autowired
-    private DataIntegrityService dataIntegrityService;
 
-    @Autowired
+    @Mock
+    private I18nManager i18nManager;
+
+    @Mock
     private DataElementService dataElementService;
 
-    @Autowired
+    @Mock
     private IndicatorService indicatorService;
 
-    @Autowired
+    @Mock
     private DataSetService dataSetService;
 
-    @Autowired
+    @Mock
     private OrganisationUnitService organisationUnitService;
 
-    @Autowired
+    @Mock
     private OrganisationUnitGroupService organisationUnitGroupService;
+
+    @Mock
+    private ValidationRuleService validationRuleService;
+
+    @Mock
+    private ExpressionService expressionService;
+
+    @Mock
+    private DataEntryFormService dataEntryFormService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PeriodService periodService;
+
+    @Mock
+    private ProgramIndicatorService programIndicatorService;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private DefaultDataIntegrityService subject;
+
+    private EnhancedRandom rnd;
 
     private DataElement elementA;
     private DataElement elementB;
-    private DataElement elementC;
-    
+
     private DataElementGroup elementGroupA;
-    
+
     private IndicatorType indicatorTypeA;
-    
+
     private Indicator indicatorA;
     private Indicator indicatorB;
     private Indicator indicatorC;
-    
+
     private IndicatorGroup indicatorGroupA;
-    
+
     private DataSet dataSetA;
     private DataSet dataSetB;
-    
+
     private OrganisationUnit unitA;
     private OrganisationUnit unitB;
     private OrganisationUnit unitC;
     private OrganisationUnit unitD;
     private OrganisationUnit unitE;
     private OrganisationUnit unitF;
-    
+    private List<OrganisationUnit> allOrgUnits;
+
     private OrganisationUnitGroup unitGroupA;
     private OrganisationUnitGroup unitGroupB;
     private OrganisationUnitGroup unitGroupC;
     private OrganisationUnitGroup unitGroupD;
-      
+
+    @Before
+    public void setUp()
+    {
+        subject = new DefaultDataIntegrityService( i18nManager, dataElementService, indicatorService, dataSetService,
+                organisationUnitService, organisationUnitGroupService, validationRuleService, expressionService,
+                dataEntryFormService, categoryService, periodService, programIndicatorService );
+
+        rnd = aNewEnhancedRandomBuilder().build();
+        setUpFixtures();
+    }
 
     // -------------------------------------------------------------------------
     // Fixture
     // -------------------------------------------------------------------------
 
-    @Override
-    public void setUpTest()
+
+    private void setUpFixtures()
     {
         // ---------------------------------------------------------------------
         // Objects
@@ -122,108 +176,77 @@ public class DataIntegrityServiceTest
 
         elementA = createDataElement( 'A' );
         elementB = createDataElement( 'B' );
-        elementC = createDataElement( 'C' );
 
-        dataElementService.addDataElement( elementA );
-        dataElementService.addDataElement( elementB );
-        dataElementService.addDataElement( elementC );
-        
         indicatorTypeA = createIndicatorType( 'A' );
-        
-        indicatorService.addIndicatorType( indicatorTypeA );
-        
+
         indicatorA = createIndicator( 'A', indicatorTypeA );
         indicatorB = createIndicator( 'B', indicatorTypeA );
         indicatorC = createIndicator( 'C', indicatorTypeA );
-        
+
         indicatorA.setNumerator( " " );
         indicatorB.setNumerator( "Numerator" );
         indicatorB.setDenominator( "Denominator" );
         indicatorC.setNumerator( "Numerator" );
         indicatorC.setDenominator( "Denominator" );
 
-        indicatorService.addIndicator( indicatorA );
-        indicatorService.addIndicator( indicatorB );
-        indicatorService.addIndicator( indicatorC );        
-        
         unitA = createOrganisationUnit( 'A' );
         unitB = createOrganisationUnit( 'B', unitA );
         unitC = createOrganisationUnit( 'C', unitB );
         unitD = createOrganisationUnit( 'D', unitC );
         unitE = createOrganisationUnit( 'E', unitD );
         unitF = createOrganisationUnit( 'F' );
-
-        organisationUnitService.addOrganisationUnit( unitA );
-        organisationUnitService.addOrganisationUnit( unitB );
-        organisationUnitService.addOrganisationUnit( unitC );
-        organisationUnitService.addOrganisationUnit( unitD ); 
-        organisationUnitService.addOrganisationUnit( unitE );
-        organisationUnitService.addOrganisationUnit( unitF );
-        
         unitA.setParent( unitC );
+        allOrgUnits = Lists.newArrayList(unitA, unitB, unitC, unitD, unitE, unitF);
 
-        organisationUnitService.updateOrganisationUnit( unitA );
-        
         dataSetA = createDataSet( 'A', new MonthlyPeriodType() );
         dataSetB = createDataSet( 'B', new QuarterlyPeriodType() );
 
         dataSetA.addDataSetElement( elementA );
         dataSetA.addDataSetElement( elementB );
-        
+
         dataSetA.getSources().add( unitA );
         unitA.getDataSets().add( dataSetA );
-        
-        dataSetB.addDataSetElement( elementA );     
-        
-        dataSetService.addDataSet( dataSetA );
-        dataSetService.addDataSet( dataSetB );
-        
+
+        dataSetB.addDataSetElement( elementA );
+
         // ---------------------------------------------------------------------
         // Groups
         // ---------------------------------------------------------------------
 
         elementGroupA = createDataElementGroup( 'A' );
-        
+
         elementGroupA.getMembers().add( elementA );
         elementA.getGroups().add( elementGroupA );
-        
-        dataElementService.addDataElementGroup( elementGroupA );
-        
+
         indicatorGroupA = createIndicatorGroup( 'A' );
-        
+
         indicatorGroupA.getMembers().add( indicatorA );
         indicatorA.getGroups().add( indicatorGroupA );
-        
-        indicatorService.addIndicatorGroup( indicatorGroupA );
-        
+
         unitGroupA = createOrganisationUnitGroup( 'A' );
         unitGroupB = createOrganisationUnitGroup( 'B' );
         unitGroupC = createOrganisationUnitGroup( 'C' );
         unitGroupD = createOrganisationUnitGroup( 'D' );
-        
+
         unitGroupA.getMembers().add( unitA );
         unitGroupA.getMembers().add( unitB );
         unitGroupA.getMembers().add( unitC );
         unitA.getGroups().add( unitGroupA );
         unitB.getGroups().add( unitGroupA );
         unitC.getGroups().add( unitGroupA );
-        
+
         unitGroupB.getMembers().add( unitA );
         unitGroupB.getMembers().add( unitB );
         unitGroupB.getMembers().add( unitF );
         unitA.getGroups().add( unitGroupB );
         unitB.getGroups().add( unitGroupB );
         unitF.getGroups().add( unitGroupB );
-        
+
         unitGroupC.getMembers().add( unitA );
         unitA.getGroups().add( unitGroupC );
-        
-        organisationUnitGroupService.addOrganisationUnitGroup( unitGroupA );
-        organisationUnitGroupService.addOrganisationUnitGroup( unitGroupB );
-        organisationUnitGroupService.addOrganisationUnitGroup( unitGroupC );
-        organisationUnitGroupService.addOrganisationUnitGroup( unitGroupD );
+
     }
-    
+
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -231,79 +254,143 @@ public class DataIntegrityServiceTest
     @Test
     public void testGetDataElementsWithoutDataSet()
     {
-        Collection<DataElement> expected = dataIntegrityService.getDataElementsWithoutDataSet();
-        
-        assertTrue( equals( expected, elementC ) );
+        subject.getDataElementsWithoutDataSet();
+        verify(dataElementService).getDataElementsWithoutDataSets();
+        verifyNoMoreInteractions(dataElementService);
     }
 
     @Test
     public void testGetDataElementsWithoutGroups()
     {
-        Collection<DataElement> expected = dataIntegrityService.getDataElementsWithoutGroups();
-        
-        assertTrue( message( expected ), equals( expected, elementB, elementC ) );
+        subject.getDataElementsWithoutGroups();
+        verify(dataElementService).getDataElementsWithoutGroups();
+        verifyNoMoreInteractions(dataElementService);
     }
 
     @Test
     public void testGetDataElementsAssignedToDataSetsWithDifferentPeriodType()
     {
-        Map<DataElement, Collection<DataSet>> expected = dataIntegrityService.getDataElementsAssignedToDataSetsWithDifferentPeriodTypes();
-        
-        assertEquals( 1, expected.size() );
-        assertEquals( elementA, expected.keySet().iterator().next() );
-        assertTrue( equals( expected.get( elementA ), dataSetA, dataSetB ) );
+        String seed = "abcde";
+        Map<String, DataElement> dataElements = createRandomDataElements(6, seed);
+
+        DataSet dataSet1 = rnd.nextObject( DataSet.class, "periodType", "workflow" );
+        dataSet1.setPeriodType( PeriodType.getPeriodTypeFromIsoString( "2011" ) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 1) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 2) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 3) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 4) );
+
+        DataSet dataSet2 = rnd.nextObject( DataSet.class, "periodType", "workflow" );
+        dataSet2.setPeriodType( PeriodType.getByIndex( 5 ) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 4) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 5) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 6) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 1) );
+
+        when( dataElementService.getAllDataElements() ).thenReturn(new ArrayList<>(dataElements.values()));
+        when( dataSetService.getAllDataSets() ).thenReturn( newArrayList( dataSet1, dataSet2 ) );
+
+        SortedMap<DataElement, Collection<DataSet>> result = subject
+                .getDataElementsAssignedToDataSetsWithDifferentPeriodTypes();
+
+        assertThat( result.get( dataElements.get(seed + 4) ), hasSize( 2 ) );
+        assertThat( result.get( dataElements.get(seed + 1) ), hasSize( 2 ) );
+        assertThat( result.get( dataElements.get(seed + 4) ), containsInAnyOrder( dataSet1, dataSet2 ) );
+        assertThat( result.get( dataElements.get(seed + 1) ), containsInAnyOrder( dataSet1, dataSet2 ) );
     }
+
+    @Test
+    public void testGetDataElementsAssignedToDataSetsWithDifferentPeriodTypeNoResult()
+    {
+
+        String seed = "abcde";
+        Map<String, DataElement> dataElements = createRandomDataElements(6, seed);
+
+        DataSet dataSet1 = rnd.nextObject( DataSet.class, "periodType", "workflow" );
+        dataSet1.setPeriodType( PeriodType.getPeriodTypeFromIsoString( "2011" ) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 1) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 2) );
+        dataSet1.addDataSetElement( dataElements.get(seed + 3) );
+
+        DataSet dataSet2 = rnd.nextObject( DataSet.class, "periodType", "workflow" );
+        dataSet2.setPeriodType( PeriodType.getByIndex( 5 ) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 4) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 5) );
+        dataSet2.addDataSetElement( dataElements.get(seed + 6) );
+
+        when( dataElementService.getAllDataElements() ).thenReturn(new ArrayList<>(dataElements.values()));
+        when( dataSetService.getAllDataSets() ).thenReturn( newArrayList( dataSet1, dataSet2 ) );
+
+        SortedMap<DataElement, Collection<DataSet>> result = subject
+                .getDataElementsAssignedToDataSetsWithDifferentPeriodTypes();
+        assertThat(result.keySet(), hasSize(0));
+    }
+
 
     @Test
     public void testGetDataSetsNotAssignedToOrganisationUnits()
     {
-        Collection<DataSet> expected = dataIntegrityService.getDataSetsNotAssignedToOrganisationUnits();
-        
-        assertTrue( message( expected ), equals( expected, dataSetB ) );
+        when(dataSetService.getAllDataSets()).thenReturn(Lists.newArrayList(dataSetA, dataSetB));
+        Collection<DataSet> expected = subject.getDataSetsNotAssignedToOrganisationUnits();
+        assertThat(expected, hasSize(1));
+        assertThat(expected, hasItem(dataSetB));
     }
 
     @Test
     public void testGetIndicatorsWithIdenticalFormulas()
     {
-        Set<Set<Indicator>> expected = dataIntegrityService.getIndicatorsWithIdenticalFormulas();
+        when(indicatorService.getAllIndicators()).thenReturn(Lists.newArrayList(indicatorA, indicatorB, indicatorC));
+        Set<Set<Indicator>> expected = subject.getIndicatorsWithIdenticalFormulas();
 
         Collection<Indicator> violation = expected.iterator().next();
-        
-        assertEquals( 1, expected.size());        
-        assertEquals( 2, violation.size() );
-        assertTrue( violation.contains( indicatorB ) );
-        assertTrue( violation.contains( indicatorC ) );
+        assertThat(expected, hasSize(1));
+        assertThat(violation, hasSize(2));
+        assertThat(violation, hasItem(indicatorB));
+        assertThat(violation, hasItem(indicatorC));
     }
 
     @Test
     public void testGetIndicatorsWithoutGroups()
     {
-        Collection<Indicator> expected = dataIntegrityService.getIndicatorsWithoutGroups();
-        
-        assertTrue( message( expected ), equals( expected, indicatorB, indicatorC ) );
+        subject.getIndicatorsWithoutGroups();
+        verify(indicatorService).getIndicatorsWithoutGroups();
+        verifyNoMoreInteractions(dataElementService);
     }
 
     @Test
     public void testGetOrganisationUnitsWithCyclicReferences()
     {
-        Collection<OrganisationUnit> expected = dataIntegrityService.getOrganisationUnitsWithCyclicReferences();
-        
-        assertTrue( message( expected ), equals( expected, unitA, unitB, unitC ) );
+        when(organisationUnitService.getAllOrganisationUnits()).thenReturn(allOrgUnits);
+
+        Collection<OrganisationUnit> expected = subject.getOrganisationUnitsWithCyclicReferences();
+        assertThat(expected, hasSize(3));
+        assertThat(expected, hasItems(unitA, unitB, unitC));
     }
 
     @Test
     public void testGetOrphanedOrganisationUnits()
     {
-        Collection<OrganisationUnit> expected = dataIntegrityService.getOrphanedOrganisationUnits();
-        
-        assertTrue( message( expected ), equals( expected, unitF ) );
+        when(organisationUnitService.getAllOrganisationUnits()).thenReturn(allOrgUnits);
+
+        Collection<OrganisationUnit> expected = subject.getOrphanedOrganisationUnits();
+        assertThat(expected, hasSize(1));
+        assertThat(expected, hasItem(unitF));
     }
 
     @Test
     public void testGetOrganisationUnitsWithoutGroups()
     {
-        Collection<OrganisationUnit> expected = dataIntegrityService.getOrganisationUnitsWithoutGroups();
-        
-        assertTrue( message( expected ), equals( expected, unitD, unitE ) );
+        subject.getOrganisationUnitsWithoutGroups();
+        verify(organisationUnitService).getOrganisationUnitsWithoutGroups();
+        verifyNoMoreInteractions(organisationUnitService);
+    }
+
+    private Map<String, DataElement> createRandomDataElements(int quantity, String uidSeed) {
+
+        return IntStream.range( 1, quantity + 1 ).mapToObj(i -> {
+            DataElement d = rnd.nextObject( DataElement.class );
+            d.setUid( uidSeed + i );
+            return d;
+        } ).collect( Collectors.toMap(DataElement::getUid, Function.identity()) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -61,6 +61,11 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -166,6 +166,18 @@
       <artifactId>javax.servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <!-- TEST -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -89,7 +89,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -161,17 +160,8 @@ public class DefaultDimensionService
     public <T extends IdentifiableObject> List<T> getCanReadObjects( User user, List<T> objects )
     {
         List<T> list = new ArrayList<>( objects );
-        Iterator<T> iterator = list.iterator();
 
-        while ( iterator.hasNext() )
-        {
-            T object = iterator.next();
-
-            if ( !aclService.canRead( user, object ) )
-            {
-                iterator.remove();
-            }
-        }
+        list.removeIf(object -> !aclService.canRead(user, object));
 
         return list;
     }
@@ -350,10 +340,10 @@ public class DefaultDimensionService
             String id1 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 1 );
             String id2 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 2 );
 
-            DataElementOperand operand = null;
-            ReportingRate reportingRate = null;
-            ProgramDataElementDimensionItem programDataElement = null;
-            ProgramTrackedEntityAttributeDimensionItem programAttribute = null;
+            DataElementOperand operand;
+            ReportingRate reportingRate;
+            ProgramDataElementDimensionItem programDataElement;
+            ProgramTrackedEntityAttributeDimensionItem programAttribute;
 
             if ( ( operand = getDataElementOperand( idScheme, id0, id1, id2 ) ) != null )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -28,27 +28,31 @@ package org.hisp.dhis.expression;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Sets;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.expression.MissingValueStrategy.*;
+import static org.hisp.dhis.system.util.MathUtils.calculateExpression;
+import static org.hisp.dhis.system.util.MathUtils.isEqual;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hisp.dhis.common.DimensionService;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.GenericStore;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.ListMap;
-import org.hisp.dhis.common.SetMap;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.common.exception.InvalidIdentifierReferenceException;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.indicator.Indicator;
@@ -60,21 +64,10 @@ import org.hisp.dhis.system.jep.CustomFunctions;
 import org.hisp.dhis.system.util.DateUtils;
 import org.hisp.dhis.system.util.ExpressionUtils;
 import org.hisp.dhis.system.util.MathUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.expression.MissingValueStrategy.*;
-import static org.hisp.dhis.system.util.MathUtils.*;
+import com.google.common.collect.Sets;
 
 /**
  * The expression is a string describing a formula containing data element ids
@@ -95,50 +88,38 @@ public class DefaultExpressionService
 
     private GenericStore<Expression> expressionStore;
 
-    public void setExpressionStore( GenericStore<Expression> expressionStore )
-    {
-        this.expressionStore = expressionStore;
-    }
-
     private DataElementService dataElementService;
-
-    public void setDataElementService( DataElementService dataElementService )
-    {
-        this.dataElementService = dataElementService;
-    }
 
     private ConstantService constantService;
 
-    public void setConstantService( ConstantService constantService )
-    {
-        this.constantService = constantService;
-    }
-
     private CategoryService categoryService;
-
-    public void setCategoryService( CategoryService categoryService )
-    {
-        this.categoryService = categoryService;
-    }
 
     private OrganisationUnitGroupService organisationUnitGroupService;
 
-    public void setOrganisationUnitGroupService( OrganisationUnitGroupService organisationUnitGroupService )
-    {
-        this.organisationUnitGroupService = organisationUnitGroupService;
-    }
-
     private DimensionService dimensionService;
-
-    public void setDimensionService( DimensionService dimensionService )
-    {
-        this.dimensionService = dimensionService;
-    }
 
     private IdentifiableObjectManager idObjectManager;
 
-    public void setIdObjectManager( IdentifiableObjectManager idObjectManager )
+    @Autowired
+    public DefaultExpressionService( GenericStore<Expression> expressionStore, DataElementService dataElementService,
+        ConstantService constantService, CategoryService categoryService,
+        OrganisationUnitGroupService organisationUnitGroupService, DimensionService dimensionService,
+        IdentifiableObjectManager idObjectManager )
     {
+        checkNotNull(expressionStore);
+        checkNotNull(dataElementService);
+        checkNotNull(constantService);
+        checkNotNull(categoryService);
+        checkNotNull(organisationUnitGroupService);
+        checkNotNull(dimensionService);
+        checkNotNull(idObjectManager);
+
+        this.expressionStore = expressionStore;
+        this.dataElementService = dataElementService;
+        this.constantService = constantService;
+        this.categoryService = categoryService;
+        this.organisationUnitGroupService = organisationUnitGroupService;
+        this.dimensionService = dimensionService;
         this.idObjectManager = idObjectManager;
     }
 
@@ -186,14 +167,14 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
     // Business logic
     // -------------------------------------------------------------------------
-    
+
     @Override
     public Double getIndicatorValue( Indicator indicator, Period period,
         Map<? extends DimensionalItemObject, Double> valueMap, Map<String, Double> constantMap,
         Map<String, Integer> orgUnitCountMap )
     {
         IndicatorValue value = getIndicatorValueObject( indicator, period, valueMap, constantMap, orgUnitCountMap );
-        
+
         return value != null ? value.getValue() : null;
     }
 
@@ -284,24 +265,24 @@ public class DefaultExpressionService
     @Override
     public Set<CategoryOptionCombo> getOptionCombosInExpression( String expression )
     {
-        return getIdObjectsInExpression( CATEGORY_OPTION_COMBO_OPERAND_PATTERN, expression, 
+        return getIdObjectsInExpression( CATEGORY_OPTION_COMBO_OPERAND_PATTERN, expression,
             ( m ) -> categoryService.getCategoryOptionCombo( m.group( GROUP_CATEGORORY_OPTION_COMBO ) ) );
     }
 
     @Override
     public Set<OrganisationUnitGroup> getOrganisationUnitGroupsInExpression( String expression )
     {
-        return getIdObjectsInExpression( OU_GROUP_PATTERN, expression, 
+        return getIdObjectsInExpression( OU_GROUP_PATTERN, expression,
             ( m ) -> organisationUnitGroupService.getOrganisationUnitGroup( m.group( GROUP_ID ) ) );
     }
 
     /**
      * Returns a set of identifiable objects which are referenced in
      * the given expression based on the given regular expression pattern.
-     * 
+     *
      * @param pattern the regular expression pattern to match identifiable objects on.
      * @param expression the expression where identifiable objects are referenced.
-     * @param provider the provider of identifiable objects, accepts a matcher and 
+     * @param provider the provider of identifiable objects, accepts a matcher and
      *        provides the object.
      * @return a set of identifiable objects.
      */
@@ -313,7 +294,6 @@ public class DefaultExpressionService
         {
             return  objects;
         }
-        
         final Matcher matcher = pattern.matcher( expression );
 
         while ( matcher.find() )
@@ -343,9 +323,7 @@ public class DefaultExpressionService
             {
                 String dataElementUid = StringUtils.trimToNull( matcher.group( GROUP_DATA_ELEMENT ) );
                 String optionComboUid = StringUtils.trimToNull( matcher.group( GROUP_CATEGORORY_OPTION_COMBO ) );
-
                 DataElement dataElement = dataElementService.getDataElement( dataElementUid );
-
                 CategoryOptionCombo optionCombo = optionComboUid == null ? null :
                     categoryService.getCategoryOptionCombo( optionComboUid );
 
@@ -460,7 +438,6 @@ public class DefaultExpressionService
         while ( matcher.find() )
         {
             String dimensionItem = matcher.group( GROUP_ID );
-            
             DimensionalItemObject dimensionItemObject = dimensionService.getDataDimensionalItemObject( dimensionItem );
 
             if ( dimensionItemObject != null )
@@ -475,17 +452,15 @@ public class DefaultExpressionService
     @Override
     public Set<DimensionalItemObject> getDimensionalItemObjectsInIndicators( Collection<Indicator> indicators )
     {
-        Set<DimensionalItemObject> items = Sets.newHashSet();
-
-        for ( Indicator indicator : indicators )
-        {
-            items.addAll( getDimensionalItemObjectsInExpression( indicator.getNumerator() ) );
-            items.addAll( getDimensionalItemObjectsInExpression( indicator.getDenominator() ) );
-        }
-
-        return items;
+        return indicators.stream()
+                .flatMap(
+                        i -> Stream.of(i.getNumerator(), i.getDenominator())
+                )
+                .map( this::getDimensionalItemObjectsInExpression )
+                .flatMap( Set::stream )
+                .collect(Collectors.toSet());
     }
-    
+
     @Override
     public Set<OrganisationUnitGroup> getOrganisationUnitGroupsInIndicators( Collection<Indicator> indicators )
     {
@@ -695,10 +670,10 @@ public class DefaultExpressionService
         if ( indicators != null && !indicators.isEmpty() )
         {
             Map<String, Constant> constants = new CachingMap<String, Constant>()
-                .load( idObjectManager.getAllNoAcl( Constant.class ), c -> c.getUid() );
+                .load( idObjectManager.getAllNoAcl( Constant.class ), BaseIdentifiableObject::getUid);
 
             Map<String, OrganisationUnitGroup> orgUnitGroups = new CachingMap<String, OrganisationUnitGroup>()
-                .load( idObjectManager.getAllNoAcl( OrganisationUnitGroup.class ), g -> g.getUid() );
+                .load( idObjectManager.getAllNoAcl( OrganisationUnitGroup.class ), BaseIdentifiableObject::getUid);
 
             for ( Indicator indicator : indicators )
             {
@@ -787,7 +762,7 @@ public class DefaultExpressionService
 
     /**
      * Generates an expression based on the given data maps.
-     * 
+     *
      * @param expression the expression.
      * @param valueMap the value map.
      * @param constantMap the constant map.
@@ -799,14 +774,14 @@ public class DefaultExpressionService
      */
     private String generateExpression( String expression, Map<? extends DimensionalItemObject, Double> valueMap,
         Map<String, Double> constantMap, Map<String, Integer> orgUnitCountMap, Integer days,
-        MissingValueStrategy missingValueStrategy, 
+        MissingValueStrategy missingValueStrategy,
         Map<String, List<Double>> aggregateMap )
     {
         if ( expression == null || expression.isEmpty() )
         {
             return null;
         }
-        
+
         expression = ExpressionUtils.normalizeExpression( expression );
 
         Map<String, Double> dimensionItemValueMap = valueMap.entrySet().stream().

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -887,13 +887,13 @@
   </bean>
 
   <bean id="org.hisp.dhis.expression.ExpressionService" class="org.hisp.dhis.expression.DefaultExpressionService">
-    <property name="expressionStore" ref="org.hisp.dhis.expression.ExpressionStore" />
-    <property name="dataElementService" ref="org.hisp.dhis.dataelement.DataElementService" />
-    <property name="constantService" ref="org.hisp.dhis.constant.ConstantService" />
-    <property name="categoryService" ref="org.hisp.dhis.category.CategoryService" />
-    <property name="organisationUnitGroupService" ref="org.hisp.dhis.organisationunit.OrganisationUnitGroupService" />
-    <property name="dimensionService" ref="org.hisp.dhis.dimension.DimensionService" />
-    <property name="idObjectManager" ref="org.hisp.dhis.common.IdentifiableObjectManager" />
+    <constructor-arg index="0" ref="org.hisp.dhis.expression.ExpressionStore"/>
+    <constructor-arg index="1" ref="org.hisp.dhis.dataelement.DataElementService"/>
+    <constructor-arg index="2" ref="org.hisp.dhis.constant.ConstantService"/>
+    <constructor-arg index="3" ref="org.hisp.dhis.category.CategoryService"/>
+    <constructor-arg index="4" ref="org.hisp.dhis.organisationunit.OrganisationUnitGroupService"/>
+    <constructor-arg index="5" ref="org.hisp.dhis.dimension.DimensionService"/>
+    <constructor-arg index="6" ref="org.hisp.dhis.common.IdentifiableObjectManager"/>
   </bean>
 
   <bean id="validationNotificationMessageRenderer" class="org.hisp.dhis.notification.ValidationNotificationMessageRenderer" />

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -1,0 +1,741 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.expression;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.*;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
+import static org.hisp.dhis.expression.Expression.SEPARATOR;
+import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
+import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.*;
+
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.hisp.dhis.category.*;
+import org.hisp.dhis.common.*;
+import org.hisp.dhis.constant.Constant;
+import org.hisp.dhis.constant.ConstantService;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorType;
+import org.hisp.dhis.indicator.IndicatorValue;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.program.ProgramDataElementDimensionItem;
+import org.hisp.dhis.program.ProgramIndicator;
+import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ExpressionService2Test {
+
+    @Mock
+    private HibernateGenericStore hibernateGenericStore;
+    @Mock
+    private DataElementService dataElementService;
+    @Mock
+    private CategoryService categoryService;
+    @Mock
+    private ConstantService constantService;
+    @Mock
+    private OrganisationUnitGroupService organisationUnitGroupService;
+    @Mock
+    private IdentifiableObjectManager idObjectManager;
+    @Mock
+    private DimensionService dimensionService;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private DefaultExpressionService target;
+
+    private CategoryOption categoryOptionA;
+    private CategoryOption categoryOptionB;
+    private CategoryOption categoryOptionC;
+    private CategoryOption categoryOptionD;
+
+    private Category categoryA;
+    private Category categoryB;
+
+    private CategoryCombo categoryCombo;
+
+    private DataElement deA;
+    private DataElement deB;
+    private DataElement deC;
+    private DataElement deD;
+    private DataElement deE;
+    private DataElementOperand opA;
+    private DataElementOperand opB;
+
+    private ProgramTrackedEntityAttributeDimensionItem pteaA;
+    private ProgramDataElementDimensionItem pdeA;
+    private ProgramIndicator piA;
+
+    private Period period;
+
+    private OrganisationUnit unitA;
+    private OrganisationUnit unitB;
+    private OrganisationUnit unitC;
+
+    private CategoryOptionCombo coc;
+    private CategoryOptionCombo cocA;
+    private CategoryOptionCombo cocB;
+
+    private Constant constantA;
+
+    private OrganisationUnitGroup groupA;
+
+    private ReportingRate reportingRate;
+
+    private String expressionA;
+    private String expressionB;
+    private String expressionC;
+    private String expressionD;
+    private String expressionE;
+    private String expressionF;
+    private String expressionG;
+    private String expressionH;
+    private String expressionI;
+    private String expressionK;
+    private String expressionJ;
+    private String expressionL;
+    private String expressionM;
+    private String expressionN;
+
+    private String expressionR;
+
+    private BeanRandomizer rnd;
+    private static final double DELTA = 0.01;
+
+    @Before
+    public void setUp() {
+        target = new DefaultExpressionService(hibernateGenericStore, dataElementService, constantService,
+                categoryService, organisationUnitGroupService, dimensionService, idObjectManager);
+        rnd = new BeanRandomizer();
+
+        // SETUP FIXTURES
+
+        categoryOptionA = new CategoryOption( "Under 5" );
+        categoryOptionB = new CategoryOption( "Over 5" );
+        categoryOptionC = new CategoryOption( "Male" );
+        categoryOptionD = new CategoryOption( "Female" );
+
+        categoryA = new Category( "Age", DataDimensionType.DISAGGREGATION );
+        categoryB = new Category( "Gender", DataDimensionType.DISAGGREGATION );
+
+        categoryA.getCategoryOptions().add( categoryOptionA );
+        categoryA.getCategoryOptions().add( categoryOptionB );
+        categoryB.getCategoryOptions().add( categoryOptionC );
+        categoryB.getCategoryOptions().add( categoryOptionD );
+
+        categoryCombo = new CategoryCombo( "Age and gender", DataDimensionType.DISAGGREGATION );
+        categoryCombo.getCategories().add( categoryA );
+        categoryCombo.getCategories().add( categoryB );
+        categoryCombo.generateOptionCombos();
+
+        List<CategoryOptionCombo> optionCombos = Lists.newArrayList( categoryCombo.getOptionCombos() );
+
+        cocA = optionCombos.get( 0 );
+        cocA.setUid(CodeGenerator.generateUid());
+        cocB = optionCombos.get( 1 );
+        cocB.setUid(CodeGenerator.generateUid());
+
+        deA = createDataElement( 'A' );
+        deB = createDataElement( 'B' );
+        deC = createDataElement( 'C' );
+        deD = createDataElement( 'D' );
+        deE = createDataElement( 'E', categoryCombo );
+
+        coc = rnd.randomObject(CategoryOptionCombo.class);
+        coc.setName(DEFAULT_CATEGORY_COMBO_NAME);
+
+        optionCombos.add( coc );
+
+        opA = new DataElementOperand( deA, coc );
+        opB = new DataElementOperand( deB, coc );
+
+        period = createPeriod( getDate( 2000, 1, 1 ), getDate( 2000, 1, 31 ) );
+
+        pteaA = rnd.randomObject(ProgramTrackedEntityAttributeDimensionItem.class);
+        pdeA = rnd.randomObject(ProgramDataElementDimensionItem.class);
+        piA = rnd.randomObject(ProgramIndicator.class);
+
+
+        unitA = createOrganisationUnit( 'A' );
+        unitB = createOrganisationUnit( 'B' );
+        unitC = createOrganisationUnit( 'C' );
+
+        constantA = rnd.randomObject(Constant.class);
+        constantA.setName("ConstantA");
+        constantA.setValue(2.0);
+
+        groupA = createOrganisationUnitGroup( 'A' );
+        groupA.addOrganisationUnit( unitA );
+        groupA.addOrganisationUnit( unitB );
+        groupA.addOrganisationUnit( unitC );
+
+
+        DataSet dataSetA = createDataSet( 'A' );
+        dataSetA.setUid( "a23dataSetA" );
+        dataSetA.addOrganisationUnit( unitA );
+
+        reportingRate = new ReportingRate( dataSetA );
+
+        expressionA = "#{" + opA.getDimensionItem() + "}+#{" + opB.getDimensionItem() + "}";
+        expressionB = "#{" + deC.getUid() + SEPARATOR + coc.getUid() + "}-#{" + deD.getUid() + SEPARATOR
+                + coc.getUid() + "}";
+        expressionC = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + "}+#{" + deE.getUid() + "}-10";
+        expressionD = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + "}+" + SYMBOL_DAYS;
+        expressionE = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + "}*C{" + constantA.getUid() + "}";
+        expressionF = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + "}";
+        expressionG = expressionF + "+#{" + deB.getUid() + "}-#{" + deC.getUid() + "}";
+        expressionH = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + "}*OUG{" + groupA.getUid() + "}";
+        expressionI = "#{" + opA.getDimensionItem() + "}*" + "#{" + deB.getDimensionItem() + "}+" + "C{" + constantA.getUid() + "}+5-" +
+                "D{" + pdeA.getDimensionItem() + "}+" + "A{" + pteaA.getDimensionItem() + "}-10+" + "I{" + piA.getDimensionItem() + "}";
+        expressionJ = "#{" + opA.getDimensionItem() + "}+#{" + opB.getDimensionItem() + "}";
+        expressionK = "1.5*AVG(" + expressionJ + ")";
+        expressionL = expressionA + "+AVG("+expressionJ+")+1.5*STDDEV("+expressionJ+")+" + expressionB;
+        expressionM = "#{" + deA.getUid() + SEPARATOR + SYMBOL_WILDCARD + "}-#{" + deB.getUid() + SEPARATOR + coc.getUid() + "}";
+        expressionN = "#{" + deA.getUid() + SEPARATOR + cocA.getUid() + SEPARATOR + cocB.getUid() + "}-#{" + deB.getUid() + SEPARATOR + cocA.getUid() + "}";
+        expressionR = "#{" + deB.getUid() + SEPARATOR + coc.getUid() + "}" + " + R{" + reportingRate.getUid() + ".REPORTING_RATE}";
+
+    }
+
+    @Test
+    public void testGetElementsAndOptionCombosInExpression() {
+        Set<String> ids = target.getElementsAndOptionCombosInExpression( expressionC );
+
+        assertEquals( 2, ids.size() );
+        assertTrue( ids.contains( deA.getUid() + SEPARATOR + coc.getUid() ) );
+        assertTrue( ids.contains( deE.getUid() ) );
+    }
+
+
+    @Test
+    public void testGetDimensionalItemIdsInExpressionNullOrEmpty() {
+        SetMap<Class<? extends DimensionalItemObject>, String> res = target.getDimensionalItemIdsInExpression( null );
+        assertEquals(0, res.size());
+        res = target.getDimensionalItemIdsInExpression( "" );
+        assertEquals(0, res.size());
+    }
+
+
+    @Test
+    public void testGetDimensionalItemIdsInExpression()
+    {
+        SetMap<Class<? extends DimensionalItemObject>, String> idMap = target.getDimensionalItemIdsInExpression( expressionI );
+
+        assertEquals( 4, idMap.size() );
+        assertTrue( idMap.containsKey( DataElementOperand.class ) );
+        assertTrue( idMap.containsKey( ProgramDataElementDimensionItem.class ) );
+        assertTrue( idMap.containsKey( ProgramTrackedEntityAttributeDimensionItem.class ) );
+        assertTrue( idMap.containsKey( ProgramIndicator.class ) );
+
+        assertEquals( 2, idMap.get( DataElementOperand.class ).size() );
+        assertTrue( idMap.get( DataElementOperand.class ).contains( opA.getDimensionItem() ) );
+        assertTrue( idMap.get( DataElementOperand.class ).contains( deB.getDimensionItem() ) );
+
+        assertEquals( 1, idMap.get( ProgramDataElementDimensionItem.class ).size() );
+        assertTrue( idMap.get( ProgramDataElementDimensionItem.class ).contains( pdeA.getDimensionItem() ) );
+
+        assertEquals( 1, idMap.get( ProgramTrackedEntityAttributeDimensionItem.class ).size() );
+        assertTrue( idMap.get( ProgramTrackedEntityAttributeDimensionItem.class ).contains( pteaA.getDimensionItem() ) );
+
+        assertEquals( 1, idMap.get( ProgramIndicator.class ).size() );
+        assertTrue( idMap.get( ProgramIndicator.class ).contains( piA.getDimensionItem() ) );
+    }
+
+    @Test
+    public void testGetDimensionalItemObjectsInIndicators()
+    {
+        when( dimensionService.getDataDimensionalItemObject( opA.getDimensionItem() ) ).thenReturn( opA );
+        when( dimensionService.getDataDimensionalItemObject( opB.getDimensionItem() ) ).thenReturn( opB );
+        when( dimensionService.getDataDimensionalItemObject( deB.getDimensionItem() ) ).thenReturn( deB );
+        when( dimensionService.getDataDimensionalItemObject( pdeA.getDimensionItem() ) ).thenReturn( pdeA );
+        when( dimensionService.getDataDimensionalItemObject( pteaA.getDimensionItem() ) ).thenReturn( pteaA );
+        when( dimensionService.getDataDimensionalItemObject( piA.getDimensionItem() ) ).thenReturn( piA );
+
+        Indicator indicator = createIndicator( 'A', null );
+        indicator.setNumerator( expressionI );
+        indicator.setDenominator( expressionA );
+
+        Set<Indicator> indicators = Sets.newHashSet( indicator );
+
+        Set<DimensionalItemObject> items = target.getDimensionalItemObjectsInIndicators( indicators );
+
+        assertEquals( 6, items.size() );
+        assertThat(items, hasItems(opA, opB, deB, piA, pdeA, pteaA));
+    }
+
+    @Test
+    public void testGetDataElementsInExpression()
+    {
+
+        when( dataElementService.getDataElement( opA.getDimensionItem().split( "\\." )[0] ) )
+            .thenReturn( opA.getDataElement() );
+        when( dataElementService.getDataElement( opB.getDimensionItem().split( "\\." )[0] ) )
+            .thenReturn( opB.getDataElement() );
+        Set<DataElement> dataElements = target.getDataElementsInExpression( expressionA );
+
+        assertThat( dataElements, hasSize( 2 ) );
+        assertThat( dataElements, hasItems( opA.getDataElement(), opB.getDataElement() ) );
+
+        // Expression G
+        when( dataElementService.getDataElement( deA.getUid() ) ).thenReturn( deA );
+        when( dataElementService.getDataElement( deB.getUid() ) ).thenReturn( deB );
+        when( dataElementService.getDataElement( deC.getUid() ) ).thenReturn( deC );
+
+        dataElements = target.getDataElementsInExpression( expressionG );
+
+        assertThat( dataElements, hasSize( 3 ) );
+        assertThat( dataElements, hasItems( deA, deB, deC ) );
+
+        dataElements = target.getDataElementsInExpression( expressionM );
+
+        assertThat( dataElements, hasSize( 2 ) );
+        assertThat( dataElements, hasItems( deA, deB ) );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetOperandsInExpression()
+    {
+        when(dataElementService.getDataElement(opA.getDimensionItem().split("\\.")[0])).thenReturn(deA);
+        when(categoryService.getCategoryOptionCombo(opA.getDimensionItem().split("\\.")[1])).thenReturn(coc);
+        when(dataElementService.getDataElement(opB.getDimensionItem().split("\\.")[0])).thenReturn(deB);
+        when(categoryService.getCategoryOptionCombo(opB.getDimensionItem().split("\\.")[1])).thenReturn(coc);
+
+        Set<DataElementOperand> operands = target.getOperandsInExpression( expressionA );
+
+        assertEquals( 2, operands.size() );
+
+        assertThat( operands,
+                IsIterableContainingInAnyOrder.containsInAnyOrder(
+                        allOf( hasProperty( "dataElement", is( deA) ),
+                               hasProperty( "categoryOptionCombo", is( coc) ),
+                               hasProperty( "attributeOptionCombo", is(nullValue())) ),
+                        allOf( hasProperty( "dataElement", is( deB) ),
+                               hasProperty( "categoryOptionCombo", is( coc ) ),
+                               hasProperty( "attributeOptionCombo", is(nullValue()) ) ) ) );
+
+    }
+
+    @Test
+    public void testGetOperandsInExpressionWhenNull()
+    {
+        assertThat( target.getOperandsInExpression( null ), hasSize( 0 ) );
+    }
+
+    @Test
+    public void testGetReportingRatesInExpression()
+    {
+        when( dimensionService.getDataDimensionalItemObject( deB.getUid() + SEPARATOR + coc.getUid() ) ).thenReturn( new BaseDimensionalItemObject("1"));
+        when( dimensionService.getDataDimensionalItemObject( reportingRate.getUid() + ".REPORTING_RATE" ) ).thenReturn( reportingRate );
+        Set<DimensionalItemObject> reportingRates = target.getDimensionalItemObjectsInExpression( expressionR );
+
+        assertEquals( 2, reportingRates.size() );
+        assertTrue( reportingRates.contains( reportingRate ) );
+    }
+
+    @Test
+    public void testGetAggregatesAndNonAggregatesInExpression()
+    {
+        Set<String> aggregates = new HashSet<>();
+        Set<String> nonAggregates = new HashSet<>();
+        target.getAggregatesAndNonAggregatesInExpression( expressionK, aggregates, nonAggregates );
+
+        assertEquals( 1, aggregates.size() );
+        assertTrue( aggregates.contains( expressionJ ) );
+
+        assertEquals( 1, nonAggregates.size() );
+        assertTrue( nonAggregates.contains( "1.5*" ) );
+
+        aggregates = new HashSet<>();
+        nonAggregates = new HashSet<>();
+        target.getAggregatesAndNonAggregatesInExpression( expressionL, aggregates, nonAggregates );
+
+        assertEquals( 1, aggregates.size() );
+        assertTrue( aggregates.contains( expressionJ ) );
+
+        assertEquals( 3, nonAggregates.size() );
+        assertTrue( nonAggregates.contains( expressionA + "+" ) );
+        assertTrue( nonAggregates.contains( "+1.5*" ) );
+        assertTrue( nonAggregates.contains( "+" + expressionB ) );
+    }
+
+    @Test
+    public void testCalculateExpressionWithCustomFunctions()
+    {
+        assertEquals( 5.0, calculateExpression( "COUNT([1,2,3,4,5])" ) );
+        assertEquals( 15.0, calculateExpression( "SUM([1,2,3,4,5])" ) );
+        assertEquals( 1.0, calculateExpression( "MIN([1,2,3,4,5])" ) );
+        assertEquals( 5.0, calculateExpression( "MAX([1,2,3,4,5])" ) );
+        assertEquals( 3.0, calculateExpression( "AVG([1,2,3,4,5])" ) );
+        assertEquals( Math.sqrt( 2 ), calculateExpression( "STDDEV([1,2,3,4,5])" ) );
+    }
+
+    private Object calculateExpression( String expressionString )
+    {
+        Expression expression = new Expression( expressionString, "Test " + expressionString );
+
+        return target.getExpressionValue( expression, new HashMap<>(),
+                new HashMap<>(), new HashMap<>(), 0 );
+    }
+
+    @Test
+    public void testGetOptionCombosInExpression()
+    {
+        when(categoryService.getCategoryOptionCombo(coc.getUid() )).thenReturn(coc);
+        Set<CategoryOptionCombo> optionCombos = target.getOptionCombosInExpression( expressionG );
+
+        assertNotNull( optionCombos );
+        assertThat(optionCombos, hasSize(1));
+        assertThat(optionCombos, hasItem(coc));
+    }
+
+    @Test
+    public void testExpressionIsValid()
+    {
+        when( dimensionService.getDataDimensionalItemObject( opA.getUid() ) ).thenReturn( opA );
+        when( dimensionService.getDataDimensionalItemObject( opB.getUid() ) ).thenReturn( opB );
+        when( dimensionService.getDataDimensionalItemObject( deA.getUid() + SEPARATOR + coc.getUid() ) )
+            .thenReturn( deA );
+        when( dimensionService.getDataDimensionalItemObject( deA.getUid() + SEPARATOR + SYMBOL_WILDCARD ) )
+                .thenReturn( deA );
+        when( dimensionService.getDataDimensionalItemObject( deB.getUid() + SEPARATOR + coc.getUid() ) )
+            .thenReturn( deB );
+        when( dimensionService.getDataDimensionalItemObject( deC.getUid() + SEPARATOR + coc.getUid() ) )
+            .thenReturn( deC );
+        when( dimensionService.getDataDimensionalItemObject( deD.getUid() + SEPARATOR + coc.getUid() ) )
+            .thenReturn( deC );
+        when( dimensionService.getDataDimensionalItemObject( deE.getUid() ) ).thenReturn( deE );
+        when( idObjectManager.getNoAcl( Constant.class, constantA.getUid() ) ).thenReturn( constantA );
+        when( idObjectManager.getNoAcl( OrganisationUnitGroup.class, groupA.getUid() ) ).thenReturn( groupA );
+
+        when( dimensionService.getDataDimensionalItemObject( reportingRate.getUid() + ".REPORTING_RATE" ) )
+                .thenReturn( reportingRate );
+        when( dimensionService.getDataDimensionalItemObject( deA.getUid() + SEPARATOR + cocA.getUid() + SEPARATOR + cocB.getUid() ) ).thenReturn( deA );
+        when( dimensionService.getDataDimensionalItemObject( deB.getUid() + SEPARATOR + cocA.getUid() ) ).thenReturn( deB );
+
+        assertTrue( target.expressionIsValid( expressionA ).isValid() );
+        assertTrue( target.expressionIsValid( expressionB ).isValid() );
+        assertTrue( target.expressionIsValid( expressionC ).isValid() );
+        assertTrue( target.expressionIsValid( expressionD ).isValid() );
+        assertTrue( target.expressionIsValid( expressionE ).isValid() );
+        assertTrue( target.expressionIsValid( expressionH ).isValid() );
+        assertTrue( target.expressionIsValid( expressionK ).isValid() );
+        assertTrue( target.expressionIsValid( expressionL ).isValid() );
+        assertTrue( target.expressionIsValid( expressionM ).isValid() );
+        assertTrue( target.expressionIsValid( expressionN ).isValid() );
+        assertTrue( target.expressionIsValid( expressionR ).isValid() );
+
+        String expression = "#{nonExisting" + SEPARATOR + coc.getUid() + "} + 12";
+
+        assertEquals( ExpressionValidationOutcome.DIMENSIONAL_ITEM_OBJECT_DOES_NOT_EXIST, target.expressionIsValid( expression ) );
+
+        expression = "#{" + deA.getUid() + SEPARATOR + "999} + 12";
+
+        assertEquals( ExpressionValidationOutcome.EXPRESSION_IS_NOT_WELL_FORMED, target
+                .expressionIsValid( expression ) );
+
+        expression = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + "} + ( 12";
+
+        assertEquals( ExpressionValidationOutcome.EXPRESSION_IS_NOT_WELL_FORMED, target.expressionIsValid( expression ) );
+
+        expression = "12 x 4";
+
+        assertEquals( ExpressionValidationOutcome.EXPRESSION_IS_NOT_WELL_FORMED, target.expressionIsValid( expression ) );
+
+        expression = "1.5*AVG(" + target;
+
+        assertEquals( ExpressionValidationOutcome.EXPRESSION_IS_NOT_WELL_FORMED, target.expressionIsValid( expression ) );
+
+        expression = "12 + C{nonExisting}";
+
+        assertEquals( ExpressionValidationOutcome.CONSTANT_DOES_NOT_EXIST, target.expressionIsValid( expression ) );
+
+        expression = "12 + OUG{nonExisting}";
+
+        assertEquals( ExpressionValidationOutcome.ORG_UNIT_GROUP_DOES_NOT_EXIST, target.expressionIsValid( expression ) );
+    }
+
+    @Test
+    public void testGetExpressionDescription()
+    {
+        when(dimensionService.getDataDimensionalItemObject(opA.getDimensionItem())).thenReturn(opA);
+        when(dimensionService.getDataDimensionalItemObject(opB.getDimensionItem())).thenReturn(opB);
+
+        String description = target.getExpressionDescription( expressionA );
+        assertThat( description, is( opA.getDisplayName() + "+" + opB.getDisplayName() ) );
+
+        description = target.getExpressionDescription( expressionD );
+        assertThat( description, is( opA.getDisplayName() + "+" + ExpressionService.DAYS_DESCRIPTION ) );
+
+        when(constantService.getConstant(constantA.getUid())).thenReturn(constantA);
+        description = target.getExpressionDescription( expressionE );
+        assertThat( description, is( opA.getDisplayName() + "*" + constantA.getDisplayName() ) );
+
+        when(organisationUnitGroupService.getOrganisationUnitGroup(groupA.getUid())).thenReturn(groupA);
+        description = target.getExpressionDescription( expressionH );
+        assertThat( description, is( opA.getDisplayName() + "*" + groupA.getDisplayName() ) );
+
+        when( dimensionService.getDataDimensionalItemObject( deA.getUid() + SEPARATOR + SYMBOL_WILDCARD ) )
+                .thenReturn( deA );
+        when( dimensionService.getDataDimensionalItemObject( deB.getUid() + SEPARATOR + coc.getUid() ) )
+            .thenReturn( deB );
+        description = target.getExpressionDescription( expressionM );
+        assertThat( description, is( deA.getDisplayName() + "-" + deB.getDisplayName() ) );
+
+        when( dimensionService.getDataDimensionalItemObject( reportingRate.getUid() + ".REPORTING_RATE" ) )
+                .thenReturn( reportingRate );
+        description = target.getExpressionDescription( expressionR );
+        assertThat( description, is( deB.getDisplayName() + " + " + reportingRate.getDisplayName() ) );
+    }
+
+    @Test
+    public void testGenerateExpressionWithMap()
+    {
+        Map<DimensionalItemObject, Double> valueMap = new HashMap<>();
+        valueMap.put( new DataElementOperand( deA, coc ), 12d );
+        valueMap.put( new DataElementOperand( deB, coc ), 34d );
+        valueMap.put( new DataElementOperand( deA, cocA, cocB ), 26d );
+        valueMap.put( new DataElementOperand( deB, cocA ), 16d );
+        valueMap.put( reportingRate, 20d );
+
+        Map<String, Double> constantMap = new HashMap<>();
+        constantMap.put( constantA.getUid(), 2.0 );
+
+        Map<String, Integer> orgUnitCountMap = new HashMap<>();
+        orgUnitCountMap.put( groupA.getUid(), groupA.getMembers().size() );
+
+
+        assertEquals( "12.0+34.0", target.generateExpression( expressionA, valueMap, constantMap, null, null, null ) );
+        assertEquals( "12.0+5", target.generateExpression( expressionD, valueMap, constantMap, null, 5, null ) );
+        assertEquals( "12.0*2.0", target.generateExpression( expressionE, valueMap, constantMap, null, null, null ) );
+        assertEquals( "12.0*3", target.generateExpression( expressionH, valueMap, constantMap, orgUnitCountMap, null, null ) );
+        assertEquals( "26.0-16.0", target.generateExpression( expressionN, valueMap, constantMap, orgUnitCountMap, null, null ) );
+        assertEquals( "34.0 + 20.0", target.generateExpression( expressionR, valueMap, constantMap, orgUnitCountMap, null, null ) );
+    }
+
+    @Test
+    public void testGenerateExpressionWithMapNullIfNoValues()
+    {
+        Map<DataElementOperand, Double> valueMap = new HashMap<>();
+
+        Map<String, Double> constantMap = new HashMap<>();
+
+        assertNull( target.generateExpression( expressionA, valueMap, constantMap, null, null, MissingValueStrategy.SKIP_IF_ANY_VALUE_MISSING ) );
+        assertNull( target.generateExpression( expressionD, valueMap, constantMap, null, 5, MissingValueStrategy.SKIP_IF_ANY_VALUE_MISSING ) );
+        assertNotNull( target.generateExpression( expressionE, valueMap, constantMap, null, null, MissingValueStrategy.NEVER_SKIP ) );
+    }
+
+    @Test
+    public void testGetExpressionValue()
+    {
+        Expression expA = new Expression( expressionA, null );
+        Expression expD = new Expression( expressionD, null );
+        Expression expE = new Expression( expressionE, null );
+        Expression expH = new Expression( expressionH, null );
+        Expression expN = new Expression( expressionN, null );
+        Expression expR = new Expression( expressionR, null );
+
+        Map<DimensionalItemObject, Double> valueMap = new HashMap<>();
+        valueMap.put( new DataElementOperand( deA, coc ), 12d );
+        valueMap.put( new DataElementOperand( deB, coc ), 34d );
+        valueMap.put( new DataElementOperand( deA, cocA, cocB ), 26d );
+        valueMap.put( new DataElementOperand( deB, cocA ), 16d );
+        valueMap.put( reportingRate, 20d );
+
+        Map<String, Double> constantMap = new HashMap<>();
+        constantMap.put( constantA.getUid(), 2.0 );
+
+        Map<String, Integer> orgUnitCountMap = new HashMap<>();
+        orgUnitCountMap.put( groupA.getUid(), groupA.getMembers().size() );
+
+        assertEquals( 46d, target.getExpressionValue( expA, valueMap, constantMap, null, null ), DELTA );
+        assertEquals( 17d, target.getExpressionValue( expD, valueMap, constantMap, null, 5 ), DELTA );
+        assertEquals( 24d, target.getExpressionValue( expE, valueMap, constantMap, null, null ), DELTA );
+        assertEquals( 36d, target.getExpressionValue( expH, valueMap, constantMap, orgUnitCountMap, null ), DELTA );
+        assertEquals( 10d, target.getExpressionValue( expN, valueMap, constantMap, orgUnitCountMap, null ), DELTA );
+        assertEquals( 54d, target.getExpressionValue( expR, valueMap, constantMap, orgUnitCountMap, null ), DELTA );
+    }
+
+    @Test
+    public void testGetIndicatorValue()
+    {
+        IndicatorType indicatorType = new IndicatorType( "A", 100, false );
+
+        Indicator indicatorA = createIndicator( 'A', indicatorType );
+        indicatorA.setNumerator( expressionE );
+        indicatorA.setDenominator( expressionF );
+
+        Indicator indicatorB = createIndicator( 'B', indicatorType );
+        indicatorB.setNumerator( expressionN );
+        indicatorB.setDenominator( expressionF );
+
+        Map<DataElementOperand, Double> valueMap = new HashMap<>();
+        valueMap.put( new DataElementOperand( deA, coc ), 12d );
+        valueMap.put( new DataElementOperand( deB, coc ), 34d );
+        valueMap.put( new DataElementOperand( deA, cocA, cocB ), 46d );
+        valueMap.put( new DataElementOperand( deB, cocA ), 10d );
+
+        Map<String, Double> constantMap = new HashMap<>();
+        constantMap.put( constantA.getUid(), 2.0 );
+
+        assertEquals( 200d, target.getIndicatorValue( indicatorA, period, valueMap, constantMap, null ), DELTA );
+        assertEquals( 300d, target.getIndicatorValue( indicatorB, period, valueMap, constantMap, null ), DELTA );
+    }
+
+    @Test
+    public void testGetIndicatorValueObject()
+    {
+        IndicatorType indicatorType = new IndicatorType( "A", 100, false );
+
+        Indicator indicatorA = createIndicator( 'A', indicatorType );
+        indicatorA.setNumerator( expressionE );
+        indicatorA.setDenominator( expressionF );
+
+        Map<DataElementOperand, Double> valueMap = new HashMap<>();
+
+        valueMap.put( new DataElementOperand( deA, coc ), 12d );
+        valueMap.put( new DataElementOperand( deB, coc ), 34d );
+        valueMap.put( new DataElementOperand( deA, cocA, cocB ), 46d );
+        valueMap.put( new DataElementOperand( deB, cocA ), 10d );
+
+        Map<String, Double> constantMap = new HashMap<>();
+        constantMap.put( constantA.getUid(), 2.0 );
+
+        IndicatorValue value = target.getIndicatorValueObject( indicatorA, period, valueMap, constantMap, null );
+
+        assertEquals( 24d, value.getNumeratorValue(), DELTA );
+        assertEquals( 12d, value.getDenominatorValue(), DELTA );
+        assertEquals( 100, value.getMultiplier() );
+        assertEquals( 1, value.getDivisor() );
+        assertEquals( 100d, value.getFactor(), DELTA );
+        assertEquals( 200d, value.getValue(), DELTA );
+
+        // # ------------------------------------------------------------------- #
+
+        Indicator indicatorB = createIndicator( 'B', indicatorType );
+        indicatorB.setNumerator( expressionN );
+        indicatorB.setDenominator( expressionF );
+        indicatorB.setAnnualized( true );
+
+        value = target.getIndicatorValueObject( indicatorB, period, valueMap, constantMap, null );
+
+        assertEquals( 36d, value.getNumeratorValue(), DELTA );
+        assertEquals( 12d, value.getDenominatorValue(), DELTA );
+        assertEquals( 36500, value.getMultiplier() );
+        assertEquals( 31, value.getDivisor() );
+        assertEquals( 1177.419, value.getFactor(), DELTA );
+        assertEquals( 3532.258, value.getValue(), DELTA );
+    }
+
+    // -------------------------------------------------------------------------
+    // CRUD tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void verifyExpressionIsUpdated()
+    {
+        Expression expression = rnd.randomObject( Expression.class );
+        target.updateExpression(expression);
+        verify( hibernateGenericStore ).update( expression );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void verifyExpressionIsDeleted()
+    {
+        Expression expression = rnd.randomObject( Expression.class );
+        target.deleteExpression(expression);
+        verify( hibernateGenericStore ).delete( expression );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void verifyExpressionIsAdded()
+    {
+
+        Expression expression = rnd.randomObject( Expression.class );
+        int id = target.addExpression( expression );
+        assertThat( id, is( expression.getId() ) );
+        verify( hibernateGenericStore ).save( expression );
+
+    }
+
+    @Test
+    public void verifyAllExpressionsCanBeFetched()
+    {
+        when( hibernateGenericStore.getAll() ).thenReturn( Lists.newArrayList( rnd.randomObject( Expression.class ) ) );
+        List<Expression> expressions = target.getAllExpressions();
+        assertThat( expressions, hasSize( 1 ) );
+        verify( hibernateGenericStore ).getAll();
+
+    }
+
+    @Test
+    public void testGetOrganisationUnitGroupsInExpression()
+    {
+        when(organisationUnitGroupService.getOrganisationUnitGroup(groupA.getUid())).thenReturn(groupA);
+        Set<OrganisationUnitGroup> groups = target.getOrganisationUnitGroupsInExpression( expressionH );
+        assertThat(groups, hasSize(1));
+        assertThat(groups, hasItem(groupA));
+
+        groups = target.getOrganisationUnitGroupsInExpression( null );
+
+        assertNotNull( groups );
+        assertThat(groups, hasSize(0));
+    }
+
+
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -28,18 +28,21 @@ package org.hisp.dhis.expression;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static org.hisp.dhis.expression.Expression.SEPARATOR;
+import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
+import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
+import static org.junit.Assert.*;
+
+import java.util.*;
+
 import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.category.Category;
-import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.category.CategoryOption;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.category.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
-import org.hisp.dhis.dataelement.*;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.datavalue.DataValueService;
@@ -60,12 +63,12 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.*;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
-import static org.hisp.dhis.expression.Expression.SEPARATOR;
-import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
-import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
-import static org.junit.Assert.*;
+/*
+ * THIS TEST IS DEPRECATED BY ExpressionService2Test !!!
+ */
 
 /**
  * @author Lars Helge Overland
@@ -232,7 +235,6 @@ public class ExpressionServiceTest
 
         coc = categoryService.getDefaultCategoryOptionCombo();
 
-        coc.getId();
         optionCombos.add( coc );
 
         opA = new DataElementOperand( deA, coc );
@@ -417,7 +419,7 @@ public class ExpressionServiceTest
     {
         Set<String> aggregates = new HashSet<>();
         Set<String> nonAggregates = new HashSet<>();
-        expressionService.getAggregatesAndNonAggregatesInExpression( expressionK.toString(), aggregates, nonAggregates );
+        expressionService.getAggregatesAndNonAggregatesInExpression( expressionK, aggregates, nonAggregates );
 
         assertEquals( 1, aggregates.size() );
         assertTrue( aggregates.contains( expressionJ ) );
@@ -427,7 +429,7 @@ public class ExpressionServiceTest
 
         aggregates = new HashSet<>();
         nonAggregates = new HashSet<>();
-        expressionService.getAggregatesAndNonAggregatesInExpression( expressionL.toString(), aggregates, nonAggregates );
+        expressionService.getAggregatesAndNonAggregatesInExpression( expressionL, aggregates, nonAggregates );
 
         assertEquals( 1, aggregates.size() );
         assertTrue( aggregates.contains( expressionJ ) );
@@ -453,8 +455,8 @@ public class ExpressionServiceTest
     {
         Expression expression = new Expression( expressionString, "Test " + expressionString );
         
-        return expressionService.getExpressionValue( expression, new HashMap<DimensionalItemObject, Double>(),
-            new HashMap<String, Double>(), new HashMap<String, Integer>(), 0 );
+        return expressionService.getExpressionValue( expression, new HashMap<>(),
+                new HashMap<>(), new HashMap<>(), 0 );
     }
 
     @Test
@@ -750,7 +752,7 @@ public class ExpressionServiceTest
 
         List<Expression> expressions = expressionService.getAllExpressions();
 
-        assertTrue( expressions.size() == 2 );
+        assertEquals(2, expressions.size());
         assertTrue( expressions.contains( exprA ) );
         assertTrue( expressions.contains( exprB ) );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -56,7 +56,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsGatewayTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
@@ -49,7 +49,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
- * @Author Zubair Asghar.
+ * @author Zubair Asghar.
  */
 
 @RunWith( MockitoJUnitRunner.class )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
@@ -41,7 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -50,7 +50,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @Author Zubair Asghar.
+ * @author Zubair Asghar.
  */
 @RunWith( MockitoJUnitRunner.class )
 public class SmsMessageSenderTest
@@ -116,11 +116,11 @@ public class SmsMessageSenderTest
         when( gatewayAdministrationService.getGatewayConfigurationMap() ).thenReturn( configMap );
 
         // stub for UserSettingService
-        when( userSettingService.getUserSetting( any(), any() ) ).thenReturn( Boolean.valueOf( true ) );
+        when( userSettingService.getUserSetting( any(), any() ) ).thenReturn(Boolean.TRUE);
 
         // stub for SmsGateways
         when ( bulkSmsGateway.accept( any() ) ).thenReturn( true );
-        when( bulkSmsGateway.send( anyString(), anyString(), anySetOf( String.class ), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).thenReturn( okStatus );
+        when( bulkSmsGateway.send( anyString(), anyString(), anySet( ), isA( BulkSmsGatewayConfig.class ) ) ).thenReturn( okStatus );
         when ( bulkSmsGateway.sendBatch( any(), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).thenReturn( summaryResponses );
     }
 
@@ -135,7 +135,7 @@ public class SmsMessageSenderTest
 
         verify( gatewayAdministrationService, times( 1 ) ).getDefaultGateway();
         verify( bulkSmsGateway, times( 1 ) ).accept( any() );
-        verify( bulkSmsGateway, times( 1 ) ).send( anyString(), anyString(), anySetOf( String.class ), any() );
+        verify( bulkSmsGateway, times( 1 ) ).send( anyString(), anyString(), anySet( ), any() );
     }
 
     @Test
@@ -196,7 +196,7 @@ public class SmsMessageSenderTest
     @Test
     public void testSendMessageWithUserSMSSettingsDisabled()
     {
-        when( userSettingService.getUserSetting( any(), any() ) ).thenReturn( Boolean.valueOf( false ) );
+        when( userSettingService.getUserSetting( any(), any() ) ).thenReturn(Boolean.FALSE);
 
         OutboundMessageResponse status = smsMessageSender.sendMessage( subject, text, footer, sender, users, false );
 
@@ -218,7 +218,7 @@ public class SmsMessageSenderTest
     @Test
     public void testSendMessageFailed()
     {
-        when( bulkSmsGateway.send( anyString(), anyString(), anySetOf( String.class ), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).thenReturn( failedStatus );
+        when( bulkSmsGateway.send( anyString(), anyString(), anySet( ), isA( BulkSmsGatewayConfig.class ) ) ).thenReturn( failedStatus );
 
         OutboundMessageResponse status = smsMessageSender.sendMessage( subject, text, recipientsNormalized );
 
@@ -233,7 +233,7 @@ public class SmsMessageSenderTest
     {
         Set<String> tempRecipients = Sets.newHashSet();
 
-        when( bulkSmsGateway.send( anyString(), anyString(), anySetOf( String.class ), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).thenAnswer( invocation ->
+        when( bulkSmsGateway.send( anyString(), anyString(), anySet( ), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).thenAnswer( invocation ->
         {
             tempRecipients.addAll( (Set<String>) invocation.getArguments()[2] );
             return okStatus;
@@ -259,7 +259,7 @@ public class SmsMessageSenderTest
 
         generateRecipients( 500 );
 
-        when( bulkSmsGateway.send( anyString(), anyString(), anySetOf( String.class ), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).then( invocation ->
+        when( bulkSmsGateway.send( anyString(), anyString(), anySet( ), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).then( invocation ->
         {
             recipientList.add( (Set<String>) invocation.getArguments()[2] );
 
@@ -271,7 +271,7 @@ public class SmsMessageSenderTest
         assertNotNull( status );
         assertTrue( status.isOk() );
 
-        recipientList.stream().forEach( set -> assertTrue( set.size() <= MAX_ALLOWED_RECIPIENTS ) );
+        recipientList.forEach(set -> assertTrue( set.size() <= MAX_ALLOWED_RECIPIENTS ) );
     }
 
     @Test
@@ -328,7 +328,7 @@ public class SmsMessageSenderTest
     {
         summaryResponses.clear();
 
-        when ( bulkSmsGateway.sendBatch( any(), Matchers.isA( BulkSmsGatewayConfig.class ) ) ).then( invocation ->
+        when ( bulkSmsGateway.sendBatch( any(), isA( BulkSmsGatewayConfig.class ) ) ).then( invocation ->
         {
             OutboundMessageBatch batch = (OutboundMessageBatch) invocation.getArguments()[0];
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
@@ -62,7 +62,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -169,11 +169,6 @@ public class DataValueListenerTest extends DhisConvenienceTest
         when( registrationService.getCompleteDataSetRegistration( any(), any(), any(), any() ) )
             .thenReturn( fetchedCompleteDataSetRegistration );
 
-        doAnswer(invocation -> {
-            savedCompleteDataSetRegistration = (CompleteDataSetRegistration) invocation.getArguments()[0];
-            return savedCompleteDataSetRegistration;
-        }).when( registrationService ).saveCompleteDataSetRegistration( any() );
-
         doAnswer( invocation -> {
             deletedCompleteDataSetRegistration = (CompleteDataSetRegistration) invocation.getArguments()[0];
             return deletedCompleteDataSetRegistration;
@@ -183,11 +178,6 @@ public class DataValueListenerTest extends DhisConvenienceTest
         when( dataValueService.getDataValue( any(), any(), any(), any() ) )
             .thenReturn( fetchedDataValue );
 
-        when( dataValueService.addDataValue( any() ) )
-            .thenAnswer( invocation -> {
-                addedDataValue = (DataValue) invocation.getArguments()[0];
-                return addedDataValue;
-            });
 
         doAnswer( invocation -> {
             updatedDataValue = (DataValue) invocation.getArguments()[0];
@@ -214,14 +204,11 @@ public class DataValueListenerTest extends DhisConvenienceTest
             return updatedIncomingSms;
         }).when( incomingSmsService ).update( any() );
 
-        // Mock for dataElementService
-        when( dataElementService.getDataElement( anyInt() ) ).thenReturn( dataElement );
-
         // Mock for smsSender
         when( smsSender.isConfigured() ).thenReturn( smsConfigured );
 
-        when( smsSender.sendMessage( anyString(), anyString(), anyString() ) ).thenAnswer( invocation -> {
-            message = (String) invocation.getArguments()[1];
+        when( smsSender.sendMessage( any(), any(), anyString() ) ).thenAnswer( invocation -> {
+            message = invocation.getArgument(1);
             return response;
         });
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -54,7 +54,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 
 import static org.junit.Assert.*;
@@ -140,7 +140,7 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
         // Mock for smsSender
         when( smsSender.isConfigured() ).thenReturn( true );
 
-        when( smsSender.sendMessage( anyString(), anyString(), anyString() ) ).thenAnswer( invocation -> {
+        when( smsSender.sendMessage( any(), any(), anyString() ) ).thenAnswer( invocation -> {
             message = (String) invocation.getArguments()[1];
             return response;
         });

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/textpattern/TestDefaultTextPatternService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/textpattern/TestDefaultTextPatternService.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -84,12 +84,17 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
@@ -28,9 +28,13 @@ package org.hisp.dhis.dxf2.metadata.sync;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.castor.core.util.Assert;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
@@ -43,8 +47,7 @@ import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.List;
-import java.util.Map;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Performs the meta data sync related tasks in service layer.
@@ -56,17 +59,29 @@ public class DefaultMetadataSyncService
 {
     private static final Log log = LogFactory.getLog( DefaultMetadataSyncService.class );
 
-    @Autowired
     private MetadataVersionDelegate metadataVersionDelegate;
 
-    @Autowired
     private MetadataVersionService metadataVersionService;
 
-    @Autowired
     private MetadataSyncDelegate metadataSyncDelegate;
 
-    @Autowired
     private MetadataSyncImportHandler metadataSyncImportHandler;
+
+    @Autowired
+    public DefaultMetadataSyncService( MetadataVersionDelegate metadataVersionDelegate,
+        MetadataVersionService metadataVersionService, MetadataSyncDelegate metadataSyncDelegate,
+        MetadataSyncImportHandler metadataSyncImportHandler )
+    {
+        checkNotNull(metadataVersionDelegate);
+        checkNotNull(metadataVersionService);
+        checkNotNull(metadataSyncDelegate);
+        checkNotNull(metadataSyncImportHandler);
+
+        this.metadataVersionDelegate = metadataVersionDelegate;
+        this.metadataVersionService = metadataVersionService;
+        this.metadataSyncDelegate = metadataSyncDelegate;
+        this.metadataSyncImportHandler = metadataSyncImportHandler;
+    }
 
     @Override
     public MetadataSyncParams getParamsFromMap( Map<String, List<String>> parameters )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegate.java
@@ -28,6 +28,12 @@ package org.hisp.dhis.dxf2.metadata.version;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.dxf2.metadata.sync.exception.RemoteServerUnavailableException;
@@ -44,11 +50,7 @@ import org.hisp.dhis.system.util.HttpUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Handling remote calls for metadata version.
@@ -59,17 +61,29 @@ public class MetadataVersionDelegate
 {
     private static final Log log = LogFactory.getLog( MetadataVersionDelegate.class );
 
-    @Autowired
     private DefaultMetadataSystemSettingService metadataSystemSettingService;
 
-    @Autowired
     private SynchronizationManager synchronizationManager;
 
-    @Autowired
     private RenderService renderService;
 
-    @Autowired
     private MetadataVersionService metadataVersionService;
+
+    @Autowired
+    public MetadataVersionDelegate( DefaultMetadataSystemSettingService metadataSystemSettingService,
+        SynchronizationManager synchronizationManager, RenderService renderService,
+        MetadataVersionService metadataVersionService )
+    {
+        checkNotNull(metadataSystemSettingService);
+        checkNotNull(synchronizationManager);
+        checkNotNull(renderService);
+        checkNotNull(metadataVersionService);
+
+        this.metadataSystemSettingService = metadataSystemSettingService;
+        this.synchronizationManager = synchronizationManager;
+        this.renderService = renderService;
+        this.metadataVersionService = metadataVersionService;
+    }
 
     private int VERSION_TIMEOUT = 120000;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
@@ -28,13 +28,20 @@ package org.hisp.dhis.dxf2.metadata.sync;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
-import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
-import org.hisp.dhis.dxf2.metadata.systemsettings.DefaultMetadataSystemSettingService;
-import org.hisp.dhis.dxf2.metadata.version.MetadataVersionDelegate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
+import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
+import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
+import org.hisp.dhis.dxf2.metadata.version.MetadataVersionDelegate;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
@@ -42,63 +49,51 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.*;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * @author sultanm
  */
 public class DefaultMetadataSyncServiceTest
-    extends DhisSpringTest
 {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @InjectMocks
-    @Autowired
     private MetadataSyncService metadataSyncService;
 
-    @Autowired
     @Mock
     private MetadataVersionDelegate metadataVersionDelegate;
 
-    @Autowired
     @Mock
     private MetadataSyncDelegate metadataSyncDelegate;
 
-    @Autowired
-    @Mock
-    private DefaultMetadataSystemSettingService metadataSystemSettingService;
-
-    @Autowired
     @Mock
     private MetadataVersionService metadataVersionService;
 
-    @Autowired
     @Mock
     private MetadataSyncImportHandler metadataSyncImportHandler;
 
     private Map<String, List<String>> parameters;
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     @Before
     public void setup()
     {
-        MockitoAnnotations.initMocks( this );
-
+        metadataSyncService = new DefaultMetadataSyncService( metadataVersionDelegate, metadataVersionService,
+            metadataSyncDelegate, metadataSyncImportHandler );
         parameters = new HashMap<>();
+
     }
 
     @Test
-    public void testShouldThrowExceptionWhenVersionNameNotPresentInParameters() throws MetadataSyncServiceException
+    public void testShouldThrowExceptionWhenVersionNameNotPresentInParameters()
+        throws MetadataSyncServiceException
     {
         expectedException.expect( MetadataSyncServiceException.class );
         expectedException.expectMessage( "Missing required parameter: 'versionName'" );
@@ -107,7 +102,8 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParametersAreNull() throws MetadataSyncServiceException
+    public void testShouldThrowExceptionWhenParametersAreNull()
+        throws MetadataSyncServiceException
     {
         expectedException.expect( MetadataSyncServiceException.class );
         expectedException.expectMessage( "Missing required parameter: 'versionName'" );
@@ -116,7 +112,8 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParametersHaveVersionNameAsNull() throws MetadataSyncServiceException
+    public void testShouldThrowExceptionWhenParametersHaveVersionNameAsNull()
+        throws MetadataSyncServiceException
     {
         parameters.put( "versionName", null );
 
@@ -127,7 +124,8 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParametersHaveVersionNameAssignedToEmptyList() throws MetadataSyncServiceException
+    public void testShouldThrowExceptionWhenParametersHaveVersionNameAssignedToEmptyList()
+        throws MetadataSyncServiceException
     {
         parameters.put( "versionName", new ArrayList<>() );
 
@@ -138,29 +136,29 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldReturnNullWhenVersionNameIsAssignedToListHavingNullEntry() throws Exception
+    public void testShouldReturnNullWhenVersionNameIsAssignedToListHavingNullEntry()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( null );
 
         MetadataSyncParams paramsFromMap = metadataSyncService.getParamsFromMap( parameters );
 
-        assertEquals( null, paramsFromMap.getVersion() );
+        assertNull( paramsFromMap.getVersion() );
     }
 
     @Test
-    public void testShouldReturnNullWhenVersionNameIsAssignedToListHavingEmptyString() throws Exception
+    public void testShouldReturnNullWhenVersionNameIsAssignedToListHavingEmptyString()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( "" );
 
         MetadataSyncParams paramsFromMap = metadataSyncService.getParamsFromMap( parameters );
 
-        assertEquals( null, paramsFromMap.getVersion() );
+        assertNull( paramsFromMap.getVersion() );
     }
 
     @Test
-    public void testShouldGetExceptionIfRemoteVersionIsNotAvailable() throws Exception
+    public void testShouldGetExceptionIfRemoteVersionIsNotAvailable()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( "testVersion" );
@@ -168,13 +166,14 @@ public class DefaultMetadataSyncServiceTest
         when( metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" ) ).thenReturn( null );
 
         expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "The MetadataVersion could not be fetched from the remote server for the versionName: testVersion" );
+        expectedException.expectMessage(
+            "The MetadataVersion could not be fetched from the remote server for the versionName: testVersion" );
 
         metadataSyncService.getParamsFromMap( parameters );
     }
 
     @Test
-    public void testShouldGetMetadataVersionForGivenVersionName() throws Exception
+    public void testShouldGetMetadataVersionForGivenVersionName()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( "testVersion" );
@@ -187,7 +186,8 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenSyncParamsIsNull() throws DhisVersionMismatchException
+    public void testShouldThrowExceptionWhenSyncParamsIsNull()
+        throws DhisVersionMismatchException
     {
         expectedException.expect( MetadataSyncServiceException.class );
         expectedException.expectMessage( "MetadataSyncParams cant be null" );
@@ -196,19 +196,22 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenVersionIsNulInSyncParams() throws DhisVersionMismatchException
+    public void testShouldThrowExceptionWhenVersionIsNulInSyncParams()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = new MetadataSyncParams();
         syncParams.setVersion( null );
 
         expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "MetadataVersion for the Sync cant be null. The ClassListMap could not be constructed." );
+        expectedException
+            .expectMessage( "MetadataVersion for the Sync cant be null. The ClassListMap could not be constructed." );
 
         metadataSyncService.doMetadataSync( syncParams );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenSnapshotReturnsNullForGivenVersion() throws DhisVersionMismatchException
+    public void testShouldThrowExceptionWhenSnapshotReturnsNullForGivenVersion()
+        throws DhisVersionMismatchException
     {
 
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
@@ -224,48 +227,58 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenDHISVersionsMismatch() throws DhisVersionMismatchException
+    public void testShouldThrowExceptionWhenDHISVersionsMismatch()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
         String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
         when( syncParams.getVersion() ).thenReturn( metadataVersion );
-        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) ).thenReturn( expectedMetadataSnapshot );
-        when ( metadataSyncDelegate.shouldStopSync( expectedMetadataSnapshot ) ).thenReturn( true );
-        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot)).thenReturn( true );
+        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) )
+            .thenReturn( expectedMetadataSnapshot );
+        when( metadataSyncDelegate.shouldStopSync( expectedMetadataSnapshot ) ).thenReturn( true );
+        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) )
+            .thenReturn( true );
 
         expectedException.expect( DhisVersionMismatchException.class );
-        expectedException.expectMessage( "Metadata sync failed because your version of DHIS does not match the master version" );
+        expectedException
+            .expectMessage( "Metadata sync failed because your version of DHIS does not match the master version" );
 
         metadataSyncService.doMetadataSync( syncParams );
     }
 
     @Test
-    public void testShouldNotThrowExceptionWhenDHISVersionsMismatch() throws DhisVersionMismatchException
+    public void testShouldNotThrowExceptionWhenDHISVersionsMismatch()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
         String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}";
 
         when( syncParams.getVersion() ).thenReturn( metadataVersion );
-        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) ).thenReturn( expectedMetadataSnapshot );
-        when ( metadataSyncDelegate.shouldStopSync( expectedMetadataSnapshot ) ).thenReturn( false );
-        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) ).thenReturn( true );
+        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) )
+            .thenReturn( expectedMetadataSnapshot );
+        when( metadataSyncDelegate.shouldStopSync( expectedMetadataSnapshot ) ).thenReturn( false );
+        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) )
+            .thenReturn( true );
 
         metadataSyncService.doMetadataSync( syncParams );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenSnapshotNotPassingIntegrity() throws DhisVersionMismatchException
+    public void testShouldThrowExceptionWhenSnapshotNotPassingIntegrity()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
         String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
         when( syncParams.getVersion() ).thenReturn( metadataVersion );
-        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) ).thenReturn( expectedMetadataSnapshot );
-        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) ).thenReturn( false );
+        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) )
+            .thenReturn( expectedMetadataSnapshot );
+        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) )
+            .thenReturn( false );
 
         expectedException.expect( MetadataSyncServiceException.class );
         expectedException.expectMessage( "Metadata snapshot is corrupted." );
@@ -274,37 +287,40 @@ public class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldStoreMetadataSnapshotInDataStoreAndImport() throws DhisVersionMismatchException
+    public void testShouldStoreMetadataSnapshotInDataStoreAndImport()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
-        MetadataImportParams metadataImportParams = new MetadataImportParams();
         MetadataSyncSummary metadataSyncSummary = new MetadataSyncSummary();
         metadataSyncSummary.setMetadataVersion( metadataVersion );
         String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
         when( syncParams.getVersion() ).thenReturn( metadataVersion );
-        when( syncParams.getImportParams() ).thenReturn( metadataImportParams );
         when( metadataVersionService.getVersionData( "testVersion" ) ).thenReturn( null );
-        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) ).thenReturn( expectedMetadataSnapshot );
-        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) ).thenReturn( true );
-        when( metadataSyncImportHandler.importMetadata(syncParams,expectedMetadataSnapshot) ).thenReturn( metadataSyncSummary );
+        when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) )
+            .thenReturn( expectedMetadataSnapshot );
+        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) )
+            .thenReturn( true );
+        when( metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) )
+            .thenReturn( metadataSyncSummary );
 
         MetadataSyncSummary actualSummary = metadataSyncService.doMetadataSync( syncParams );
 
-        verify( metadataVersionService, times( 1 ) ).createMetadataVersionInDataStore( metadataVersion.getName(), expectedMetadataSnapshot );
-        assertEquals( null, actualSummary.getImportReport() );
-        assertEquals( null, actualSummary.getImportSummary() );
+        verify( metadataVersionService, times( 1 ) ).createMetadataVersionInDataStore( metadataVersion.getName(),
+            expectedMetadataSnapshot );
+        assertNull( actualSummary.getImportReport() );
+        assertNull( actualSummary.getImportSummary() );
         assertEquals( metadataVersion, actualSummary.getMetadataVersion() );
     }
 
     @Test
-    public void testShouldNotStoreMetadataSnapshotInDataStoreWhenAlreadyExistsInLocalStore() throws DhisVersionMismatchException
+    public void testShouldNotStoreMetadataSnapshotInDataStoreWhenAlreadyExistsInLocalStore()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
 
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
-        MetadataImportParams metadataImportParams = new MetadataImportParams();
 
         MetadataSyncSummary metadataSyncSummary = new MetadataSyncSummary();
         metadataSyncSummary.setMetadataVersion( metadataVersion );
@@ -312,49 +328,47 @@ public class DefaultMetadataSyncServiceTest
         String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
         when( syncParams.getVersion() ).thenReturn( metadataVersion );
-        when( syncParams.getImportParams() ).thenReturn( metadataImportParams );
         when( metadataVersionService.getVersionData( "testVersion" ) ).thenReturn( expectedMetadataSnapshot );
 
-        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) ).thenReturn( true );
-        when( metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) ).thenReturn( metadataSyncSummary );
+        when( metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) )
+            .thenReturn( metadataSyncSummary );
 
         MetadataSyncSummary actualSummary = metadataSyncService.doMetadataSync( syncParams );
 
-        verify( metadataVersionService, never() ).createMetadataVersionInDataStore( metadataVersion.getName(), expectedMetadataSnapshot );
+        verify( metadataVersionService, never() ).createMetadataVersionInDataStore( metadataVersion.getName(),
+            expectedMetadataSnapshot );
         verify( metadataVersionDelegate, never() ).downloadMetadataVersionSnapshot( metadataVersion );
-        assertEquals( null, actualSummary.getImportReport() );
-        assertEquals( null, actualSummary.getImportSummary() );
+        assertNull( actualSummary.getImportReport() );
+        assertNull( actualSummary.getImportSummary() );
         assertEquals( metadataVersion, actualSummary.getMetadataVersion() );
     }
 
     @Test
-    public void testShouldVerifyImportParamsAtomicTypeForTheGivenBestEffortVersion() throws DhisVersionMismatchException
+    public void testShouldVerifyImportParamsAtomicTypeForTheGivenBestEffortVersion()
+        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = new MetadataSyncParams();
 
-        MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT);
+        MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         MetadataImportParams metadataImportParams = new MetadataImportParams();
 
-        syncParams.setVersion( metadataVersion);
+        syncParams.setVersion( metadataVersion );
         syncParams.setImportParams( metadataImportParams );
 
         MetadataSyncSummary metadataSyncSummary = new MetadataSyncSummary();
         metadataSyncSummary.setMetadataVersion( metadataVersion );
         String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
-        when( metadataVersionService.getVersionData( "testVersion" ) ).thenReturn(expectedMetadataSnapshot );
-        when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) ).thenReturn( true );
+        when( metadataVersionService.getVersionData( "testVersion" ) ).thenReturn( expectedMetadataSnapshot );
 
         metadataSyncService.doMetadataSync( syncParams );
 
-        verify( metadataSyncImportHandler, times( 1 )).importMetadata( (argThat( new ArgumentMatcher<MetadataSyncParams>() {
-            @Override
-            public boolean matches(Object syncParams) {
-                return ((MetadataSyncParams) syncParams).getImportParams().getAtomicMode().equals(AtomicMode.NONE);
-            }
-        })), eq(expectedMetadataSnapshot));
+        verify( metadataSyncImportHandler, times( 1 ) ).importMetadata(
+            (argThat( metadataSyncParams -> syncParams.getImportParams().getAtomicMode().equals( AtomicMode.NONE ) )),
+            eq( expectedMetadataSnapshot ) );
 
-        verify( metadataVersionService, never() ).createMetadataVersionInDataStore( metadataVersion.getName(), expectedMetadataSnapshot );
+        verify( metadataVersionService, never() ).createMetadataVersionInDataStore( metadataVersion.getName(),
+            expectedMetadataSnapshot );
         verify( metadataVersionDelegate, never() ).downloadMetadataVersionSnapshot( metadataVersion );
 
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
@@ -28,9 +28,16 @@ package org.hisp.dhis.dxf2.metadata.version;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.http.HttpResponse;
-import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.IntegrationTest;
 import org.hisp.dhis.dxf2.metadata.sync.exception.RemoteServerUnavailableException;
 import org.hisp.dhis.dxf2.metadata.systemsettings.DefaultMetadataSystemSettingService;
 import org.hisp.dhis.dxf2.metadata.version.exception.MetadataVersionServiceException;
@@ -46,68 +53,62 @@ import org.hisp.dhis.system.util.HttpUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.omg.CORBA.portable.InputStream;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
 
 /**
  * @author anilkumk
  */
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( HttpUtils.class )
-@Category( IntegrationTest.class )
 public class MetadataVersionDelegateTest
-    extends DhisSpringTest
 {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Autowired
-    @InjectMocks
-    private MetadataVersionDelegate metadataVersionDelegate;
+    private MetadataVersionDelegate target;
 
-    @Autowired
     @Mock
     private SynchronizationManager synchronizationManager;
 
-    @Autowired
     @Mock
     private DefaultMetadataSystemSettingService metadataSystemSettingService;
 
-    @Autowired
     @Mock
     private MetadataVersionService metadataVersionService;
 
-    @Autowired
     @Mock
     private RenderService renderService;
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     private HttpResponse httpResponse;
+
     private MetadataVersion metadataVersion;
+
     private int VERSION_TIMEOUT = 120000;
+
     private int DOWNLOAD_TIMEOUT = 300000;
+
     private String username = "username";
+
     private String password = "password";
+
     private String versionUrl = "http://localhost:9080/api/metadata/version?versionName=Version_Name";
+
     private String baselineUrl = "http://localhost:9080/api/metadata/version/history?baseline=testVersion";
+
     private String downloadUrl = "http://localhost:9080/api/metadata/version/testVersion/data.gz";
+
     private String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
 
     @Before
@@ -120,16 +121,16 @@ public class MetadataVersionDelegateTest
         metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
 
+        target = new MetadataVersionDelegate( metadataSystemSettingService, synchronizationManager, renderService,
+            metadataVersionService );
+
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenServerNotAvailable() throws Exception
+    public void testShouldThrowExceptionWhenServerNotAvailable()
     {
-        String url = "http://localhost:9080/api/metadata/version?versionName=Version_Name";
-
-        when( metadataSystemSettingService.getVersionDetailsUrl( "testversion" ) ).thenReturn( url );
 
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( false, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
@@ -137,48 +138,51 @@ public class MetadataVersionDelegateTest
         expectedException.expect( RemoteServerUnavailableException.class );
         expectedException.expectMessage( "test_message" );
 
-        metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        target.getRemoteMetadataVersion( "testVersion" );
     }
 
     @Test
-    public void testShouldGetRemoteVersionNullWhenDhisResponseReturnsNull() throws Exception
+    public void testShouldGetRemoteVersionNullWhenDhisResponseReturnsNull()
+        throws Exception
     {
-        String url = "http://localhost:9080/api/metadata/version?versionName=Version_Name";
-
-        when( metadataSystemSettingService.getVersionDetailsUrl( "testversion" ) ).thenReturn( url );
 
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( null );
-        MetadataVersion version = metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( null );
+        MetadataVersion version = target.getRemoteMetadataVersion( "testVersion" );
 
-        assertEquals( null, version );
+        assertNull( version );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenHTTPRequestFails() throws Exception
+    public void testShouldThrowExceptionWhenHTTPRequestFails()
+        throws Exception
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "testMessage", null );
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenThrow( new Exception( "" ) );
+        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenThrow( new Exception( "" ) );
 
         expectedException.expect( MetadataVersionServiceException.class );
-        metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        target.getRemoteMetadataVersion( "testVersion" );
     }
 
     @Test
-    public void testShouldGetRemoteMetadataVersionWithStatusOk() throws Exception
+    public void testShouldGetRemoteMetadataVersionWithStatusOk()
+        throws Exception
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "testMessage", null );
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
+        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
         when( renderService.fromJson( response, MetadataVersion.class ) ).thenReturn( metadataVersion );
-        MetadataVersion remoteMetadataVersion = metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        MetadataVersion remoteMetadataVersion = target.getRemoteMetadataVersion( "testVersion" );
 
         assertEquals( metadataVersion.getType(), remoteMetadataVersion.getType() );
         assertEquals( metadataVersion.getHashCode(), remoteMetadataVersion.getHashCode() );
@@ -187,7 +191,8 @@ public class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldGetMetaDataDifferenceWithStatusOk() throws Exception
+    public void testShouldGetMetaDataDifferenceWithStatusOk()
+        throws Exception
     {
         String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
@@ -205,26 +210,30 @@ public class MetadataVersionDelegateTest
 
         PowerMockito.mockStatic( HttpUtils.class );
 
-        PowerMockito.when( HttpUtils.httpGET( url, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
+        PowerMockito.when( HttpUtils.httpGET( url, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
 
         List<MetadataVersion> metadataVersionList = new ArrayList<>();
         metadataVersionList.add( metadataVersion );
 
         when( metadataSystemSettingService.getMetaDataDifferenceURL( "testVersion" ) ).thenReturn( baselineUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        when( renderService.fromMetadataVersion( any( InputStream.class ), eq( RenderFormat.JSON ) ) ).thenReturn( metadataVersionList );
+        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
+        when( renderService.fromMetadataVersion( any( ByteArrayInputStream.class ), eq( RenderFormat.JSON ) ) )
+            .thenReturn( metadataVersionList );
 
-        List<MetadataVersion> metaDataDifference = metadataVersionDelegate.getMetaDataDifference( metadataVersion );
+        List<MetadataVersion> metaDataDifference = target.getMetaDataDifference( metadataVersion );
 
-        assertTrue( metaDataDifference.size() == metadataVersionList.size() );
+        assertEquals( metaDataDifference.size(), metadataVersionList.size() );
         assertEquals( metadataVersionList.get( 0 ).getType(), metaDataDifference.get( 0 ).getType() );
         assertEquals( metadataVersionList.get( 0 ).getName(), metaDataDifference.get( 0 ).getName() );
         assertEquals( metadataVersionList.get( 0 ).getHashCode(), metaDataDifference.get( 0 ).getHashCode() );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenRenderServiceThrowsExceptionWhileGettingMetadataDifference() throws Exception
+    public void testShouldThrowExceptionWhenRenderServiceThrowsExceptionWhileGettingMetadataDifference()
+        throws Exception
     {
         String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
@@ -240,17 +249,20 @@ public class MetadataVersionDelegateTest
 
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
 
-        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        when( renderService.fromMetadataVersion( any( InputStream.class ), eq( RenderFormat.JSON ) ) ).thenThrow( new IOException( "" ) );
+        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
+        when( renderService.fromMetadataVersion( any( ByteArrayInputStream.class ), eq( RenderFormat.JSON ) ) )
+            .thenThrow( new IOException( "" ) );
 
         expectedException.expect( MetadataVersionServiceException.class );
         expectedException.expectMessage( "Exception occurred while trying to do JSON conversion. Caused by: " );
 
-        metadataVersionDelegate.getMetaDataDifference( metadataVersion );
+        target.getMetaDataDifference( metadataVersion );
     }
 
     @Test
-    public void testShouldReturnEmptyMetadataDifference() throws Exception
+    public void testShouldReturnEmptyMetadataDifference()
+        throws Exception
     {
         String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
@@ -264,27 +276,26 @@ public class MetadataVersionDelegateTest
 
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
 
-        DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.BAD_REQUEST.value() );
+        DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response,
+            HttpStatus.BAD_REQUEST.value() );
 
-        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        when( renderService.fromMetadataVersion( any( InputStream.class ), eq( RenderFormat.JSON ) ) ).thenThrow( new IOException( "" ) );
+        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
 
         expectedException.expect( MetadataVersionServiceException.class );
-        expectedException.expectMessage( "Client Error. Http call failed with status code: 400 Caused by: " + dhisHttpResponse.getResponse() );
+        expectedException.expectMessage(
+            "Client Error. Http call failed with status code: 400 Caused by: " + dhisHttpResponse.getResponse() );
 
-        metadataVersionDelegate.getMetaDataDifference( metadataVersion );
+        target.getMetaDataDifference( metadataVersion );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithClientError() throws Exception
+    public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithClientError()
+        throws Exception
     {
         String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
-
-        String url = "http://localhost:9080/api/metadata/version?versionName=Version_Name";
-
-        when( metadataSystemSettingService.getVersionDetailsUrl( "testversion" ) ).thenReturn( url );
 
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
@@ -294,63 +305,67 @@ public class MetadataVersionDelegateTest
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        when( renderService.fromJson( response, MetadataVersion.class ) ).thenReturn( metadataVersion );
+        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
 
         expectedException.expect( MetadataVersionServiceException.class );
-        expectedException.expectMessage( "Client Error. Http call failed with status code: " + HttpStatus.CONFLICT.value() + " Caused by: " + response );
+        expectedException.expectMessage( "Client Error. Http call failed with status code: "
+            + HttpStatus.CONFLICT.value() + " Caused by: " + response );
 
-        metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        target.getRemoteMetadataVersion( "testVersion" );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithServerError() throws Exception
+    public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithServerError()
+        throws Exception
     {
         String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
-
-        String url = "http://localhost:9080/api/metadata/version?versionName=Version_Name";
-
-        when( metadataSystemSettingService.getVersionDetailsUrl( "testversion" ) ).thenReturn( url );
 
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
 
         HttpResponse httpResponse = mock( HttpResponse.class );
 
-        DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.GATEWAY_TIMEOUT.value() );
+        DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response,
+            HttpStatus.GATEWAY_TIMEOUT.value() );
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        when( renderService.fromJson( response, MetadataVersion.class ) ).thenReturn( metadataVersion );
+        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
 
         expectedException.expect( MetadataVersionServiceException.class );
-        expectedException.expectMessage( "Server Error. Http call failed with status code: " + HttpStatus.GATEWAY_TIMEOUT.value() + " Caused by: " + response );
+        expectedException.expectMessage( "Server Error. Http call failed with status code: "
+            + HttpStatus.GATEWAY_TIMEOUT.value() + " Caused by: " + response );
 
-        metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        target.getRemoteMetadataVersion( "testVersion" );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenRenderServiceThrowsException() throws Exception
+    public void testShouldThrowExceptionWhenRenderServiceThrowsException()
+        throws Exception
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "testMessage", null );
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        when( renderService.fromJson( response, MetadataVersion.class ) ).thenThrow( new MetadataVersionServiceException( "" ) );
+        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
+        when( renderService.fromJson( response, MetadataVersion.class ) )
+            .thenThrow( new MetadataVersionServiceException( "" ) );
 
         expectedException.expect( MetadataVersionServiceException.class );
         expectedException.expectMessage( "Exception occurred while trying to do JSON conversion for metadata version" );
 
-        metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" );
+        target.getRemoteMetadataVersion( "testVersion" );
     }
 
     @Test
-    public void testShouldDownloadMetadataVersion() throws Exception
+    public void testShouldDownloadMetadataVersion()
+        throws Exception
     {
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
@@ -365,14 +380,16 @@ public class MetadataVersionDelegateTest
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
 
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) ).thenReturn( dhisHttpResponse );
-        String actualVersionSnapShot = metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion );
+        PowerMockito.when( HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) )
+            .thenReturn( dhisHttpResponse );
+        String actualVersionSnapShot = target.downloadMetadataVersionSnapshot( metadataVersion );
 
         assertEquals( response, actualVersionSnapShot );
     }
 
     @Test
-    public void testShouldNotDownloadMetadataVersion() throws Exception
+    public void testShouldNotDownloadMetadataVersion()
+        throws Exception
     {
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
@@ -384,16 +401,17 @@ public class MetadataVersionDelegateTest
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
 
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) ).thenReturn( null );
-        String actualMetadataVersionSnapshot = metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion );
+        PowerMockito.when( HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) )
+            .thenReturn( null );
+        String actualMetadataVersionSnapshot = target.downloadMetadataVersionSnapshot( metadataVersion );
 
-        assertEquals( null, actualMetadataVersionSnapshot );
+        assertNull(actualMetadataVersionSnapshot);
     }
 
     @Test
-    public void testShouldAddNewMetadataVersion() throws Exception
+    public void testShouldAddNewMetadataVersion()
     {
-        metadataVersionDelegate.addNewMetadataVersion( metadataVersion );
+        target.addNewMetadataVersion( metadataVersion );
 
         verify( metadataVersionService, times( 1 ) ).addVersion( metadataVersion );
     }

--- a/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
@@ -25,7 +25,11 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-core</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -45,7 +45,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -25,7 +25,12 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-core</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -52,7 +52,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
@@ -76,6 +76,11 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql </artifactId>
       <version>1.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.benas</groupId>
+      <artifactId>random-beans</artifactId>
+      <version>3.7.0</version>
     </dependency>
   </dependencies>
   <properties>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/BeanRandomizer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/BeanRandomizer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.random;
+
+import io.github.benas.randombeans.FieldDefinitionBuilder;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import org.hisp.dhis.period.PeriodType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class BeanRandomizer
+{
+    private EnhancedRandom rnd;
+
+    public BeanRandomizer() {
+        rnd = aNewEnhancedRandomBuilder()
+                .randomize(PeriodType.class, new PeriodTypeRandomizer())
+                .randomize(FieldDefinitionBuilder.field().named("uid").ofType(String.class).get(),
+                        new UidRandomizer())
+                .build();
+    }
+
+    public <T> T randomObject(final Class<T> type, final String... excludedFields )
+    {
+        return rnd.nextObject( type, excludedFields );
+    }
+
+    public <T> List<T> randomObjects(final Class<T> type, int amount, final String... excludedFields )
+    {
+        return rnd.objects( type, amount, excludedFields ).collect( Collectors.toList() );
+    }
+
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/PeriodTypeRandomizer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/PeriodTypeRandomizer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.random;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.hisp.dhis.period.PeriodType;
+
+import io.github.benas.randombeans.api.Randomizer;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class PeriodTypeRandomizer
+    implements
+    Randomizer<PeriodType>
+{
+
+    private List<PeriodType> periodTypes = Arrays.asList(
+            PeriodType.getPeriodTypeFromIsoString( "2011" ),
+            PeriodType.getPeriodTypeFromIsoString( "201101" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011W1" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011W32" ),
+            PeriodType.getPeriodTypeFromIsoString( "20110101" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011Q3" ),
+            PeriodType.getPeriodTypeFromIsoString( "201101B" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011S1" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011AprilS1" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011April" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011July" ),
+            PeriodType.getPeriodTypeFromIsoString( "2011Oct" )
+    );
+
+    @Override
+    public PeriodType getRandomValue()
+    {
+        return periodTypes.get(new Random().nextInt(periodTypes.size() -1 ));
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/UidRandomizer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/UidRandomizer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.random;
+
+import org.hisp.dhis.common.CodeGenerator;
+
+import io.github.benas.randombeans.api.Randomizer;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UidRandomizer
+    implements
+    Randomizer<String>
+{
+
+    @Override
+    public String getRandomValue()
+    {
+        return CodeGenerator.generateUid();
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/documentation/controller/dataelement/DataElementControllerDocumentation.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/documentation/controller/dataelement/DataElementControllerDocumentation.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.webapi.documentation.common.ResponseDocumentation;
 import org.hisp.dhis.webapi.documentation.common.TestUtils;
 import org.hisp.dhis.webapi.documentation.controller.AbstractWebApiTest;
 import org.junit.Test;
-import org.mockito.internal.matchers.GreaterThan;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.payload.FieldDescriptor;
@@ -94,14 +93,13 @@ public class DataElementControllerDocumentation
         DataElement de = createDataElement( 'A' );
         manager.save( de );
 
-        List<FieldDescriptor> fieldDescriptors = new ArrayList<>();
-        fieldDescriptors.addAll( ResponseDocumentation.pager() );
+        List<FieldDescriptor> fieldDescriptors = new ArrayList<>(ResponseDocumentation.pager());
         fieldDescriptors.add( fieldWithPath( "dataElements" ).description( "Data elements" ) );
 
         mvc.perform( get( "/dataElements?filter=name:like:DataElementA" )
             .session( session )
             .contentType( TestUtils.APPLICATION_JSON_UTF8 ) )
-            .andExpect( jsonPath( "$.pager.total", new GreaterThan<Integer>( 0 ) ) )
+            .andExpect( jsonPath( "$.pager.total", org.hamcrest.Matchers.greaterThan( 0 ) ) )
             .andDo( documentPrettyPrint( "data-elements/filter",
                 responseFields( fieldDescriptors.toArray( new FieldDescriptor[fieldDescriptors.size()] ) ) ) );
     }
@@ -116,7 +114,7 @@ public class DataElementControllerDocumentation
         mvc.perform( get( "/dataElements?filter=name:ilike:DataElementA" )
             .session( session )
             .contentType( TestUtils.APPLICATION_JSON_UTF8 ) )
-            .andExpect( jsonPath( "$.pager.total", new GreaterThan<Integer>( 0 ) ) );
+            .andExpect( jsonPath( "$.pager.total", org.hamcrest.Matchers.greaterThan( 0 ) ) );
     }
 
     @Test
@@ -129,7 +127,7 @@ public class DataElementControllerDocumentation
         mvc.perform( get( "/dataElements?filter=name:eq:DataElementA" )
             .session( session )
             .contentType( TestUtils.APPLICATION_JSON_UTF8 ) )
-            .andExpect( jsonPath( "$.pager.total", new GreaterThan<Integer>( 0 ) ) );
+            .andExpect( jsonPath( "$.pager.total", org.hamcrest.Matchers.greaterThan( 0 ) ) );
     }
 
     @Test
@@ -139,8 +137,7 @@ public class DataElementControllerDocumentation
         DataElement de = createDataElement( 'A' );
         manager.save( de );
 
-        List<FieldDescriptor> fieldDescriptors = new ArrayList<>();
-        fieldDescriptors.addAll( ResponseDocumentation.pager() );
+        List<FieldDescriptor> fieldDescriptors = new ArrayList<>(ResponseDocumentation.pager());
         fieldDescriptors.add( fieldWithPath( "dataElements" ).description( "Data elements" ) );
 
         mvc.perform( get( "/dataElements?filter=name:eq:DataElementA&fields=id,name,valueType" )

--- a/dhis-2/dhis-web/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -785,16 +785,6 @@
         <version>2.4.2</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
-      </dependency>
-      <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>2.9.9</version>
@@ -1309,12 +1299,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>19.0</version>
@@ -1373,8 +1357,31 @@
       </dependency>
       <!-- Test -->
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>1.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.23.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
+        <artifactId>powermock-api-mockito2</artifactId>
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
@@ -1415,7 +1422,7 @@
     <!-- Keep in sync with Hibernate -->
     <javassist.version>3.20.0-GA</javassist.version>
     <!-- unit test dependencies-->
-    <powermock.version>1.6.6</powermock.version>
+    <powermock.version>2.0.0</powermock.version>
     <jackson.version>2.9.8</jackson.version>
     <slf4j.version>1.7.5</slf4j.version>
     <geotools.version>18.0</geotools.version>


### PR DESCRIPTION
- removed deprecated Mockito dependency, bumped mockito to 2.X
- introduced random-beans lib for random bean generation during test
- created BeanRandomizer class for wrapping random-beans with reusable configuration
- converted some existing unit tests to use mocks rather than instantiating the spring context
- bumped power-mock to 2.0.0