### PR TITLE
Add default values for regressionType and HideEmptyItemStrategy in BasChart

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/chart/BaseChart.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/chart/BaseChart.java
@@ -77,7 +77,7 @@ public abstract class BaseChart
 
     protected boolean noSpaceBetweenColumns;
 
-    protected RegressionType regressionType;
+    protected RegressionType regressionType = RegressionType.NONE;
 
     protected Double targetLineValue;
 
@@ -89,7 +89,7 @@ public abstract class BaseChart
 
     protected boolean showData;
 
-    protected HideEmptyItemStrategy hideEmptyRowItems;
+    protected HideEmptyItemStrategy hideEmptyRowItems = HideEmptyItemStrategy.NONE;
 
     protected boolean percentStackedValues;
 


### PR DESCRIPTION
Properties regressionType and hideEmptyRowItems in BaseChart was null by default which caused issues when inserting into not-null fields in database. These properties now have "NONE" as their default values.

Issue: DHIS2-5735