### PR TITLE
Fix integration test failing with out of memory postgres

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationTestConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationTestConfig.java
@@ -1,3 +1,5 @@
+package org.hisp.dhis;
+
 /*
  * Copyright (c) 2004-2018, University of Oslo
  * All rights reserved.
@@ -26,10 +28,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis;
-
 import java.util.Properties;
 
+import org.hisp.dhis.container.DhisPostgisContainerProvider;
+import org.hisp.dhis.container.DhisPostgreSQLContainer;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +39,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgisContainerProvider;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -73,8 +74,8 @@ public class IntegrationTestConfig
 
     private JdbcDatabaseContainer<?> initContainer()
     {
-        JdbcDatabaseContainer<?> postgisContainer = new PostgisContainerProvider()
-            .newInstance()
+        DhisPostgreSQLContainer<?> postgisContainer = ((DhisPostgreSQLContainer<?>) new DhisPostgisContainerProvider().newInstance())
+            .appendCustomPostgresConfig( "max_locks_per_transaction=100" )
             .withDatabaseName( POSTGRES_DATABASE_NAME )
             .withUsername( POSTGRES_CREDENTIALS )
             .withPassword( POSTGRES_CREDENTIALS );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
@@ -1,0 +1,57 @@
+package org.hisp.dhis.container;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgisContainerProvider;
+
+/**
+ * Custom PostgisContainerProvider to create
+ * {@link DhisPostgreSQLContainer}
+ * 
+ * @author Ameen Mohamed <ameen@dhis2.org>
+ *
+ */
+@SuppressWarnings( "rawtypes" )
+public class DhisPostgisContainerProvider extends PostgisContainerProvider
+{
+    private static final String DEFAULT_TAG = "10";
+    private static final String DEFAULT_IMAGE = "mdillon/postgis";
+
+    @Override
+    public JdbcDatabaseContainer newInstance() {
+        return newInstance(DEFAULT_TAG);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        return new DhisPostgreSQLContainer(DEFAULT_IMAGE + ":" + tag);
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
@@ -45,13 +45,15 @@ public class DhisPostgisContainerProvider extends PostgisContainerProvider
     private static final String DEFAULT_IMAGE = "mdillon/postgis";
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
-        return newInstance(DEFAULT_TAG);
+    public JdbcDatabaseContainer newInstance()
+    {
+        return newInstance( DEFAULT_TAG );
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
-        return new DhisPostgreSQLContainer(DEFAULT_IMAGE + ":" + tag);
+    public JdbcDatabaseContainer newInstance( String tag )
+    {
+        return new DhisPostgreSQLContainer( DEFAULT_IMAGE + ":" + tag );
     }
 
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.container;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
@@ -1,0 +1,99 @@
+package org.hisp.dhis.container;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Custom {@link PostgreSQLContainer} that provides additional fluent api to
+ * customize postgres configuration.
+ * 
+ * @author Ameen Mohamed <ameen@dhis2.org>
+ *
+ */
+public class DhisPostgreSQLContainer<SELF extends DhisPostgreSQLContainer<SELF>> extends PostgreSQLContainer<SELF>
+{
+    private Set<String> customPostgresConfigs = new HashSet<>();
+    
+    public DhisPostgreSQLContainer( final String dockerImageName )
+    {
+        super( dockerImageName );
+    }
+
+    @Override
+    protected void configure()
+    {
+        addExposedPort( POSTGRESQL_PORT );
+        addEnv( "POSTGRES_DB", getDatabaseName() );
+        addEnv( "POSTGRES_USER", getUsername() );
+        addEnv( "POSTGRES_PASSWORD", getPassword() );
+        setCommand( getPostgresCommandWithCustomConfigs() );
+    }
+
+    
+    private String getPostgresCommandWithCustomConfigs()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append( "postgres" );
+
+        if ( !this.customPostgresConfigs.isEmpty() )
+        {
+            this.customPostgresConfigs.forEach( config -> {
+                builder.append( " -c " );
+                builder.append( config );
+            } );
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Append custom postgres configuration to be customized when starting the
+     * container. The configAndValue should be of the form
+     * "configName=configValue". This method can be invoked multiple times to
+     * add multiple custom commands.
+     * 
+     * @param configAndValue The configuration and value of the form
+     *        "configName=configValue"
+     * @return the DhisPostgreSQLContainer
+     */
+    public SELF appendCustomPostgresConfig( String configAndValue )
+    {
+        if ( !StringUtils.isBlank( configAndValue ) )
+        {
+            this.customPostgresConfigs.add( configAndValue );
+        }
+        return self();
+    }
+    
+    
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
@@ -44,7 +44,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class DhisPostgreSQLContainer<SELF extends DhisPostgreSQLContainer<SELF>> extends PostgreSQLContainer<SELF>
 {
     private Set<String> customPostgresConfigs = new HashSet<>();
-    
+
     public DhisPostgreSQLContainer( final String dockerImageName )
     {
         super( dockerImageName );
@@ -60,7 +60,6 @@ public class DhisPostgreSQLContainer<SELF extends DhisPostgreSQLContainer<SELF>>
         setCommand( getPostgresCommandWithCustomConfigs() );
     }
 
-    
     private String getPostgresCommandWithCustomConfigs()
     {
         StringBuilder builder = new StringBuilder();

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.container;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Extended testcontainer classes to create a custom DhisPostgreSQLContainer that can be used to provide custom configurations for postgres when the postgres container starts for integration tests. max_locks_per_transaction is now set to 100 for postgres test containers.