### PR TITLE
DHIS2 6159: Download parameter for /api/metadata endpoint

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api-test/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api-test/pom.xml
@@ -156,6 +156,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-test</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerTest.java
@@ -1,0 +1,85 @@
+package org.hisp.dhis.webapi.controller.metadata;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.UserSettingService;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Unit tests for {@link MetadataExportControllerTest}.
+ *
+ * @author Volker Schmidt
+ */
+public class MetadataExportControllerTest
+{
+    @Mock
+    private MetadataExportService metadataExportService;
+
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private UserSettingService userSettingService;
+
+    @InjectMocks
+    private MetadataExportController controller;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Test
+    public void withoutDownload()
+    {
+        ResponseEntity<RootNode> responseEntity = controller.getMetadata( false, null, false );
+        Assert.assertNull( responseEntity.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+    }
+
+    @Test
+    public void withDownload()
+    {
+        ResponseEntity<RootNode> responseEntity = controller.getMetadata( false, null, true );
+        Assert.assertNotNull( responseEntity.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( "attachment; filename=metadata", responseEntity.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).get( 0 ) );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverterTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverterTest.java
@@ -1,0 +1,222 @@
+package org.hisp.dhis.webapi.mvc.messageconverter;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.net.HttpHeaders;
+import org.apache.commons.io.IOUtils;
+import org.hisp.dhis.common.Compression;
+import org.hisp.dhis.node.NodeService;
+import org.hisp.dhis.node.types.RootNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.mock.http.MockHttpOutputMessage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipInputStream;
+
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Unit tests for {@link AbstractRootNodeMessageConverter}.
+ *
+ * @author Volker Schmidt <volker@dhis2.org>
+ */
+public class AbstractRootNodeMessageConverterTest
+{
+    @Mock
+    private NodeService nodeService;
+
+    private AbstractRootNodeMessageConverter converter;
+
+    private AbstractRootNodeMessageConverter converterGzip;
+
+    private AbstractRootNodeMessageConverter converterZip;
+
+    private RootNode rootNode = new RootNode( "Test" + System.currentTimeMillis() );
+
+    private MockHttpOutputMessage httpOutputMessage = new MockHttpOutputMessage();
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Before
+    public void before()
+    {
+        converter = Mockito.mock( AbstractRootNodeMessageConverter.class, withSettings()
+            .useConstructor( nodeService, "other/xzx", "xzx", Compression.NONE ).defaultAnswer( CALLS_REAL_METHODS ) );
+        converterGzip = Mockito.mock( AbstractRootNodeMessageConverter.class, withSettings()
+            .useConstructor( nodeService, "other/xzx", "xzx", Compression.GZIP ).defaultAnswer( CALLS_REAL_METHODS ) );
+        converterZip = Mockito.mock( AbstractRootNodeMessageConverter.class, withSettings()
+            .useConstructor( nodeService, "other/xzx", "xzx", Compression.ZIP ).defaultAnswer( CALLS_REAL_METHODS ) );
+    }
+
+    @Test
+    public void isAttachmentNull()
+    {
+        Assert.assertFalse( converter.isAttachment( null ) );
+    }
+
+    @Test
+    public void isAttachmentInline()
+    {
+        Assert.assertFalse( converter.isAttachment( "inline; filename=test.txt" ) );
+    }
+
+    @Test
+    public void isAttachment()
+    {
+        Assert.assertTrue( converter.isAttachment( "attachment; filename=test.txt" ) );
+    }
+
+    @Test
+    public void getExtensibleAttachmentFilenameNull()
+    {
+        Assert.assertNull( converter.getExtensibleAttachmentFilename( null ) );
+    }
+
+    @Test
+    public void getExtensibleAttachmentFilenameInline()
+    {
+        Assert.assertNull( converter.getExtensibleAttachmentFilename( "inline; filename=metadata" ) );
+    }
+
+    @Test
+    public void getExtensibleAttachmentFilename()
+    {
+        Assert.assertEquals( "metadata", converter.getExtensibleAttachmentFilename( "attachment; filename=metadata" ) );
+    }
+
+    @Test
+    public void getExtensibleAttachmentFilenameOther()
+    {
+        Assert.assertNull( converter.getExtensibleAttachmentFilename( "attachment; filename=other" ) );
+    }
+
+    @Test
+    public void writeInternalWithoutAttachmentUncompressed() throws IOException
+    {
+        Mockito.doAnswer( invocation -> {
+            ((OutputStream) invocation.getArgument( 2 )).write( rootNode.getName().getBytes( StandardCharsets.UTF_8 ) );
+            return null;
+        } ).when( nodeService ).serialize( Mockito.same( rootNode ), Mockito.eq( "other/xzx" ), Mockito.any( OutputStream.class ) );
+        converter.writeInternal( rootNode, httpOutputMessage );
+        Assert.assertNull( httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( rootNode.getName(), new String( httpOutputMessage.getBodyAsBytes(), StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    public void writeInternalWithAttachmentUncompressed() throws IOException
+    {
+        Mockito.doAnswer( invocation -> {
+            ((OutputStream) invocation.getArgument( 2 )).write( rootNode.getName().getBytes( StandardCharsets.UTF_8 ) );
+            return null;
+        } ).when( nodeService ).serialize( Mockito.same( rootNode ), Mockito.eq( "other/xzx" ), Mockito.any( OutputStream.class ) );
+        httpOutputMessage.getHeaders().set( HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=metadata" );
+        converter.writeInternal( rootNode, httpOutputMessage );
+        Assert.assertNotNull( httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( 1, httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).size() );
+        Assert.assertEquals( "attachment; filename=metadata.xzx", httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).get( 0 ) );
+        Assert.assertEquals( rootNode.getName(), new String( httpOutputMessage.getBodyAsBytes(), StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    public void writeInternalWithAttachmentGzip() throws IOException
+    {
+        Mockito.doAnswer( invocation -> {
+            ((OutputStream) invocation.getArgument( 2 )).write( rootNode.getName().getBytes( StandardCharsets.UTF_8 ) );
+            return null;
+        } ).when( nodeService ).serialize( Mockito.same( rootNode ), Mockito.eq( "other/xzx" ), Mockito.any( OutputStream.class ) );
+        httpOutputMessage.getHeaders().set( HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=metadata" );
+        converterGzip.writeInternal( rootNode, httpOutputMessage );
+        Assert.assertNotNull( httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( 1, httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).size() );
+        Assert.assertEquals( "attachment; filename=metadata.xzx.gz", httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).get( 0 ) );
+        Assert.assertEquals( rootNode.getName(),
+            IOUtils.toString( new GZIPInputStream( new ByteArrayInputStream( httpOutputMessage.getBodyAsBytes() ) ), StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    public void writeInternalWithoutAttachmentGzip() throws IOException
+    {
+        Mockito.doAnswer( invocation -> {
+            ((OutputStream) invocation.getArgument( 2 )).write( rootNode.getName().getBytes( StandardCharsets.UTF_8 ) );
+            return null;
+        } ).when( nodeService ).serialize( Mockito.same( rootNode ), Mockito.eq( "other/xzx" ), Mockito.any( OutputStream.class ) );
+        converterGzip.writeInternal( rootNode, httpOutputMessage );
+        Assert.assertNotNull( httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( 1, httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).size() );
+        Assert.assertEquals( "attachment; filename=metadata.xzx.gz", httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).get( 0 ) );
+        Assert.assertEquals( rootNode.getName(),
+            IOUtils.toString( new GZIPInputStream( new ByteArrayInputStream( httpOutputMessage.getBodyAsBytes() ) ), StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    public void writeInternalWithoutAttachmentZip() throws IOException
+    {
+        Mockito.doAnswer( invocation -> {
+            ((OutputStream) invocation.getArgument( 2 )).write( rootNode.getName().getBytes( StandardCharsets.UTF_8 ) );
+            return null;
+        } ).when( nodeService ).serialize( Mockito.same( rootNode ), Mockito.eq( "other/xzx" ), Mockito.any( OutputStream.class ) );
+        converterZip.writeInternal( rootNode, httpOutputMessage );
+        Assert.assertNotNull( httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( 1, httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).size() );
+        Assert.assertEquals( "attachment; filename=metadata.xzx.zip", httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).get( 0 ) );
+        final ZipInputStream zipInputStream = new ZipInputStream( new ByteArrayInputStream( httpOutputMessage.getBodyAsBytes() ) );
+        Assert.assertNotNull( zipInputStream.getNextEntry() );
+        Assert.assertEquals( rootNode.getName(), IOUtils.toString( zipInputStream, StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    public void writeInternalWithAttachmentZip() throws IOException
+    {
+        Mockito.doAnswer( invocation -> {
+            ((OutputStream) invocation.getArgument( 2 )).write( rootNode.getName().getBytes( StandardCharsets.UTF_8 ) );
+            return null;
+        } ).when( nodeService ).serialize( Mockito.same( rootNode ), Mockito.eq( "other/xzx" ), Mockito.any( OutputStream.class ) );
+        httpOutputMessage.getHeaders().set( HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=metadata" );
+        converterZip.writeInternal( rootNode, httpOutputMessage );
+        Assert.assertNotNull( httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
+        Assert.assertEquals( 1, httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).size() );
+        Assert.assertEquals( "attachment; filename=metadata.xzx.zip", httpOutputMessage.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ).get( 0 ) );
+        final ZipInputStream zipInputStream = new ZipInputStream( new ByteArrayInputStream( httpOutputMessage.getBodyAsBytes() ) );
+        Assert.assertNotNull( zipInputStream.getNextEntry() );
+        Assert.assertEquals( rootNode.getName(), IOUtils.toString( zipInputStream, StandardCharsets.UTF_8 ) );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.common.cache.Cacheability;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -139,5 +140,23 @@ public class ContextUtilsTest
         response.reset();
         contextUtils.configureAnalyticsResponse( response, null, CacheStrategy.CACHE_1_HOUR, null, false, outsideThreshold.getLatestEndDate() );
         assertEquals( "max-age=3600, public", response.getHeader( "Cache-Control" ) );
+    }
+
+    @Test
+    public void testGetAttachmentFileNameNull()
+    {
+        Assert.assertNull( ContextUtils.getAttachmentFileName( null ) );
+    }
+
+    @Test
+    public void testGetAttachmentFileNameInline()
+    {
+        Assert.assertNull( ContextUtils.getAttachmentFileName( "inline; filename=test.txt" ) );
+    }
+
+    @Test
+    public void testGetAttachmentFileName()
+    {
+        Assert.assertEquals( "test.txt", ContextUtils.getAttachmentFileName( "attachment; filename=test.txt" ) );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportController.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.webapi.controller.metadata;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
@@ -38,14 +39,15 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.Locale;
 
@@ -70,8 +72,9 @@ public class MetadataExportController
     private UserSettingService userSettingService;
 
     @RequestMapping( value = "", method = RequestMethod.GET )
-    public @ResponseBody RootNode getMetadata(
-        @RequestParam( required = false, defaultValue = "false" ) boolean translate, @RequestParam( required = false ) String locale )
+    public ResponseEntity<RootNode> getMetadata(
+        @RequestParam( required = false, defaultValue = "false" ) boolean translate, @RequestParam( required = false ) String locale,
+        @RequestParam( required = false, defaultValue = "false" ) boolean download )
     {
         if ( translate )
         {
@@ -81,8 +84,15 @@ public class MetadataExportController
 
         MetadataExportParams params = metadataExportService.getParamsFromMap( contextService.getParameterValuesMap() );
         metadataExportService.validate( params );
+        RootNode rootNode = metadataExportService.getMetadataAsNode( params );
 
-        return metadataExportService.getMetadataAsNode( params );
+        HttpHeaders headers = new HttpHeaders();
+        if (download)
+        {
+            // triggers that corresponding message converter adds also a file name with a correct extension
+            headers.add( HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=metadata" );
+        }
+        return new ResponseEntity<>( rootNode, headers, HttpStatus.OK );
     }
 
     private void setUserContext( User user, TranslateParams translateParams )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverter.java
@@ -1,0 +1,165 @@
+package org.hisp.dhis.webapi.mvc.messageconverter;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.Compression;
+import org.hisp.dhis.node.NodeService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Abstract base class for HTTP message converters that convert root nodes.
+ *
+ * @author Volker Schmidt <volker@dhis2.org>
+ */
+public abstract class AbstractRootNodeMessageConverter extends AbstractHttpMessageConverter<RootNode>
+{
+    /**
+     * File name that will get a media type related suffix when included as an attachment file name.
+     */
+    private static final Set<String> EXTENSIBLE_ATTACHMENT_FILENAMES = Collections.unmodifiableSet( new HashSet<>( Collections.singleton( "metadata" ) ) );
+
+    private final NodeService nodeService;
+
+    private final String contentType;
+
+    private final String fileExtension;
+
+    private final Compression compression;
+
+    protected AbstractRootNodeMessageConverter( @Nonnull NodeService nodeService, @Nonnull String contentType, @Nonnull String fileExtension, Compression compression )
+    {
+        this.nodeService = nodeService;
+        this.contentType = contentType;
+        this.fileExtension = fileExtension;
+        this.compression = compression;
+    }
+
+    protected Compression getCompression()
+    {
+        return compression;
+    }
+
+    @Override
+    protected boolean supports( Class<?> clazz )
+    {
+        return RootNode.class.equals( clazz );
+    }
+
+    @Override
+    protected boolean canRead( MediaType mediaType )
+    {
+        return false;
+    }
+
+    @Override
+    protected RootNode readInternal( Class<? extends RootNode> clazz, HttpInputMessage inputMessage )
+    {
+        return null;
+    }
+
+    @Override
+    protected void writeInternal( RootNode rootNode, HttpOutputMessage outputMessage ) throws IOException, HttpMessageNotWritableException
+    {
+        final String contentDisposition = outputMessage.getHeaders().getFirst( ContextUtils.HEADER_CONTENT_DISPOSITION );
+        final boolean attachment = isAttachment( contentDisposition );
+        final String extensibleAttachmentFilename = getExtensibleAttachmentFilename( contentDisposition );
+        if ( Compression.GZIP == compression )
+        {
+            if ( !attachment || (extensibleAttachmentFilename != null) )
+            {
+                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION, getContentDispositionHeaderValue( extensibleAttachmentFilename, "gz" ) );
+                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary" );
+            }
+
+            GZIPOutputStream outputStream = new GZIPOutputStream( outputMessage.getBody() );
+            nodeService.serialize( rootNode, contentType, outputStream );
+            outputStream.close();
+        }
+        else if ( Compression.ZIP == compression )
+        {
+            if ( !attachment || (extensibleAttachmentFilename != null) )
+            {
+                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION, getContentDispositionHeaderValue( extensibleAttachmentFilename, "zip" ) );
+                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary" );
+            }
+
+            ZipOutputStream outputStream = new ZipOutputStream( outputMessage.getBody() );
+            outputStream.putNextEntry( new ZipEntry( "metadata." + fileExtension ) );
+            nodeService.serialize( rootNode, contentType, outputStream );
+            outputStream.close();
+        }
+        else
+        {
+            if ( extensibleAttachmentFilename != null )
+            {
+                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION, getContentDispositionHeaderValue( extensibleAttachmentFilename, null ) );
+            }
+
+            nodeService.serialize( rootNode, contentType, outputMessage.getBody() );
+            outputMessage.getBody().close();
+        }
+    }
+
+    @Nonnull
+    protected String getContentDispositionHeaderValue( @Nullable String extensibleFilename, @Nullable String compressionExtension )
+    {
+        final String suffix = (compressionExtension == null) ? "" : "." + compressionExtension;
+        return "attachment; filename=" + StringUtils.defaultString( extensibleFilename, "metadata" ) + "." + fileExtension + suffix;
+    }
+
+    protected boolean isAttachment( @Nullable String contentDispositionHeaderValue )
+    {
+        return (contentDispositionHeaderValue != null) && contentDispositionHeaderValue.contains( "attachment" );
+    }
+
+    @Nullable
+    protected String getExtensibleAttachmentFilename( @Nullable String contentDispositionHeaderValue )
+    {
+        final String filename = ContextUtils.getAttachmentFileName( contentDispositionHeaderValue );
+        return (filename != null) && EXTENSIBLE_ATTACHMENT_FILENAMES.contains( filename ) ? filename : null;
+    }
+}
+

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
@@ -29,59 +29,28 @@ package org.hisp.dhis.webapi.mvc.messageconverter;
  */
 
 import com.google.common.collect.ImmutableList;
+import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.node.NodeService;
-import org.hisp.dhis.node.types.RootNode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Component
-public class CsvMessageConverter extends AbstractHttpMessageConverter<RootNode>
+public class CsvMessageConverter extends AbstractRootNodeMessageConverter
 {
     public static final ImmutableList<MediaType> SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType>builder()
         .add( new MediaType( "application", "csv" ) )
         .add( new MediaType( "text", "csv" ) )
         .build();
 
-    @Autowired
-    private NodeService nodeService;
-
-    public CsvMessageConverter()
+    public CsvMessageConverter( @Nonnull @Autowired NodeService nodeService )
     {
+        super( nodeService, "application/csv", "csv", Compression.NONE );
         setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
-    }
-
-    @Override
-    protected boolean supports( Class<?> clazz )
-    {
-        return RootNode.class.equals( clazz );
-    }
-
-    @Override
-    protected boolean canRead( MediaType mediaType )
-    {
-        return false;
-    }
-
-    @Override
-    protected RootNode readInternal( Class<? extends RootNode> clazz, HttpInputMessage inputMessage ) throws IOException, HttpMessageNotReadableException
-    {
-        return null;
-    }
-
-    @Override
-    protected void writeInternal( RootNode rootNode, HttpOutputMessage outputMessage ) throws IOException, HttpMessageNotWritableException
-    {
-        nodeService.serialize( rootNode, "application/csv", outputMessage.getBody() );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/ExcelMessageConverter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/ExcelMessageConverter.java
@@ -29,58 +29,27 @@ package org.hisp.dhis.webapi.mvc.messageconverter;
  */
 
 import com.google.common.collect.ImmutableList;
+import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.node.NodeService;
-import org.hisp.dhis.node.types.RootNode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Component
-public class ExcelMessageConverter extends AbstractHttpMessageConverter<RootNode>
+public class ExcelMessageConverter extends AbstractRootNodeMessageConverter
 {
     public static final ImmutableList<MediaType> SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType>builder()
         .add( new MediaType( "application", "vnd.ms-excel" ) )
         .build();
 
-    @Autowired
-    private NodeService nodeService;
-
-    public ExcelMessageConverter()
+    public ExcelMessageConverter( @Nonnull @Autowired NodeService nodeService )
     {
+        super( nodeService, "application/vnd.ms-excel", "xlsx", Compression.NONE );
         setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
-    }
-
-    @Override
-    protected boolean supports( Class<?> clazz )
-    {
-        return RootNode.class.equals( clazz );
-    }
-
-    @Override
-    protected boolean canRead( MediaType mediaType )
-    {
-        return false;
-    }
-
-    @Override
-    protected RootNode readInternal( Class<? extends RootNode> clazz, HttpInputMessage inputMessage ) throws IOException, HttpMessageNotReadableException
-    {
-        return null;
-    }
-
-    @Override
-    protected void writeInternal( RootNode rootNode, HttpOutputMessage outputMessage ) throws IOException, HttpMessageNotWritableException
-    {
-        nodeService.serialize( rootNode, "application/vnd.ms-excel", outputMessage.getBody() );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/JsonPMessageConverter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/JsonPMessageConverter.java
@@ -30,25 +30,24 @@ package org.hisp.dhis.webapi.mvc.messageconverter;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.node.NodeService;
 import org.hisp.dhis.node.serializers.Jackson2JsonNodeSerializer;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class JsonPMessageConverter extends AbstractHttpMessageConverter<RootNode>
+public class JsonPMessageConverter extends AbstractRootNodeMessageConverter
 {
     public static final String DEFAULT_CALLBACK_PARAMETER = "callback";
 
@@ -58,33 +57,13 @@ public class JsonPMessageConverter extends AbstractHttpMessageConverter<RootNode
         .add( new MediaType( "text", "javascript" ) )
         .build();
 
-    @Autowired
-    private NodeService nodeService;
-
-    @Autowired
     private ContextService contextService;
 
-    public JsonPMessageConverter()
+    public JsonPMessageConverter( @Autowired @Nonnull NodeService nodeService, @Autowired @Nonnull ContextService contextService )
     {
+        super( nodeService, "application/json", "jsonp", Compression.NONE );
+        this.contextService = contextService;
         setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
-    }
-
-    @Override
-    protected boolean supports( Class<?> clazz )
-    {
-        return RootNode.class.equals( clazz );
-    }
-
-    @Override
-    protected boolean canRead( MediaType mediaType )
-    {
-        return false;
-    }
-
-    @Override
-    protected RootNode readInternal( Class<? extends RootNode> clazz, HttpInputMessage inputMessage ) throws IOException, HttpMessageNotReadableException
-    {
-        return null;
     }
 
     @Override
@@ -105,6 +84,6 @@ public class JsonPMessageConverter extends AbstractHttpMessageConverter<RootNode
 
         rootNode.getConfig().getProperties().put( Jackson2JsonNodeSerializer.JSONP_CALLBACK, callbackParam );
 
-        nodeService.serialize( rootNode, "application/json", outputMessage.getBody() );
+        super.writeInternal( rootNode, outputMessage );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/PdfMessageConverter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/PdfMessageConverter.java
@@ -29,58 +29,27 @@ package org.hisp.dhis.webapi.mvc.messageconverter;
  */
 
 import com.google.common.collect.ImmutableList;
+import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.node.NodeService;
-import org.hisp.dhis.node.types.RootNode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Component
-public class PdfMessageConverter extends AbstractHttpMessageConverter<RootNode>
+public class PdfMessageConverter extends AbstractRootNodeMessageConverter
 {
     public static final ImmutableList<MediaType> SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType>builder()
         .add( new MediaType( "application", "pdf" ) )
         .build();
 
-    @Autowired
-    private NodeService nodeService;
-
-    public PdfMessageConverter()
+    public PdfMessageConverter( @Nonnull @Autowired NodeService nodeService )
     {
+        super( nodeService, "application/pdf", "pdf", Compression.NONE );
         setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
-    }
-
-    @Override
-    protected boolean supports( Class<?> clazz )
-    {
-        return RootNode.class.equals( clazz );
-    }
-
-    @Override
-    protected boolean canRead( MediaType mediaType )
-    {
-        return false;
-    }
-
-    @Override
-    protected RootNode readInternal( Class<? extends RootNode> clazz, HttpInputMessage inputMessage ) throws IOException, HttpMessageNotReadableException
-    {
-        return null;
-    }
-
-    @Override
-    protected void writeInternal( RootNode rootNode, HttpOutputMessage outputMessage ) throws IOException, HttpMessageNotWritableException
-    {
-        nodeService.serialize( rootNode, "application/pdf", outputMessage.getBody() );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java
@@ -31,25 +31,15 @@ package org.hisp.dhis.webapi.mvc.messageconverter;
 import com.google.common.collect.ImmutableList;
 import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.node.NodeService;
-import org.hisp.dhis.node.types.RootNode;
-import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.http.converter.HttpMessageNotWritableException;
 
-import java.io.IOException;
-import java.util.zip.GZIPOutputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import javax.annotation.Nonnull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class XmlMessageConverter extends AbstractHttpMessageConverter<RootNode>
+public class XmlMessageConverter extends AbstractRootNodeMessageConverter
 {
     public static final ImmutableList<MediaType> SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType>builder()
         .add( new MediaType( "application", "xml" ) )
@@ -66,16 +56,10 @@ public class XmlMessageConverter extends AbstractHttpMessageConverter<RootNode>
         .add( new MediaType( "text", "xml+zip" ) )
         .build();
 
-    @Autowired
-    private NodeService nodeService;
-
-    private Compression compression;
-
-    public XmlMessageConverter( Compression compression )
+    public XmlMessageConverter( @Autowired @Nonnull NodeService nodeService, Compression compression )
     {
-        this.compression = compression;
-
-        switch ( this.compression )
+        super( nodeService, "application/xml", "xml", compression );
+        switch ( getCompression() )
         {
             case NONE:
                 setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
@@ -85,59 +69,6 @@ public class XmlMessageConverter extends AbstractHttpMessageConverter<RootNode>
                 break;
             case ZIP:
                 setSupportedMediaTypes( ZIP_SUPPORTED_MEDIA_TYPES );
-        }
-    }
-
-    @Override
-    protected boolean supports( Class<?> clazz )
-    {
-        return RootNode.class.equals( clazz );
-    }
-
-    @Override
-    protected boolean canRead( MediaType mediaType )
-    {
-        return false;
-    }
-
-    @Override
-    protected RootNode readInternal( Class<? extends RootNode> clazz, HttpInputMessage inputMessage ) throws IOException, HttpMessageNotReadableException
-    {
-        return null;
-    }
-
-    @Override
-    protected void writeInternal( RootNode rootNode, HttpOutputMessage outputMessage ) throws IOException, HttpMessageNotWritableException
-    {
-        if ( Compression.GZIP == compression )
-        {
-            if ( !outputMessage.getHeaders().getFirst( ContextUtils.HEADER_CONTENT_DISPOSITION  ).contains( "attachment" ) )
-            {
-                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION, "attachment; filename=metadata.xml.gz" );
-                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary" );
-            }
-
-            GZIPOutputStream outputStream = new GZIPOutputStream( outputMessage.getBody() );
-            nodeService.serialize( rootNode, "application/xml", outputStream );
-            outputStream.close();
-        }
-        else if ( Compression.ZIP == compression )
-        {
-            if ( !outputMessage.getHeaders().getFirst( ContextUtils.HEADER_CONTENT_DISPOSITION  ).contains( "attachment" )  )
-            {
-                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION, "attachment; filename=metadata.xml.zip" );
-                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary" );
-            }
-
-            ZipOutputStream outputStream = new ZipOutputStream( outputMessage.getBody() );
-            outputStream.putNextEntry( new ZipEntry( "metadata.xml" ) );
-            nodeService.serialize( rootNode, "application/xml", outputStream );
-            outputStream.close();
-        }
-        else
-        {
-            nodeService.serialize( rootNode, "application/xml", outputMessage.getBody() );
-            outputMessage.getBody().close();
         }
     }
 }


### PR DESCRIPTION
- Parameter download=true can be added to /api/metadata in order to request that Content-Disposition: Attachment is added to the response in order to force the browser to offer downloading the file instead of displaying it in browser window.