### PR TITLE
Fixed an issue with TEI and relationship access

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -1272,7 +1272,9 @@ public abstract class AbstractTrackedEntityInstanceService
         {
             for ( RelationshipItem relationshipItem : daoTrackedEntityInstance.getRelationshipItems() )
             {
-                if ( relationshipItem.getRelationship().getFrom().equals( relationshipItem ) )
+                org.hisp.dhis.relationship.Relationship daoRelationship = relationshipItem.getRelationship();
+
+                if ( daoRelationship.getFrom().equals( relationshipItem ) && trackerAccessManager.canRead( user, daoRelationship ).isEmpty() )
                 {
                     Relationship relationship = relationshipService.getRelationship( relationshipItem.getRelationship(),
                         RelationshipParams.FALSE, user );


### PR DESCRIPTION
TEI payloads that included relationships with entities the user did not have view access for would reject the entire request. Relationships are now only included if the user have sufficient access to both parts of the relationship

Issue: DHIS2-5870