### PR TITLE
Avoid potential circular check for tei-pi-psi

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstance.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstance.java
@@ -105,7 +105,10 @@ public class TrackedEntityInstance
             createdAtClient = created;
         }
 
-        lastUpdatedAtClient = lastUpdated;
+        if ( lastUpdatedAtClient == null )
+        {
+            lastUpdatedAtClient = lastUpdated;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -98,6 +98,8 @@ public class ImportOptions
 
     private NotificationLevel notificationLevel;
 
+    private boolean skipLastUpdated;
+
     //--------------------------------------------------------------------------
     // Constructors
     //--------------------------------------------------------------------------
@@ -365,6 +367,13 @@ public class ImportOptions
         return notificationLevel;
     }
 
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isSkipLastUpdated()
+    {
+        return skipLastUpdated;
+    }
+
     //--------------------------------------------------------------------------
     // Set methods
     //--------------------------------------------------------------------------
@@ -566,6 +575,12 @@ public class ImportOptions
         return this;
     }
 
+    public ImportOptions setSkipLastUpdated( boolean skipLastUpdated )
+    {
+        this.skipLastUpdated = skipLastUpdated;
+        return this;
+    }
+
     @Override
     public String toString()
     {
@@ -587,6 +602,7 @@ public class ImportOptions
             .add( "requireCategoryOptionCombo", requireCategoryOptionCombo )
             .add( "requireAttributeOptionCombo", requireAttributeOptionCombo )
             .add( "force", force )
+            .add( "skipLastUpdated", skipLastUpdated )
             .toString();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -1315,8 +1315,13 @@ public abstract class AbstractEventService
         }
 
         saveTrackedEntityComment( programStageInstance, event, storedBy );        
-        programStageInstanceService.updateProgramStageInstance( programStageInstance );        
-        updateTrackedEntityInstance( programStageInstance, importOptions.getUser(), bulkUpdate );        
+        programStageInstanceService.updateProgramStageInstance( programStageInstance );
+
+        if ( !importOptions.isSkipLastUpdated() )
+        {
+            updateTrackedEntityInstance( programStageInstance, importOptions.getUser(), bulkUpdate );
+        }
+
         sendProgramNotification( programStageInstance, importOptions );
 
         Set<TrackedEntityDataValue> dataValues = new HashSet<>(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -406,12 +406,6 @@ public abstract class AbstractTrackedEntityInstanceService
         teiService.addTrackedEntityInstance( daoEntityInstance );
 
         updateAttributeValues( dtoEntityInstance, daoEntityInstance, null, importOptions.getUser() );
-        updateDateFields( dtoEntityInstance, daoEntityInstance );
-
-        daoEntityInstance.setFeatureType( dtoEntityInstance.getFeatureType() );
-        daoEntityInstance.setCoordinates( dtoEntityInstance.getCoordinates() );
-
-        teiService.updateTrackedEntityInstance( daoEntityInstance );
 
         importSummary.setReference( daoEntityInstance.getUid() );
         importSummary.getImportCount().incrementImported();
@@ -654,6 +648,11 @@ public abstract class AbstractTrackedEntityInstanceService
         daoEntityInstance.setTrackedEntityType( trackedEntityType );
         daoEntityInstance.setUid( CodeGenerator.isValidUid( dtoEntityInstance.getTrackedEntityInstance() ) ?
                 dtoEntityInstance.getTrackedEntityInstance() : CodeGenerator.generateUid() );
+
+        updateDateFields( dtoEntityInstance, daoEntityInstance );
+
+        daoEntityInstance.setFeatureType( dtoEntityInstance.getFeatureType() );
+        daoEntityInstance.setCoordinates( dtoEntityInstance.getCoordinates() );
 
         return daoEntityInstance;
     }
@@ -1051,8 +1050,6 @@ public abstract class AbstractTrackedEntityInstanceService
     private void updateDateFields( TrackedEntityInstance dtoEntityInstance,
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoEntityInstance )
     {
-        daoEntityInstance.setAutoFields();
-
         Date createdAtClient = DateUtils.parseDate( dtoEntityInstance.getCreatedAtClient() );
 
         if ( createdAtClient != null )
@@ -1066,6 +1063,8 @@ public abstract class AbstractTrackedEntityInstanceService
         {
             daoEntityInstance.setLastUpdatedAtClient( DateUtils.parseDate( lastUpdatedAtClient ) );
         }
+
+        daoEntityInstance.setAutoFields();
     }
 
     private String getStoredBy( Attribute attributeValue, ImportSummary importSummary, String fallbackUsername )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -659,6 +659,7 @@ public class TrackedEntityInstanceController
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response ) throws IOException
     {
         importOptions.setStrategy( strategy );
+        importOptions.setSkipLastUpdated( true );
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
 
         if ( !importOptions.isAsync() )
@@ -702,6 +703,7 @@ public class TrackedEntityInstanceController
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response ) throws IOException
     {
         importOptions.setStrategy( strategy );
+        importOptions.setSkipLastUpdated( true );
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
 
         if ( !importOptions.isAsync() )


### PR DESCRIPTION
- Skip time stamp update when unnecessary
- Remove unnecessary TEI update

The rule is: If event payload is received through TEI endpoint, there is no need to update TEI while processing events.