### PR TITLE
Fix technical weakness in event table managers

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
@@ -68,7 +68,7 @@ public class JdbcPartitionManager
             "where table_name like '" + tableType.getTableName() + "%' " +
             "and table_type = 'BASE TABLE'";
 
-        log.info( "Name likeness query analytics SQL: " + sql );
+        log.info( "Information schema analytics table SQL: " + sql );
 
         Set<String> partitions = new HashSet<>( jdbcTemplate.queryForList( sql, String.class ) );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
@@ -50,8 +50,7 @@ public class JdbcPartitionManager
 {
     private static final Log log = LogFactory.getLog( JdbcPartitionManager.class );
 
-    private Map<AnalyticsTableType, Set<String>> analyticsPartitions = 
-        new HashMap<AnalyticsTableType, Set<String>>();
+    private Map<AnalyticsTableType, Set<String>> analyticsPartitions = new HashMap<>();
 
     @Autowired
     private JdbcTemplate jdbcTemplate;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
@@ -111,6 +111,6 @@ public class JdbcPartitionManager
     @Override
     public void clearCaches()
     {
-        analyticsPartitions = new HashMap<AnalyticsTableType, Set<String>>();
+        analyticsPartitions = new HashMap<>();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
@@ -79,6 +79,17 @@ public class JdbcPartitionManager
     @Override
     public Set<String> getEventAnalyticsPartitions()
     {
+        return getTablesWithNameLikeness( AnalyticsTableType.EVENT.getTableName() );
+    }
+
+    @Override
+    public Set<String> getEnrollmentAnalyticsPartitions()
+    {
+        return getTablesWithNameLikeness( AnalyticsTableType.ENROLLMENT.getTableName() );
+    }
+
+    private Set<String> getTablesWithNameLikeness( String nameLikeness )
+    {
         if ( analyticsEventPartitions != null )
         {
             return analyticsEventPartitions;
@@ -86,11 +97,10 @@ public class JdbcPartitionManager
 
         final String sql =
             "select table_name from information_schema.tables " +
-            "where table_name like '" + AnalyticsTableType.EVENT.getTableName() + "%' " +
-            "or table_name like '" + AnalyticsTableType.ENROLLMENT.getTableName() + "%' " +
+            "where table_name like '" + nameLikeness + "%' " +
             "and table_type = 'BASE TABLE'";
 
-        log.info( "Information schema event analytics SQL: " + sql );
+        log.info( "Name likeness query analytics SQL: " + sql );
 
         Set<String> partitions = new HashSet<>( jdbcTemplate.queryForList( sql, String.class ) );
         analyticsEventPartitions = partitions;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/PartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/PartitionManager.java
@@ -45,6 +45,11 @@ public interface PartitionManager
     Set<String> getDataValueAnalyticsPartitions();
 
     /**
+     * Returns a set of names of current enrollment analytics partitions.
+     */
+    Set<String> getEnrollmentAnalyticsPartitions();
+
+    /**
      * Returns a set of names of current event analytics partitions.
      */
     Set<String> getEventAnalyticsPartitions();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/PartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/PartitionManager.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.partition;
 
 import java.util.Set;
 
+import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.Partitions;
 
 /**
@@ -40,19 +41,11 @@ import org.hisp.dhis.analytics.Partitions;
 public interface PartitionManager
 {
     /**
-     * Returns a set of names of current data value analytics partitions.
-     */
-    Set<String> getDataValueAnalyticsPartitions();
-
-    /**
-     * Returns a set of names of current enrollment analytics partitions.
-     */
-    Set<String> getEnrollmentAnalyticsPartitions();
-
-    /**
      * Returns a set of names of current event analytics partitions.
+     * 
+     * @param tableType the type to get all existing table partitions for.
      */
-    Set<String> getEventAnalyticsPartitions();
+    Set<String> getAnalyticsPartitions( AnalyticsTableType tableType );
 
     /**
      * Indicates whether the given analytics table exists.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -122,6 +122,12 @@ public abstract class AbstractJdbcTableManager
     // Implementation
     // -------------------------------------------------------------------------
 
+    @Override
+    public Set<String> getExistingDatabaseTables()
+    {
+        return partitionManager.getAnalyticsPartitions( getAnalyticsTableType() );
+    }
+    
     /**
      * Override in order to perform work before tables are being generated.
      */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -128,7 +128,7 @@ public class JdbcAnalyticsTableManager
     @Override
     public Set<String> getExistingDatabaseTables()
     {
-        return partitionManager.getDataValueAnalyticsPartitions();
+        return partitionManager.getAnalyticsPartitions( AnalyticsTableType.DATA_VALUE );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -126,12 +126,6 @@ public class JdbcAnalyticsTableManager
     }
 
     @Override
-    public Set<String> getExistingDatabaseTables()
-    {
-        return partitionManager.getAnalyticsPartitions( AnalyticsTableType.DATA_VALUE );
-    }
-
-    @Override
     public String validState()
     {
         boolean hasData = jdbcTemplate.queryForRowSet( "select dataelementid from datavalue dv where dv.deleted is false limit 1" ).next();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -98,7 +98,7 @@ public class JdbcEnrollmentAnalyticsTableManager
     @Override
     public Set<String> getExistingDatabaseTables()
     {
-        return new HashSet<>(); //TODO this must be implemented properly
+        return partitionManager.getEnrollmentAnalyticsPartitions();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -98,7 +98,7 @@ public class JdbcEnrollmentAnalyticsTableManager
     @Override
     public Set<String> getExistingDatabaseTables()
     {
-        return partitionManager.getEnrollmentAnalyticsPartitions();
+        return partitionManager.getAnalyticsPartitions( AnalyticsTableType.ENROLLMENT );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -96,12 +96,6 @@ public class JdbcEnrollmentAnalyticsTableManager
     }
 
     @Override
-    public Set<String> getExistingDatabaseTables()
-    {
-        return partitionManager.getAnalyticsPartitions( AnalyticsTableType.ENROLLMENT );
-    }
-
-    @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
         return Lists.newArrayList();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -120,7 +120,7 @@ public class JdbcEventAnalyticsTableManager
     @Override
     public Set<String> getExistingDatabaseTables()
     {
-        return partitionManager.getEventAnalyticsPartitions();
+        return partitionManager.getAnalyticsPartitions( AnalyticsTableType.EVENT );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -118,12 +118,6 @@ public class JdbcEventAnalyticsTableManager
     }
 
     @Override
-    public Set<String> getExistingDatabaseTables()
-    {
-        return partitionManager.getAnalyticsPartitions( AnalyticsTableType.EVENT );
-    }
-
-    @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
         return Lists.newArrayList(


### PR DESCRIPTION
The event table manager was counting both the event and enrollment tables as its own. At the same time the enrollment table manager did not return any tables in the getExistingDatabaseTables() function.