### PR TITLE
Fixed issue with import of job configurations (#5918)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -34,12 +34,12 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.schema.annotation.Property;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 
+import javax.annotation.Nonnull;
 import java.util.Date;
 
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
@@ -86,7 +86,7 @@ public class JobConfiguration
     private boolean inMemoryJob = false;
 
     private String userUid;
-    
+
     private boolean leaderOnlyJob = false;
 
     public JobConfiguration()
@@ -114,7 +114,7 @@ public class JobConfiguration
         this.inMemoryJob = inMemoryJob;
         constructor( name, jobType, cronExpression, jobParameters, continuousExecution, enabled );
     }
-    
+
     public JobConfiguration( String name, JobType jobType, String cronExpression, JobParameters jobParameters, boolean leaderOnlyJob)
     {
         this.leaderOnlyJob = leaderOnlyJob;
@@ -206,7 +206,7 @@ public class JobConfiguration
     {
         this.enabled = enabled;
     }
-    
+
     public void setLeaderOnlyJob( boolean leaderOnlyJob )
     {
         this.leaderOnlyJob = leaderOnlyJob;
@@ -299,7 +299,7 @@ public class JobConfiguration
     {
         return enabled;
     }
-    
+
     @JacksonXmlProperty
     @JsonProperty
     public boolean isLeaderOnlyJob()
@@ -319,42 +319,33 @@ public class JobConfiguration
         return userUid;
     }
 
-    @Override
-    public int compareTo( IdentifiableObject jobConfiguration )
+    /**
+     * Checks if this job has changes compared to the specified job configuration that are only
+     * allowed for configurable jobs.
+     *
+     * @param jobConfiguration the job configuration that should be checked.
+     * @return <code>true</code> if this job configuration has changes in fields that are only
+     * allowed for configurable jobs, <code>false</code> otherwise.
+     */
+    public boolean hasNonConfigurableJobChanges( @Nonnull JobConfiguration jobConfiguration )
     {
-        JobConfiguration compareJobConfiguration = (JobConfiguration) jobConfiguration;
-
-        if ( jobType != compareJobConfiguration.getJobType() )
+        if ( jobType != jobConfiguration.getJobType() )
         {
-            return -1;
+            return true;
         }
-
-        if ( jobStatus != compareJobConfiguration.getJobStatus() )
+        if ( jobStatus != jobConfiguration.getJobStatus() )
         {
-            return -1;
+            return true;
         }
-
-        if ( jobParameters != compareJobConfiguration.getJobParameters() )
+        if ( jobParameters != jobConfiguration.getJobParameters() )
         {
-            return -1;
+            return true;
         }
-
-        if ( continuousExecution != compareJobConfiguration.isContinuousExecution() )
+        if ( continuousExecution != jobConfiguration.isContinuousExecution() )
         {
-            return -1;
+            return true;
         }
-
-        if ( enabled != compareJobConfiguration.isEnabled() )
-        {
-            return -1;
-        }
-
-        if ( !cronExpression.equals( compareJobConfiguration.getCronExpression() ) )
-        {
-            return 1;
-        }
-
-        return -1;
+        return enabled != jobConfiguration.isEnabled();
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -34,12 +34,12 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.schema.annotation.Property;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 
-import javax.annotation.Nonnull;
 import java.util.Date;
 
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
@@ -319,33 +319,42 @@ public class JobConfiguration
         return userUid;
     }
 
-    /**
-     * Checks if this job has changes compared to the specified job configuration that are only
-     * allowed for configurable jobs.
-     *
-     * @param jobConfiguration the job configuration that should be checked.
-     * @return <code>true</code> if this job configuration has changes in fields that are only
-     * allowed for configurable jobs, <code>false</code> otherwise.
-     */
-    public boolean hasNonConfigurableJobChanges( @Nonnull JobConfiguration jobConfiguration )
+    @Override
+    public int compareTo( IdentifiableObject jobConfiguration )
     {
-        if ( jobType != jobConfiguration.getJobType() )
+        JobConfiguration compareJobConfiguration = (JobConfiguration) jobConfiguration;
+
+        if ( jobType != compareJobConfiguration.getJobType() )
         {
-            return true;
+            return -1;
         }
-        if ( jobStatus != jobConfiguration.getJobStatus() )
+
+        if ( jobStatus != compareJobConfiguration.getJobStatus() )
         {
-            return true;
+            return -1;
         }
-        if ( jobParameters != jobConfiguration.getJobParameters() )
+
+        if ( jobParameters != compareJobConfiguration.getJobParameters() )
         {
-            return true;
+            return -1;
         }
-        if ( continuousExecution != jobConfiguration.isContinuousExecution() )
+
+        if ( continuousExecution != compareJobConfiguration.isContinuousExecution() )
         {
-            return true;
+            return -1;
         }
-        return enabled != jobConfiguration.isEnabled();
+
+        if ( enabled != compareJobConfiguration.isEnabled() )
+        {
+            return -1;
+        }
+
+        if ( !cronExpression.equals( compareJobConfiguration.getCronExpression() ) )
+        {
+            return 1;
+        }
+
+        return -1;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.scheduling;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -45,6 +46,7 @@ import java.io.IOException;
 public class JobConfigurationDeserializer
     extends JsonDeserializer<JobConfiguration>
 {
+    private final String ID = "id";
     private final String NAME = "name";
     private final String JOB_TYPE = "jobType";
     private final String ENABLED = "enabled";
@@ -82,14 +84,22 @@ public class JobConfigurationDeserializer
         boolean enabled = !root.has( ENABLED ) || root.get( ENABLED ).asBoolean();
 
         boolean continuousExecution = root.has( CONTINUOUS_EXECUTION ) && root.get( CONTINUOUS_EXECUTION ).asBoolean();
-        
+
         boolean leaderOnlyJob = root.has( LEAER_ONLY_JOB ) && root.get( LEAER_ONLY_JOB ).asBoolean();
 
         String cronExpression = root.has( CRON_EXPRESSION ) ? root.get( CRON_EXPRESSION ).textValue() : "";
 
-         JobConfiguration jobConfiguration = new JobConfiguration( root.get( NAME ).textValue(), jobType,
+
+        JobConfiguration jobConfiguration = new JobConfiguration( root.get( NAME ).textValue(), jobType,
             cronExpression, jobParameters, continuousExecution, enabled );
          jobConfiguration.setLeaderOnlyJob( leaderOnlyJob );
+
+        JsonNode idNode = root.get( ID );
+        if ( (idNode != null) && !idNode.isNull() && idNode.isValueNode() )
+        {
+            jobConfiguration.setUid( idNode.textValue() );
+        }
+
          return jobConfiguration;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.scheduling;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -46,7 +45,6 @@ import java.io.IOException;
 public class JobConfigurationDeserializer
     extends JsonDeserializer<JobConfiguration>
 {
-    private final String ID = "id";
     private final String NAME = "name";
     private final String JOB_TYPE = "jobType";
     private final String ENABLED = "enabled";
@@ -89,17 +87,9 @@ public class JobConfigurationDeserializer
 
         String cronExpression = root.has( CRON_EXPRESSION ) ? root.get( CRON_EXPRESSION ).textValue() : "";
 
-
         JobConfiguration jobConfiguration = new JobConfiguration( root.get( NAME ).textValue(), jobType,
             cronExpression, jobParameters, continuousExecution, enabled );
          jobConfiguration.setLeaderOnlyJob( leaderOnlyJob );
-
-        JsonNode idNode = root.get( ID );
-        if ( (idNode != null) && !idNode.isNull() && idNode.isValueNode() )
-        {
-            jobConfiguration.setUid( idNode.textValue() );
-        }
-
          return jobConfiguration;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -75,7 +75,7 @@ public class SchedulerStart extends AbstractStartupRoutine
     private final String DEFAULT_DATA_SET_NOTIFICATION = "Dataset notification";
     private final String DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES_UID = "uwWCT2BMmlq";
     private final String DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES = "Remove expired reserved values";
-    private final String DEFAULT_LEADER_ELECTION_UID = "pd6O228pqr0";
+    private final String DEFAULT_LEADER_ELECTION_UID = "MoUd5BTQ3lY";
     private final String DEFAULT_LEADER_ELECTION = "Leader election in cluster";
 
     @Autowired

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -63,12 +63,19 @@ public class SchedulerStart extends AbstractStartupRoutine
     private final String CRON_DAILY_2AM = "0 0 2 ? * *";
     private final String CRON_DAILY_7AM = "0 0 7 ? * *";
     private final String LEADER_JOB_CRON_FORMAT = "0 0/%s * * * *";
+    private final String DEFAULT_FILE_RESOURCE_CLEANUP_UID = "pd6O228pqr0";
     private final String DEFAULT_FILE_RESOURCE_CLEANUP = "File resource clean up";
+    private final String DEFAULT_DATA_STATISTICS_UID = "BFa3jDsbtdO";
     private final String DEFAULT_DATA_STATISTICS = "Data statistics";
+    private final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION_UID = "Js3vHn2AVuG";
     private final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION = "Validation result notification";
+    private final String DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID = "sHMedQF7VYa";
     private final String DEFAULT_CREDENTIALS_EXPIRY_ALERT = "Credentials expiry alert";
+    private final String DEFAULT_DATA_SET_NOTIFICATION_UID = "YvAwAmrqAtN";
     private final String DEFAULT_DATA_SET_NOTIFICATION = "Dataset notification";
+    private final String DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES_UID = "uwWCT2BMmlq";
     private final String DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES = "Remove expired reserved values";
+    private final String DEFAULT_LEADER_ELECTION_UID = "pd6O228pqr0";
     private final String DEFAULT_LEADER_ELECTION = "Leader election in cluster";
 
     @Autowired
@@ -161,6 +168,7 @@ public class SchedulerStart extends AbstractStartupRoutine
         {
             JobConfiguration fileResourceCleanUp = new JobConfiguration( DEFAULT_FILE_RESOURCE_CLEANUP,
                 FILE_RESOURCE_CLEANUP, CRON_DAILY_2AM, null, false, true );
+            fileResourceCleanUp.setUid( DEFAULT_FILE_RESOURCE_CLEANUP_UID );
             fileResourceCleanUp.setLeaderOnlyJob( true );
             addAndScheduleJob( fileResourceCleanUp );
         }
@@ -171,6 +179,7 @@ public class SchedulerStart extends AbstractStartupRoutine
                 CRON_DAILY_2AM, null, false, true );
             portJob( systemSettingManager, dataStatistics, SettingKey.LAST_SUCCESSFUL_DATA_STATISTICS );
             dataStatistics.setLeaderOnlyJob( true );
+            dataStatistics.setUid( DEFAULT_DATA_STATISTICS_UID );
             addAndScheduleJob( dataStatistics );
         }
 
@@ -179,6 +188,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration validationResultNotification = new JobConfiguration( DEFAULT_VALIDATION_RESULTS_NOTIFICATION,
                 VALIDATION_RESULTS_NOTIFICATION, CRON_DAILY_7AM, null, false, true );
             validationResultNotification.setLeaderOnlyJob( true );
+            validationResultNotification.setUid( DEFAULT_VALIDATION_RESULTS_NOTIFICATION_UID );
             addAndScheduleJob( validationResultNotification );
         }
 
@@ -187,6 +197,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration credentialsExpiryAlert = new JobConfiguration( DEFAULT_CREDENTIALS_EXPIRY_ALERT,
                 CREDENTIALS_EXPIRY_ALERT, CRON_DAILY_2AM, null, false, true );
             credentialsExpiryAlert.setLeaderOnlyJob( true );
+            credentialsExpiryAlert.setUid( DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID );
             addAndScheduleJob( credentialsExpiryAlert );
         }
 
@@ -195,6 +206,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration dataSetNotification = new JobConfiguration( DEFAULT_DATA_SET_NOTIFICATION,
                 DATA_SET_NOTIFICATION, CRON_DAILY_2AM, null, false, true );
             dataSetNotification.setLeaderOnlyJob( true );
+            dataSetNotification.setUid( DEFAULT_DATA_SET_NOTIFICATION_UID );
             addAndScheduleJob( dataSetNotification );
         }
 
@@ -203,6 +215,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration removeExpiredReservedValues = new JobConfiguration( DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES,
                 REMOVE_EXPIRED_RESERVED_VALUES, CRON_HOURLY, null, false, true );
             removeExpiredReservedValues.setLeaderOnlyJob( true );
+            removeExpiredReservedValues.setUid( DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES_UID );
             addAndScheduleJob( removeExpiredReservedValues );
         }
 
@@ -211,6 +224,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration leaderElectionJobConfiguration = new JobConfiguration( DEFAULT_LEADER_ELECTION,
                 LEADER_ELECTION, String.format( LEADER_JOB_CRON_FORMAT, leaderElectionTime ), null, false, true );
             leaderElectionJobConfiguration.setLeaderOnlyJob( false );
+            leaderElectionJobConfiguration.setUid( DEFAULT_LEADER_ELECTION_UID );
             addAndScheduleJob( leaderElectionJobConfiguration );
         }
         else

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -60,6 +60,8 @@ public class JobConfigurationObjectBundleHook
 {
     private static final Log log = LogFactory.getLog( JobConfigurationObjectBundleHook.class );
 
+    private static final int SUCCESS = 1;
+
     @Autowired
     private JobConfigurationService jobConfigurationService;
 
@@ -128,7 +130,7 @@ public class JobConfigurationObjectBundleHook
         JobConfiguration persitedJobConfiguration = jobConfigurationService.getJobConfigurationByUid( jobConfiguration.getUid() );
         if ( persitedJobConfiguration != null && !persitedJobConfiguration.isConfigurable() )
         {
-            if ( persitedJobConfiguration.hasNonConfigurableJobChanges( jobConfiguration ) )
+            if ( !Objects.equals( persitedJobConfiguration.compareTo( jobConfiguration ), SUCCESS ) )
             {
                 errorReports
                     .add( new ErrorReport( JobConfiguration.class, ErrorCode.E7003, jobConfiguration.getJobType() ) );
@@ -171,13 +173,7 @@ public class JobConfigurationObjectBundleHook
         ErrorReport jobValidation = job.validate();
         if ( jobValidation != null )
         {
-            // If the error is caused by the environment and the job is a non configurable job
-            // that exists already, then the error can be ignored. Job has the issue with and
-            // without updating it.
-            if ( (jobValidation.getErrorCode() != ErrorCode.E7010) || (persitedJobConfiguration == null) || jobConfiguration.isConfigurable() )
-            {
-                errorReports.add( jobValidation );
-            }
+            errorReports.add( jobValidation );
         }
 
         return errorReports;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.metadata;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.dxf2.csv.CsvImportClass;
 import org.hisp.dhis.dxf2.csv.CsvImportOptions;
@@ -42,6 +43,7 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -62,6 +64,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.GML_IMPORT;
@@ -109,7 +112,13 @@ public class MetadataImportController
     public void postJsonMetadata( HttpServletRequest request, HttpServletResponse response ) throws IOException
     {
         MetadataImportParams params = metadataImportService.getParamsFromMap( contextService.getParameterValuesMap() );
-        params.setObjects( renderService.fromMetadata( StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() ), RenderFormat.JSON ) );
+
+        final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects =
+            renderService.fromMetadata( StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() ), RenderFormat.JSON );
+        // remove all data that cannot be exported explicitly and is not supported with other data formats
+        objects.remove( JobConfiguration.class );
+        params.setObjects( objects );
+
         response.setContentType( MediaType.APPLICATION_JSON_UTF8_VALUE );
 
         if ( params.hasJobId() )


### PR DESCRIPTION
- Job configurations were not imported in 2.29.
- Since 2.30 it is tried to import them from JSON (neither XML nor CSV), but this fails.

Changes:
- Job configurations have been excluded from import (like in 2.29).
- New system jobs have standard UIDs in order to enable import on different systems in future versions.