### PR TITLE
Added protection of sharing settings of default objects (#4455).

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -113,6 +113,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-commons</artifactId>
     </dependency>

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/Category.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/Category.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +58,7 @@ import java.util.List;
  */
 @JacksonXmlRootElement( localName = "category", namespace = DxfNamespaces.DXF_2_0 )
 public class Category
-    extends BaseDimensionalObject implements MetadataObject
+    extends BaseDimensionalObject implements SystemDefaultMetadataObject
 {
     public static final String DEFAULT_NAME = "default";
 
@@ -149,6 +149,7 @@ public class Category
         return null;
     }
 
+    @Override
     public boolean isDefault()
     {
         return DEFAULT_NAME.equals( name );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
@@ -39,7 +39,7 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.CombinationGenerator;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  */
 @JacksonXmlRootElement( localName = "categoryCombo", namespace = DxfNamespaces.DXF_2_0 )
 public class CategoryCombo
-    extends BaseIdentifiableObject implements MetadataObject
+    extends BaseIdentifiableObject implements SystemDefaultMetadataObject
 {
     public static final String DEFAULT_CATEGORY_COMBO_NAME = "default";
 
@@ -104,6 +104,7 @@ public class CategoryCombo
     // -------------------------------------------------------------------------
 
     @JsonProperty( "isDefault" )
+    @Override
     public boolean isDefault()
     {
         return DEFAULT_CATEGORY_COMBO_NAME.equals( name );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -39,8 +39,8 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.ObjectStyle;
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 
@@ -53,7 +53,7 @@ import java.util.Set;
  */
 @JacksonXmlRootElement( localName = "categoryOption", namespace = DxfNamespaces.DXF_2_0 )
 public class CategoryOption
-    extends BaseDimensionalItemObject implements MetadataObject
+    extends BaseDimensionalItemObject implements SystemDefaultMetadataObject
 {
     public static final String DEFAULT_NAME = "default";
 
@@ -90,6 +90,7 @@ public class CategoryOption
     // -------------------------------------------------------------------------
 
     @JsonProperty( "isDefault" )
+    @Override
     public boolean isDefault()
     {
         return DEFAULT_NAME.equals( name );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DateRange;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 import java.util.Date;
@@ -55,7 +55,7 @@ import java.util.Set;
  */
 @JacksonXmlRootElement( localName = "categoryOptionCombo", namespace = DxfNamespaces.DXF_2_0 )
 public class CategoryOptionCombo
-    extends BaseDimensionalItemObject implements MetadataObject
+    extends BaseDimensionalItemObject implements SystemDefaultMetadataObject
 {
     public static final String DEFAULT_NAME = "default";
 
@@ -196,6 +196,7 @@ public class CategoryOptionCombo
         categoryOptions.clear();
     }
 
+    @Override
     public boolean isDefault()
     {
         return categoryCombo != null && DEFAULT_NAME.equals( categoryCombo.getName() );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SystemDefaultMetadataObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SystemDefaultMetadataObject.java
@@ -1,0 +1,47 @@
+package org.hisp.dhis.common;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Marker interface marking the class as a proper metadata object
+ * (not data, not embedded object, etc) and specifies that the system itself
+ * creates a predefined set of metadata objects of this type.
+ *
+ * @author Volker Schmidt
+ */
+public interface SystemDefaultMetadataObject extends MetadataObject
+{
+    /**
+     * Checks if this metadata object is a system default metadata object.
+     *
+     * @return <code>true</code> if this metadata object is a system default
+     * metadata object, <code>false</code> if it is user generated.
+     */
+    boolean isDefault();
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryComboTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryComboTest.java
@@ -1,0 +1,65 @@
+package org.hisp.dhis.category;
+
+/*
+ *
+ *  Copyright (c) 2004-2019, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CategoryCombo}.
+ *
+ * @author Volker Schmidt
+ */
+public class CategoryComboTest
+{
+    @Test
+    public void hasDefault()
+    {
+        Assert.assertTrue( SystemDefaultMetadataObject.class.isAssignableFrom( CategoryCombo.class ) );
+    }
+
+    @Test
+    public void isDefault()
+    {
+        CategoryCombo category = new CategoryCombo();
+        category.setName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME );
+        Assert.assertTrue( category.isDefault() );
+    }
+
+    @Test
+    public void isNotDefault()
+    {
+        CategoryCombo category = new CategoryCombo();
+        category.setName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME + "x" );
+        Assert.assertFalse( category.isDefault() );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
@@ -1,0 +1,71 @@
+package org.hisp.dhis.category;
+
+/*
+ *
+ *  Copyright (c) 2004-2019, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CategoryOptionCombo}.
+ *
+ * @author Volker Schmidt
+ */
+public class CategoryOptionComboTest
+{
+    @Test
+    public void hasDefault()
+    {
+        Assert.assertTrue( SystemDefaultMetadataObject.class.isAssignableFrom( CategoryOption.class ) );
+    }
+
+    @Test
+    public void isDefault()
+    {
+        CategoryCombo category = new CategoryCombo();
+        category.setName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME );
+
+        CategoryOptionCombo categoryOptionCombo = new CategoryOptionCombo();
+        categoryOptionCombo.setCategoryCombo( category );
+        Assert.assertTrue( categoryOptionCombo.isDefault() );
+    }
+
+    @Test
+    public void isNotDefault()
+    {
+        CategoryCombo category = new CategoryCombo();
+        category.setName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME + "x" );
+
+        CategoryOptionCombo categoryOptionCombo = new CategoryOptionCombo();
+        categoryOptionCombo.setCategoryCombo( category );
+        Assert.assertFalse( categoryOptionCombo.isDefault() );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionTest.java
@@ -1,0 +1,65 @@
+package org.hisp.dhis.category;
+
+/*
+ *
+ *  Copyright (c) 2004-2019, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CategoryOption}.
+ *
+ * @author Volker Schmidt
+ */
+public class CategoryOptionTest
+{
+    @Test
+    public void hasDefault()
+    {
+        Assert.assertTrue( SystemDefaultMetadataObject.class.isAssignableFrom( CategoryOption.class ) );
+    }
+
+    @Test
+    public void isDefault()
+    {
+        CategoryOption category = new CategoryOption();
+        category.setName( CategoryOption.DEFAULT_NAME );
+        Assert.assertTrue( category.isDefault() );
+    }
+
+    @Test
+    public void isNotDefault()
+    {
+        CategoryOption category = new CategoryOption();
+        category.setName( CategoryOption.DEFAULT_NAME + "x" );
+        Assert.assertFalse( category.isDefault() );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryTest.java
@@ -1,0 +1,65 @@
+package org.hisp.dhis.category;
+
+/*
+ *
+ *  Copyright (c) 2004-2019, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Category}.
+ *
+ * @author Volker Schmidt
+ */
+public class CategoryTest
+{
+    @Test
+    public void hasDefault()
+    {
+        Assert.assertTrue( SystemDefaultMetadataObject.class.isAssignableFrom( Category.class ) );
+    }
+
+    @Test
+    public void isDefault()
+    {
+        Category category = new Category();
+        category.setName( Category.DEFAULT_NAME );
+        Assert.assertTrue( category.isDefault() );
+    }
+
+    @Test
+    public void isNotDefault()
+    {
+        Category category = new Category();
+        category.setName( Category.DEFAULT_NAME + "x" );
+        Assert.assertFalse( category.isDefault() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.program.Program;
@@ -225,6 +226,11 @@ public class SharingController
         if ( object == null )
         {
             throw new WebMessageException( WebMessageUtils.notFound( "Object of type " + type + " with ID " + id + " was not found." ) );
+        }
+
+        if ( ( object instanceof SystemDefaultMetadataObject ) && ( (SystemDefaultMetadataObject) object ).isDefault() )
+        {
+            throw new WebMessageException( WebMessageUtils.conflict( "Sharing settings of system default metadata object of type " + type + " cannot be modified." ) );
         }
 
         User user = currentUserService.getCurrentUser();

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -1,0 +1,150 @@
+package org.hisp.dhis.webapi.controller;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.UserAccessService;
+import org.hisp.dhis.user.UserGroupAccessService;
+import org.hisp.dhis.user.UserGroupService;
+import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.webapi.service.WebMessageService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.hamcrest.core.StringContains.containsString;
+
+/**
+ * Unit tests for {@link SharingController}.
+ *
+ * @author Volker Schmidt
+ */
+public class SharingControllerTest
+{
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private IdentifiableObjectManager manager;
+
+    @Mock
+    private UserGroupService userGroupService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserGroupAccessService userGroupAccessService;
+
+    @Mock
+    private UserAccessService userAccessService;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private WebMessageService webMessageService;
+
+    @Mock
+    private RenderService renderService;
+
+    @Mock
+    private SchemaService schemaService;
+
+    private MockHttpServletRequest request = new MockHttpServletRequest();
+
+    private MockHttpServletResponse response = new MockHttpServletResponse();
+
+    @InjectMocks
+    private SharingController sharingController;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test( expected = AccessDeniedException.class )
+    public void notSystemDefaultMetadataNoAccess() throws Exception
+    {
+        final OrganisationUnit organisationUnit = new OrganisationUnit();
+
+        Mockito.doReturn( OrganisationUnit.class ).when( aclService ).classForType( Mockito.eq( "organisationUnit" ) );
+        Mockito.when( aclService.isShareable( Mockito.eq( OrganisationUnit.class ) ) ).thenReturn( true );
+        Mockito.doReturn( organisationUnit ).when( manager ).get( Mockito.eq( OrganisationUnit.class ), Mockito.eq( "kkSjhdhks" ) );
+
+        sharingController.setSharing( "organisationUnit", "kkSjhdhks", response, request );
+    }
+
+    @Test( expected = AccessDeniedException.class )
+    public void systemDefaultMetadataNoAccess() throws Exception
+    {
+        final Category category = new Category();
+        category.setName( Category.DEFAULT_NAME + "x" );
+
+        Mockito.doReturn( Category.class ).when( aclService ).classForType( Mockito.eq( "category" ) );
+        Mockito.when( aclService.isShareable( Mockito.eq( Category.class ) ) ).thenReturn( true );
+        Mockito.when( manager.get( Mockito.eq( Category.class ), Mockito.eq( "kkSjhdhks" ) ) ).thenReturn( category );
+
+        sharingController.setSharing( "category", "kkSjhdhks", response, request );
+    }
+
+    @Test( expected = WebMessageException.class )
+    public void systemDefaultMetadata() throws Exception
+    {
+        final Category category = new Category();
+        category.setName( Category.DEFAULT_NAME );
+
+        Mockito.doReturn( Category.class ).when( aclService ).classForType( Mockito.eq( "category" ) );
+        Mockito.when( aclService.isShareable( Mockito.eq( Category.class ) ) ).thenReturn( true );
+        Mockito.when( manager.get( Mockito.eq( Category.class ), Mockito.eq( "kkSjhdhks" ) ) ).thenReturn( category );
+
+        try
+        {
+            sharingController.setSharing( "category", "kkSjhdhks", response, request );
+        }
+        catch ( WebMessageException e )
+        {
+            Assert.assertThat( e.getWebMessage().getMessage(), containsString( "Sharing settings of system default metadata object" ) );
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
The classes had already a method isDefault(), but no common interface that defines that method. A new interface that can be used to check if an object is a system default metadata object has been introduced and is checked when sharing settings are tried to get updated.