### PR TITLE
DHIS2-5766: Add support for flagging and recording potential duplicates

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationStatus.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationStatus.java
@@ -1,0 +1,36 @@
+package org.hisp.dhis.deduplication;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public enum DeduplicationStatus
+{
+        OPEN,
+        INVALID,
+        MERGED
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicate.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicate.java
@@ -1,0 +1,119 @@
+package org.hisp.dhis.deduplication;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.annotation.Property;
+import org.hisp.dhis.schema.annotation.PropertyRange;
+
+public class PotentialDuplicate
+    extends BaseIdentifiableObject
+{
+
+        /**
+         * teiA represents the UID of a TrackedEntityInstance.
+         * teiA is required.
+         * teiA is a potential duplicate of teiB.
+         * if teiB is null, it indicates a user has flagged teiA as
+         * a potential duplicate, without knowing which TrackedEntityInstance
+         * it is a duplicate of.
+         */
+        private String teiA;
+
+        /**
+         * teiB represents the UID of a TrackedEntityInstance.
+         * teiB is optional.
+         * teiB is a potential duplicate of teiA.
+         */
+        private String teiB;
+
+        /**
+         * status represents the state of the PotentialDuplicate.
+         * all new Potential duplicates are OPEN by default.
+         */
+        private DeduplicationStatus status = DeduplicationStatus.OPEN;
+
+        public PotentialDuplicate()
+        {
+        }
+
+        public PotentialDuplicate( String teiA )
+        {
+                this.teiA = teiA;
+        }
+
+        public PotentialDuplicate( String teiA, String teiB )
+        {
+                this.teiA = teiA;
+                this.teiB = teiB;
+        }
+
+        @JsonProperty
+        @JacksonXmlProperty
+        @Property( value = PropertyType.IDENTIFIER, required = Property.Value.TRUE )
+        @PropertyRange( min = 11, max = 11 )
+        public String getTeiA()
+        {
+                return teiA;
+        }
+
+        public void setTeiA( String teiA )
+        {
+                this.teiA = teiA;
+        }
+
+        @JsonProperty
+        @JacksonXmlProperty
+        @Property( value = PropertyType.IDENTIFIER, required = Property.Value.FALSE )
+        @PropertyRange( min = 11, max = 11 )
+        public String getTeiB()
+        {
+                return teiB;
+        }
+
+        public void setTeiB( String teiB )
+        {
+                this.teiB = teiB;
+        }
+
+        @JsonProperty
+        @JacksonXmlProperty
+        public DeduplicationStatus getStatus()
+        {
+                return status;
+        }
+
+        public void setStatus( DeduplicationStatus status )
+        {
+                this.status = status;
+        }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/deduplication/hibernate/PotentialDuplicate.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/deduplication/hibernate/PotentialDuplicate.hbm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd"
+        [<!ENTITY identifiableProperties SYSTEM "classpath://org/hisp/dhis/common/identifiableProperties.hbm">]
+        >
+
+<hibernate-mapping>
+    <class name="org.hisp.dhis.deduplication.PotentialDuplicate" table="potentialduplicate">
+
+        <cache usage="read-write" />
+
+        <id name="id" column="potentialduplicateid">
+            <generator class="sequence">
+                <param name="sequence">potentialduplicatesequence</param>
+            </generator>
+        </id>
+
+
+        <!-- IdentifiableObject Properties -->
+
+        <property name="uid" column="uid" unique="true" length="11" not-null="true" />
+
+        <property name="created" type="timestamp" not-null="true" />
+
+        <property name="lastUpdated" type="timestamp" not-null="true" />
+
+        <many-to-one name="lastUpdatedBy" class="org.hisp.dhis.user.User" column="lastupdatedby" foreign-key="fk_lastupdateby_userid" />
+
+
+        <!-- Potential Duplicate Properties -->
+
+        <property name="teiA" column="teiA" length="11" not-null="true" />
+
+        <property name="teiB" column="teiB" length="11" not-null="false" />
+
+        <property name="status" column="status">
+            <type name="org.hibernate.type.EnumType">
+                <param name="enumClass">org.hisp.dhis.deduplication.DeduplicationStatus</param>
+                <param name="userNamed">true</param>
+                <param name="type">12</param>
+            </type>
+        </property>
+
+    </class>
+</hibernate-mapping>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__PotentialDuplicate_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__PotentialDuplicate_table.sql
@@ -1,0 +1,18 @@
+CREATE SEQUENCE potentialduplicatesequence;
+
+CREATE TABLE potentialduplicate (
+  potentialduplicateid BIGINT NOT NULL PRIMARY KEY,
+  uid CHARACTER VARYING(11) NOT NULL UNIQUE,
+  created TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  lastUpdated TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  lastUpdatedBy BIGINT NOT NULL,
+  teiA CHARACTER VARYING(11) NOT NULL,
+  teiB CHARACTER VARYING(11),
+  status CHARACTER VARYING(255) NOT NULL
+);
+
+ALTER TABLE potentialduplicate
+ADD CONSTRAINT potentialduplicate_teia_teib UNIQUE (teiA, teiB);
+
+ALTER TABLE potentialduplicate
+ADD CONSTRAINT potentialduplicate_lastupdatedby_user FOREIGN KEY (lastUpdatedBy) REFERENCES users(userid);


### PR DESCRIPTION
To allow users to flag TEIs as potential duplicates and persist these, we create a new model and table to record these potential duplicates. Additionally we create a new api endpoint for marking TEIs as potential duplicates.


1. Added model and related database files