### PR TITLE
Fix missing required annotation for RelationshipConstraint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipType.java
@@ -34,6 +34,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.annotation.Property;
 
 /**
  * @author Abyot Asalefew
@@ -65,6 +67,7 @@ public class RelationshipType
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @Property( required = Property.Value.TRUE )
     public RelationshipConstraint getFromConstraint()
     {
         return fromConstraint;
@@ -77,6 +80,7 @@ public class RelationshipType
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @Property( required = Property.Value.TRUE )
     public RelationshipConstraint getToConstraint()
     {
         return toConstraint;


### PR DESCRIPTION
Schema for RelationshipType was previously reporting the RelationshipConstraint "from" and "to" as not required, while it is in fact required. Annotations were added to the properties to report them as required in the schemas endpoint.

Issue: DHIS2-5738