### PR TITLE
Fixes sort issues on /api/users endpoint (#4645)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.user;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.feedback.ErrorReport;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -113,7 +114,7 @@ public interface UserService
 
     /**
      * Checks if the given user represents the last user with ALL authority.
-     * 
+     *
      * @param userCredentials the user.
      * @return true if the given user represents the last user with ALL authority.
      */
@@ -121,7 +122,7 @@ public interface UserService
 
     /**
      * Checks if the given user role represents the last role with ALL authority.
-     * 
+     *
      * @param userAuthorityGroup the user role.
      * @return true if the given user role represents the last role with ALL authority.
      */
@@ -129,11 +130,23 @@ public interface UserService
 
     /**
      * Returns a list of users based on the given query parameters.
+     * The default order of last name and first name will be applied.
      *
      * @param params the user query parameters.
      * @return a List of users.
      */
     List<User> getUsers( UserQueryParams params );
+
+    /**
+     * Returns a list of users based on the given query parameters.
+     * If the specified list of orders are empty, default order of
+     * last name and first name will be applied.
+     *
+     * @param params the user query parameters.
+     * @param orders the already validated order strings (e.g. email:asc).
+     * @return a List of users.
+     */
+    List<User> getUsers( UserQueryParams params, @Nullable List<String> orders );
 
     /**
      * Returns the number of users based on the given query parameters.
@@ -360,7 +373,7 @@ public interface UserService
 
     /**
      * Returns list of active users whose credentials are expiring with in few days.
-     * 
+     *
      * @return list of active users whose credentials are expiring with in few days.
      */
     List<User> getExpiringUsers();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -28,9 +28,10 @@ package org.hisp.dhis.user;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.List;
-
 import org.hisp.dhis.common.IdentifiableObjectStore;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * @author Nguyen Hong Duc
@@ -42,15 +43,27 @@ public interface UserStore
 
     /**
      * Returns a list of users based on the given query parameters.
-     * 
+     *
+     *
      * @param params the user query parameters.
      * @return a List of users.
      */
     List<User> getUsers( UserQueryParams params );
 
     /**
+     * Returns a list of users based on the given query parameters.
+     * If the specified list of orders are empty, default order of
+     * last name and first name will be applied.
+     *
+     * @param params the user query parameters.
+     * @param orders the already validated order strings (e.g. email:asc).
+     * @return a List of users.
+     */
+    List<User> getUsers( UserQueryParams params, @Nullable List<String> orders );
+
+    /**
      * Returns the number of users based on the given query parameters.
-     * 
+     *
      * @param params the user query parameters.
      * @return number of users.
      */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -200,24 +200,31 @@ public class JpaQueryUtils
         {
             return null;
         }
+
         return StringUtils.defaultIfEmpty( orders.stream().filter( org.hisp.dhis.query.Order::isPersisted ).map( o -> {
             final StringBuilder sb = new StringBuilder();
             final boolean ignoreCase = isIgnoreCase( o );
+
             if ( ignoreCase )
             {
                 sb.append( "lower(" );
             }
+
             if ( alias != null )
             {
                 sb.append( alias ).append( '.' );
             }
+
             sb.append( o.getProperty().getName() );
+
             if ( ignoreCase )
             {
                 sb.append( ")" );
             }
+
             sb.append( ' ' );
             sb.append( o.isAscending() ? "asc" : "desc" );
+
             return sb.toString();
         } ).collect( Collectors.joining( "," ) ), null );
     }
@@ -238,13 +245,17 @@ public class JpaQueryUtils
         {
             return null;
         }
+
         return StringUtils.defaultIfEmpty( orders.stream().filter( o -> o.isPersisted() && isIgnoreCase( o ) ).map( o -> {
             final StringBuilder sb = new StringBuilder( "lower(" );
+
             if ( alias != null )
             {
                 sb.append( alias ).append( '.' );
             }
+
             sb.append( o.getProperty().getName() ).append( ')' );
+
             return sb.toString();
         } ).collect( Collectors.joining( "," ) ), null );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Order.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Order.java
@@ -32,6 +32,7 @@ import com.google.common.base.MoreObjects;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.system.util.ReflectionUtils;
 
+import javax.annotation.Nonnull;
 import java.util.Date;
 import java.util.Objects;
 
@@ -202,6 +203,21 @@ public class Order
             && Objects.equals( this.property, other.property );
     }
 
+    /**
+     * @return the order string (e.g. <code>name:iasc</code>).
+     */
+    @Nonnull
+    public String toOrderString()
+    {
+        final StringBuilder sb = new StringBuilder( property.getName() );
+        sb.append( ':' );
+        if ( isIgnoreCase() )
+        {
+            sb.append( 'i' );
+        }
+        sb.append( isAscending() ? "asc" : "desc" );
+        return sb.toString();
+    }
 
     @Override
     public String toString()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Order.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Order.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.query;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -88,9 +88,20 @@ public class Order
         Object o1 = ReflectionUtils.invokeMethod( lside, property.getGetterMethod() );
         Object o2 = ReflectionUtils.invokeMethod( rside, property.getGetterMethod() );
 
-        if ( o1 == null || o2 == null )
+        if ( o1 == o2 )
         {
             return 0;
+        }
+
+        // for null values use the same order like PostgreSQL in order to have same effect like DB ordering
+        // (NULLs are greater than other values)
+        if ( o1 == null || o2 == null )
+        {
+            if ( o1 == null )
+            {
+                return isAscending() ? 1 : -1;
+            }
+            return isAscending() ? -1 : 1;
         }
 
         if ( String.class.isInstance( o1 ) && String.class.isInstance( o2 ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -28,19 +28,25 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
-import org.hisp.dhis.api.util.DateUtils;
-
 import com.google.common.base.Enums;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.hisp.dhis.api.util.DateUtils;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -413,4 +419,62 @@ public final class QueryUtils
         }
     }
 
+    /**
+     * Converts the specified string orders (e.g. <code>name:asc</code>) to order objects.
+     *
+     * @param orders the order strings that should be converted.
+     * @param schema the schema that should be used to perform the conversion.
+     * @return the converted order.
+     */
+    @Nonnull
+    public static List<Order> convertOrderStrings( @Nullable Collection<String> orders, @Nonnull Schema schema )
+    {
+        if ( orders == null )
+        {
+            return Collections.emptyList();
+        }
+
+        final Map<String, Order> result = new LinkedHashMap<>();
+        for ( String o : orders )
+        {
+            String[] split = o.split( ":" );
+
+            //Using ascending as default direction.
+            String direction = "asc";
+
+            if ( split.length < 1 )
+            {
+                continue;
+            }
+            else if ( split.length == 2 )
+            {
+                direction = split[1].toLowerCase();
+            }
+
+            String propertyName = split[0];
+            Property property = schema.getProperty( propertyName );
+
+
+            if ( result.containsKey( propertyName ) || !schema.haveProperty( propertyName )
+                || !validProperty( property ) || !validDirection( direction ) )
+            {
+                continue;
+            }
+
+            result.put( propertyName, Order.from( direction, property ) );
+        }
+
+        return new ArrayList<>( result.values() );
+    }
+
+    private static boolean validProperty( Property property )
+    {
+        return property.isSimple();
+    }
+
+    private static boolean validDirection( String direction )
+    {
+        return "asc".equals( direction ) || "desc".equals( direction )
+            || "iasc".equals( direction ) || "idesc".equals( direction );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -28,13 +28,7 @@ package org.hisp.dhis.user;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -52,7 +46,13 @@ import org.hisp.dhis.system.filter.UserAuthorityGroupCanIssueFilter;
 import org.joda.time.DateTime;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.collect.Lists;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Chau Thu Tran
@@ -190,6 +190,12 @@ public class DefaultUserService
     @Override
     public List<User> getUsers( UserQueryParams params )
     {
+        return getUsers( params, null );
+    }
+
+    @Override
+    public List<User> getUsers( UserQueryParams params, @Nullable List<String> orders )
+    {
         handleUserQueryParams( params );
 
         if ( !validateUserQueryParams( params ) )
@@ -197,7 +203,7 @@ public class DefaultUserService
             return Lists.newArrayList();
         }
 
-        return userStore.getUsers( params );
+        return userStore.getUsers( params, orders );
     }
 
     @Override
@@ -242,7 +248,7 @@ public class DefaultUserService
             cal.add( Calendar.MONTH, (params.getInactiveMonths() * -1) );
             params.setInactiveSince( cal.getTime() );
         }
-        
+
         if ( params.isUserOrgUnits() && params.hasUser() )
         {
             params.setOrganisationUnits( Lists.newArrayList( params.getUser().getOrganisationUnits() ) );
@@ -579,7 +585,7 @@ public class DefaultUserService
         }
 
         // Validate user role
-        
+
         boolean canGrantOwnUserAuthorityGroups = (Boolean) systemSettingManager.getSystemSetting( SettingKey.CAN_GRANT_OWN_USER_AUTHORITY_GROUPS );
 
         List<UserAuthorityGroup> roles = userAuthorityGroupStore.getByUid( user.getUserCredentials().getUserAuthorityGroups().stream().map( r -> r.getUid() ).collect( Collectors.toList() ) );
@@ -593,7 +599,7 @@ public class DefaultUserService
         } );
 
         // Validate user group
-        
+
         boolean canAdd = currentUser.getUserCredentials().isAuthorized( UserGroup.AUTH_USER_ADD );
 
         if ( canAdd )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
@@ -48,13 +48,19 @@ public class JpaQueryUtilsTest
     @Test
     public void createOrderExpressionNull()
     {
-        Assert.assertNull( JpaQueryUtils.createOrderExpression( null ) );
+        Assert.assertNull( JpaQueryUtils.createOrderExpression( null, null ) );
+    }
+
+    @Test
+    public void createSelectOrderExpressionNull()
+    {
+        Assert.assertNull( JpaQueryUtils.createSelectOrderExpression( null, null ) );
     }
 
     @Test
     public void createOrderExpressionEmpty()
     {
-        Assert.assertNull( JpaQueryUtils.createOrderExpression( new ArrayList<>() ) );
+        Assert.assertNull( JpaQueryUtils.createOrderExpression( new ArrayList<>(), null ) );
     }
 
     @Test
@@ -64,7 +70,17 @@ public class JpaQueryUtilsTest
         property.setName( "valueTest" );
         property.setSimple( true );
         property.setPersisted( false );
-        Assert.assertNull( JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property, Direction.ASCENDING ) ) ) );
+        Assert.assertNull( JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property, Direction.ASCENDING ) ), null ) );
+    }
+
+    @Test
+    public void createSelectOrderExpressionNoPersistent()
+    {
+        final Property property = new Property();
+        property.setName( "valueTest" );
+        property.setSimple( true );
+        property.setPersisted( false );
+        Assert.assertNull( JpaQueryUtils.createSelectOrderExpression( Collections.singletonList( new Order( property, Direction.ASCENDING ) ), null ) );
     }
 
     @Test
@@ -103,7 +119,47 @@ public class JpaQueryUtilsTest
             new Order( property3, Direction.ASCENDING ).ignoreCase(),
             new Order( property4, Direction.ASCENDING ).ignoreCase(),
             new Order( property5, Direction.DESCENDING )
-        ) ) );
+        ), null ) );
+    }
+
+    @Test
+    public void createSelectOrderExpression()
+    {
+        final Property property1 = new Property();
+        property1.setName( "value1" );
+        property1.setSimple( true );
+        property1.setPersisted( true );
+        property1.setKlass( String.class );
+
+        final Property property2 = new Property();
+        property2.setName( "value2" );
+        property2.setSimple( true );
+        property2.setPersisted( false );
+
+        final Property property3 = new Property();
+        property3.setName( "value3" );
+        property3.setSimple( true );
+        property3.setKlass( Integer.class );
+        property3.setPersisted( true );
+
+        final Property property4 = new Property();
+        property4.setName( "value4" );
+        property4.setSimple( true );
+        property4.setPersisted( true );
+        property4.setKlass( String.class );
+
+        final Property property5 = new Property();
+        property5.setName( "value5" );
+        property5.setSimple( true );
+        property5.setPersisted( true );
+
+        Assert.assertEquals( "lower(value1),lower(value4)", JpaQueryUtils.createSelectOrderExpression( Arrays.asList(
+            new Order( property1, Direction.ASCENDING ).ignoreCase(),
+            new Order( property2, Direction.ASCENDING ),
+            new Order( property3, Direction.ASCENDING ).ignoreCase(),
+            new Order( property4, Direction.ASCENDING ).ignoreCase(),
+            new Order( property5, Direction.DESCENDING )
+        ), null ) );
     }
 
     @Test
@@ -114,6 +170,41 @@ public class JpaQueryUtilsTest
         property1.setSimple( true );
         property1.setPersisted( true );
 
-        Assert.assertEquals( "value1 asc", JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property1, Direction.ASCENDING ) ) ) );
+        Assert.assertEquals( "value1 asc", JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property1, Direction.ASCENDING ) ), null ) );
+    }
+
+    @Test
+    public void createSelectOrderExpressionSingle()
+    {
+        final Property property1 = new Property();
+        property1.setName( "value1" );
+        property1.setSimple( true );
+        property1.setKlass( String.class );
+        property1.setPersisted( true );
+
+        Assert.assertEquals( "lower(value1)", JpaQueryUtils.createSelectOrderExpression( Collections.singletonList( new Order( property1, Direction.ASCENDING ).ignoreCase() ), null ) );
+    }
+
+    @Test
+    public void createOrderExpressionAlias()
+    {
+        final Property property1 = new Property();
+        property1.setName( "value1" );
+        property1.setSimple( true );
+        property1.setPersisted( true );
+
+        Assert.assertEquals( "x.value1 asc", JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property1, Direction.ASCENDING ) ), "x" ) );
+    }
+
+    @Test
+    public void createSelectOrderExpressionAlias()
+    {
+        final Property property1 = new Property();
+        property1.setName( "value1" );
+        property1.setSimple( true );
+        property1.setKlass( String.class );
+        property1.setPersisted( true );
+
+        Assert.assertEquals( "lower(x.value1)", JpaQueryUtils.createSelectOrderExpression( Collections.singletonList( new Order( property1, Direction.ASCENDING ).ignoreCase() ), "x" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
@@ -1,0 +1,119 @@
+package org.hisp.dhis.query;
+
+/*
+ *
+ *  Copyright (c) 2004-2019, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import org.hisp.dhis.schema.Property;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Unit tests for {@link JpaQueryUtils}.
+ *
+ * @author volsch
+ */
+public class JpaQueryUtilsTest
+{
+    @Test
+    public void createOrderExpressionNull()
+    {
+        Assert.assertNull( JpaQueryUtils.createOrderExpression( null ) );
+    }
+
+    @Test
+    public void createOrderExpressionEmpty()
+    {
+        Assert.assertNull( JpaQueryUtils.createOrderExpression( new ArrayList<>() ) );
+    }
+
+    @Test
+    public void createOrderExpressionNoPersistent()
+    {
+        final Property property = new Property();
+        property.setName( "valueTest" );
+        property.setSimple( true );
+        property.setPersisted( false );
+        Assert.assertNull( JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property, Direction.ASCENDING ) ) ) );
+    }
+
+    @Test
+    public void createOrderExpression()
+    {
+        final Property property1 = new Property();
+        property1.setName( "value1" );
+        property1.setSimple( true );
+        property1.setPersisted( true );
+
+        final Property property2 = new Property();
+        property2.setName( "value2" );
+        property2.setSimple( true );
+        property2.setPersisted( false );
+
+        final Property property3 = new Property();
+        property3.setName( "value3" );
+        property3.setSimple( true );
+        property3.setKlass( Integer.class );
+        property3.setPersisted( true );
+
+        final Property property4 = new Property();
+        property4.setName( "value4" );
+        property4.setSimple( true );
+        property4.setPersisted( true );
+        property4.setKlass( String.class );
+
+        final Property property5 = new Property();
+        property5.setName( "value5" );
+        property5.setSimple( true );
+        property5.setPersisted( true );
+
+        Assert.assertEquals( "value1 asc,value3 asc,lower(value4) asc,value5 desc", JpaQueryUtils.createOrderExpression( Arrays.asList(
+            new Order( property1, Direction.ASCENDING ),
+            new Order( property2, Direction.ASCENDING ),
+            new Order( property3, Direction.ASCENDING ).ignoreCase(),
+            new Order( property4, Direction.ASCENDING ).ignoreCase(),
+            new Order( property5, Direction.DESCENDING )
+        ) ) );
+    }
+
+    @Test
+    public void createOrderExpressionSingle()
+    {
+        final Property property1 = new Property();
+        property1.setName( "value1" );
+        property1.setSimple( true );
+        property1.setPersisted( true );
+
+        Assert.assertEquals( "value1 asc", JpaQueryUtils.createOrderExpression( Collections.singletonList( new Order( property1, Direction.ASCENDING ) ) ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
@@ -1,0 +1,126 @@
+package org.hisp.dhis.query;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.hisp.dhis.schema.Property;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.beans.PropertyDescriptor;
+
+import static org.hamcrest.Matchers.lessThan;
+
+/**
+ * Unit tests for {@link Order}.
+ *
+ * @author Volker Schmidt
+ */
+public class OrderTest
+{
+    private TestObject object1;
+
+    private TestObject object2;
+
+    private Property valueProperty;
+
+    private Order orderAsc;
+
+    private Order orderDesc;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        object1 = new TestObject();
+        object2 = new TestObject();
+        PropertyDescriptor propertyDescriptor = PropertyUtils.getPropertyDescriptor( object1, "value" );
+        valueProperty = new Property( String.class, propertyDescriptor.getReadMethod(), propertyDescriptor.getWriteMethod() );
+        orderAsc = new Order( valueProperty, Direction.ASCENDING );
+        orderDesc = new Order( valueProperty, Direction.DESCENDING );
+    }
+
+    @Test
+    public void bothNull()
+    {
+        Assert.assertEquals( 0, orderAsc.compare( object1, object2 ) );
+        Assert.assertEquals( 0, orderAsc.compare( object2, object1 ) );
+    }
+
+    @Test
+    public void leftNullAsc()
+    {
+        object2.setValue( "Test" );
+        Assert.assertEquals( 1, orderAsc.compare( object1, object2 ) );
+    }
+
+    @Test
+    public void rightNullAsc()
+    {
+        object1.setValue( "Test" );
+        Assert.assertEquals( -1, orderAsc.compare( object1, object2 ) );
+    }
+
+    @Test
+    public void leftNullDesc()
+    {
+        object2.setValue( "Test" );
+        Assert.assertEquals( -1, orderDesc.compare( object1, object2 ) );
+    }
+
+    @Test
+    public void rightNullDesc()
+    {
+        object1.setValue( "Test" );
+        Assert.assertEquals( 1, orderDesc.compare( object1, object2 ) );
+    }
+
+    @Test
+    public void bothNonNullAsc()
+    {
+        object1.setValue( "Test1" );
+        object2.setValue( "Test2" );
+        Assert.assertThat( orderAsc.compare( object1, object2 ), lessThan( 0 ) );
+    }
+
+    public static class TestObject
+    {
+        private String value;
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        public void setValue( String value )
+        {
+            this.value = value;
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
@@ -62,6 +62,7 @@ public class OrderTest
         object2 = new TestObject();
         PropertyDescriptor propertyDescriptor = PropertyUtils.getPropertyDescriptor( object1, "value" );
         valueProperty = new Property( String.class, propertyDescriptor.getReadMethod(), propertyDescriptor.getWriteMethod() );
+        valueProperty.setName( "value" );
         orderAsc = new Order( valueProperty, Direction.ASCENDING );
         orderDesc = new Order( valueProperty, Direction.DESCENDING );
     }
@@ -107,6 +108,30 @@ public class OrderTest
         object1.setValue( "Test1" );
         object2.setValue( "Test2" );
         Assert.assertThat( orderAsc.compare( object1, object2 ), lessThan( 0 ) );
+    }
+
+    @Test
+    public void toOrderStringAsc()
+    {
+        Assert.assertEquals( "value:asc", Order.from( "asc", valueProperty ).toOrderString() );
+    }
+
+    @Test
+    public void toOrderStringDesc()
+    {
+        Assert.assertEquals( "value:desc", Order.from( "desc", valueProperty ).toOrderString() );
+    }
+
+    @Test
+    public void toOrderStringIAsc()
+    {
+        Assert.assertEquals( "value:iasc", Order.from( "iasc", valueProperty ).toOrderString() );
+    }
+
+    @Test
+    public void toOrderStringIDesc()
+    {
+        Assert.assertEquals( "value:idesc", Order.from( "idesc", valueProperty ).toOrderString() );
     }
 
     public static class TestObject

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
@@ -28,22 +28,70 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public class QueryUtilsTest
 {
+    private Schema schema;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        schema = new Schema( Attribute.class, "attribute", "attributes" );
+
+        Property property = new Property( String.class );
+        property.setName( "value1" );
+        property.setSimple( true );
+        schema.addProperty( property );
+
+        property = new Property( String.class );
+        property.setName( "value2" );
+        property.setSimple( false );
+        schema.addProperty( property );
+
+        property = new Property( String.class );
+        property.setName( "value3" );
+        property.setSimple( true );
+        schema.addProperty( property );
+
+        property = new Property( Integer.class );
+        property.setName( "value4" );
+        property.setSimple( true );
+        schema.addProperty( property );
+
+        property = new Property( String.class );
+        property.setName( "value5" );
+        property.setSimple( true );
+        schema.addProperty( property );
+
+        property = new Property( String.class );
+        property.setName( "value6" );
+        property.setSimple( true );
+        schema.addProperty( property );
+
+        property = new Property( String.class );
+        property.setName( "value7" );
+        property.setSimple( true );
+        schema.addProperty( property );
+    }
+
     @Test
     public void testParseValidEnum()
     {
@@ -146,5 +194,24 @@ public class QueryUtilsTest
         assertEquals( "in (1,2,3)", QueryUtils.parseFilterOperator( "in", "[1,2,3]") );
 
         assertEquals( "is not null", QueryUtils.parseFilterOperator( "!null",  null) );
+    }
+
+    @Test
+    public void testConvertOrderStringsNull()
+    {
+        Assert.assertEquals( Collections.emptyList(), QueryUtils.convertOrderStrings( null, schema ) );
+    }
+
+    @Test
+    public void testConvertOrderStrings()
+    {
+        List<Order> orders = QueryUtils.convertOrderStrings(
+            Arrays.asList( "value1:asc", "value2:asc", "value3:iasc", "value4:desc", "value5:idesc", "value6:xdesc", "value7" ), schema );
+        Assert.assertEquals( 5, orders.size() );
+        Assert.assertEquals( orders.get( 0 ), Order.from( "asc", schema.getProperty( "value1" ) ) );
+        Assert.assertEquals( orders.get( 1 ), Order.from( "iasc", schema.getProperty( "value3" ) ) );
+        Assert.assertEquals( orders.get( 2 ), Order.from( "desc", schema.getProperty( "value4" ) ) );
+        Assert.assertEquals( orders.get( 3 ), Order.from( "idesc", schema.getProperty( "value5" ) ) );
+        Assert.assertEquals( orders.get( 4 ), Order.from( "asc", schema.getProperty( "value7" ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -51,7 +52,7 @@ public class UserServiceTest
 {
     @Autowired
     private UserService userService;
-    
+
     @Autowired
     private UserGroupService userGroupService;
 
@@ -60,7 +61,7 @@ public class UserServiceTest
 
     @Autowired
     private SystemSettingManager systemSettingManager;
-    
+
     private OrganisationUnit unitA;
     private OrganisationUnit unitB;
     private OrganisationUnit unitC;
@@ -70,11 +71,11 @@ public class UserServiceTest
     private UserAuthorityGroup roleA;
     private UserAuthorityGroup roleB;
     private UserAuthorityGroup roleC;
-    
+
     @Override
     public void setUpTest()
         throws Exception
-    { 
+    {
         unitA = createOrganisationUnit( 'A' );
         unitB = createOrganisationUnit( 'B' );
         unitC = createOrganisationUnit( 'C', unitA );
@@ -86,21 +87,21 @@ public class UserServiceTest
         organisationUnitService.addOrganisationUnit( unitC );
         organisationUnitService.addOrganisationUnit( unitD );
         organisationUnitService.addOrganisationUnit( unitE );
-        
+
         roleA = createUserAuthorityGroup( 'A' );
         roleB = createUserAuthorityGroup( 'B' );
         roleC = createUserAuthorityGroup( 'C' );
-        
+
         roleA.getAuthorities().add( "AuthA" );
         roleA.getAuthorities().add( "AuthB" );
         roleA.getAuthorities().add( "AuthC" );
         roleA.getAuthorities().add( "AuthD" );
-        
+
         roleB.getAuthorities().add( "AuthA" );
         roleB.getAuthorities().add( "AuthB" );
-        
+
         roleC.getAuthorities().add( "AuthC" );
-        
+
         userService.addUserAuthorityGroup( roleA );
         userService.addUserAuthorityGroup( roleB );
         userService.addUserAuthorityGroup( roleC );
@@ -108,24 +109,24 @@ public class UserServiceTest
 
     @Test
     public void testAddGetUser()
-    {        
+    {
         Set<OrganisationUnit> units = new HashSet<>();
-        
+
         units.add( unitA );
         units.add( unitB );
 
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
-        
+
         userA.setOrganisationUnits( units );
         userB.setOrganisationUnits( units );
 
         long idA = userService.addUser( userA );
         long idB = userService.addUser( userB );
-        
+
         assertEquals( userA, userService.getUser( idA ) );
         assertEquals( userB, userService.getUser( idB ) );
-        
+
         assertEquals( units, userService.getUser( idA ).getOrganisationUnits() );
         assertEquals( units, userService.getUser( idB ).getOrganisationUnits() );
     }
@@ -141,14 +142,14 @@ public class UserServiceTest
 
         assertEquals( userA, userService.getUser( idA ) );
         assertEquals( userB, userService.getUser( idB ) );
-        
+
         userA.setSurname( "UpdatedSurnameA" );
-        
+
         userService.updateUser( userA );
-        
+
         assertEquals( userService.getUser( idA ).getSurname(), "UpdatedSurnameA" );
     }
-    
+
     @Test
     public void testDeleteUser()
     {
@@ -160,9 +161,9 @@ public class UserServiceTest
 
         assertEquals( userA, userService.getUser( idA ) );
         assertEquals( userB, userService.getUser( idB ) );
-        
+
         userService.deleteUser( userA );
-        
+
         assertNull( userService.getUser( idA ) );
         assertNotNull( userService.getUser( idB ) );
     }
@@ -171,7 +172,7 @@ public class UserServiceTest
     public void testUserByOrgUnits()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
@@ -186,7 +187,7 @@ public class UserServiceTest
         UserCredentials credentialsB = createUserCredentials( 'B', userB );
         UserCredentials credentialsC = createUserCredentials( 'C', userC );
         UserCredentials credentialsD = createUserCredentials( 'D', userD );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
@@ -196,13 +197,13 @@ public class UserServiceTest
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
         userService.addUserCredentials( credentialsD );
-        
+
         UserQueryParams params = new UserQueryParams()
             .addOrganisationUnit( unitA )
             .setUser( userA );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 1, users.size() );
         assertTrue( users.contains( userA ) );
 
@@ -210,19 +211,19 @@ public class UserServiceTest
             .addOrganisationUnit( unitA )
             .setIncludeOrgUnitChildren( true )
             .setUser( userA );
-        
+
         users = userService.getUsers( params );
-        
+
         assertEquals( 2, users.size() );
         assertTrue( users.contains( userA ) );
         assertTrue( users.contains( userC ) );
     }
-    
+
     @Test
     public void testGetUserOrgUnits()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User currentUser = createUser( 'Z' );
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
@@ -237,7 +238,7 @@ public class UserServiceTest
         userC.addOrganisationUnit( unitC );
         userD.addOrganisationUnit( unitD );
         userE.addOrganisationUnit( unitE );
-        
+
         UserCredentials currentCredentials = createUserCredentials( 'Z', currentUser );
         UserCredentials credentialsA = createUserCredentials( 'A', userA );
         UserCredentials credentialsB = createUserCredentials( 'B', userB );
@@ -262,56 +263,56 @@ public class UserServiceTest
         UserQueryParams params = new UserQueryParams()
             .setUser( currentUser )
             .setUserOrgUnits( true );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 3, users.size() );
         assertTrue( users.contains( currentUser ) );
         assertTrue( users.contains( userA ) );
         assertTrue( users.contains( userB ) );
-        
+
         params = new UserQueryParams()
             .setUser( currentUser )
             .setUserOrgUnits( true )
             .setIncludeOrgUnitChildren( true );
-        
+
         users = userService.getUsers( params );
 
         assertEquals( 5, users.size() );
         assertTrue( users.contains( currentUser ) );
         assertTrue( users.contains( userA ) );
         assertTrue( users.contains( userB ) );
-        assertTrue( users.contains( userC ) );     
-        assertTrue( users.contains( userD) );        
+        assertTrue( users.contains( userC ) );
+        assertTrue( users.contains( userD ) );
     }
-    
+
     @Test
     public void testManagedGroups()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         // TODO find way to override in parameters
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
         User userD = createUser( 'D' );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
         userService.addUser( userD );
-        
+
         UserGroup userGroup1 = createUserGroup( 'A', Sets.newHashSet( userA, userB ) );
         UserGroup userGroup2 = createUserGroup( 'B', Sets.newHashSet( userC, userD ) );
         userA.getGroups().add( userGroup1 );
         userB.getGroups().add( userGroup1 );
         userC.getGroups().add( userGroup2 );
         userD.getGroups().add( userGroup2 );
-        
+
         userGroup1.setManagedGroups( Sets.newHashSet( userGroup2 ) );
         userGroup2.setManagedByGroups( Sets.newHashSet( userGroup1 ) );
-        
+
         long group1 = userGroupService.addUserGroup( userGroup1 );
         long group2 = userGroupService.addUserGroup( userGroup2 );
 
@@ -319,7 +320,7 @@ public class UserServiceTest
         assertTrue( userGroupService.getUserGroup( group1 ).getManagedGroups().contains( userGroup2 ) );
         assertEquals( 1, userGroupService.getUserGroup( group2 ).getManagedByGroups().size() );
         assertTrue( userGroupService.getUserGroup( group2 ).getManagedByGroups().contains( userGroup1 ) );
-        
+
         assertTrue( userA.canManage( userGroup2 ) );
         assertTrue( userB.canManage( userGroup2 ) );
         assertFalse( userC.canManage( userGroup1 ) );
@@ -331,7 +332,7 @@ public class UserServiceTest
         assertTrue( userA.canManage( userD ) );
         assertFalse( userC.canManage( userA ) );
         assertFalse( userC.canManage( userB ) );
-        
+
         assertTrue( userC.isManagedBy( userGroup1 ) );
         assertTrue( userD.isManagedBy( userGroup1 ) );
         assertFalse( userA.isManagedBy( userGroup2 ) );
@@ -349,11 +350,11 @@ public class UserServiceTest
     public void testGetByPhoneNumber()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
-        
+
         userA.setPhoneNumber( "73647271" );
         userB.setPhoneNumber( "23452134" );
         userC.setPhoneNumber( "14543232" );
@@ -361,26 +362,79 @@ public class UserServiceTest
         UserCredentials credentialsA = createUserCredentials( 'A', userA );
         UserCredentials credentialsB = createUserCredentials( 'B', userB );
         UserCredentials credentialsC = createUserCredentials( 'C', userC );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
-        
+
         userService.addUserCredentials( credentialsA );
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
-               
+
         List<User> users = userService.getUsersByPhoneNumber( "23452134" );
-        
+
         assertEquals( 1, users.size() );
         assertEquals( userB, users.get( 0 ) );
+    }
+
+    @Test
+    public void testGetOrdered()
+    {
+        systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
+
+        User userA = createUser( 'A' );
+        User userB = createUser( 'B' );
+        User userC = createUser( 'C' );
+
+        userA.setSurname( "Yong" );
+        userA.setFirstName( "Anne" );
+        userA.setEmail( "lost@space.com" );
+        userA.getOrganisationUnits().add( unitA );
+        userB.setSurname( "Arden" );
+        userB.setFirstName( "Jenny" );
+        userB.setEmail( "Inside@other.com" );
+        userB.getOrganisationUnits().add( unitA );
+        userC.setSurname( "Smith" );
+        userC.setFirstName( "Igor" );
+        userC.setEmail( "home@other.com" );
+        userC.getOrganisationUnits().add( unitA );
+
+        UserCredentials credentialsA = createUserCredentials( 'A', userA );
+        UserCredentials credentialsB = createUserCredentials( 'B', userB );
+        UserCredentials credentialsC = createUserCredentials( 'C', userC );
+
+        userService.addUser( userA );
+        userService.addUser( userB );
+        userService.addUser( userC );
+
+        userService.addUserCredentials( credentialsA );
+        userService.addUserCredentials( credentialsB );
+        userService.addUserCredentials( credentialsC );
+
+        List<User> users = userService.getUsers( new UserQueryParams().addOrganisationUnit( unitA ), Collections.singletonList( "email:idesc" ) );
+        assertEquals( 3, users.size() );
+        assertEquals( userA, users.get( 0 ) );
+        assertEquals( userB, users.get( 1 ) );
+        assertEquals( userC, users.get( 2 ) );
+
+        users = userService.getUsers( new UserQueryParams().addOrganisationUnit( unitA ), null );
+        assertEquals( 3, users.size() );
+        assertEquals( userA, users.get( 2 ) );
+        assertEquals( userB, users.get( 0 ) );
+        assertEquals( userC, users.get( 1 ) );
+
+        users = userService.getUsers( new UserQueryParams().addOrganisationUnit( unitA ), Collections.singletonList( "firstName:asc" ) );
+        assertEquals( 3, users.size() );
+        assertEquals( userA, users.get( 0 ) );
+        assertEquals( userB, users.get( 2 ) );
+        assertEquals( userC, users.get( 1 ) );
     }
 
     @Test
     public void testGetManagedGroupsLessAuthoritiesDisjointRoles()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, false );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
@@ -404,21 +458,21 @@ public class UserServiceTest
         credentialsE.getUserAuthorityGroups().add( roleA );
         credentialsE.getUserAuthorityGroups().add( roleB );
         credentialsF.getUserAuthorityGroups().add( roleC );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
         userService.addUser( userD );
         userService.addUser( userE );
         userService.addUser( userF );
-        
+
         userService.addUserCredentials( credentialsA );
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
         userService.addUserCredentials( credentialsD );
         userService.addUserCredentials( credentialsE );
         userService.addUserCredentials( credentialsF );
-        
+
         UserGroup userGroup1 = createUserGroup( 'A', Sets.newHashSet( userA, userB ) );
         UserGroup userGroup2 = createUserGroup( 'B', Sets.newHashSet( userC, userD, userE, userF ) );
         userA.getGroups().add( userGroup1 );
@@ -427,48 +481,48 @@ public class UserServiceTest
         userD.getGroups().add( userGroup2 );
         userE.getGroups().add( userGroup2 );
         userF.getGroups().add( userGroup2 );
-        
+
         userGroup1.setManagedGroups( Sets.newHashSet( userGroup2 ) );
         userGroup2.setManagedByGroups( Sets.newHashSet( userGroup1 ) );
-        
+
         userGroupService.addUserGroup( userGroup1 );
         userGroupService.addUserGroup( userGroup2 );
-        
+
         UserQueryParams params = new UserQueryParams();
         params.setCanManage( true );
         params.setAuthSubset( true );
         params.setUser( userA );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 2, users.size() );
         assertTrue( users.contains( userD ) );
         assertTrue( users.contains( userF ) );
-        
+
         assertEquals( 2, userService.getUserCount( params ) );
-        
+
         params.setUser( userB );
-        
+
         users = userService.getUsers( params);
 
         assertEquals( 0, users.size() );
 
         assertEquals( 0, userService.getUserCount( params ) );
-        
+
         params.setUser( userC );
-        
+
         users = userService.getUsers( params);
-        
+
         assertEquals( 0, users.size() );
 
-        assertEquals( 0, userService.getUserCount( params ) );        
+        assertEquals( 0, userService.getUserCount( params ) );
     }
 
     @Test
     public void testGetManagedGroupsSearch()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
@@ -482,14 +536,14 @@ public class UserServiceTest
         UserCredentials credentialsD = createUserCredentials( 'D', userD );
         UserCredentials credentialsE = createUserCredentials( 'E', userE );
         UserCredentials credentialsF = createUserCredentials( 'F', userF );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
         userService.addUser( userD );
         userService.addUser( userE );
         userService.addUser( userF );
-        
+
         userService.addUserCredentials( credentialsA );
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
@@ -499,20 +553,20 @@ public class UserServiceTest
 
         UserQueryParams params = new UserQueryParams();
         params.setQuery( "rstnameA" );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 1, users.size() );
         assertTrue( users.contains( userA ) );
 
-        assertEquals( 1, userService.getUserCount( params ) );        
+        assertEquals( 1, userService.getUserCount( params ) );
     }
 
     @Test
     public void testGetManagedGroupsSelfRegistered()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
@@ -522,25 +576,25 @@ public class UserServiceTest
         UserCredentials credentialsB = createUserCredentials( 'B', userB );
         UserCredentials credentialsC = createUserCredentials( 'C', userC );
         UserCredentials credentialsD = createUserCredentials( 'D', userD );
-        
+
         credentialsA.setSelfRegistered( true );
         credentialsC.setSelfRegistered( true );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
         userService.addUser( userD );
-        
+
         userService.addUserCredentials( credentialsA );
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
         userService.addUserCredentials( credentialsD );
-        
+
         UserQueryParams params = new UserQueryParams();
         params.setSelfRegistered( true );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 2, users.size() );
         assertTrue( users.contains( userA ) );
         assertTrue( users.contains( userC ) );
@@ -552,7 +606,7 @@ public class UserServiceTest
     public void testGetManagedGroupsOrganisationUnit()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
@@ -563,17 +617,17 @@ public class UserServiceTest
         userB.getOrganisationUnits().add( unitB );
         userC.getOrganisationUnits().add( unitA );
         userD.getOrganisationUnits().add( unitB );
-        
+
         UserCredentials credentialsA = createUserCredentials( 'A', userA );
         UserCredentials credentialsB = createUserCredentials( 'B', userB );
         UserCredentials credentialsC = createUserCredentials( 'C', userC );
         UserCredentials credentialsD = createUserCredentials( 'D', userD );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
         userService.addUser( userD );
-        
+
         userService.addUserCredentials( credentialsA );
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
@@ -581,9 +635,9 @@ public class UserServiceTest
 
         UserQueryParams params = new UserQueryParams();
         params.getOrganisationUnits().add( unitA );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 2, users.size() );
         assertTrue( users.contains( userA ) );
         assertTrue( users.contains( userC ) );
@@ -595,7 +649,7 @@ public class UserServiceTest
     public void testGetInvitations()
     {
         systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
-        
+
         User userA = createUser( 'A' );
         User userB = createUser( 'B' );
         User userC = createUser( 'C' );
@@ -605,15 +659,15 @@ public class UserServiceTest
         UserCredentials credentialsB = createUserCredentials( 'B', userB );
         UserCredentials credentialsC = createUserCredentials( 'C', userC );
         UserCredentials credentialsD = createUserCredentials( 'D', userD );
-        
+
         credentialsB.setInvitation( true );
         credentialsD.setInvitation( true );
-        
+
         userService.addUser( userA );
         userService.addUser( userB );
         userService.addUser( userC );
         userService.addUser( userD );
-        
+
         userService.addUserCredentials( credentialsA );
         userService.addUserCredentials( credentialsB );
         userService.addUserCredentials( credentialsC );
@@ -621,19 +675,19 @@ public class UserServiceTest
 
         UserQueryParams params = new UserQueryParams();
         params.setInvitationStatus( UserInvitationStatus.ALL );
-        
+
         List<User> users = userService.getUsers( params );
-        
+
         assertEquals( 2, users.size() );
         assertTrue( users.contains( userB ) );
         assertTrue( users.contains( userD ) );
 
         assertEquals( 2, userService.getUserCount( params ) );
-        
+
         params.setInvitationStatus( UserInvitationStatus.EXPIRED );
-        
+
         users = userService.getUsers( params );
-        
+
         assertEquals( 0, users.size() );
 
         assertEquals( 0, userService.getUserCount( params ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/OrderParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/OrderParams.java
@@ -29,15 +29,12 @@ package org.hisp.dhis.dxf2.common;
  */
 
 import com.google.common.base.MoreObjects;
-
 import org.hisp.dhis.query.Order;
-import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.query.QueryUtils;
 import org.hisp.dhis.schema.Schema;
-import java.util.ArrayList;
+
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -64,49 +61,7 @@ public class OrderParams
 
     public List<Order> getOrders( Schema schema )
     {
-        Map<String, Order> orders = new LinkedHashMap<>();
-
-        for ( String o : order )
-        {
-            String[] split = o.split( ":" );
-
-            //Using ascending as default direction. 
-            String direction = "asc";
-            
-            if ( split.length < 1 )
-            {
-                continue;
-            }
-            else if ( split.length == 2 )
-            {
-                direction = split[1].toLowerCase();
-            }
-
-            String propertyName = split[0];
-            Property property = schema.getProperty( propertyName );
-            
-
-            if ( orders.containsKey( propertyName ) || !schema.haveProperty( propertyName )
-                || !validProperty( property ) || !validDirection( direction ) )
-            {
-                continue;
-            }
-
-            orders.put( propertyName, Order.from( direction, property ) );
-        }
-
-        return new ArrayList<>( orders.values() );
-    }
-
-    private boolean validProperty( Property property )
-    {
-        return property.isSimple();
-    }
-
-    private boolean validDirection( String direction )
-    {
-        return "asc".equals( direction ) || "desc".equals( direction )
-            || "iasc".equals( direction ) || "idesc".equals( direction );
+        return QueryUtils.convertOrderStrings( order, schema );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserQueryParams;
 import org.hisp.dhis.user.UserService;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -114,6 +115,12 @@ public class MockUserService implements UserService
 
     @Override
     public List<User> getUsers( UserQueryParams params )
+    {
+        return null;
+    }
+
+    @Override
+    public List<User> getUsers( UserQueryParams params, @Nullable List<String> orders )
     {
         return null;
     }
@@ -306,6 +313,6 @@ public class MockUserService implements UserService
 
     @Override
     public void set2FA( User user, Boolean twoFA )
-    {        
+    {
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -85,6 +85,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -160,8 +161,10 @@ public class UserController
             params.setMax( pager.getPageSize() );
         }
 
-        List<User> users = userService.getUsers( params );
+        List<User> users = userService.getUsers( params,
+            ( orders == null ) ? null : orders.stream().map( Order::toOrderString ).collect( Collectors.toList() ) );
 
+        // keep the memory query on the result
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );


### PR DESCRIPTION
- In memory query engines does not handle null values correctly (random order).
- Sort on resulting users is based on paged result not on absolut result.