### PR TITLE
Remove circular dependency between Spring beans

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
@@ -38,103 +38,58 @@ import org.hisp.dhis.user.User;
  */
 public interface TrackerOwnershipManager
 {
-    public static final String OWNERSHIP_ACCESS_DENIED = "OWNERSHIP_ACCESS_DENIED";
-    
-    public static final String PROGRAM_ACCESS_CLOSED = "PROGRAM_ACCESS_CLOSED";
+    String OWNERSHIP_ACCESS_DENIED = "OWNERSHIP_ACCESS_DENIED";
 
-    /**
-     * @param teiUid the tracked entity instance uid
-     * @param programUid the prorgram uid
-     * @param orgUnitUid the org unit uid
-     * @param skipAccessValidation whether ownership access validation has to be
-     *        skipped or not.
-     */
-    void transferOwnership( String teiUid, String programUid, String orgUnitUid, boolean skipAccessValidation,
-        boolean createIfNotExists );
+    String PROGRAM_ACCESS_CLOSED = "PROGRAM_ACCESS_CLOSED";
 
     /**
      * @param entityInstance The tracked entity instance object
-     * @param progrprogramamId The program object
-     * @param organisationUnit The org unit that has to become the owner
+     * @param program The program object
+     * @param orgUnit The org unit that has to become the owner
      * @param skipAccessValidation whether ownership access validation has to be
      *        skipped or not.
      */
     void transferOwnership( TrackedEntityInstance entityInstance, Program program, OrganisationUnit orgUnit,
-        boolean skipAccessValidation, boolean createIfNotExists );
-
-    /**
-     * @param teiUid the tracked entity instance uid
-     * @param programUid the prorgram uid
-     * @param orgUnitUid the org unit uid
-     * @param skipAccessValidation whether ownership access validation has to be
-     *        skipped or not.
-     */
-    void assignOwnership( String teiUid, String programUid, String orgUnitUid, boolean skipAccessValidation,
-        boolean overwriteIfExists );
+                            boolean skipAccessValidation, boolean createIfNotExists );
 
     /**
      * @param entityInstance The tracked entity instance object
-     * @param progrprogramamId The program object
+     * @param program The program object
      * @param organisationUnit The org unit that has to become the owner
-     * @param skipAccessValidation
-     * @param overwriteIfExists
      */
     void assignOwnership( TrackedEntityInstance entityInstance, Program program, OrganisationUnit organisationUnit,
-        boolean skipAccessValidation, boolean overwriteIfExists );
+                          boolean skipAccessValidation, boolean overwriteIfExists );
 
     /**
      * Check whether the user has access (as owner or has temporarily broken the
      * glass) for the tracked entity instance - program combination.
-     * 
+     *
      * @param user The user with which access has to be checked for.
      * @param entityInstance The tracked entity instance.
      * @param program The program.
      * @return true if the user has access, false otherwise.
      */
     boolean hasAccess( User user, TrackedEntityInstance entityInstance, Program program );
-    
-    
+
+
     /**
      * Check whether the user has access (as owner or has temporarily broken the
      * glass) for the program instance.
-     * 
+     *
      * @param user The user with which access has to be checked for.
-     * @param programInstance The program instance. 
+     * @param programInstance The program instance.
      * @return true if the user has access, false otherwise.
      */
     boolean hasAccess( User user, ProgramInstance programInstance );
 
     /**
-     * Check whether the user has access (as owner or has temporarily broken the
-     * glass) for the tracked entity instance - program combination.
-     * 
-     * @param user The user with which access has to be checked for.
-     * @param teiUid the tracked entity instance uid
-     * @param programUid the program uid
-     * @return true if the user has access, false otherwise.
-     */
-    boolean hasAccess( User user, String teiUid, String programUid );
-
-    /**
      * Grant temporary ownership for a user for a specific tei-program
      * combination
-     * 
-     * @param teiUid The tracked entity instance uid
-     * @param programUid The program Uid
-     * @param user The user object
-     * @param reason The reason for requesting temporary ownership
-     */
-    void grantTemporaryOwnership( String teiUid, String programUid, User user, String reason  );
-
-    /**
-     * Grant temporary ownership for a user for a specific tei-program
-     * combination
-     * 
+     *
      * @param entityInstance The tracked entity instance object
      * @param program The program object
      * @param user The user for which temporary access is granted.
      * @param reason The reason for requesting temporary ownership
      */
     void grantTemporaryOwnership( TrackedEntityInstance entityInstance, Program program, User user, String reason );
-
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -38,18 +38,18 @@ import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramOwnershipHistory;
 import org.hisp.dhis.program.ProgramOwnershipHistoryService;
-import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramTempOwnershipAudit;
 import org.hisp.dhis.program.ProgramTempOwnershipAuditService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Ameen Mohamed
@@ -66,75 +66,42 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     // Dependencies
     // -------------------------------------------------------------------------
 
-    private TrackedEntityInstanceService trackedEntityInstanceService;
-
-    @Autowired
-    public void setTrackedEntityInstanceService( TrackedEntityInstanceService trackedEntityInstanceService )
-    {
-        this.trackedEntityInstanceService = trackedEntityInstanceService;
-    }
-
     private CurrentUserService currentUserService;
 
-    @Autowired
-    public void setCurrentUserService( CurrentUserService currentUserService )
+    private final TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
+
+    private final CacheProvider cacheProvider;
+
+    private final ProgramTempOwnershipAuditService programTempOwnershipAuditService;
+
+    private final ProgramOwnershipHistoryService programOwnershipHistoryService;
+
+    public DefaultTrackerOwnershipManager( CurrentUserService currentUserService,
+        TrackedEntityProgramOwnerService trackedEntityProgramOwnerService, CacheProvider cacheProvider,
+        ProgramTempOwnershipAuditService programTempOwnershipAuditService,
+        ProgramOwnershipHistoryService programOwnershipHistoryService )
     {
+        checkNotNull( currentUserService );
+        checkNotNull( trackedEntityProgramOwnerService );
+        checkNotNull( cacheProvider );
+        checkNotNull( programTempOwnershipAuditService );
+        checkNotNull( programOwnershipHistoryService );
+
         this.currentUserService = currentUserService;
-    }
-
-    private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
-
-    @Autowired
-    public void setTrackedEntityProgramOwnerService( TrackedEntityProgramOwnerService trackedEntityProgramOwnerService )
-    {
         this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
-    }
-
-    private CacheProvider cacheProvider;
-
-    @Autowired
-    public void setCacheProvider( CacheProvider cacheProvider )
-    {
         this.cacheProvider = cacheProvider;
-    }
-
-    private ProgramService programService;
-
-    @Autowired
-    public void setProgramService( ProgramService programService )
-    {
-        this.programService = programService;
-    }
-
-    private ProgramTempOwnershipAuditService programTempOwnershipAuditService;
-
-    @Autowired
-    public void setProgramTempOwnershipAuditService( ProgramTempOwnershipAuditService programTempOwnershipAuditService )
-    {
         this.programTempOwnershipAuditService = programTempOwnershipAuditService;
-    }
-
-    private ProgramOwnershipHistoryService programOwnershipHistoryService;
-
-    @Autowired
-    public void setProgramOwnershipHistoryService( ProgramOwnershipHistoryService programOwnershipHistoryService )
-    {
         this.programOwnershipHistoryService = programOwnershipHistoryService;
     }
 
-    private OrganisationUnitService organisationUnitService;
-
-    @Autowired
-    public void setOrganisationUnitService( OrganisationUnitService organisationUnitService )
-    {
-        this.organisationUnitService = organisationUnitService;
+    /**
+     * Used only by test harness. Remove after test refactoring
+     *
+     */
+    @Deprecated
+    public void setCurrentUserService(CurrentUserService currentUserService) {
+        this.currentUserService = currentUserService;
     }
-
-    public void setTemporaryTrackerOwnershipCache( Cache<Boolean> temporaryTrackerOwnershipCache )
-    {
-        this.temporaryTrackerOwnershipCache = temporaryTrackerOwnershipCache;
-    }
-   
     /**
      * Cache for storing temporary ownership grants.
      */
@@ -156,15 +123,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     // -------------------------------------------------------------------------
 
     @Override
-    public void transferOwnership( String teiUid, String programUid, String orgUnitUid, boolean skipAccessValidation, boolean createIfNotExists )
-    {
-        Program program = programService.getProgram( programUid );
-        TrackedEntityInstance entityInstance = trackedEntityInstanceService.getTrackedEntityInstance( teiUid );
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgUnitUid );
-        transferOwnership( entityInstance, program, orgUnit, skipAccessValidation, createIfNotExists );
-    }
-
-    @Override
+    @Transactional
     public void transferOwnership( TrackedEntityInstance entityInstance, Program program, OrganisationUnit orgUnit, boolean skipAccessValidation,
         boolean createIfNotExists )
     {
@@ -198,15 +157,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     }
 
     @Override
-    public void assignOwnership( String teiUid, String programUid, String orgUnitUid, boolean skipAccessValidation, boolean overwriteIfExists )
-    {
-        Program program = programService.getProgram( programUid );
-        TrackedEntityInstance entityInstance = trackedEntityInstanceService.getTrackedEntityInstance( teiUid );
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgUnitUid );
-        assignOwnership( entityInstance, program, orgUnit, skipAccessValidation, overwriteIfExists );
-    }
-
-    @Override
+    @Transactional
     public void assignOwnership( TrackedEntityInstance entityInstance, Program program, OrganisationUnit organisationUnit, boolean skipAccessValidation,
         boolean overwriteIfExists )
     {
@@ -240,21 +191,14 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     }
 
     @Override
-    public void grantTemporaryOwnership( String teiUid, String programUid, User user, String reason )
-    {
-        TrackedEntityInstance entityInstance = trackedEntityInstanceService.getTrackedEntityInstance( teiUid );
-        Program program = programService.getProgram( programUid );
-        grantTemporaryOwnership( entityInstance, program, user, reason );
-    }
-
-    @Override
+    @Transactional
     public void grantTemporaryOwnership( TrackedEntityInstance entityInstance, Program program, User user, String reason )
     {
         if ( canSkipOwnershipCheck( user, program ) || entityInstance == null )
         {
             return;
         }
-        if ( user != null && program.isProtected() )
+        if (program.isProtected())
         {
             programTempOwnershipAuditService
                 .addProgramTempOwnershipAudit( new ProgramTempOwnershipAudit( program, entityInstance, reason, user.getUsername() ) );
@@ -263,6 +207,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean hasAccess( User user, TrackedEntityInstance entityInstance, Program program )
     {
         if ( canSkipOwnershipCheck( user, program ) || entityInstance == null )
@@ -282,6 +227,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     }
     
     @Override
+    @Transactional(readOnly = true)
     public boolean hasAccess( User user, ProgramInstance programInstance )
     {
         Program program = programInstance.getProgram();
@@ -304,14 +250,6 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
         }
     }
 
-    @Override
-    public boolean hasAccess( User user, String teiUid, String programUid )
-    {
-        Program program = programService.getProgram( programUid );
-        TrackedEntityInstance entityInstance = trackedEntityInstanceService.getTrackedEntityInstance( teiUid );
-        return hasAccess( user, entityInstance, program );
-    }
-
     // -------------------------------------------------------------------------
     // Private Helper Methods
     // -------------------------------------------------------------------------
@@ -320,14 +258,11 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
      * Generates a unique key for the tei-program-user combination to be put
      * into cache.
      * 
-     * @param teiUid
-     * @param programUid
-     * @param username
      * @return A unique cache key
      */
     private String tempAccessKey( String teiUid, String programUid, String username )
     {
-        return new StringBuilder().append( username ).append( COLON ).append( programUid ).append( COLON ).append( teiUid ).toString();
+        return username + COLON + programUid + COLON + teiUid;
     }
 
     /**
@@ -340,7 +275,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
      */
     private OrganisationUnit getOwner( TrackedEntityInstance entityInstance, Program program )
     {
-        OrganisationUnit ou = null;
+        OrganisationUnit ou;
         TrackedEntityProgramOwner trackedEntityProgramOwner = trackedEntityProgramOwnerService.getTrackedEntityProgramOwner( entityInstance.getId(),
             program.getId() );
         if ( trackedEntityProgramOwner == null )
@@ -390,8 +325,6 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
      * Ownership check can be skipped if the user is super user or if the
      * program is without registration.
      * 
-     * @param user
-     * @param program
      * @return true if ownership check can be skipped
      */
     private boolean canSkipOwnershipCheck( User user, Program program )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -634,7 +634,9 @@ public abstract class AbstractEventService
 
         for ( Event event : eventList )
         {
-            if ( trackerOwnershipAccessManager.hasAccess( user, event.getTrackedEntityInstance(), event.getProgram() ) )
+            if ( trackerOwnershipAccessManager.hasAccess( user,
+                entityInstanceService.getTrackedEntityInstance( event.getTrackedEntityInstance() ),
+                programService.getProgram( event.getProgram() ) ) )
             {
                 events.getEvents().add( event );
             }
@@ -832,7 +834,9 @@ public abstract class AbstractEventService
 
         for ( EventRow eventRow : eventRowList )
         {
-            if ( trackerOwnershipAccessManager.hasAccess( user, eventRow.getTrackedEntityInstance(), eventRow.getProgram() ) )
+            if ( trackerOwnershipAccessManager.hasAccess( user,
+                entityInstanceService.getTrackedEntityInstance( eventRow.getTrackedEntityInstance() ),
+                programService.getProgram( eventRow.getProgram() ) ) )
             {
                 eventRows.getEventRows().add( eventRow );
             }
@@ -1332,7 +1336,7 @@ public abstract class AbstractEventService
         }
 
         saveTrackedEntityComment( programStageInstance, event, storedBy );
-        preheatDataElementsCache( event, importOptions );
+        preheatDataElementsCache( event );
         eventDataValueService.processDataValues( programStageInstance, event, true, singleValue, importOptions, importSummary, dataElementCache );
         programStageInstanceService.updateProgramStageInstance( programStageInstance );
 
@@ -1353,10 +1357,13 @@ public abstract class AbstractEventService
         return importSummary;
     }
 
-    private void preheatDataElementsCache(Event event, ImportOptions importOptions) {
-        Set<String> dataElementUids = event.getDataValues().stream().map( dv -> dv.getDataElement() ).collect( Collectors.toSet());
+    private void preheatDataElementsCache( Event event )
+    {
+        Set<String> dataElementUids = event.getDataValues().stream().map( dv -> dv.getDataElement() )
+            .collect( Collectors.toSet() );
 
-        List<DataElement> dataElements = manager.getObjects( DataElement.class, IdentifiableProperty.UID, dataElementUids );
+        List<DataElement> dataElements = manager.getObjects( DataElement.class, IdentifiableProperty.UID,
+            dataElementUids );
 
         dataElements.forEach( de -> dataElementCache.put( de.getUid(), de ) );
     }
@@ -1623,7 +1630,7 @@ public abstract class AbstractEventService
         String storedBy = getValidUsername( event.getStoredBy(), importSummary, importOptions.getUser() != null ? importOptions.getUser().getUsername() : "[Unknown]" );
         String completedBy = getValidUsername( event.getCompletedBy(), importSummary, importOptions.getUser() != null ? importOptions.getUser().getUsername() : "[Unknown]" );
 
-        CategoryOptionCombo aoc = null;
+        CategoryOptionCombo aoc;
 
         if ( (event.getAttributeCategoryOptions() != null && program.getCategoryCombo() != null)
             || event.getAttributeOptionCombo() != null )
@@ -1803,7 +1810,7 @@ public abstract class AbstractEventService
             programStageInstance.setCompletedDate( completedDate );
         }
 
-        preheatDataElementsCache( event, importOptions );
+        preheatDataElementsCache( event );
 
         if ( programStageInstance.getId() == 0 )
         {

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -28,14 +28,15 @@ package org.hisp.dhis.webapi.controller.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.io.IOException;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -71,6 +72,15 @@ public class TrackerOwnershipController
     protected ContextService contextService;
 
     @Autowired
+    private TrackedEntityInstanceService trackedEntityInstanceService;
+
+    @Autowired
+    private ProgramService programService;
+
+    @Autowired
+    private OrganisationUnitService organisationUnitService;
+
+    @Autowired
     private WebMessageService webMessageService;
 
     // -------------------------------------------------------------------------
@@ -80,21 +90,21 @@ public class TrackerOwnershipController
 
     @RequestMapping( value = "/transfer", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE )
     public void updateTrackerProgramOwner( @RequestParam String trackedEntityInstance, @RequestParam String program,
-        @RequestParam String ou, HttpServletRequest request, HttpServletResponse response )
-        throws IOException
-    {
-        trackerOwnershipAccessManager.transferOwnership( trackedEntityInstance, program, ou, false, false );
+        @RequestParam String ou, HttpServletRequest request, HttpServletResponse response ) {
 
+        trackerOwnershipAccessManager.transferOwnership(
+            trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstance ),
+            programService.getProgram( program ), organisationUnitService.getOrganisationUnit( ou ), false, false );
         webMessageService.send( WebMessageUtils.ok( "Ownership transferred" ), response, request );
     }
 
     @RequestMapping( value = "/override", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
     public void overrideOwnershipAccess( @RequestParam String trackedEntityInstance, @RequestParam String reason,
-        @RequestParam String program, HttpServletRequest request, HttpServletResponse response )
-        throws IOException
-    {
-        trackerOwnershipAccessManager.grantTemporaryOwnership( trackedEntityInstance, program,
-            currentUserService.getCurrentUser(), reason );
+        @RequestParam String program, HttpServletRequest request, HttpServletResponse response ) {
+
+        trackerOwnershipAccessManager.grantTemporaryOwnership(
+            trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstance ),
+            programService.getProgram( program ), currentUserService.getCurrentUser(), reason );
 
         webMessageService.send( WebMessageUtils.ok( "Temporary Ownership granted" ), response, request );
     }


### PR DESCRIPTION
- Removed overloaded methods from `TrackerOwnershipManager` which were forcing the class to do a lookup through the `TrackedEntityInstanceService`