### PR TITLE
Fix user creation issues

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -40,6 +40,8 @@ import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.annotation.Property;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.security.Authorities;
 import org.springframework.util.StringUtils;
@@ -621,6 +623,7 @@ public class User
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @Property( required = Property.Value.TRUE, value = PropertyType.REFERENCE )
     public UserCredentials getUserCredentials()
     {
         return userCredentials;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -61,7 +61,7 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
     private FileResourceService fileResourceService;
 
     @Autowired
-    CurrentUserService currentUserService;
+    private CurrentUserService currentUserService;
 
     @Override
     public <T extends IdentifiableObject> List<ErrorReport> validate( T object, ObjectBundle bundle )
@@ -92,11 +92,14 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
 
         User currentUser = currentUserService.getCurrentUser();
 
-        user.getUserCredentials().getCogsDimensionConstraints().addAll(
-            currentUser.getUserCredentials().getCogsDimensionConstraints() );
+        if ( currentUser != null )
+        {
+            user.getUserCredentials().getCogsDimensionConstraints().addAll(
+                currentUser.getUserCredentials().getCogsDimensionConstraints() );
 
-        user.getUserCredentials().getCatDimensionConstraints().addAll(
-            currentUser.getUserCredentials().getCatDimensionConstraints() );
+            user.getUserCredentials().getCatDimensionConstraints().addAll(
+                currentUser.getUserCredentials().getCatDimensionConstraints() );
+        }
 
         bundle.putExtras( user, "uc", user.getUserCredentials() );
         user.setUserCredentials( null );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.schema.MergeParams;
 import org.hisp.dhis.system.util.ValidationUtils;
+import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
@@ -58,6 +59,9 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
 
     @Autowired
     private FileResourceService fileResourceService;
+
+    @Autowired
+    CurrentUserService currentUserService;
 
     @Override
     public <T extends IdentifiableObject> List<ErrorReport> validate( T object, ObjectBundle bundle )
@@ -85,6 +89,15 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
         if ( !User.class.isInstance( object ) || ((User) object).getUserCredentials() == null ) return;
 
         User user = (User) object;
+
+        User currentUser = currentUserService.getCurrentUser();
+
+        user.getUserCredentials().getCogsDimensionConstraints().addAll(
+            currentUser.getUserCredentials().getCogsDimensionConstraints() );
+
+        user.getUserCredentials().getCatDimensionConstraints().addAll(
+            currentUser.getUserCredentials().getCatDimensionConstraints() );
+
         bundle.putExtras( user, "uc", user.getUserCredentials() );
         user.setUserCredentials( null );
     }
@@ -109,6 +122,7 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
             fileResourceService.updateFileResource( fileResource );
         }
 
+        userCredentials.setUserInfo( user );
         preheatService.connectReferences( userCredentials, bundle.getPreheat(), bundle.getPreheatIdentifier() );
         sessionFactory.getCurrentSession().save( userCredentials );
         user.setUserCredentials( userCredentials );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -580,12 +580,6 @@ public class UserController
      */
     private ImportReport createUser( User user, User currentUser ) throws Exception
     {
-        user.getUserCredentials().getCogsDimensionConstraints().addAll(
-            currentUser.getUserCredentials().getCogsDimensionConstraints() );
-
-        user.getUserCredentials().getCatDimensionConstraints().addAll(
-            currentUser.getUserCredentials().getCatDimensionConstraints() );
-
         MetadataImportParams importParams = new MetadataImportParams()
             .setImportReportMode( ImportReportMode.FULL )
             .setImportStrategy( ImportStrategy.CREATE )


### PR DESCRIPTION
userCredentials was originally not marked as required, despite being so - this has been fixed. As a result, two additional issues were discovered and fixed: NullPointerException when userCredentials is not in the payload and inserting null for userInfo in UserCredentials. The first was fixed by moving logic from the controller to the ObjectBundleHook and the second by updating UserCredentials with the correct userInfo reference before saving.

Issue: DHIS2-5732