### PR TITLE
Fix Permanently remove soft deleted tracked entity instances due to FK

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -138,6 +138,7 @@ public class JdbcMaintenanceStore
             "delete from programinstance where programinstanceid in " + piSelect,
             "delete from trackedentityattributevalue where trackedentityinstanceid in " + teiSelect,
             "delete from trackedentityattributevalueaudit where trackedentityinstanceid in " + teiSelect,
+            "delete from trackedentityprogramowner where trackedentityinstanceid in " + teiSelect,
             "delete from trackedentityinstance where deleted is true" };
 
         return jdbcTemplate.batchUpdate( sqlStmts )[sqlStmts.length - 1];


### PR DESCRIPTION
This commit is fixing:
DHIS2-5456: Error in updating "Permanently remove soft deleted tracked entity instances"