### PR TITLE
Optimize web apps build 

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -27,6 +27,7 @@
                         <BUILD_DIR>${project.build.directory}</BUILD_DIR>
                         <ARTIFACT_ID>${project.artifactId}</ARTIFACT_ID>
                         <APPS>./apps-to-bundle.json</APPS>
+                        <DEFAULT_BRANCH>v31</DEFAULT_BRANCH>
                     </environmentVariables> 
                 </configuration>
                 <executions>

--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -27,7 +27,7 @@
                         <BUILD_DIR>${project.build.directory}</BUILD_DIR>
                         <ARTIFACT_ID>${project.artifactId}</ARTIFACT_ID>
                         <APPS>./apps-to-bundle.json</APPS>
-                        <DEFAULT_BRANCH>v31</DEFAULT_BRANCH>
+                        <DEFAULT_BRANCH>master</DEFAULT_BRANCH>
                     </environmentVariables> 
                 </configuration>
                 <executions>

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/bundle-apps.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/bundle-apps.js
@@ -24,7 +24,7 @@ const root = process.cwd()
 const apps = require(path.join(root, process.env.APPS))
 const artifact = process.env.ARTIFACT_ID
 const build_dir = process.env.BUILD_DIR
-
+const default_branch = process.env.DEFAULT_BRANCH
 
 
 
@@ -65,7 +65,7 @@ async function main(opts = {}) {
 
     const new_apps = []
     for (const app of apps) {
-        const promise = clone_app(app, path.join(build_dir, artifact))
+        const promise = clone_app(app, path.join(build_dir, artifact), default_branch)
         new_apps.push(promise)
     }
 

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
@@ -64,7 +64,7 @@ async function checkout (name, path, treeish) {
 async function clone (name, url, clone_path, treeish) {
     console.log(`[clone] [${name}] clone started, using ${treeish}`)
     let retries = 0
-    try { // Naively try as branch first, this will fail if hash is a commit-sha
+    try { // Naively try as branch first, this will fail if treeish is a commit-sha
         await exec(`git clone --depth 1 --branch ${treeish} ${url} ${clone_path}`)
         console.log(`[clone] [${name}] shallow clone successful`)
     } catch (err) {

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
@@ -41,9 +41,7 @@ async function fetch (name, path) {
 }
 
 
-async function checkout (name, path, hash) {
-    const treeish = hash ? hash : 'master'
-
+async function checkout (name, path, treeish) {
     let retries = 0
     while (retries <= 100) {
         try {
@@ -63,11 +61,11 @@ async function checkout (name, path, hash) {
     }
 }
 
-async function clone (name, url, clone_path, hash = 'master') {
-    console.log(`[clone] [${name}] clone started, using ${hash}`)
+async function clone (name, url, clone_path, treeish) {
+    console.log(`[clone] [${name}] clone started, using ${treeish}`)
     let retries = 0
     try { // Naively try as branch first, this will fail if hash is a commit-sha
-        await exec(`git clone --depth 1 --branch ${hash} ${url} ${clone_path}`)
+        await exec(`git clone --depth 1 --branch ${treeish} ${url} ${clone_path}`)
         console.log(`[clone] [${name}] shallow clone successful`)
     } catch (err) {
         console.log(`[clone] [${name}] shallow clone failed. Starting clone with --no-single-branch. This may take some time`)
@@ -101,15 +99,16 @@ async function show_sha (repo_path) {
     return refspec
 }
 
-async function clone_app (repo, target, complete_callback) {
+async function clone_app (repo, target, default_branch) {
     const { url, hash } = split_repo_path(repo)
+    const treeish = hash ? hash : default_branch
     const repo_name = ex_clone_path(url)
 
     const clone_path = path.join(target, repo_name)
 
     try {
-        await clone(repo_name, url, clone_path, hash)
-        const ref = await checkout(repo_name, clone_path, hash)
+        await clone(repo_name, url, clone_path, treeish)
+        const ref = await checkout(repo_name, clone_path, treeish)
         const sha = await show_sha(clone_path)
 
         const pkg_name = require(path.join(clone_path, 'package.json')).name


### PR DESCRIPTION
The size of the history of d2-ci repos have increased a lot. Cloning https://github.com/d2-ci/maintenance-app is 300MB of just history. `--depth 1 --no-single-branch` does not reduce the size a lot, due to `--no-single-branch`, probably because of the vast amount of branches. 

This commit changes the behaviour of cloning the repos. Now it first tries to do a true shallow clone. This dramatically decreases the objects downloaded. However, this comes with a small catch: we cannot use this for commit hashes (surprisingly works with tags though). So that means we have to use the old method with --no-single-branch when a commit is specified in `apps-to-bundle.json`. However this will decrease the build time in most clean-install cases tremendously. 


Results on my machine:
dhis-web-apps build time: 05:28 min
to: Total time: 48.975 s

Notice that the times before seemed to be heavily fluctuant. Probably due to some automatic throttling from github, as I went from consistent 450 kb/s on some repos to 20MB/s on others on my gigabit lined server. 