### PR TITLE
Fix double encoded request in data-entry-app (v30)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1075,13 +1075,11 @@ function organisationUnitSelected( orgUnits, orgUnitNames, children )
 dhis2.de.fetchDataSets = function( ou )
 {
     var def = $.Deferred();
+    var fieldsParam = encodeURIComponent('id,dataSets[id],children[id,dataSets[id]]');
 
     $.ajax({
         type: 'GET',
-        url: '../api/organisationUnits/' + ou,
-        data: {
-            fields: encodeURIComponent('id,dataSets[id],children[id,dataSets[id]]')
-        }
+        url: '../api/organisationUnits/' + ou + '?fields=' + fieldsParam
     }).done(function(data) {
         dhis2.de._updateDataSets(data);
 


### PR DESCRIPTION
@varl noticed that after the changes from https://jira.dhis2.org/browse/DHIS2-5081, we're sending a double encoded request from the data-entry app (from [here](https://github.com/dhis2/dhis2-core/blob/2.30/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js#L1079)). It doesn't affect all browser (doesn't affect FF for example).

See also:

- https://github.com/dhis2/dhis2-core/pull/3071
- https://github.com/dhis2/dhis2-core/pull/3072
- https://github.com/dhis2/dhis2-core/pull/3073