### PR TITLE
Fix unintended removal of relationships for TrackedEntityInstances

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -733,6 +733,9 @@ public abstract class AbstractTrackedEntityInstanceService
                 // Remove items we cant write to
                 .filter(
                     relationship -> trackerAccessManager.canWrite( importOptions.getUser(), relationship ).isEmpty() )
+                .filter(
+                    relationship -> relationship.getFrom().getTrackedEntityInstance().getUid().equals( daoEntityInstance.getUid() )
+                )
                 .map( org.hisp.dhis.relationship.Relationship::getUid )
                 // Remove items we are already referencing
                 .filter( ( uid ) -> !relationshipUids.contains( uid ) )


### PR DESCRIPTION
When updating a TrackedEntityInstance, relationships pointing to the TEI would be removed. Only relationships pointing out form the tei is now applicable for removing during update.

Issue: DHIS2-5685