### PR TITLE
DHIS2-5956 Dimension Restriction slows down pivot tables

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionService.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.common;
  */
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.user.User;
 
@@ -75,4 +77,20 @@ public interface DimensionService
      * @return a dimensional item object.
      */
     DimensionalItemObject getDataDimensionalItemObject( IdScheme idScheme, String dimensionItem );
+
+    /**
+     * Gets a set of dimension item objects from their ids.
+     *
+     * @param itemIds a set of ids of the dimension item objects to get.
+     * @return the set of dimension item objects built from the ids.
+     */
+    Set<DimensionalItemObject> getDataDimensionalItemObjects( Set<DimensionalItemId> itemIds );
+
+    /**
+     * Gets a map from dimension item ids to their dimension item objects.
+     *
+     * @param itemIds a set of ids of the dimension item objects to get.
+     * @return a map from the item ids to the dimension item objects.
+     */
+    Map<DimensionalItemId, DimensionalItemObject> getDataDimensionalItemObjectMap( Set<DimensionalItemId> itemIds );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
@@ -1,0 +1,193 @@
+package org.hisp.dhis.common;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static org.apache.commons.lang3.EnumUtils.isValidEnum;
+
+/**
+ * Holds the DimensionItemType of a DimensionalItemObject, and the identifier
+ * strings of the objects that that make up the DimensionalItemObject
+ *
+ * @author Jim Grace
+ */
+public class DimensionalItemId
+{
+    // -------------------------------------------------------------------------
+    // Properties
+    // -------------------------------------------------------------------------
+
+    /**
+     * The type of DimensionalItemObject whose ids we have
+     */
+    private DimensionItemType dimensionItemType;
+
+    /**
+     * The first id for the DimensionalItemObject
+     */
+    private String id0;
+
+    /**
+     * The second id (if any) for the DimensionalItemObject
+     */
+    private String id1;
+
+    /**
+     * The third id (if any) for the DimensionalItemObject
+     */
+    private String id2;
+
+    // -------------------------------------------------------------------------
+    // Constructors
+    // -------------------------------------------------------------------------
+
+    public DimensionalItemId( DimensionItemType dimensionItemType, String id0 )
+    {
+        this.dimensionItemType = dimensionItemType;
+        this.id0 = id0;
+    }
+
+    public DimensionalItemId( DimensionItemType dimensionItemType, String id0, String id1 )
+    {
+        this.dimensionItemType = dimensionItemType;
+        this.id0 = id0;
+        this.id1 = id1;
+    }
+
+    public DimensionalItemId( DimensionItemType dimensionItemType, String id0, String id1, String id2 )
+    {
+        this.dimensionItemType = dimensionItemType;
+        this.id0 = id0;
+        this.id1 = id1;
+        this.id2 = id2;
+    }
+
+    // -------------------------------------------------------------------------
+    // Logic
+    // -------------------------------------------------------------------------
+
+    public boolean hasValidIds()
+    {
+        switch ( dimensionItemType )
+        {
+            case DATA_ELEMENT:
+            case PROGRAM_INDICATOR:
+                return id0 != null && id1 == null && id2 == null;
+
+            case DATA_ELEMENT_OPERAND:
+                return id0 != null && ( id1 != null || id2 != null );
+
+            case REPORTING_RATE:
+                return id0 != null && id1 != null && id2 == null
+                    && isValidEnum( ReportingRateMetric.class, id1 );
+
+            case PROGRAM_DATA_ELEMENT:
+            case PROGRAM_ATTRIBUTE:
+                return id0 != null && id1 != null && id2 == null;
+
+            default:
+                return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // hashCode, equals and toString
+    // -------------------------------------------------------------------------
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        DimensionalItemId that = (DimensionalItemId) o;
+
+        return Objects.equals( this.dimensionItemType, that.dimensionItemType )
+            && Objects.equals( this.id0, that.id0 )
+            && Objects.equals( this.id1, that.id1 )
+            && Objects.equals( this.id2, that.id2 );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = dimensionItemType.hashCode();
+
+        result = 31 * result + ( id0 == null ? 0 : id0.hashCode() );
+        result = 31 * result + ( id1 == null ? 0 : id1.hashCode() );
+        result = 31 * result + ( id2 == null ? 0 : id2.hashCode() );
+
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper( this )
+            .add( "dimensionItemType", dimensionItemType )
+            .add( "id0", id0 )
+            .add( "id1", id1 )
+            .add( "id2", id2 )
+            .toString();
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters
+    // -------------------------------------------------------------------------
+
+    public DimensionItemType getDimensionItemType()
+    {
+        return dimensionItemType;
+    }
+
+    public String getId0()
+    {
+        return id0;
+    }
+
+    public String getId1()
+    {
+        return id1;
+    }
+
+    public String getId2()
+    {
+        return id2;
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -28,11 +28,9 @@ package org.hisp.dhis.expression;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.ImmutableMap;
+import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.ListMap;
-import org.hisp.dhis.common.ReportingRate;
-import org.hisp.dhis.common.SetMap;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -40,9 +38,6 @@ import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.program.ProgramDataElementDimensionItem;
-import org.hisp.dhis.program.ProgramIndicator;
-import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 
 import java.util.Collection;
 import java.util.List;
@@ -142,17 +137,6 @@ public interface ExpressionService
      */
     String TRUE_VALUE = "1";
     String FALSE_VALUE = "0";
-
-    /**
-     * Variable types with their associated classes.
-     */
-    static final Map<String, Class<? extends DimensionalItemObject>> VARIABLE_TYPES = ImmutableMap.of(
-        "#", DataElementOperand.class,
-        "D", ProgramDataElementDimensionItem.class,
-        "A", ProgramTrackedEntityAttributeDimensionItem.class,
-        "I", ProgramIndicator.class,
-        "R", ReportingRate.class
-    );
 
     String GROUP_KEY = "key";
     String GROUP_ID = "id";
@@ -341,9 +325,9 @@ public interface ExpressionService
      * in the given expression.
      *
      * @param expression the expression.
-     * @return sets of dimensional item identifiers, mapped by class.
+     * @return set of dimensional item identifiers.
      */
-    SetMap<Class<? extends DimensionalItemObject>, String> getDimensionalItemIdsInExpression( String expression );
+    Set<DimensionalItemId> getDimensionalItemIdsInExpression( String expression );
 
     /**
      * Returns all dimensional item objects which are present in the given expression.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -28,12 +28,15 @@ package org.hisp.dhis.dimension;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
@@ -42,8 +45,10 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.ReportingRate;
 import org.hisp.dhis.common.ReportingRateMetric;
+import org.hisp.dhis.common.SetMap;
 import org.hisp.dhis.commons.collection.UniqueArrayList;
 import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.category.CategoryOptionGroup;
@@ -89,8 +94,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.EnumUtils.isValidEnum;
 import static org.hisp.dhis.common.DimensionType.*;
@@ -106,6 +114,8 @@ import static org.hisp.dhis.organisationunit.OrganisationUnit.*;
 public class DefaultDimensionService
     implements DimensionService
 {
+    private static final Log log = LogFactory.getLog( DefaultDimensionService.class );
+
     @Autowired
     private IdentifiableObjectManager idObjectManager;
 
@@ -376,9 +386,204 @@ public class DefaultDimensionService
         return null;
     }
 
+    @Override
+    public Set<DimensionalItemObject> getDataDimensionalItemObjects( Set<DimensionalItemId> itemIds )
+    {
+        return new HashSet<>( getDataDimensionalItemObjectMap( itemIds ).values() );
+    }
+
+    @Override
+    public Map<DimensionalItemId, DimensionalItemObject> getDataDimensionalItemObjectMap( Set<DimensionalItemId> itemIds )
+    {
+        SetMap<Class<? extends IdentifiableObject>, String> atomicIds = getAtomicIds( itemIds );
+
+        MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> atomicObjects = getAtomicObjects( atomicIds );
+
+        return getItemObjectMap( itemIds, atomicObjects );
+    }
+
     //--------------------------------------------------------------------------
     // Supportive methods
     //--------------------------------------------------------------------------
+
+    /**
+     * Breaks down a set of dimensional item ids into the atomic object ids
+     * stored in the database. Returns a map from each class of atomic objects
+     * to the set of ids for that object class.
+     *
+     * @param itemIds a set of dimension item object ids.
+     * @return map from atomic object classes to sets of atomic ids.
+     */
+    private SetMap<Class<? extends IdentifiableObject>, String> getAtomicIds( Set<DimensionalItemId> itemIds )
+    {
+        SetMap<Class<? extends IdentifiableObject>, String> atomicIds = new SetMap<>();
+
+        for ( DimensionalItemId id : itemIds )
+        {
+            if ( !id.hasValidIds() )
+            {
+                continue;
+            }
+
+            switch ( id.getDimensionItemType() )
+            {
+                case DATA_ELEMENT:
+                    atomicIds.putValue( DataElement.class, id.getId0() );
+                    break;
+
+                case DATA_ELEMENT_OPERAND:
+                    atomicIds.putValue( DataElement.class, id.getId0() );
+                    if ( id.getId1() != null )
+                    {
+                        atomicIds.putValue( CategoryOptionCombo.class, id.getId1() );
+                    }
+                    if ( id.getId2() != null )
+                    {
+                        atomicIds.putValue( CategoryOptionCombo.class, id.getId2() );
+                    }
+                    break;
+
+                case REPORTING_RATE:
+                    atomicIds.putValue( DataSet.class, id.getId0() );
+                    break;
+
+                case PROGRAM_DATA_ELEMENT:
+                    atomicIds.putValue( Program.class, id.getId0() );
+                    atomicIds.putValue( DataElement.class, id.getId1() );
+                    break;
+
+                case PROGRAM_ATTRIBUTE:
+                    atomicIds.putValue( Program.class, id.getId0() );
+                    atomicIds.putValue( TrackedEntityAttribute.class, id.getId1() );
+                    break;
+
+                case PROGRAM_INDICATOR:
+                    atomicIds.putValue( ProgramIndicator.class, id.getId0() );
+                    break;
+
+                default:
+                    log.warn( "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getAtomicIds" );
+                    break;
+            }
+        }
+
+        return atomicIds;
+    }
+
+    /**
+     * Finds the atomic identifiable objects from the database for each object
+     * class. This is done for all objects in each class in a single call, for
+     * performance (especially for validation rules which may need to look up
+     * hundreds if not thousands of objects from a class.
+     *
+     * @param atomicIds a map from each class of atomic objects to the set
+     *                  of ids for that identifiable object class.
+     * @return a map from each class of atomic objects to a map that associates
+     *         each id of that class with an atomic object.
+     */
+    private MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> getAtomicObjects(
+        SetMap<Class<? extends IdentifiableObject>, String> atomicIds )
+    {
+        MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> atomicObjects = new MapMap<>();
+
+        for ( Map.Entry<Class<? extends IdentifiableObject>, Set<String>> e : atomicIds.entrySet() )
+        {
+            atomicObjects.putEntries( e.getKey(),
+                idObjectManager.get( e.getKey(), e.getValue() ).stream()
+                    .collect( Collectors.toMap( IdentifiableObject::getUid, o -> o ) ) );
+        }
+
+        return atomicObjects;
+    }
+
+    /**
+     * Gets a map from dimension item ids to their dimension item objects.
+     *
+     * @param itemIds a set of ids of the dimension item objects to get.
+     * @param atomicObjects a map from each class of atomic objects to a map that
+     *                      associates each id of that class with an atomic object.
+     * @return a map from the item ids to the dimension item objects.
+     */
+    private Map<DimensionalItemId, DimensionalItemObject> getItemObjectMap(Set<DimensionalItemId> itemIds,
+        MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> atomicObjects )
+    {
+        Map<DimensionalItemId, DimensionalItemObject> itemObjectMap = new HashMap<>();
+
+        for ( DimensionalItemId id : itemIds )
+        {
+            if ( !id.hasValidIds() )
+            {
+                continue;
+            }
+
+            switch ( id.getDimensionItemType() )
+            {
+                case DATA_ELEMENT:
+                    DataElement dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
+                    if ( dataElement != null )
+                    {
+                        itemObjectMap.put( id, dataElement );
+                    }
+                    break;
+
+                case DATA_ELEMENT_OPERAND:
+                    dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
+                    CategoryOptionCombo categoryOptionCombo = id.getId1() == null ? null : (CategoryOptionCombo) atomicObjects.getValue( CategoryOptionCombo.class, id.getId1() );
+                    CategoryOptionCombo attributeOptionCombo = id.getId2() == null ? null : (CategoryOptionCombo) atomicObjects.getValue( CategoryOptionCombo.class, id.getId2() );
+                    if ( dataElement != null &&
+                        ( id.getId1() != null ) == ( categoryOptionCombo != null ) &&
+                        ( id.getId2() != null ) == ( attributeOptionCombo != null ) )
+                    {
+                        DataElementOperand dataElementOperand = new DataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
+                        itemObjectMap.put( id, dataElementOperand );
+                    }
+                    break;
+
+                case REPORTING_RATE:
+                    DataSet dataSet = (DataSet) atomicObjects.getValue( DataSet.class, id.getId0() );
+                    if ( dataSet != null )
+                    {
+                        ReportingRate reportingRate = new ReportingRate( dataSet, ReportingRateMetric.valueOf( id.getId1() ) );
+                        itemObjectMap.put( id, reportingRate );
+                    }
+                    break;
+
+                case PROGRAM_DATA_ELEMENT:
+                    Program program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
+                    dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId1() );
+                    if ( program != null && dataElement != null )
+                    {
+                        ProgramDataElementDimensionItem programDataElementDimensionItem = new ProgramDataElementDimensionItem( program, dataElement );
+                        itemObjectMap.put( id, programDataElementDimensionItem );
+                    }
+                    break;
+
+                case PROGRAM_ATTRIBUTE:
+                    program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
+                    TrackedEntityAttribute attribute = (TrackedEntityAttribute) atomicObjects.getValue( TrackedEntityAttribute.class, id.getId1() );
+                    if ( program != null && attribute != null )
+                    {
+                        ProgramTrackedEntityAttributeDimensionItem programTrackedEntityAttributeDimensionItem = new ProgramTrackedEntityAttributeDimensionItem( program, attribute );
+                        itemObjectMap.put( id, programTrackedEntityAttributeDimensionItem );
+                    }
+                    break;
+
+                case PROGRAM_INDICATOR:
+                    ProgramIndicator programIndicator = (ProgramIndicator) atomicObjects.getValue( ProgramIndicator.class, id.getId0() );
+                    if ( programIndicator != null )
+                    {
+                        itemObjectMap.put( id, programIndicator );
+                    }
+                    break;
+
+                default:
+                    log.warn( "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getItemObjectMap" );
+                    break;
+            }
+        }
+
+        return itemObjectMap;
+    }
 
     /**
      * Returns a {@link DataElementOperand}. For identifier wild cards

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
@@ -40,12 +40,18 @@ import org.hisp.dhis.organisationunit.*;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 import org.hisp.dhis.reporttable.ReportTable;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hisp.dhis.common.DimensionItemType.*;
 import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
@@ -69,6 +75,8 @@ public class DimensionServiceTest
     private Program prA;
     
     private TrackedEntityAttribute atA;
+
+    private ProgramIndicator piA;
     
     private Period peA;
     private Period peB;
@@ -95,7 +103,27 @@ public class DimensionServiceTest
     private OrganisationUnitGroup ouGroupA;
     private OrganisationUnitGroup ouGroupB;
     private OrganisationUnitGroup ouGroupC;
-        
+
+    private DimensionalItemObject itemObjectA;
+    private DimensionalItemObject itemObjectB;
+    private DimensionalItemObject itemObjectC;
+    private DimensionalItemObject itemObjectD;
+    private DimensionalItemObject itemObjectE;
+    private DimensionalItemObject itemObjectF;
+    private DimensionalItemObject itemObjectG;
+    private DimensionalItemObject itemObjectH;
+
+    private DimensionalItemId itemIdA;
+    private DimensionalItemId itemIdB;
+    private DimensionalItemId itemIdC;
+    private DimensionalItemId itemIdD;
+    private DimensionalItemId itemIdE;
+    private DimensionalItemId itemIdF;
+    private DimensionalItemId itemIdG;
+    private DimensionalItemId itemIdH;
+
+    private Set<DimensionalItemId> itemIds;
+
     @Autowired
     private DataElementService dataElementService;
     
@@ -139,6 +167,10 @@ public class DimensionServiceTest
         atA = createTrackedEntityAttribute( 'A' );
         
         idObjectManager.save( atA );
+
+        piA = createProgramIndicator( 'A', prA, null, null );
+
+        idObjectManager.save( piA );
         
         peA = createPeriod( "201201" );
         peB = createPeriod( "201202" );
@@ -212,6 +244,34 @@ public class DimensionServiceTest
         ouGroupSetA.getOrganisationUnitGroups().add( ouGroupC );
         
         organisationUnitGroupService.updateOrganisationUnitGroupSet( ouGroupSetA );
+
+        itemObjectA = deA;
+        itemObjectB = new DataElementOperand( deA, cocA );
+        itemObjectC = new DataElementOperand( deA, null, cocA );
+        itemObjectD = new DataElementOperand( deA, cocA, cocA );
+        itemObjectE = new ReportingRate( dsA );
+        itemObjectF = new ProgramDataElementDimensionItem( prA, deA );
+        itemObjectG = new ProgramTrackedEntityAttributeDimensionItem( prA, atA );
+        itemObjectH = piA;
+
+        itemIdA = new DimensionalItemId( DATA_ELEMENT, deA.getUid() );
+        itemIdB = new DimensionalItemId( DATA_ELEMENT_OPERAND, deA.getUid(), cocA.getUid() );
+        itemIdC = new DimensionalItemId( DATA_ELEMENT_OPERAND, deA.getUid(), null, cocA.getUid() );
+        itemIdD = new DimensionalItemId( DATA_ELEMENT_OPERAND, deA.getUid(), cocA.getUid(), cocA.getUid() );
+        itemIdE = new DimensionalItemId( REPORTING_RATE, dsA.getUid(), ReportingRateMetric.REPORTING_RATE.name() );
+        itemIdF = new DimensionalItemId( PROGRAM_DATA_ELEMENT, prA.getUid(), deA.getUid() );
+        itemIdG = new DimensionalItemId( PROGRAM_ATTRIBUTE, prA.getUid(), atA.getUid() );
+        itemIdH = new DimensionalItemId( PROGRAM_INDICATOR, piA.getUid() );
+
+        itemIds = new HashSet<>();
+        itemIds.add( itemIdA );
+        itemIds.add( itemIdB );
+        itemIds.add( itemIdC );
+        itemIds.add( itemIdD );
+        itemIds.add( itemIdE );
+        itemIds.add( itemIdF );
+        itemIds.add( itemIdG );
+        itemIds.add( itemIdH );
     }
         
     @Test
@@ -369,5 +429,51 @@ public class DimensionServiceTest
 
         assertNotNull( dimensionService.getDataDimensionalItemObject( idK ) );
         assertEquals( deoE, dimensionService.getDataDimensionalItemObject( idK ) );
+    }
+
+    @Test
+    public void testGetDataDimensionalItemObjects()
+    {
+        Set<DimensionalItemObject> objects = dimensionService.getDataDimensionalItemObjects( new HashSet<>() );
+
+        assertNotNull( objects );
+        assertEquals( 0, objects.size() );
+
+        objects = dimensionService.getDataDimensionalItemObjects( itemIds );
+
+        assertNotNull( objects );
+        assertEquals( 8, objects.size() );
+
+        assertTrue( objects.contains( itemObjectA ) );
+        assertTrue( objects.contains( itemObjectB ) );
+        assertTrue( objects.contains( itemObjectC ) );
+        assertTrue( objects.contains( itemObjectD ) );
+        assertTrue( objects.contains( itemObjectE ) );
+        assertTrue( objects.contains( itemObjectF ) );
+        assertTrue( objects.contains( itemObjectG ) );
+        assertTrue( objects.contains( itemObjectH ) );
+    }
+
+    @Test
+    public void testGetDataDimensionalItemObjectMap()
+    {
+        Map<DimensionalItemId, DimensionalItemObject> map = dimensionService.getDataDimensionalItemObjectMap( new HashSet<>() );
+
+        assertNotNull( map );
+        assertEquals( 0, map.size() );
+
+        map = dimensionService.getDataDimensionalItemObjectMap( itemIds );
+
+        assertNotNull( map );
+        assertEquals( 8, map.size() );
+
+        assertEquals( itemObjectA, map.get( itemIdA ) );
+        assertEquals( itemObjectB, map.get( itemIdB ) );
+        assertEquals( itemObjectC, map.get( itemIdC ) );
+        assertEquals( itemObjectD, map.get( itemIdD ) );
+        assertEquals( itemObjectE, map.get( itemIdE ) );
+        assertEquals( itemObjectF, map.get( itemIdF ) );
+        assertEquals( itemObjectG, map.get( itemIdG ) );
+        assertEquals( itemObjectH, map.get( itemIdH ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -51,12 +51,8 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.AnalyticsType;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramIndicator;
-import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 import org.hisp.dhis.system.util.Clock;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.validation.notification.ValidationNotificationService;
@@ -65,10 +61,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_ESCAPED_SEP;
-import static org.hisp.dhis.commons.util.TextUtils.splitSafe;
 
 /**
  * @author Jim Grace
@@ -90,7 +82,7 @@ public class DefaultValidationService
     private ExpressionService expressionService;
 
     @Autowired
-    private IdentifiableObjectManager idObjectManager;
+    private DimensionService dimensionService;
 
     @Autowired
     private DataValueService dataValueService;
@@ -334,9 +326,9 @@ public class DefaultValidationService
     {
         // 1. Find all dimensional object IDs in the expressions of the validation rules.
 
-        SetMap<Class<? extends DimensionalItemObject>, String> allItemIds = new SetMap<>();
+        Set<DimensionalItemId> allItemIds = new HashSet<>();
 
-        SetMap<PeriodTypeExtended, String> periodItemIds = new SetMap<>();
+        SetMap<PeriodTypeExtended, DimensionalItemId> periodItemIds = new SetMap<>();
 
         for ( ValidationRule rule : rules )
         {
@@ -349,47 +341,38 @@ public class DefaultValidationService
 
             periodX.getRuleXs().add( new ValidationRuleExtended( rule ) );
 
-            SetMap<Class<? extends DimensionalItemObject>, String> dimensionItemIdentifiers = expressionService
-                .getDimensionalItemIdsInExpression( rule.getLeftSide().getExpression() );
-            dimensionItemIdentifiers.putValues(
+            Set<DimensionalItemId> ruleIds = Sets.union(
+                expressionService.getDimensionalItemIdsInExpression( rule.getLeftSide().getExpression() ),
                 expressionService.getDimensionalItemIdsInExpression( rule.getRightSide().getExpression() ) );
-
-            Set<String> ruleIds = dimensionItemIdentifiers.values().stream()
-                .reduce( new HashSet<>(), Sets::union );
 
             periodItemIds.putValues( periodX, ruleIds );
 
-            allItemIds.putValues( dimensionItemIdentifiers );
+            allItemIds.addAll( ruleIds );
         }
 
         // 2. Get the dimensional objects from the IDs. (Get them all at once for best performance.)
 
-        Map<String, DimensionalItemObject> dimensionItemMap = getDimensionalItemObjects( allItemIds );
+        Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap = dimensionService.getDataDimensionalItemObjectMap( allItemIds );
 
         // 3. Save the dimensional objects in the extended period types.
 
-        for ( Map.Entry<PeriodTypeExtended, Set<String>> entry : periodItemIds.entrySet() )
+        for ( Map.Entry<PeriodTypeExtended, Set<DimensionalItemId>> entry : periodItemIds.entrySet() )
         {
             PeriodTypeExtended periodTypeX = entry.getKey();
 
-            for ( String itemId : entry.getValue() )
+            for ( DimensionalItemId itemId : entry.getValue() )
             {
                 DimensionalItemObject item = dimensionItemMap.get( itemId );
 
                 if ( item != null )
                 {
-                    if ( DimensionItemType.DATA_ELEMENT_OPERAND == item.getDimensionItemType() )
+                    if ( DimensionItemType.DATA_ELEMENT == item.getDimensionItemType() )
                     {
-                        DataElementOperand deo = (DataElementOperand) item;
-
-                        if ( deo.getCategoryOptionCombo() != null )
-                        {
-                            periodTypeX.addDataElementOperand( deo );
-                        }
-                        else
-                        {
-                            periodTypeX.addDataElement( deo.getDataElement() );
-                        }
+                        periodTypeX.addDataElement( (DataElement) item );
+                    }
+                    else if ( DimensionItemType.DATA_ELEMENT_OPERAND == item.getDimensionItemType() )
+                    {
+                        periodTypeX.addDataElementOperand( (DataElementOperand) item );
                     }
                     else if ( hasAttributeOptions( item ) )
                     {
@@ -415,144 +398,6 @@ public class DefaultValidationService
     {
         return object.getDimensionItemType() != DimensionItemType.PROGRAM_INDICATOR
             || ( (ProgramIndicator)object ).getAnalyticsType() != AnalyticsType.ENROLLMENT;
-    }
-
-    /**
-     * Gets all required DimensionalItemObjects from their UIDs.
-     *
-     * @param expressionIdMap UIDs of DimensionalItemObjects to get.
-     * @return map of the DimensionalItemObjects.
-     */
-    private Map<String, DimensionalItemObject> getDimensionalItemObjects(
-        SetMap<Class<? extends DimensionalItemObject>, String> expressionIdMap )
-    {
-        // 1. Get ids for all the individual IdentifiableObjects within the DimensionalItemObjects:
-
-        SetMap<Class<? extends IdentifiableObject>, String> idsToGet = new SetMap<>();
-
-        getIdentifiableObjectIds( idsToGet, expressionIdMap, DataElementOperand.class, DataElement.class,
-            CategoryOptionCombo.class );
-        getIdentifiableObjectIds( idsToGet, expressionIdMap, ProgramDataElementDimensionItem.class, Program.class,
-            DataElement.class );
-        getIdentifiableObjectIds( idsToGet, expressionIdMap, ProgramTrackedEntityAttributeDimensionItem.class,
-            Program.class, TrackedEntityAttribute.class );
-        getIdentifiableObjectIds( idsToGet, expressionIdMap, ProgramIndicator.class, ProgramIndicator.class );
-
-        // 2. Look up all the IdentifiableObjects (each class all together, for best performance):
-
-        MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> idMap = new MapMap<>();
-
-        for ( Map.Entry<Class<? extends IdentifiableObject>, Set<String>> e : idsToGet.entrySet() )
-        {
-            idMap.putEntries( e.getKey(), idObjectManager.get( e.getKey(), e.getValue() ).stream()
-                .collect( Collectors.toMap( IdentifiableObject::getUid, o -> o ) ) );
-        }
-
-        // 3. Build the map of DimensionalItemObjects:
-
-        Map<String, DimensionalItemObject> dimObjects = new HashMap<>();
-
-        for ( Map.Entry<Class<? extends DimensionalItemObject>, Set<String>> entry : expressionIdMap.entrySet() )
-        {
-            for ( String id : entry.getValue() )
-            {
-                if ( entry.getKey() == DataElementOperand.class )
-                {
-                    DataElementOperand deo = new DataElementOperand(
-                        (DataElement) idMap.getValue( DataElement.class, getIdPart( id, 0 ) ),
-                        (CategoryOptionCombo) idMap
-                            .getValue( CategoryOptionCombo.class, getIdPart( id, 1 ) ) );
-
-                    if ( deo.getDataElement() != null &&
-                         (deo.getCategoryOptionCombo() != null || getIdPart( id, 1 ) == null ) )
-                    {
-                        dimObjects.put( id, deo );
-                    }
-                }
-                else if ( entry.getKey() == ProgramDataElementDimensionItem.class )
-                {
-                    ProgramDataElementDimensionItem pde = new ProgramDataElementDimensionItem(
-                        (Program) idMap.getValue( Program.class, getIdPart( id, 0 ) ),
-                        (DataElement) idMap.getValue( DataElement.class, getIdPart( id, 1 ) ) );
-
-                    if ( pde.getProgram() != null && pde.getDataElement() != null )
-                    {
-                        dimObjects.put( id, pde );
-                    }
-                }
-                else if ( entry.getKey() == ProgramTrackedEntityAttributeDimensionItem.class )
-                {
-                    ProgramTrackedEntityAttributeDimensionItem pa = new ProgramTrackedEntityAttributeDimensionItem(
-                        (Program) idMap.getValue( Program.class, getIdPart( id, 0 ) ),
-                        (TrackedEntityAttribute) idMap.getValue( TrackedEntityAttribute.class, getIdPart( id, 1 ) ) );
-
-                    if ( pa.getProgram() != null && pa.getAttribute() != null )
-                    {
-                        dimObjects.put( id, pa );
-                    }
-                }
-                else if ( entry.getKey() == ProgramIndicator.class )
-                {
-                    ProgramIndicator pi = (ProgramIndicator) idMap.getValue( ProgramIndicator.class, id );
-
-                    if ( pi != null )
-                    {
-                        dimObjects.put( id, pi );
-                    }
-                }
-            }
-        }
-
-        return dimObjects;
-    }
-
-    /**
-     * Takes all the identifiers within a dimensional object class, and splits
-     * them into identifiers for the identifiable objects that make up
-     * the dimensional object.
-     *
-     * @param idsToGet        To add to: identifiable object IDs to look up.
-     * @param expressionIdMap Dimensional object IDs from expression.
-     * @param dimClass        Class of dimensional object
-     * @param idClasses       Component class(es) of identifiable objects
-     */
-    @SafeVarargs
-    private final void getIdentifiableObjectIds( SetMap<Class<? extends IdentifiableObject>, String> idsToGet,
-        SetMap<Class<? extends DimensionalItemObject>, String> expressionIdMap,
-        Class<? extends DimensionalItemObject> dimClass,
-        Class<? extends IdentifiableObject>... idClasses )
-    {
-        Set<String> expressionIds = expressionIdMap.get( dimClass );
-
-        if ( expressionIds == null )
-        {
-            return;
-        }
-
-        for ( int i = 0; i < idClasses.length; i++ )
-        {
-            for ( String expressionId : expressionIds )
-            {
-                String objectId = getIdPart( expressionId, i );
-
-                if ( objectId != null )
-                {
-                    idsToGet.putValue( idClasses[i], objectId );
-                }
-            }
-        }
-    }
-
-    /**
-     * Gets part of an object identifier which may be composite.
-     *
-     * @param id    The identifier to parse.
-     * @param index Index of the part to return.
-     * @return The identifier part.
-     */
-    private String getIdPart( String id, int index )
-    {
-        return splitSafe( id, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, index );
     }
 
     /**


### PR DESCRIPTION
When parsing expressions, each DimensionalItemObject (and each IdentifiableObject it contains) has been looked up individually, slowing performance when many objects are needed in an expression, and especially when sharing is checked on each object. This fix looks up all IdentifiableObjects of each type with a single call.