### PR TITLE
Fix issue with RelationshipConstraint PropertyType

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipType.java
@@ -67,7 +67,7 @@ public class RelationshipType
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @Property( required = Property.Value.TRUE )
+    @Property( required = Property.Value.TRUE, value = PropertyType.COMPLEX )
     public RelationshipConstraint getFromConstraint()
     {
         return fromConstraint;
@@ -80,7 +80,7 @@ public class RelationshipType
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @Property( required = Property.Value.TRUE )
+    @Property( required = Property.Value.TRUE, value = PropertyType.COMPLEX )
     public RelationshipConstraint getToConstraint()
     {
         return toConstraint;


### PR DESCRIPTION
The PropertyType of RelationshipContraint was incorrectly falling back to the default TEXT, causing validation errors in the Maintenance app. It is now correctly being marked as COMPLEX.

Issue: DHIS2-6050