### PR TITLE
Avoid potential circular check for tei-pi-psi

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstance.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstance.java
@@ -97,7 +97,10 @@ public class TrackedEntityInstance
             createdAtClient = created;
         }
 
-        lastUpdatedAtClient = lastUpdated;
+        if ( lastUpdatedAtClient == null )
+        {
+            lastUpdatedAtClient = lastUpdated;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -100,6 +100,8 @@ public class ImportOptions
 
     private NotificationLevel notificationLevel;
 
+    private boolean skipLastUpdated;
+
     //--------------------------------------------------------------------------
     // Constructors
     //--------------------------------------------------------------------------
@@ -140,6 +142,7 @@ public class ImportOptions
         options.notificationLevel = this.notificationLevel;
         options.ignoreEmptyCollection = this.ignoreEmptyCollection;
         options.firstRowIsHeader = this.firstRowIsHeader;
+        options.skipLastUpdated = this.skipLastUpdated;
 
         return options;
     }
@@ -377,6 +380,13 @@ public class ImportOptions
         return firstRowIsHeader;
     }
 
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isSkipLastUpdated()
+    {
+        return skipLastUpdated;
+    }
+
     //--------------------------------------------------------------------------
     // Set methods
     //--------------------------------------------------------------------------
@@ -584,6 +594,12 @@ public class ImportOptions
         return this;
     }
 
+    public ImportOptions setSkipLastUpdated( boolean skipLastUpdated )
+    {
+        this.skipLastUpdated = skipLastUpdated;
+        return this;
+    }
+
     @Override
     public String toString()
     {
@@ -608,6 +624,7 @@ public class ImportOptions
             .add( "requireAttributeOptionCombo", requireAttributeOptionCombo )
             .add( "force", force )
             .add( "firstRowIsHeader", firstRowIsHeader )
+            .add( "skipLastUpdated", skipLastUpdated )
             .toString();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -1335,7 +1335,11 @@ public abstract class AbstractEventService
         preheatDataElementsCache( event, importOptions );
         eventDataValueService.processDataValues( programStageInstance, event, true, singleValue, importOptions, importSummary, dataElementCache );
         programStageInstanceService.updateProgramStageInstance( programStageInstance );
-        updateTrackedEntityInstance( programStageInstance, importOptions.getUser(), bulkUpdate );
+
+        if ( !importOptions.isSkipLastUpdated() )
+        {
+            updateTrackedEntityInstance( programStageInstance, importOptions.getUser(), bulkUpdate );
+        }
 
         if ( importSummary.getConflicts().size() > 0 ) {
             importSummary.setStatus( ImportStatus.ERROR );
@@ -1693,7 +1697,10 @@ public abstract class AbstractEventService
                     programStageInstance, aoc, assignedUser, importOptions, importSummary );
             }
 
-            updateTrackedEntityInstance( programStageInstance, importOptions.getUser(), bulkSave );
+            if ( !importOptions.isSkipLastUpdated() )
+            {
+                updateTrackedEntityInstance( programStageInstance, importOptions.getUser(), bulkSave );
+            }
 
             importSummary.setReference( programStageInstance.getUid() );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -366,6 +366,8 @@ public abstract class AbstractTrackedEntityInstanceService
         daoEntityInstance.setUid( CodeGenerator.isValidUid( dtoEntityInstance.getTrackedEntityInstance() ) ?
             dtoEntityInstance.getTrackedEntityInstance() : CodeGenerator.generateUid() );
 
+        updateDateFields( dtoEntityInstance, daoEntityInstance );
+
         return daoEntityInstance;
     }
 
@@ -474,9 +476,6 @@ public abstract class AbstractTrackedEntityInstanceService
         teiService.addTrackedEntityInstance( daoEntityInstance );
 
         addAttributeValues( dtoEntityInstance, daoEntityInstance, importOptions.getUser() );
-        updateDateFields( dtoEntityInstance, daoEntityInstance );
-
-        teiService.updateTrackedEntityInstance( daoEntityInstance );
 
         importSummary.setReference( daoEntityInstance.getUid() );
         importSummary.getImportCount().incrementImported();
@@ -1145,8 +1144,6 @@ public abstract class AbstractTrackedEntityInstanceService
     private void updateDateFields( TrackedEntityInstance dtoEntityInstance,
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoEntityInstance )
     {
-        daoEntityInstance.setAutoFields();
-
         Date createdAtClient = DateUtils.parseDate( dtoEntityInstance.getCreatedAtClient() );
 
         if ( createdAtClient != null )
@@ -1160,6 +1157,8 @@ public abstract class AbstractTrackedEntityInstanceService
         {
             daoEntityInstance.setLastUpdatedAtClient( DateUtils.parseDate( lastUpdatedAtClient ) );
         }
+
+        daoEntityInstance.setAutoFields();
     }
 
     private String getStoredBy( Attribute attributeValue, ImportSummary importSummary,
@@ -1196,6 +1195,7 @@ public abstract class AbstractTrackedEntityInstanceService
         if ( importOptions == null )
         {
             importOptions = new ImportOptions();
+            importOptions.setSkipLastUpdated( true );
         }
 
         if ( importOptions.getUser() == null )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -654,6 +654,7 @@ public class TrackedEntityInstanceController
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response ) throws IOException
     {
         importOptions.setStrategy( strategy );
+        importOptions.setSkipLastUpdated( true );
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
 
         if ( !importOptions.isAsync() )


### PR DESCRIPTION
- Skip time stamp update when unnecessary
- Remove unnecessary TEI update

The rule is: If event payload is received through TEI endpoint, there is no need to update TEI while processing events.  