### PR TITLE
Remove overriding method for POST maps

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -119,20 +119,6 @@ public class MapController
     //--------------------------------------------------------------------------
 
     @Override
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
-    @ResponseStatus( HttpStatus.CREATED )
-    public void postJsonObject( HttpServletRequest request, HttpServletResponse response ) throws Exception
-    {
-        Map map = deserializeJsonEntity( request, response );
-        map.getTranslations().clear();
-
-        mappingService.addMap( map );
-
-        response.addHeader( "Location", MapSchemaDescriptor.API_ENDPOINT + "/" + map.getUid() );
-        webMessageService.send( WebMessageUtils.created( "Map created" ), response, request );
-    }
-
-    @Override
     @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = "application/json" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void putJsonObject( @PathVariable String uid, HttpServletRequest request, HttpServletResponse response ) throws Exception


### PR DESCRIPTION
Method was using the same logic as AbstractCrudController, but did not return the proper response as expected. By removing the method, maps are now created similar like other metadata using AbstractCrudController and returns the appropriate response.

Issue: DHIS2-5739