### PR TITLE
Add incoming relationships to TrackedEntityInstance payload

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -1276,7 +1276,7 @@ public abstract class AbstractTrackedEntityInstanceService
             {
                 org.hisp.dhis.relationship.Relationship daoRelationship = relationshipItem.getRelationship();
 
-                if ( daoRelationship.getFrom().equals( relationshipItem ) && trackerAccessManager.canRead( user, daoRelationship ).isEmpty() )
+                if ( trackerAccessManager.canRead( user, daoRelationship ).isEmpty() )
                 {
                     Relationship relationship = relationshipService.getRelationship( relationshipItem.getRelationship(),
                         RelationshipParams.FALSE, user );


### PR DESCRIPTION
TrackedEntityInstance payloads currently only list relationships going out from the TrackedEntityInstance. This list should also include relationships coming in to the TrackedEntityInstance.

Issue: DHIS2-5924