### PR TITLE
Fix bug pushAnalysis service throws error when generated map is null

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.mapgeneration.MapGenerationService;
+import org.hisp.dhis.mapgeneration.MapUtils;
 import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
@@ -388,6 +389,11 @@ public class DefaultPushAnalysisService
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         BufferedImage image = mapGenerationService.generateMapImageForUser( map, new Date(), null, 578, 440, user );
+
+        if ( image == null )
+        {
+            image = MapUtils.createErrorImage( "No data" );
+        }
 
         ImageIO.write( image, "PNG", baos );
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-6559

display an error image as below if generated map is null because of no data.

<img width="614" alt="Screen Shot 2019-04-08 at 10 15 46 PM" src="https://user-images.githubusercontent.com/766102/55735996-b0b24c00-5a4c-11e9-926a-57168699fdc2.png">
