### PR TITLE
Fixed issues with colliding indexes in type import reports (#5937)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/IndexedObjectContainer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/IndexedObjectContainer.java
@@ -1,0 +1,68 @@
+package org.hisp.dhis.feedback;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.common.IdentifiableObject;
+
+import javax.annotation.Nonnull;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * Container with objects where the index of the object can be retrieved by the
+ * object itself.
+ *
+ * @author Volker Schmidt
+ */
+public class IndexedObjectContainer implements ObjectIndexProvider
+{
+    private final Map<IdentifiableObject, Integer> objectsIndexMap = new IdentityHashMap<>();
+
+    @Nonnull
+    @Override
+    public Integer mergeObjectIndex( @Nonnull IdentifiableObject object )
+    {
+        return add( object );
+    }
+
+    /**
+     * Adds an object to the container of indexed objects. If the object has
+     * already an index assigned, that will not be changed.
+     *
+     * @param object the object to which an index should be assigned.
+     * @return the resulting zero based index of the added object in the container.
+     */
+    @Nonnull
+    protected Integer add( @Nonnull IdentifiableObject object )
+    {
+        final Integer newIndex = objectsIndexMap.size();
+        final Integer existingIndex = objectsIndexMap.putIfAbsent( object, newIndex );
+        return ( existingIndex == null ) ? newIndex : existingIndex;
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectIndexProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectIndexProvider.java
@@ -1,0 +1,53 @@
+package org.hisp.dhis.feedback;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.common.IdentifiableObject;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Provides a zero based index for an object. The zero based unique index
+ * may be unique based on a type.
+ *
+ * @author Volker Schmidt
+ */
+@FunctionalInterface
+public interface ObjectIndexProvider
+{
+    /**
+     * Returns the object index for the specified object. If the
+     * object has not yet an index, an index will be created.
+     *
+     * @param object the object for which an index should be returned.
+     * @return the index of the specified object.
+     */
+    @Nonnull
+    Integer mergeObjectIndex( @Nonnull IdentifiableObject object );
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectReport.java
@@ -34,7 +34,10 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.base.MoreObjects;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.IdentifiableObject;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,6 +64,16 @@ public class ObjectReport
     private String displayName;
 
     private Map<ErrorCode, List<ErrorReport>> errorReportsByCode = new HashMap<>();
+
+    public ObjectReport( @Nonnull IdentifiableObject object, @Nonnull ObjectIndexProvider objectIndexProvider )
+    {
+        this( object, objectIndexProvider, null );
+    }
+
+    public ObjectReport( @Nonnull IdentifiableObject object, @Nonnull ObjectIndexProvider objectIndexProvider, @Nullable String uid )
+    {
+        this( object.getClass(), objectIndexProvider.mergeObjectIndex( object ), uid == null ? object.getUid() : uid );
+    }
 
     public ObjectReport( Class<?> klass, Integer index )
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/TypedIndexedObjectContainer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/TypedIndexedObjectContainer.java
@@ -1,0 +1,74 @@
+package org.hisp.dhis.feedback;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.common.IdentifiableObject;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link IndexedObjectContainer}s for each object type.
+ *
+ * @author Volker Schmidt
+ */
+public class TypedIndexedObjectContainer implements ObjectIndexProvider
+{
+    private final Map<Class<? extends IdentifiableObject>, IndexedObjectContainer> typedIndexedObjectContainers = new HashMap<>();
+
+    /**
+     * Get the typed container for the specified object class.
+     *
+     * @param c the object class for which the container should be returned.
+     * @return the container (if it does not exists, the method creates a container).
+     */
+    @Nonnull
+    public IndexedObjectContainer getTypedContainer( @Nonnull Class<? extends IdentifiableObject> c )
+    {
+        return typedIndexedObjectContainers.computeIfAbsent( c, key -> new IndexedObjectContainer() );
+    }
+
+    @Nonnull
+    @Override
+    public Integer mergeObjectIndex( @Nonnull IdentifiableObject object )
+    {
+        return getTypedContainer( object.getClass() ).mergeObjectIndex( object );
+    }
+
+    /**
+     * Adds an object to the corresponding indexed object container.
+     *
+     * @param identifiableObject the object that should be added to the container.
+     */
+    public void add( @Nonnull IdentifiableObject identifiableObject )
+    {
+        getTypedContainer( identifiableObject.getClass() ).add( identifiableObject );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/IndexedObjectContainerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/IndexedObjectContainerTest.java
@@ -1,0 +1,69 @@
+package org.hisp.dhis.feedback;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.attribute.Attribute;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link IndexedObjectContainer}.
+ *
+ * @author Volker Schmidt
+ */
+public class IndexedObjectContainerTest
+{
+    private final IndexedObjectContainer container = new IndexedObjectContainer();
+
+    @Test
+    public void merge()
+    {
+        final Attribute attribute1 = new Attribute();
+        final Attribute attribute2 = new Attribute();
+        final Attribute attribute3 = new Attribute();
+
+        Assert.assertEquals( (Integer) 0, container.mergeObjectIndex( attribute1 ) );
+        Assert.assertEquals( (Integer) 1, container.mergeObjectIndex( attribute2 ) );
+        Assert.assertEquals( (Integer) 0, container.mergeObjectIndex( attribute1 ) );
+        Assert.assertEquals( (Integer) 2, container.mergeObjectIndex( attribute3 ) );
+    }
+
+    @Test
+    public void add()
+    {
+        final Attribute attribute1 = new Attribute();
+        final Attribute attribute2 = new Attribute();
+        final Attribute attribute3 = new Attribute();
+
+        Assert.assertEquals( (Integer) 0, container.add( attribute1 ) );
+        Assert.assertEquals( (Integer) 1, container.add( attribute2 ) );
+        Assert.assertEquals( (Integer) 0, container.add( attribute1 ) );
+        Assert.assertEquals( (Integer) 2, container.add( attribute3 ) );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/ObjectReportTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/ObjectReportTest.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.feedback;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.attribute.Attribute;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ObjectReport}.
+ *
+ * @author Volker Schmidt
+ */
+public class ObjectReportTest
+{
+    @Test
+    public void init()
+    {
+        final Attribute attribute = new Attribute();
+        attribute.setUid( "sdkjjJHSH843" );
+
+        final ObjectReport objectReport = new ObjectReport( attribute, a -> {
+            Assert.assertSame( attribute, a );
+            return 7;
+        } );
+        Assert.assertEquals( Attribute.class, objectReport.getKlass() );
+        Assert.assertEquals( (Integer) 7, objectReport.getIndex() );
+        Assert.assertEquals( "sdkjjJHSH843", objectReport.getUid() );
+    }
+
+    @Test
+    public void initWithUid()
+    {
+        final Attribute attribute = new Attribute();
+        attribute.setUid( "sdkjjJHSH843" );
+
+        final ObjectReport objectReport = new ObjectReport( attribute, a -> {
+            Assert.assertSame( attribute, a );
+            return 9;
+        }, "kshdgh283" );
+        Assert.assertEquals( Attribute.class, objectReport.getKlass() );
+        Assert.assertEquals( (Integer) 9, objectReport.getIndex() );
+        Assert.assertEquals( "kshdgh283", objectReport.getUid() );
+    }
+
+    @Test
+    public void initWithNullUid()
+    {
+        final Attribute attribute = new Attribute();
+        attribute.setUid( "sdkjjJHSH843" );
+
+        final ObjectReport objectReport = new ObjectReport( attribute, a -> {
+            Assert.assertSame( attribute, a );
+            return 9;
+        }, null );
+        Assert.assertEquals( Attribute.class, objectReport.getKlass() );
+        Assert.assertEquals( (Integer) 9, objectReport.getIndex() );
+        Assert.assertEquals( "sdkjjJHSH843", objectReport.getUid() );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/TypedIndexedObjectContainerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/TypedIndexedObjectContainerTest.java
@@ -1,0 +1,113 @@
+package org.hisp.dhis.feedback;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.category.Category;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link TypedIndexedObjectContainer}.
+ *
+ * @author Volker Schmidt
+ */
+public class TypedIndexedObjectContainerTest
+{
+    private final TypedIndexedObjectContainer container = new TypedIndexedObjectContainer();
+
+    @Test
+    public void getContainerNew()
+    {
+        IndexedObjectContainer container1 = container.getTypedContainer( Attribute.class );
+        Assert.assertSame( container1, container.getTypedContainer( Attribute.class ) );
+
+        IndexedObjectContainer container2 = container.getTypedContainer( Category.class );
+        Assert.assertSame( container2, container.getTypedContainer( Category.class ) );
+        Assert.assertNotSame( container1, container2 );
+
+        Assert.assertSame( container1, container.getTypedContainer( Attribute.class ) );
+    }
+
+    @Test
+    public void getContainerExisting()
+    {
+        final Attribute attribute1 = new Attribute();
+        final Category category1 = new Category();
+
+        container.mergeObjectIndex( new Attribute() );
+        container.mergeObjectIndex( new Category() );
+        container.mergeObjectIndex( attribute1 );
+        container.mergeObjectIndex( category1 );
+
+        IndexedObjectContainer container1 = container.getTypedContainer( Attribute.class );
+        Assert.assertSame( 1, container1.mergeObjectIndex( attribute1 ) );
+
+        IndexedObjectContainer container2 = container.getTypedContainer( Category.class );
+        Assert.assertSame( 1, container2.mergeObjectIndex( category1 ) );
+    }
+
+    @Test
+    public void merge()
+    {
+        final Attribute attribute1 = new Attribute();
+        final Attribute attribute2 = new Attribute();
+        final Attribute attribute3 = new Attribute();
+        final Category category1 = new Category();
+        final Category category2 = new Category();
+
+        Assert.assertEquals( (Integer) 0, container.mergeObjectIndex( attribute1 ) );
+        Assert.assertEquals( (Integer) 1, container.mergeObjectIndex( attribute2 ) );
+        Assert.assertEquals( (Integer) 2, container.mergeObjectIndex( attribute3 ) );
+        Assert.assertEquals( (Integer) 0, container.mergeObjectIndex( category1 ) );
+        Assert.assertEquals( (Integer) 1, container.mergeObjectIndex( category2 ) );
+    }
+
+    @Test
+    public void add()
+    {
+        final Attribute attribute1 = new Attribute();
+        final Attribute attribute2 = new Attribute();
+        final Attribute attribute3 = new Attribute();
+        final Category category1 = new Category();
+        final Category category2 = new Category();
+
+        container.add( attribute1 );
+        container.add( attribute2 );
+        container.add( attribute3 );
+        container.add( category1 );
+        container.add( category2 );
+
+        Assert.assertEquals( (Integer) 0, container.mergeObjectIndex( attribute1 ) );
+        Assert.assertEquals( (Integer) 1, container.mergeObjectIndex( attribute2 ) );
+        Assert.assertEquals( (Integer) 2, container.mergeObjectIndex( attribute3 ) );
+        Assert.assertEquals( (Integer) 0, container.mergeObjectIndex( category1 ) );
+        Assert.assertEquals( (Integer) 1, container.mergeObjectIndex( category2 ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -241,7 +241,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
         {
             IdentifiableObject object = objects.get( idx );
 
-            ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+            ObjectReport objectReport = new ObjectReport( object, bundle );
             objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
             typeReport.addObjectReport( objectReport );
 
@@ -340,7 +340,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
             IdentifiableObject object = objects.get( idx );
             IdentifiableObject persistedObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), object );
 
-            ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+            ObjectReport objectReport = new ObjectReport( object, bundle );
             objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
             typeReport.addObjectReport( objectReport );
 
@@ -444,7 +444,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
         for ( int idx = 0; idx < persistedObjects.size(); idx++ )
         {
             IdentifiableObject object = persistedObjects.get( idx );
-            ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+            ObjectReport objectReport = new ObjectReport( object, bundle );
             objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
             typeReport.addObjectReport( objectReport );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -123,7 +123,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
             cleanDefaults( bundle.getPreheat(), nonPersistedObjects );
             cleanDefaults( bundle.getPreheat(), persistedObjects );
 
-            typeReport.merge( checkDuplicateIds( klass, persistedObjects, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+            typeReport.merge( checkDuplicateIds( bundle, klass, persistedObjects, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
 
             if ( bundle.getImportMode().isCreateAndUpdate() )
             {
@@ -133,14 +133,14 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.UPDATE ) );
                 typeReport.merge( validateBySchemas( klass, nonPersistedObjects, bundle ) );
                 typeReport.merge( validateBySchemas( klass, persistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueness( klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueness( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueness( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkMandatoryAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkMandatoryAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
 
-                TypeReport checkReferences = checkReferences( klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
+                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
 
                 if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
                 {
@@ -158,11 +158,11 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 typeReport.merge( validateSecurity( klass, nonPersistedObjects, bundle, ImportStrategy.CREATE ) );
                 typeReport.merge( validateForCreate( klass, persistedObjects, bundle ) );
                 typeReport.merge( validateBySchemas( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueness( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkMandatoryAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
 
-                TypeReport checkReferences = checkReferences( klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
+                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
 
                 if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
                 {
@@ -179,11 +179,11 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.UPDATE ) );
                 typeReport.merge( validateForUpdate( klass, nonPersistedObjects, bundle ) );
                 typeReport.merge( validateBySchemas( klass, persistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueness( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkMandatoryAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
+                typeReport.merge( checkUniqueAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
 
-                TypeReport checkReferences = checkReferences( klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
+                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
 
                 if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
                 {
@@ -242,7 +242,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReports( errorReports );
 
@@ -300,7 +300,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
             {
                 if ( !aclService.canCreate( bundle.getUser(), klass ) )
                 {
-                    ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                    ObjectReport objectReport = new ObjectReport( object, bundle );
                     objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                     objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3000, identifier.getIdentifiersWithName( bundle.getUser() ),
                         identifier.getIdentifiersWithName( object ) ) );
@@ -320,7 +320,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 {
                     if ( !aclService.canUpdate( bundle.getUser(), persistedObject ) )
                     {
-                        ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                        ObjectReport objectReport = new ObjectReport( object, bundle );
                         objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                         objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3001, identifier.getIdentifiersWithName( bundle.getUser() ),
                             identifier.getIdentifiersWithName( object ) ) );
@@ -336,7 +336,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 {
                     if ( !aclService.canDelete( bundle.getUser(), persistedObject ) )
                     {
-                        ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                        ObjectReport objectReport = new ObjectReport( object, bundle );
                         objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                         objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3002, identifier.getIdentifiersWithName( bundle.getUser() ),
                             identifier.getIdentifiersWithName( object ) ) );
@@ -357,7 +357,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
                 if ( !errorReports.isEmpty() )
                 {
-                    ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                    ObjectReport objectReport = new ObjectReport( object, bundle );
                     objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                     objectReport.addErrorReports( errorReports );
 
@@ -373,7 +373,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( !sharingErrorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReports( sharingErrorReports );
 
@@ -409,7 +409,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( object != null && object.getId() > 0 )
             {
-                ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object.getUid() );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) ).setMainId( identifiableObject.getUid() ) );
@@ -445,7 +445,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( object == null || object.getId() == 0 )
             {
-                ObjectReport objectReport = new ObjectReport( klass, idx, object != null ? object.getUid() : null );
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
@@ -483,7 +483,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( object == null || object.getId() == 0 )
             {
-                ObjectReport objectReport = new ObjectReport( klass, idx, object != null ? object.getUid() : null );
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) ).setMainId( object != null ? object.getUid() : null ) );
@@ -519,7 +519,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( !validationErrorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( klass, idx, object.getUid() );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReports( validationErrorReports );
 
@@ -555,7 +555,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         return klasses;
     }
 
-    private TypeReport checkReferences( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier, boolean skipSharing )
+    private TypeReport checkReferences( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier, boolean skipSharing )
     {
         TypeReport typeReport = new TypeReport( klass );
 
@@ -571,7 +571,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( errorReports.isEmpty() ) continue;
 
-            ObjectReport objectReport = new ObjectReport( object.getClass(), idx );
+            ObjectReport objectReport = new ObjectReport( object, bundle );
             objectReport.addErrorReports( errorReports );
             typeReport.addObjectReport( objectReport );
         }
@@ -665,7 +665,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         return preheatErrorReports;
     }
 
-    private TypeReport checkDuplicateIds( Class<? extends IdentifiableObject> klass,
+    private TypeReport checkDuplicateIds( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects, Preheat preheat, PreheatIdentifier identifier )
     {
         TypeReport typeReport = new TypeReport( klass );
@@ -689,7 +689,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(), object.getClass() )
                     .setMainId( object.getUid() ).setErrorProperty( "id" );
 
-                ObjectReport objectReport = new ObjectReport( object.getClass(), idx );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReport( errorReport );
                 typeReport.addObjectReport( objectReport );
@@ -717,7 +717,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
                 ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(), object.getClass() )
                     .setMainId( object.getUid() ).setErrorProperty( "id" );
 
-                ObjectReport objectReport = new ObjectReport( object.getClass(), idx );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReport( errorReport );
                 typeReport.addObjectReport( objectReport );
@@ -736,7 +736,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         return typeReport;
     }
 
-    private TypeReport checkUniqueness( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
+    private TypeReport checkUniqueness( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
     {
         TypeReport typeReport = new TypeReport( klass );
 
@@ -767,7 +767,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object.getClass(), idx );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReports( errorReports );
                 typeReport.addObjectReport( objectReport );
@@ -831,7 +831,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         return errorReports;
     }
 
-    private TypeReport checkMandatoryAttributes( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
+    private TypeReport checkMandatoryAttributes( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
     {
         TypeReport typeReport = new TypeReport( klass );
         Schema schema = schemaService.getDynamicSchema( klass );
@@ -842,7 +842,6 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         }
 
         Iterator<IdentifiableObject> iterator = objects.iterator();
-        int idx = 0;
 
         while ( iterator.hasNext() )
         {
@@ -851,7 +850,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object.getClass(), idx );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReports( errorReports );
                 typeReport.addObjectReport( objectReport );
@@ -859,8 +858,6 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
                 iterator.remove();
             }
-
-            idx++;
         }
 
         return typeReport;
@@ -890,7 +887,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         return errorReports;
     }
 
-    private TypeReport checkUniqueAttributes( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
+    private TypeReport checkUniqueAttributes( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
     {
         TypeReport typeReport = new TypeReport( klass );
         Schema schema = schemaService.getDynamicSchema( klass );
@@ -910,7 +907,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object.getClass(), idx );
+                ObjectReport objectReport = new ObjectReport( object, bundle );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReports( errorReports );
                 typeReport.addObjectReport( objectReport );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
@@ -33,6 +33,8 @@ import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.FlushMode;
 import org.hisp.dhis.dxf2.metadata.UserOverrideMode;
+import org.hisp.dhis.feedback.ObjectIndexProvider;
+import org.hisp.dhis.feedback.TypedIndexedObjectContainer;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.preheat.PreheatIdentifier;
@@ -41,6 +43,7 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.User;
 import org.springframework.util.StringUtils;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,7 +54,7 @@ import java.util.Set;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class ObjectBundle
+public class ObjectBundle implements ObjectIndexProvider
 {
     /**
      * User to use for import job (important for threaded imports).
@@ -138,6 +141,11 @@ public class ObjectBundle
      * Objects to import.
      */
     private Map<Boolean, Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>>> objects = new HashMap<>();
+
+    /**
+     * Contains the indexes of the objects to be imported grouped by their type.
+     */
+    private final TypedIndexedObjectContainer typedIndexedObjectContainer = new TypedIndexedObjectContainer();
 
     /**
      * Pre-scanned map of all object references (mainly used for object book hundle).
@@ -275,6 +283,13 @@ public class ObjectBundle
         return preheat;
     }
 
+    @Nonnull
+    @Override
+    public Integer mergeObjectIndex( @Nonnull IdentifiableObject object )
+    {
+        return typedIndexedObjectContainer.mergeObjectIndex( object );
+    }
+
     private void addObject( IdentifiableObject object )
     {
         if ( object == null )
@@ -301,6 +316,8 @@ public class ObjectBundle
             objects.get( Boolean.FALSE ).get( object.getClass() ).add( object );
 
         }
+
+        typedIndexedObjectContainer.add( object );
     }
 
     private void addObject( List<IdentifiableObject> objects )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleTest.java
@@ -1,0 +1,106 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ObjectBundle}.
+ *
+ * @author Volker Schmidt
+ */
+public class ObjectBundleTest
+{
+    private ObjectBundle objectBundle;
+
+    private ObjectBundleParams objectBundleParams;
+
+    private Preheat preheat;
+
+    private Attribute attribute1 = new Attribute();
+
+    private Attribute attribute2 = new Attribute();
+
+    private Attribute attribute3 = new Attribute();
+
+    private Category category1 = new Category();
+
+    private Category category2 = new Category();
+
+    @Before
+    public void setUp()
+    {
+        attribute1.setUid( "u1" );
+        attribute2.setUid( "u2" );
+        attribute2.setUid( "u3" );
+        category1.setUid( "u7" );
+        category2.setUid( "u8" );
+
+        objectBundleParams = new ObjectBundleParams();
+        preheat = new Preheat();
+
+        final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = new HashMap<>();
+        objectMap.put( Attribute.class, new ArrayList<>() );
+        objectMap.put( Category.class, new ArrayList<>() );
+
+        objectMap.get( Attribute.class ).add( attribute1 );
+        objectMap.get( Attribute.class ).add( attribute2 );
+        objectMap.get( Attribute.class ).add( attribute3 );
+        objectMap.get( Category.class ).add( category1 );
+        objectMap.get( Category.class ).add( category2 );
+
+        preheat.put( PreheatIdentifier.UID, attribute1 );
+        preheat.put( PreheatIdentifier.UID, attribute3 );
+        preheat.put( PreheatIdentifier.UID, category1 );
+
+        objectBundle = new ObjectBundle( objectBundleParams, preheat, objectMap );
+    }
+
+    @Test
+    public void objectIndex()
+    {
+        Assert.assertEquals( (Integer) 2, objectBundle.mergeObjectIndex( attribute3 ) );
+        Assert.assertEquals( (Integer) 0, objectBundle.mergeObjectIndex( attribute1 ) );
+        Assert.assertEquals( (Integer) 1, objectBundle.mergeObjectIndex( attribute2 ) );
+        Assert.assertEquals( (Integer) 1, objectBundle.mergeObjectIndex( category2 ) );
+        Assert.assertEquals( (Integer) 0, objectBundle.mergeObjectIndex( category1 ) );
+    }
+}


### PR DESCRIPTION
- Objects are divided in persisted and non-persisted objects.
- Zero based indexes for persisted and non-persisted objects
  where used for union of both (colliding indexes) when reporting
  results.
- Indexes in returned results are now the indexes of the original
  requested typed data.