### PR TITLE
[2.29] Allow access to metadata when item is not DataShareable

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/acl/AclService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/acl/AclService.java
@@ -109,6 +109,18 @@ public interface AclService
     boolean canDataRead( User user, IdentifiableObject object );
 
     /**
+     * Check if the given user has data or metadata permission over the given object
+     *
+     * Data-read permission is only considered if the given object's schema is 'DataShareable'.
+     * If not 'DataShareable', only metadata-read ACL is considered
+     *
+     * @param user User to check against
+     * @param object Object to check permission
+     * @return true, if use can access object
+     */
+    boolean canDataOrMetadataRead(User user, IdentifiableObject object);
+
+    /**
      * Can user write to this object (create)
      * <p/>
      * 1. Does user have ACL_OVERRIDE_AUTHORITIES authority?

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/acl/AclService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/acl/AclService.java
@@ -118,7 +118,7 @@ public interface AclService
      * @param object Object to check permission
      * @return true, if use can access object
      */
-    boolean canDataOrMetadataRead(User user, IdentifiableObject object);
+    boolean canDataOrMetadataRead( User user, IdentifiableObject object );
 
     /**
      * Can user write to this object (create)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -597,7 +597,7 @@ public class DefaultDataQueryService
     private List<DimensionalItemObject> getCanReadItems( User user, DimensionalObject object )
     {
         return object.getItems().stream()
-            .filter( o -> aclService.canDataRead( user, o ) )
+            .filter( o -> aclService.canDataOrMetadataRead( user, o ) )
             .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -201,6 +201,14 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    public boolean canDataOrMetadataRead( User user, IdentifiableObject object )
+    {
+        Schema schema = schemaService.getSchema( object.getClass() );
+
+        return schema.isDataShareable() ? canDataRead( user, object ) : canRead( user, object );
+    }
+
+    @Override
     public boolean canDataWrite( User user, IdentifiableObject object )
     {
         if ( object == null || haveOverrideAuthority( user ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1107,7 +1107,7 @@ public class AclServiceTest
         User user1 = createUser( "user1", "F_CATEGORY_OPTION_GROUP_SET_PUBLIC_ADD" );
         manager.save( user1 );
 
-        // non data shareable object //
+        // Non-data shareable object
 
         CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
         categoryOptionGroupSet.setAutoFields();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.chart.Chart;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.dataelement.CategoryOptionGroupSet;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementCategoryOption;
 import org.hisp.dhis.eventchart.EventChart;
@@ -1098,5 +1099,22 @@ public class AclServiceTest
         manager.update( reportTable );
 
         assertTrue( aclService.canUpdate( userB, reportTable ) );
+    }
+
+    @Test
+    public void testCanDataOrMetadataRead()
+    {
+        User user1 = createUser( "user1", "F_CATEGORY_OPTION_GROUP_SET_PUBLIC_ADD" );
+        manager.save( user1 );
+
+        // non data shareable object //
+
+        CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
+        categoryOptionGroupSet.setAutoFields();
+        categoryOptionGroupSet.setName( "cogA" );
+
+        manager.save( categoryOptionGroupSet );
+
+        assertTrue( aclService.canDataOrMetadataRead( user1, categoryOptionGroupSet ) );
     }
 }


### PR DESCRIPTION
- back-ported from 2.32