### PR TITLE
Included integration tests as parallel travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,19 @@ addons:
     - oracle-java8-installer
 before_install:
 - rm ~/.m2/settings.xml
-script:
-  -  mvn clean install -DskipTests=false -DargLine="-Xmx512m -Xms256m" -q --update-snapshots -f  ./dhis-2/pom.xml
-  -  mvn clean install -DskipTests=false -DargLine="-Xmx512m -Xms256m" -q --update-snapshots -f ./dhis-2/dhis-web/pom.xml
+
+jobs: 
+  include:
+    - stage: tests 
+      name: unit
+      script: 
+        - mvn clean install -DskipTests=false -q --update-snapshots -f ./dhis-2/pom.xml
+        - mvn clean install -DskipTests=false -q --update-snapshots -f ./dhis-2/dhis-web/pom.xml
+        
+    - name: integration
+      script: 
+        - mvn clean install -Pintegration -f ./dhis-2/pom.xml
+        
 branches:
   only:
   - master


### PR DESCRIPTION
This PR included integration test runs into travis PR check. 
Integration tests runs in parallel with unit tests and based on my tests on travis, finishes earlier than unit tests, so it doesn't bloat travis build time. 