### PR TITLE
Fix bigint flyway upgrade script

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__Use_bigint_for_id_columns.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__Use_bigint_for_id_columns.sql
@@ -1,3 +1,5 @@
+set max_locks_per_transaction = 100;
+
 -- datavalueaudit table and its foreign key references
 alter table datavalueaudit alter column datavalueauditid type bigint;
 
@@ -10,13 +12,10 @@ alter table trackedentitydatavalueaudit alter column programstageinstanceid type
 alter table programmessage alter column programstageinstanceid type bigint;
 alter table programnotificationinstance alter column programstageinstanceid type bigint;
 alter table relationshipitem alter column programstageinstanceid type bigint;
-alter table programstageinstance_trackedentityinstances alter column programstageinstanceid type bigint;
-alter table programstageinstance_outboundsms alter column programstageinstanceid type bigint;
 
 -- trackedentityinstance table and its foreign key references
 alter table trackedentityinstance alter column trackedentityinstanceid type bigint;
 alter table trackedentityinstance alter column representativeid type bigint;
-alter table programstageinstance_trackedentityinstances alter column trackedentityinstanceid type bigint;
 alter table trackedentityattributevalue alter column trackedentityinstanceid type bigint;
 alter table trackedentityattributevalueaudit alter column trackedentityinstanceid type bigint;
 alter table programinstance alter column trackedentityinstanceid type bigint;
@@ -24,8 +23,6 @@ alter table programmessage alter column trackedentityinstanceid type bigint;
 alter table programownershiphistory alter column trackedentityinstanceid type bigint;
 alter table programtempownershipaudit alter column trackedentityinstanceid type bigint;
 alter table relationshipitem alter column trackedentityinstanceid type bigint;
-alter table trackedentityaudit alter column trackedentityinstanceid type bigint;
-alter table trackedentityinstanceaudit alter column trackedentityinstanceid type bigint;
 
 -- trackedentityinstanceaudit table and its foreign key references
 alter table trackedentityinstanceaudit alter column trackedentityinstanceauditid type bigint;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__Use_bigint_for_id_columns.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__Use_bigint_for_id_columns.sql
@@ -1,5 +1,3 @@
-set max_locks_per_transaction = 100;
-
 -- datavalueaudit table and its foreign key references
 alter table datavalueaudit alter column datavalueauditid type bigint;
 


### PR DESCRIPTION
Add runtime config parameter setting for max_locks_per_transaction in the flyway script.
Removed unused tables and columns in the script.