### PR TITLE
Fixed issue with metadata import for job configurations (#5918)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.scheduling;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,12 +34,12 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.schema.annotation.Property;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 
+import javax.annotation.Nonnull;
 import java.util.Date;
 
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
@@ -86,7 +86,7 @@ public class JobConfiguration
     private boolean inMemoryJob = false;
 
     private String userUid;
-    
+
     private boolean leaderOnlyJob = false;
 
     public JobConfiguration()
@@ -114,7 +114,7 @@ public class JobConfiguration
         this.inMemoryJob = inMemoryJob;
         constructor( name, jobType, cronExpression, jobParameters, continuousExecution, enabled );
     }
-    
+
     public JobConfiguration( String name, JobType jobType, String cronExpression, JobParameters jobParameters, boolean leaderOnlyJob)
     {
         this.leaderOnlyJob = leaderOnlyJob;
@@ -206,7 +206,7 @@ public class JobConfiguration
     {
         this.enabled = enabled;
     }
-    
+
     public void setLeaderOnlyJob( boolean leaderOnlyJob )
     {
         this.leaderOnlyJob = leaderOnlyJob;
@@ -299,7 +299,7 @@ public class JobConfiguration
     {
         return enabled;
     }
-    
+
     @JacksonXmlProperty
     @JsonProperty
     public boolean isLeaderOnlyJob()
@@ -319,42 +319,33 @@ public class JobConfiguration
         return userUid;
     }
 
-    @Override
-    public int compareTo( IdentifiableObject jobConfiguration )
+    /**
+     * Checks if this job has changes compared to the specified job configuration that are only
+     * allowed for configurable jobs.
+     *
+     * @param jobConfiguration the job configuration that should be checked.
+     * @return <code>true</code> if this job configuration has changes in fields that are only
+     * allowed for configurable jobs, <code>false</code> otherwise.
+     */
+    public boolean hasNonConfigurableJobChanges( @Nonnull JobConfiguration jobConfiguration )
     {
-        JobConfiguration compareJobConfiguration = (JobConfiguration) jobConfiguration;
-
-        if ( jobType != compareJobConfiguration.getJobType() )
+        if ( jobType != jobConfiguration.getJobType() )
         {
-            return -1;
+            return true;
         }
-
-        if ( jobStatus != compareJobConfiguration.getJobStatus() )
+        if ( jobStatus != jobConfiguration.getJobStatus() )
         {
-            return -1;
+            return true;
         }
-
-        if ( jobParameters != compareJobConfiguration.getJobParameters() )
+        if ( jobParameters != jobConfiguration.getJobParameters() )
         {
-            return -1;
+            return true;
         }
-
-        if ( continuousExecution != compareJobConfiguration.isContinuousExecution() )
+        if ( continuousExecution != jobConfiguration.isContinuousExecution() )
         {
-            return -1;
+            return true;
         }
-
-        if ( enabled != compareJobConfiguration.isEnabled() )
-        {
-            return -1;
-        }
-
-        if ( !cronExpression.equals( compareJobConfiguration.getCronExpression() ) )
-        {
-            return 1;
-        }
-
-        return -1;
+        return enabled != jobConfiguration.isEnabled();
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.scheduling;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -45,6 +46,7 @@ import java.io.IOException;
 public class JobConfigurationDeserializer
     extends JsonDeserializer<JobConfiguration>
 {
+    private final String ID = "id";
     private final String NAME = "name";
     private final String JOB_TYPE = "jobType";
     private final String ENABLED = "enabled";
@@ -82,14 +84,22 @@ public class JobConfigurationDeserializer
         boolean enabled = !root.has( ENABLED ) || root.get( ENABLED ).asBoolean();
 
         boolean continuousExecution = root.has( CONTINUOUS_EXECUTION ) && root.get( CONTINUOUS_EXECUTION ).asBoolean();
-        
+
         boolean leaderOnlyJob = root.has( LEAER_ONLY_JOB ) && root.get( LEAER_ONLY_JOB ).asBoolean();
 
         String cronExpression = root.has( CRON_EXPRESSION ) ? root.get( CRON_EXPRESSION ).textValue() : "";
 
-         JobConfiguration jobConfiguration = new JobConfiguration( root.get( NAME ).textValue(), jobType,
+
+        JobConfiguration jobConfiguration = new JobConfiguration( root.get( NAME ).textValue(), jobType,
             cronExpression, jobParameters, continuousExecution, enabled );
          jobConfiguration.setLeaderOnlyJob( leaderOnlyJob );
+
+        JsonNode idNode = root.get( ID );
+        if ( (idNode != null) && !idNode.isNull() && idNode.isValueNode() )
+        {
+            jobConfiguration.setUid( idNode.textValue() );
+        }
+
          return jobConfiguration;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationDeserializer.java
@@ -95,7 +95,7 @@ public class JobConfigurationDeserializer
          jobConfiguration.setLeaderOnlyJob( leaderOnlyJob );
 
         JsonNode idNode = root.get( ID );
-        if ( (idNode != null) && !idNode.isNull() && idNode.isValueNode() )
+        if ( idNode != null && !idNode.isNull() && idNode.isValueNode() )
         {
             jobConfiguration.setUid( idNode.textValue() );
         }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationDeserializerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationDeserializerTest.java
@@ -1,0 +1,31 @@
+package org.hisp.dhis.scheduling;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Unit tests of {@link JobConfigurationDeserializer}.
+ *
+ * @author Volker Schmidt
+ */
+public class JobConfigurationDeserializerTest
+{
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void deserializeWithoutId() throws IOException
+    {
+        final JobConfiguration jobConfiguration = objectMapper.readValue( "{\"name\":\"Test\",\"jobType\":\"RESOURCE_TABLE\"}", JobConfiguration.class );
+        Assert.assertNull( jobConfiguration.getUid() );
+    }
+
+    @Test
+    public void deserializeWithId() throws IOException
+    {
+        final JobConfiguration jobConfiguration = objectMapper.readValue( "{\"id\":\"kjsdfDSU23\",\"name\":\"Test\",\"jobType\":\"RESOURCE_TABLE\"}", JobConfiguration.class );
+        Assert.assertEquals( "kjsdfDSU23", jobConfiguration.getUid() );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
@@ -1,0 +1,138 @@
+package org.hisp.dhis.scheduling;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.scheduling.parameters.MockJobParameters;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link JobConfiguration}.
+ *
+ * @author Volker Schmidt
+ */
+public class JobConfigurationTest
+{
+    private JobParameters jobParameters;
+
+    private JobConfiguration jobConfiguration;
+
+    @Before
+    public void setUp()
+    {
+        jobParameters = new MockJobParameters();
+
+        jobConfiguration = new JobConfiguration();
+        jobConfiguration.setJobType( JobType.ANALYTICS_TABLE );
+        jobConfiguration.setJobStatus( JobStatus.COMPLETED );
+        jobConfiguration.setJobParameters( jobParameters );
+        jobConfiguration.setContinuousExecution( true );
+        jobConfiguration.setEnabled( true );
+        jobConfiguration.setLeaderOnlyJob( true );
+    }
+
+    @Test
+    public void hasNonConfigurableJobChangesFalse()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.ANALYTICS_TABLE );
+        jc.setJobStatus( JobStatus.COMPLETED );
+        jc.setJobParameters( jobParameters );
+        jc.setContinuousExecution( true );
+        jc.setEnabled( true );
+        jc.setLeaderOnlyJob( false );
+        Assert.assertFalse( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+
+    @Test
+    public void hasNonConfigurableEnabled()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.ANALYTICS_TABLE );
+        jc.setJobStatus( JobStatus.COMPLETED );
+        jc.setJobParameters( jobParameters );
+        jc.setContinuousExecution( true );
+        jc.setEnabled( false );
+        jc.setLeaderOnlyJob( true );
+        Assert.assertTrue( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+
+    @Test
+    public void hasNonConfigurableJobChangesJobType()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.DATA_INTEGRITY );
+        jc.setJobStatus( JobStatus.COMPLETED );
+        jc.setJobParameters( jobParameters );
+        jc.setContinuousExecution( true );
+        jc.setEnabled( true );
+        jc.setLeaderOnlyJob( true );
+        Assert.assertTrue( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+
+    @Test
+    public void hasNonConfigurableJobChangesJobStatus()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.ANALYTICS_TABLE );
+        jc.setJobStatus( JobStatus.STOPPED );
+        jc.setJobParameters( jobParameters );
+        jc.setContinuousExecution( true );
+        jc.setEnabled( true );
+        jc.setLeaderOnlyJob( true );
+        Assert.assertTrue( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+
+    @Test
+    public void hasNonConfigurableJobChangesJobParameters()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.ANALYTICS_TABLE );
+        jc.setJobStatus( JobStatus.COMPLETED );
+        jc.setJobParameters( new MockJobParameters() );
+        jc.setContinuousExecution( true );
+        jc.setEnabled( true );
+        jc.setLeaderOnlyJob( true );
+        Assert.assertTrue( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+
+    @Test
+    public void hasNonConfigurableJobChangesContinousExecution()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.ANALYTICS_TABLE );
+        jc.setJobStatus( JobStatus.COMPLETED );
+        jc.setJobParameters( jobParameters );
+        jc.setContinuousExecution( false );
+        jc.setEnabled( true );
+        jc.setLeaderOnlyJob( true );
+        Assert.assertTrue( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
@@ -56,6 +56,7 @@ public class JobConfigurationTest
         jobConfiguration.setContinuousExecution( true );
         jobConfiguration.setEnabled( true );
         jobConfiguration.setLeaderOnlyJob( true );
+        jobConfiguration.setCronExpression( "0 0 6 * * ?" );
     }
 
     @Test
@@ -68,6 +69,20 @@ public class JobConfigurationTest
         jc.setContinuousExecution( true );
         jc.setEnabled( true );
         jc.setLeaderOnlyJob( false );
+        Assert.assertFalse( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
+    }
+
+    @Test
+    public void hasNonConfigurableJobChangesCron()
+    {
+        final JobConfiguration jc = new JobConfiguration();
+        jc.setJobType( JobType.ANALYTICS_TABLE );
+        jc.setJobStatus( JobStatus.COMPLETED );
+        jc.setJobParameters( jobParameters );
+        jc.setContinuousExecution( true );
+        jc.setEnabled( true );
+        jc.setLeaderOnlyJob( true );
+        jc.setCronExpression( "0 0 12 * * ?" );
         Assert.assertFalse( jobConfiguration.hasNonConfigurableJobChanges( jc ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -63,12 +63,19 @@ public class SchedulerStart extends AbstractStartupRoutine
     private final String CRON_DAILY_2AM = "0 0 2 ? * *";
     private final String CRON_DAILY_7AM = "0 0 7 ? * *";
     private final String LEADER_JOB_CRON_FORMAT = "0 0/%s * * * *";
+    private final String DEFAULT_FILE_RESOURCE_CLEANUP_UID = "pd6O228pqr0";
     private final String DEFAULT_FILE_RESOURCE_CLEANUP = "File resource clean up";
+    private final String DEFAULT_DATA_STATISTICS_UID = "BFa3jDsbtdO";
     private final String DEFAULT_DATA_STATISTICS = "Data statistics";
+    private final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION_UID = "Js3vHn2AVuG";
     private final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION = "Validation result notification";
+    private final String DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID = "sHMedQF7VYa";
     private final String DEFAULT_CREDENTIALS_EXPIRY_ALERT = "Credentials expiry alert";
+    private final String DEFAULT_DATA_SET_NOTIFICATION_UID = "YvAwAmrqAtN";
     private final String DEFAULT_DATA_SET_NOTIFICATION = "Dataset notification";
+    private final String DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES_UID = "uwWCT2BMmlq";
     private final String DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES = "Remove expired reserved values";
+    private final String DEFAULT_LEADER_ELECTION_UID = "MoUd5BTQ3lY";
     private final String DEFAULT_LEADER_ELECTION = "Leader election in cluster";
 
     @Autowired
@@ -161,6 +168,7 @@ public class SchedulerStart extends AbstractStartupRoutine
         {
             JobConfiguration fileResourceCleanUp = new JobConfiguration( DEFAULT_FILE_RESOURCE_CLEANUP,
                 FILE_RESOURCE_CLEANUP, CRON_DAILY_2AM, null, false, true );
+            fileResourceCleanUp.setUid( DEFAULT_FILE_RESOURCE_CLEANUP_UID );
             fileResourceCleanUp.setLeaderOnlyJob( true );
             addAndScheduleJob( fileResourceCleanUp );
         }
@@ -171,6 +179,7 @@ public class SchedulerStart extends AbstractStartupRoutine
                 CRON_DAILY_2AM, null, false, true );
             portJob( systemSettingManager, dataStatistics, SettingKey.LAST_SUCCESSFUL_DATA_STATISTICS );
             dataStatistics.setLeaderOnlyJob( true );
+            dataStatistics.setUid( DEFAULT_DATA_STATISTICS_UID );
             addAndScheduleJob( dataStatistics );
         }
 
@@ -179,6 +188,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration validationResultNotification = new JobConfiguration( DEFAULT_VALIDATION_RESULTS_NOTIFICATION,
                 VALIDATION_RESULTS_NOTIFICATION, CRON_DAILY_7AM, null, false, true );
             validationResultNotification.setLeaderOnlyJob( true );
+            validationResultNotification.setUid( DEFAULT_VALIDATION_RESULTS_NOTIFICATION_UID );
             addAndScheduleJob( validationResultNotification );
         }
 
@@ -187,6 +197,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration credentialsExpiryAlert = new JobConfiguration( DEFAULT_CREDENTIALS_EXPIRY_ALERT,
                 CREDENTIALS_EXPIRY_ALERT, CRON_DAILY_2AM, null, false, true );
             credentialsExpiryAlert.setLeaderOnlyJob( true );
+            credentialsExpiryAlert.setUid( DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID );
             addAndScheduleJob( credentialsExpiryAlert );
         }
 
@@ -195,6 +206,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration dataSetNotification = new JobConfiguration( DEFAULT_DATA_SET_NOTIFICATION,
                 DATA_SET_NOTIFICATION, CRON_DAILY_2AM, null, false, true );
             dataSetNotification.setLeaderOnlyJob( true );
+            dataSetNotification.setUid( DEFAULT_DATA_SET_NOTIFICATION_UID );
             addAndScheduleJob( dataSetNotification );
         }
 
@@ -203,6 +215,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration removeExpiredReservedValues = new JobConfiguration( DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES,
                 REMOVE_EXPIRED_RESERVED_VALUES, CRON_HOURLY, null, false, true );
             removeExpiredReservedValues.setLeaderOnlyJob( true );
+            removeExpiredReservedValues.setUid( DEFAULT_REMOVE_EXPIRED_RESERVED_VALUES_UID );
             addAndScheduleJob( removeExpiredReservedValues );
         }
 
@@ -211,6 +224,7 @@ public class SchedulerStart extends AbstractStartupRoutine
             JobConfiguration leaderElectionJobConfiguration = new JobConfiguration( DEFAULT_LEADER_ELECTION,
                 LEADER_ELECTION, String.format( LEADER_JOB_CRON_FORMAT, leaderElectionTime ), null, false, true );
             leaderElectionJobConfiguration.setLeaderOnlyJob( false );
+            leaderElectionJobConfiguration.setUid( DEFAULT_LEADER_ELECTION_UID );
             addAndScheduleJob( leaderElectionJobConfiguration );
         }
         else

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -60,8 +60,6 @@ public class JobConfigurationObjectBundleHook
 {
     private static final Log log = LogFactory.getLog( JobConfigurationObjectBundleHook.class );
 
-    private static final int SUCCESS = 1;
-
     @Autowired
     private JobConfigurationService jobConfigurationService;
 
@@ -123,14 +121,14 @@ public class JobConfigurationObjectBundleHook
         return errorReports;
     }
 
-    private List<ErrorReport> validateInternal( JobConfiguration jobConfiguration )
+    protected List<ErrorReport> validateInternal( JobConfiguration jobConfiguration )
     {
         List<ErrorReport> errorReports = new ArrayList<>();
 
         JobConfiguration persitedJobConfiguration = jobConfigurationService.getJobConfigurationByUid( jobConfiguration.getUid() );
         if ( persitedJobConfiguration != null && !persitedJobConfiguration.isConfigurable() )
         {
-            if ( !Objects.equals( persitedJobConfiguration.compareTo( jobConfiguration ), SUCCESS ) )
+            if ( persitedJobConfiguration.hasNonConfigurableJobChanges( jobConfiguration ) )
             {
                 errorReports
                     .add( new ErrorReport( JobConfiguration.class, ErrorCode.E7003, jobConfiguration.getJobType() ) );
@@ -173,7 +171,13 @@ public class JobConfigurationObjectBundleHook
         ErrorReport jobValidation = job.validate();
         if ( jobValidation != null )
         {
-            errorReports.add( jobValidation );
+            // If the error is caused by the environment and the job is a non configurable job
+            // that exists already, then the error can be ignored. Job has the issue with and
+            // without updating it.
+            if ( (jobValidation.getErrorCode() != ErrorCode.E7010) || (persitedJobConfiguration == null) || jobConfiguration.isConfigurable() )
+            {
+                errorReports.add( jobValidation );
+            }
         }
 
         return errorReports;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -174,7 +174,7 @@ public class JobConfigurationObjectBundleHook
             // If the error is caused by the environment and the job is a non configurable job
             // that exists already, then the error can be ignored. Job has the issue with and
             // without updating it.
-            if ( (jobValidation.getErrorCode() != ErrorCode.E7010) || (persitedJobConfiguration == null) || jobConfiguration.isConfigurable() )
+            if ( jobValidation.getErrorCode() != ErrorCode.E7010 || persitedJobConfiguration == null || jobConfiguration.isConfigurable() )
             {
                 errorReports.add( jobValidation );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHookTest.java
@@ -1,0 +1,200 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.SchedulingManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link JobConfigurationObjectBundleHook}.
+ *
+ * @author Volker Schmidt
+ */
+public class JobConfigurationObjectBundleHookTest
+{
+    @Mock
+    private JobConfigurationService jobConfigurationService;
+
+    @Mock
+    private SchedulingManager schedulingManager;
+
+    @Mock
+    private Job job;
+
+    @InjectMocks
+    private JobConfigurationObjectBundleHook hook;
+
+    private JobConfiguration previousJobConfiguration;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp()
+    {
+        previousJobConfiguration = new JobConfiguration();
+        previousJobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        previousJobConfiguration.setEnabled( true );
+        previousJobConfiguration.setContinuousExecution( true );
+    }
+
+    @Test
+    public void validateInternalNonConfigurableChangeError()
+    {
+        Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
+            .thenReturn( previousJobConfiguration );
+        Mockito.when( schedulingManager.getJob( Mockito.eq( JobType.ANALYTICSTABLE_UPDATE ) ) )
+            .thenReturn( job );
+
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setUid( "jsdhJSJHD" );
+        jobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        jobConfiguration.setEnabled( false );
+        jobConfiguration.setContinuousExecution( true );
+
+        List<ErrorReport> errorReports = hook.validateInternal( jobConfiguration );
+        Assert.assertEquals( 1, errorReports.size() );
+        Assert.assertEquals( ErrorCode.E7003, errorReports.get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void validateInternalNonConfigurableChange()
+    {
+        Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
+            .thenReturn( previousJobConfiguration );
+        Mockito.when( schedulingManager.getJob( Mockito.eq( JobType.ANALYTICSTABLE_UPDATE ) ) )
+            .thenReturn( job );
+
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setUid( "jsdhJSJHD" );
+        jobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        jobConfiguration.setEnabled( true );
+        jobConfiguration.setContinuousExecution( true );
+
+        List<ErrorReport> errorReports = hook.validateInternal( jobConfiguration );
+        Assert.assertEquals( 0, errorReports.size() );
+    }
+
+    @Test
+    public void validateInternalNonConfigurableShownValidationErrorNonE7010()
+    {
+        Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
+            .thenReturn( previousJobConfiguration );
+        Mockito.when( schedulingManager.getJob( Mockito.eq( JobType.ANALYTICSTABLE_UPDATE ) ) )
+            .thenReturn( job );
+        Mockito.when( job.validate() ).thenReturn( new ErrorReport( Class.class, ErrorCode.E7000 ) );
+
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setUid( "jsdhJSJHD" );
+        jobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        jobConfiguration.setEnabled( true );
+        jobConfiguration.setContinuousExecution( true );
+
+        List<ErrorReport> errorReports = hook.validateInternal( jobConfiguration );
+        Assert.assertEquals( 1, errorReports.size() );
+        Assert.assertEquals( ErrorCode.E7000, errorReports.get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void validateInternalNonConfigurableShownValidationErrorE7010Configurable()
+    {
+        Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
+            .thenReturn( previousJobConfiguration );
+        Mockito.when( schedulingManager.getJob( Mockito.eq( JobType.DATA_SYNC ) ) )
+            .thenReturn( job );
+        Mockito.when( job.validate() ).thenReturn( new ErrorReport( Class.class, ErrorCode.E7010 ) );
+
+        previousJobConfiguration.setJobType( JobType.DATA_SYNC );
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setUid( "jsdhJSJHD" );
+        jobConfiguration.setJobType( JobType.DATA_SYNC );
+        jobConfiguration.setEnabled( true );
+        jobConfiguration.setContinuousExecution( true );
+
+        List<ErrorReport> errorReports = hook.validateInternal( jobConfiguration );
+        Assert.assertEquals( 1, errorReports.size() );
+        Assert.assertEquals( ErrorCode.E7010, errorReports.get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void validateInternalNonConfigurableShownValidationErrorE7010NoPrevious()
+    {
+        Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
+            .thenReturn( null );
+        Mockito.when( schedulingManager.getJob( Mockito.eq( JobType.ANALYTICSTABLE_UPDATE ) ) )
+            .thenReturn( job );
+        Mockito.when( job.validate() ).thenReturn( new ErrorReport( Class.class, ErrorCode.E7010 ) );
+
+        previousJobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setUid( "jsdhJSJHD" );
+        jobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        jobConfiguration.setEnabled( true );
+        jobConfiguration.setContinuousExecution( true );
+
+        List<ErrorReport> errorReports = hook.validateInternal( jobConfiguration );
+        Assert.assertEquals( 1, errorReports.size() );
+        Assert.assertEquals( ErrorCode.E7010, errorReports.get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void validateInternalNonConfigurableIgnoredValidationErrorE7010()
+    {
+        Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
+            .thenReturn( previousJobConfiguration );
+        Mockito.when( schedulingManager.getJob( Mockito.eq( JobType.ANALYTICSTABLE_UPDATE ) ) )
+            .thenReturn( job );
+        Mockito.when( job.validate() ).thenReturn( new ErrorReport( Class.class, ErrorCode.E7010 ) );
+
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setUid( "jsdhJSJHD" );
+        jobConfiguration.setJobType( JobType.ANALYTICSTABLE_UPDATE );
+        jobConfiguration.setEnabled( true );
+        jobConfiguration.setContinuousExecution( true );
+
+        List<ErrorReport> errorReports = hook.validateInternal( jobConfiguration );
+        Assert.assertEquals( 0, errorReports.size() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.metadata;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.dxf2.csv.CsvImportClass;
 import org.hisp.dhis.dxf2.csv.CsvImportOptions;
@@ -42,6 +43,7 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -62,6 +64,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.GML_IMPORT;
@@ -109,7 +112,13 @@ public class MetadataImportController
     public void postJsonMetadata( HttpServletRequest request, HttpServletResponse response ) throws IOException
     {
         MetadataImportParams params = metadataImportService.getParamsFromMap( contextService.getParameterValuesMap() );
-        params.setObjects( renderService.fromMetadata( StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() ), RenderFormat.JSON ) );
+
+        final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects =
+            renderService.fromMetadata( StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() ), RenderFormat.JSON );
+        // remove all data that cannot be exported explicitly and is not supported with other data formats
+        objects.remove( JobConfiguration.class );
+        params.setObjects( objects );
+
         response.setContentType( MediaType.APPLICATION_JSON_UTF8_VALUE );
 
         if ( params.hasJobId() )


### PR DESCRIPTION
- Just adding new jobs worked for JSON (updating did not work).
- New system jobs have standard UIDs in order to enable import on
  different systems in future versions.
- Create and update has been fixed for JSON.
- Create and update has been excluded (as in 2.29 and due to sync
  issues).