### PR TITLE
Update PredictionService to use Transactional annotations

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/DefaultPredictorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/DefaultPredictorService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.predictor;
 
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -55,6 +56,7 @@ public class DefaultPredictorService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional
     public long addPredictor( Predictor predictor )
     {
         predictorStore.save( predictor );
@@ -62,30 +64,35 @@ public class DefaultPredictorService
     }
 
     @Override
+    @Transactional
     public void updatePredictor( Predictor predictor )
     {
         predictorStore.update( predictor );
     }
 
     @Override
+    @Transactional
     public void deletePredictor( Predictor predictor )
     {
         predictorStore.delete( predictor );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Predictor getPredictor( long id )
     {
         return predictorStore.get( id );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Predictor getPredictor( String uid )
     {
         return predictorStore.getByUid( uid );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Predictor> getAllPredictors()
     {
         return predictorStore.getAll();
@@ -95,6 +102,8 @@ public class DefaultPredictorService
     // Predictor group
     // -------------------------------------------------------------------------
 
+    @Override
+    @Transactional
     public long addPredictorGroup( PredictorGroup predictorGroup )
     {
         predictorGroupStore.save( predictorGroup );
@@ -103,30 +112,35 @@ public class DefaultPredictorService
     }
 
     @Override
+    @Transactional
     public void deletePredictorGroup( PredictorGroup predictorGroup )
     {
         predictorGroupStore.delete( predictorGroup );
     }
 
     @Override
+    @Transactional
     public void updatePredictorGroup( PredictorGroup predictorGroup )
     {
         predictorGroupStore.update( predictorGroup );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PredictorGroup getPredictorGroup( long id )
     {
         return predictorGroupStore.get( id );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PredictorGroup getPredictorGroup( String uid )
     {
         return predictorGroupStore.getByUid( uid );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<PredictorGroup> getAllPredictorGroups()
     {
         return predictorGroupStore.getAll();


### PR DESCRIPTION
Added `@Transactional` annotation to `PredictionService`.
A Docker-based integration test was failing and this fixed the broken test.