### PR TITLE
[DHIS2-6208] Fix error with custom boundary types

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
@@ -115,18 +115,29 @@ public class AnalyticsPeriodBoundary extends BaseIdentifiableObject implements E
     // Logic
     // -------------------------------------------------------------------------
  
+    /**
+     * Get the date representing this boundary. For end-type boundaries BEFORE_START_OF_REPORTING_PERIOD and
+     * BEFORE_END_OF_REPORTING_PERIOD, one day is added to the date. This to allow SQL and comparisons using a 
+     * less than operator to find anything before the end of the reporting period.
+     *
+     * @param reportingStartDate the reporting period start date
+     * @param reportingEndDate the reporting period end date
+     * @return the reporting start or end date is returned based on the boundary settings, potentially incremented
+     * by one day if the boundary is one of the end-type boundaries.
+     */
     public Date getBoundaryDate( Date reportingStartDate, Date reportingEndDate )
     {
         Date returnDate = null;
         
-        if ( analyticsPeriodBoundaryType.isEndBoundary() )
+        if( analyticsPeriodBoundaryType.equals( AnalyticsPeriodBoundaryType.AFTER_START_OF_REPORTING_PERIOD ) ||
+            analyticsPeriodBoundaryType.equals( AnalyticsPeriodBoundaryType.BEFORE_START_OF_REPORTING_PERIOD ) ) 
         {
-            DateTime reportingEndDateTime = new DateTime(reportingEndDate);
-            returnDate = reportingEndDateTime.plusDays(1).toDate();
+            returnDate = new Date( reportingStartDate.getTime() );
         }
         else
         {
-            returnDate = new Date( reportingStartDate.getTime() );
+            DateTime reportingEndDateTime = new DateTime(reportingEndDate);
+            returnDate = reportingEndDateTime.plusDays(1).toDate();
         }
         
         if ( offsetPeriods != null && offsetPeriodType != null )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
@@ -136,8 +136,8 @@ public class AnalyticsPeriodBoundary extends BaseIdentifiableObject implements E
         }
         else
         {
-            DateTime reportingEndDateTime = new DateTime(reportingEndDate);
-            returnDate = reportingEndDateTime.plusDays(1).toDate();
+            DateTime reportingEndDateTime = new DateTime( reportingEndDate );
+            returnDate = reportingEndDateTime.plusDays( 1 ).toDate();
         }
         
         if ( offsetPeriods != null && offsetPeriodType != null )

--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/statementbuilder/AbstractStatementBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/statementbuilder/AbstractStatementBuilder.java
@@ -368,7 +368,7 @@ public abstract class AbstractStatementBuilder
               
             for ( AnalyticsPeriodBoundary boundary : boundaries )
             {
-                sql += " and executiondate " + ( boundary.getAnalyticsPeriodBoundaryType().isStartBoundary() ? ">" : "<" ) +
+                sql += " and executiondate " + ( boundary.getAnalyticsPeriodBoundaryType().isStartBoundary() ? ">=" : "<" ) +
                     " cast( '" + format.format( boundary.getBoundaryDate( reportingStartDate, reportingEndDate ) ) + "' as date )";
             }
             


### PR DESCRIPTION
When using the custom boundary targets like data elements and attributes, combining it with the one of the affected boundary types - there was an error in the underlying query:
- "After end of reporting period" gets substituted for "After start of reporting period".
- "Before start of reporting period" gets substituted for "Before end of reporting period".