### PR TITLE
 Added skipSharing for metadata export with dependencies (#5292)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -357,7 +357,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
-    public RootNode getMetadataWithDependenciesAsNode( IdentifiableObject object )
+    public RootNode getMetadataWithDependenciesAsNode( IdentifiableObject object, @Nonnull MetadataExportParams params )
     {
         RootNode rootNode = NodeUtils.createMetadata();
         rootNode.addChild( new SimpleNode( "date", new Date(), true ) );
@@ -366,8 +366,10 @@ public class DefaultMetadataExportService implements MetadataExportService
 
         for ( Class<? extends IdentifiableObject> klass : metadata.keySet() )
         {
-            rootNode.addChild( fieldFilterService.toCollectionNode( klass, new FieldFilterParams( Lists.newArrayList( metadata.get( klass ) ),
-                Lists.newArrayList( ":owner" ) ) ) );
+            FieldFilterParams fieldFilterParams = new FieldFilterParams( Lists.newArrayList( metadata.get( klass ) ),
+                Lists.newArrayList( ":owner" ) );
+            fieldFilterParams.setSkipSharing( params.getSkipSharing() );
+            rootNode.addChild( fieldFilterService.toCollectionNode( klass, fieldFilterParams ) );
         }
 
         return rootNode;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportService.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.dxf2.metadata;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.node.types.RootNode;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +73,8 @@ public interface MetadataExportService
     MetadataExportParams getParamsFromMap( Map<String, List<String>> parameters );
 
     /**
-     * Exports an object including a set of selected dependencies.
+     * Exports an object including a set of selected dependencies. Only a subset of the
+     * specified export parameters are used for the metadata with dependencies export.
      *
      * @param object Object to export including dependencies
      * @return Original object + selected set of dependencies
@@ -80,12 +82,14 @@ public interface MetadataExportService
     Map<Class<? extends IdentifiableObject>, Set<IdentifiableObject>> getMetadataWithDependencies( IdentifiableObject object );
 
     /**
-     * Exports an object including a set of selected dependencies as RootNode.
+     * Exports an object including a set of selected dependencies as RootNode. Only a subset
+     * of the specified export parameters are used for the metadata with dependencies export.
      *
      * @param object Object to export including dependencies
+     * @param params Parameters that affect the export.
      * @return Original object + selected set of dependencies, exported as RootNode
      */
-    RootNode getMetadataWithDependenciesAsNode( IdentifiableObject object );
+    RootNode getMetadataWithDependenciesAsNode( IdentifiableObject object, @Nonnull MetadataExportParams params );
 
 
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -1,0 +1,166 @@
+package org.hisp.dhis.fieldfilter;
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.node.Node;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.beans.PropertyDescriptor;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Unit tests for {@link DefaultFieldFilterService}.
+ */
+public class DefaultFieldFilterServiceTest
+{
+    private FieldParser fieldParser = new DefaultFieldParser();
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    CurrentUserService currentUserService;
+
+    private DefaultFieldFilterService service;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp() throws Exception
+    {
+        service = new DefaultFieldFilterService( fieldParser, schemaService, aclService, currentUserService );
+    }
+
+    @Test
+    public void toCollectionNodeSkipSharingNoFields() throws Exception
+    {
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "dataElementAttribute" );
+        addProperty( propertyMap, attribute, "user" );
+        addProperty( propertyMap, attribute, "publicAccess" );
+        addProperty( propertyMap, attribute, "userGroupAccesses" );
+        addProperty( propertyMap, attribute, "userAccesses" );
+        addProperty( propertyMap, attribute, "externalAccess" );
+
+        final Schema rootSchema = new Schema( Attribute.class, "attribute", "attributes" );
+        rootSchema.setPropertyMap( propertyMap );
+        Mockito.when( schemaService.getDynamicSchema( Mockito.eq( Attribute.class ) ) ).thenReturn( rootSchema );
+
+        final Schema booleanSchema = new Schema( boolean.class, "boolean", "booleans" );
+        Mockito.when( schemaService.getDynamicSchema( Mockito.eq( boolean.class ) ) ).thenReturn( booleanSchema );
+
+        final FieldFilterParams params = new FieldFilterParams( Collections.singletonList( attribute ), Collections.emptyList(), Defaults.INCLUDE, true );
+
+        CollectionNode node = service.toCollectionNode( Attribute.class, params );
+        Assert.assertEquals( 1, node.getChildren().size() );
+        Set<String> names = extractNodeNames( node.getChildren().get( 0 ).getChildren() );
+        Assert.assertTrue( names.contains( "dataElementAttribute" ) );
+        Assert.assertFalse( names.contains( "user" ) );
+        Assert.assertFalse( names.contains( "publicAccess" ) );
+        Assert.assertFalse( names.contains( "userGroupAccesses" ) );
+        Assert.assertFalse( names.contains( "userAccesses" ) );
+        Assert.assertFalse( names.contains( "externalAccess" ) );
+    }
+
+    @Test
+    public void toCollectionNodeSkipSharingOwner() throws Exception
+    {
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "dataElementAttribute" );
+        Property p = addProperty( propertyMap, attribute, "dataSetAttribute" );
+        p.setOwner( true );
+        p.setPersisted( true );
+        addProperty( propertyMap, attribute, "user" );
+        addProperty( propertyMap, attribute, "publicAccess" );
+        addProperty( propertyMap, attribute, "userGroupAccesses" );
+        addProperty( propertyMap, attribute, "userAccesses" );
+        addProperty( propertyMap, attribute, "externalAccess" );
+
+        final Schema rootSchema = new Schema( Attribute.class, "attribute", "attributes" );
+        rootSchema.setPropertyMap( propertyMap );
+        Mockito.when( schemaService.getDynamicSchema( Mockito.eq( Attribute.class ) ) ).thenReturn( rootSchema );
+
+        final Schema booleanSchema = new Schema( boolean.class, "boolean", "booleans" );
+        Mockito.when( schemaService.getDynamicSchema( Mockito.eq( boolean.class ) ) ).thenReturn( booleanSchema );
+
+        final FieldFilterParams params = new FieldFilterParams( Collections.singletonList( attribute ), Collections.singletonList( ":owner" ), Defaults.INCLUDE, true );
+
+        CollectionNode node = service.toCollectionNode( Attribute.class, params );
+        Assert.assertEquals( 1, node.getChildren().size() );
+        Set<String> names = extractNodeNames( node.getChildren().get( 0 ).getChildren() );
+        Assert.assertFalse( names.contains( "dataElementAttribute" ) );
+        Assert.assertTrue( names.contains( "dataSetAttribute" ) );
+        Assert.assertFalse( names.contains( "user" ) );
+        Assert.assertFalse( names.contains( "publicAccess" ) );
+        Assert.assertFalse( names.contains( "userGroupAccesses" ) );
+        Assert.assertFalse( names.contains( "userAccesses" ) );
+        Assert.assertFalse( names.contains( "externalAccess" ) );
+    }
+
+    private static Set<String> extractNodeNames( Collection<Node> nodes )
+    {
+        return nodes.stream().map( Node::getName ).collect( Collectors.toSet() );
+    }
+
+    private static Property addProperty( Map<String, Property> propertyMap, Object bean, String property ) throws Exception
+    {
+        PropertyDescriptor pd = PropertyUtils.getPropertyDescriptor( bean, property );
+        Property p = new Property( pd.getPropertyType(), pd.getReadMethod(), pd.getWriteMethod() );
+        p.setName( pd.getName() );
+        p.setReadable( true );
+        propertyMap.put( pd.getName(), p );
+        return p;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -55,12 +55,20 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -152,7 +160,10 @@ public class DefaultFieldFilterService implements FieldFilterService
 
         if ( params.getSkipSharing() )
         {
-            fields = Joiner.on( "," ).join( fieldParser.modifyFilter( params.getFields(),  SHARING_FIELDS ) );
+            final List<String> fieldList = CollectionUtils.isEmpty( params.getFields() ) ? Collections.singletonList( "*" ) : params.getFields();
+            // excludes must be preserved (e.g. when field collections like :owner are used, which is not expanded by modify filter)
+            fields = Stream.concat( fieldParser.modifyFilter( fieldList, SHARING_FIELDS ).stream(), SHARING_FIELDS.stream() )
+                .filter( org.apache.commons.lang3.StringUtils::isNotBlank ).distinct().collect( Collectors.joining( "," ) );
         }
 
         if ( params.getObjects().isEmpty() )

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -1,0 +1,115 @@
+package org.hisp.dhis.webapi.controller;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.net.HttpHeaders;
+import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.dashboard.DashboardService;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DashboardController}.
+ *
+ * @author Volker Schmidt
+ */
+public class DashboardControllerTest
+{
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private MetadataExportService exportService;
+
+    @Mock
+    private DashboardService service;
+
+    @Mock
+    private Dashboard dashboard;
+
+    @InjectMocks
+    private DashboardController controller;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void getWithDependencies() throws Exception
+    {
+        getWithDependencies( false );
+    }
+
+    @Test
+    public void getWithDependenciesAsDownload() throws Exception
+    {
+        getWithDependencies( true );
+    }
+
+    private void getWithDependencies( boolean download ) throws Exception
+    {
+        final Map<String, List<String>> parameterValuesMap = new HashMap<>();
+        final MetadataExportParams exportParams = new MetadataExportParams();
+        final RootNode rootNode = new RootNode( "test" );
+
+        Mockito.when( service.getDashboard( Mockito.eq( "88dshgdga" ) ) ).thenReturn( dashboard );
+        Mockito.when( contextService.getParameterValuesMap() ).thenReturn( parameterValuesMap );
+        Mockito.when( exportService.getParamsFromMap( Mockito.same( parameterValuesMap ) ) ).thenReturn( exportParams );
+        Mockito.when( exportService.getMetadataWithDependenciesAsNode( Mockito.same( dashboard ), Mockito.same( exportParams ) ) )
+            .thenReturn( rootNode );
+
+        final ResponseEntity<RootNode> responseEntity = controller.getDataSetWithDependencies( "88dshgdga", download );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        if ( download )
+        {
+            Assert.assertEquals( "attachment; filename=metadata",
+                responseEntity.getHeaders().getFirst( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+        else
+        {
+            Assert.assertFalse( responseEntity.getHeaders().containsKey( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
@@ -1,0 +1,115 @@
+package org.hisp.dhis.webapi.controller;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.net.HttpHeaders;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DataSetController}.
+ *
+ * @author Volker Schmidt
+ */
+public class DataSetControllerTest
+{
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private MetadataExportService exportService;
+
+    @Mock
+    private DataSetService service;
+
+    @Mock
+    private DataSet dataSet;
+
+    @InjectMocks
+    private DataSetController controller;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void getWithDependencies() throws Exception
+    {
+        getWithDependencies( false );
+    }
+
+    @Test
+    public void getWithDependenciesAsDownload() throws Exception
+    {
+        getWithDependencies( true );
+    }
+
+    private void getWithDependencies( boolean download ) throws Exception
+    {
+        final Map<String, List<String>> parameterValuesMap = new HashMap<>();
+        final MetadataExportParams exportParams = new MetadataExportParams();
+        final RootNode rootNode = new RootNode( "test" );
+
+        Mockito.when( service.getDataSet( Mockito.eq( "88dshgdga" ) ) ).thenReturn( dataSet );
+        Mockito.when( contextService.getParameterValuesMap() ).thenReturn( parameterValuesMap );
+        Mockito.when( exportService.getParamsFromMap( Mockito.same( parameterValuesMap ) ) ).thenReturn( exportParams );
+        Mockito.when( exportService.getMetadataWithDependenciesAsNode( Mockito.same( dataSet ), Mockito.same( exportParams ) ) )
+            .thenReturn( rootNode );
+
+        final ResponseEntity<RootNode> responseEntity = controller.getDataSetWithDependencies( "88dshgdga", download );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        if ( download )
+        {
+            Assert.assertEquals( "attachment; filename=metadata",
+                responseEntity.getHeaders().getFirst( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+        else
+        {
+            Assert.assertFalse( responseEntity.getHeaders().containsKey( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
@@ -1,0 +1,115 @@
+package org.hisp.dhis.webapi.controller.category;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.net.HttpHeaders;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link CategoryComboController}.
+ *
+ * @author Volker Schmidt
+ */
+public class CategoryComboControllerTest
+{
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private MetadataExportService exportService;
+
+    @Mock
+    private CategoryService service;
+
+    @Mock
+    private CategoryCombo categoryCombo;
+
+    @InjectMocks
+    private CategoryComboController controller;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void getWithDependencies() throws Exception
+    {
+        getWithDependencies( false );
+    }
+
+    @Test
+    public void getWithDependenciesAsDownload() throws Exception
+    {
+        getWithDependencies( true );
+    }
+
+    private void getWithDependencies( boolean download ) throws Exception
+    {
+        final Map<String, List<String>> parameterValuesMap = new HashMap<>();
+        final MetadataExportParams exportParams = new MetadataExportParams();
+        final RootNode rootNode = new RootNode( "test" );
+
+        Mockito.when( service.getCategoryCombo( Mockito.eq( "88dshgdga" ) ) ).thenReturn( categoryCombo );
+        Mockito.when( contextService.getParameterValuesMap() ).thenReturn( parameterValuesMap );
+        Mockito.when( exportService.getParamsFromMap( Mockito.same( parameterValuesMap ) ) ).thenReturn( exportParams );
+        Mockito.when( exportService.getMetadataWithDependenciesAsNode( Mockito.same( categoryCombo ), Mockito.same( exportParams ) ) )
+            .thenReturn( rootNode );
+
+        final ResponseEntity<RootNode> responseEntity = controller.getDataSetWithDependencies( "88dshgdga", download );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        if ( download )
+        {
+            Assert.assertEquals( "attachment; filename=metadata",
+                responseEntity.getHeaders().getFirst( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+        else
+        {
+            Assert.assertFalse( responseEntity.getHeaders().containsKey( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramControllerTest.java
@@ -1,0 +1,115 @@
+package org.hisp.dhis.webapi.controller.event;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.net.HttpHeaders;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ProgramController}.
+ *
+ * @author Volker Schmidt
+ */
+public class ProgramControllerTest
+{
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private MetadataExportService exportService;
+
+    @Mock
+    private ProgramService service;
+
+    @Mock
+    private Program program;
+
+    @InjectMocks
+    private ProgramController controller;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void getWithDependencies() throws Exception
+    {
+        getWithDependencies( false );
+    }
+
+    @Test
+    public void getWithDependenciesAsDownload() throws Exception
+    {
+        getWithDependencies( true );
+    }
+
+    private void getWithDependencies( boolean download ) throws Exception
+    {
+        final Map<String, List<String>> parameterValuesMap = new HashMap<>();
+        final MetadataExportParams exportParams = new MetadataExportParams();
+        final RootNode rootNode = new RootNode( "test" );
+
+        Mockito.when( service.getProgram( Mockito.eq( "88dshgdga" ) ) ).thenReturn( program );
+        Mockito.when( contextService.getParameterValuesMap() ).thenReturn( parameterValuesMap );
+        Mockito.when( exportService.getParamsFromMap( Mockito.same( parameterValuesMap ) ) ).thenReturn( exportParams );
+        Mockito.when( exportService.getMetadataWithDependenciesAsNode( Mockito.same( program ), Mockito.same( exportParams ) ) )
+            .thenReturn( rootNode );
+
+        final ResponseEntity<RootNode> responseEntity = controller.getProgramWithDependencies( "88dshgdga", download );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        if ( download )
+        {
+            Assert.assertEquals( "attachment; filename=metadata",
+                responseEntity.getHeaders().getFirst( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+        else
+        {
+            Assert.assertFalse( responseEntity.getHeaders().containsKey( HttpHeaders.CONTENT_DISPOSITION ) );
+        }
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtilsTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtilsTest.java
@@ -1,0 +1,130 @@
+package org.hisp.dhis.webapi.controller.metadata;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.net.HttpHeaders;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link MetadataExportControllerUtils}.
+ *
+ * @author Volker Schmidt
+ */
+public class MetadataExportControllerUtilsTest
+{
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private MetadataExportService exportService;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void getWithDependencies()
+    {
+        final Map<String, List<String>> parameterValuesMap = new HashMap<>();
+        final MetadataExportParams exportParams = new MetadataExportParams();
+        final Attribute attribute = new Attribute();
+        final RootNode rootNode = new RootNode( "test" );
+
+        Mockito.when( contextService.getParameterValuesMap() ).thenReturn( parameterValuesMap );
+        Mockito.when( exportService.getParamsFromMap( Mockito.same( parameterValuesMap ) ) ).thenReturn( exportParams );
+        Mockito.when( exportService.getMetadataWithDependenciesAsNode( Mockito.same( attribute ), Mockito.same( exportParams ) ) )
+            .thenReturn( rootNode );
+
+        final ResponseEntity<RootNode> responseEntity =
+            MetadataExportControllerUtils.getWithDependencies( contextService, exportService, attribute, false );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        Assert.assertFalse( responseEntity.getHeaders().containsKey( HttpHeaders.CONTENT_DISPOSITION ) );
+    }
+
+    @Test
+    public void getWithDependenciesAsDownload()
+    {
+        final Map<String, List<String>> parameterValuesMap = new HashMap<>();
+        final MetadataExportParams exportParams = new MetadataExportParams();
+        final Attribute attribute = new Attribute();
+        final RootNode rootNode = new RootNode( "test" );
+
+        Mockito.when( contextService.getParameterValuesMap() ).thenReturn( parameterValuesMap );
+        Mockito.when( exportService.getParamsFromMap( Mockito.same( parameterValuesMap ) ) ).thenReturn( exportParams );
+        Mockito.when( exportService.getMetadataWithDependenciesAsNode( Mockito.same( attribute ), Mockito.same( exportParams ) ) )
+            .thenReturn( rootNode );
+
+        final ResponseEntity<RootNode> responseEntity =
+            MetadataExportControllerUtils.getWithDependencies( contextService, exportService, attribute, true );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        Assert.assertEquals( "attachment; filename=metadata",
+            responseEntity.getHeaders().getFirst( HttpHeaders.CONTENT_DISPOSITION ) );
+    }
+
+    @Test
+    public void createResponseEntity()
+    {
+        final RootNode rootNode = new RootNode( "test" );
+        final ResponseEntity<RootNode> responseEntity =
+            MetadataExportControllerUtils.createResponseEntity( rootNode, false );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        Assert.assertFalse( responseEntity.getHeaders().containsKey( HttpHeaders.CONTENT_DISPOSITION ) );
+    }
+
+    @Test
+    public void createResponseEntityAsDownload()
+    {
+        final RootNode rootNode = new RootNode( "test" );
+        final ResponseEntity<RootNode> responseEntity =
+            MetadataExportControllerUtils.createResponseEntity( rootNode, true );
+        Assert.assertEquals( HttpStatus.OK, responseEntity.getStatusCode() );
+        Assert.assertSame( rootNode, responseEntity.getBody() );
+        Assert.assertEquals( "attachment; filename=metadata",
+            responseEntity.getHeaders().getFirst( HttpHeaders.CONTENT_DISPOSITION ) );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -1,9 +1,7 @@
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.DhisApiVersion;
-
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,6 +28,7 @@ import org.hisp.dhis.common.DhisApiVersion;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dashboard.DashboardItem;
@@ -43,11 +42,13 @@ import org.hisp.dhis.hibernate.exception.UpdateAccessDeniedException;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.DashboardItemSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.DashboardSchemaDescriptor;
+import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -58,7 +59,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -293,7 +293,7 @@ public class DashboardController
         {
             if ( item.getContentCount() == 0 && dashboard.getItems().remove( item ) )
             {
-                dashboardService.deleteDashboardItem( item ); // Delete if empty                
+                dashboardService.deleteDashboardItem( item ); // Delete if empty
             }
 
             dashboardService.updateDashboard( dashboard );
@@ -307,8 +307,8 @@ public class DashboardController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
-    public @ResponseBody RootNode getDataSetWithDependencies( @PathVariable( "uid" ) String dashboardId, HttpServletResponse response )
-        throws WebMessageException, IOException
+    public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String dashboardId, @RequestParam( required = false, defaultValue = "false" ) boolean download )
+        throws WebMessageException
     {
         Dashboard dashboard = dashboardService.getDashboard( dashboardId );
 
@@ -317,9 +317,9 @@ public class DashboardController
             throw new WebMessageException( WebMessageUtils.notFound( "Dashboard not found for uid: " + dashboardId ) );
         }
 
-        return exportService.getMetadataWithDependenciesAsNode( dashboard );
+        return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dashboard, download );
     }
-    
+
     // -------------------------------------------------------------------------
     // Hooks
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -31,13 +31,13 @@ package org.hisp.dhis.webapi.controller;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DisplayDensity;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.dataentryform.DataEntryFormService;
 import org.hisp.dhis.dataset.DataSet;
@@ -63,6 +63,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.render.DefaultRenderService;
 import org.hisp.dhis.schema.descriptors.DataSetSchemaDescriptor;
+import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.FormUtils;
 import org.hisp.dhis.webapi.view.ClassPathUriResolver;
@@ -71,6 +72,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -428,8 +430,8 @@ public class DataSetController
     }
 
     @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
-    public @ResponseBody RootNode getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid, HttpServletResponse response )
-        throws WebMessageException, IOException
+    public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid, @RequestParam( required = false, defaultValue = "false" ) boolean download )
+        throws WebMessageException
     {
         DataSet dataSet = dataSetService.getDataSet( pvUid );
 
@@ -438,7 +440,7 @@ public class DataSetController
             throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + pvUid ) );
         }
 
-        return exportService.getMetadataWithDependenciesAsNode( dataSet );
+        return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dataSet, download );
     }
 
     /**

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -37,14 +37,15 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.CategoryComboSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
@@ -59,7 +60,7 @@ public class CategoryComboController
     private CategoryService categoryService;
 
     @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
-    public @ResponseBody RootNode getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid, HttpServletResponse response )
+    public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid, @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException, IOException
     {
         CategoryCombo categoryCombo = categoryService.getCategoryCombo( pvUid );
@@ -69,7 +70,7 @@ public class CategoryComboController
             throw new WebMessageException( WebMessageUtils.notFound( "CategoryCombo not found for uid: " + pvUid ) );
         }
 
-        return exportService.getMetadataWithDependenciesAsNode( categoryCombo );
+        return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, categoryCombo, download );
     }
 
     @Override

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dashboard/DashboardControllerV2.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dashboard/DashboardControllerV2.java
@@ -10,8 +10,10 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.DashboardSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +21,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.util.Set;
 
 /**
@@ -56,8 +56,8 @@ public class DashboardControllerV2
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
-    public @ResponseBody RootNode getDataSetWithDependencies( @PathVariable( "uid" ) String dashboardId, HttpServletResponse response )
-        throws WebMessageException, IOException
+    public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String dashboardId, @RequestParam( required = false, defaultValue = "false" ) boolean download )
+        throws WebMessageException
     {
         Dashboard dashboard = dashboardService.getDashboard( dashboardId );
 
@@ -66,6 +66,6 @@ public class DashboardControllerV2
             throw new WebMessageException( WebMessageUtils.notFound( "Dashboard not found for uid: " + dashboardId ) );
         }
 
-        return exportService.getMetadataWithDependenciesAsNode( dashboard );
+        return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dashboard, download );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
@@ -30,9 +30,9 @@ package org.hisp.dhis.webapi.controller.dataelement;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -42,16 +42,17 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.DataElementGroupSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -153,7 +154,7 @@ public class DataElementGroupController
     }
 
     @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
-    public @ResponseBody RootNode getDataElementGroupWithDependencies( @PathVariable( "uid" ) String dataElementGroupId, HttpServletResponse response )
+    public ResponseEntity<RootNode> getDataElementGroupWithDependencies( @PathVariable( "uid" ) String dataElementGroupId, @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException, IOException
     {
         DataElementGroup dataElementGroup = dataElementService.getDataElementGroup( dataElementGroupId );
@@ -163,6 +164,6 @@ public class DataElementGroupController
             throw new WebMessageException( WebMessageUtils.notFound( "DataElementGroup not found for uid: " + dataElementGroupId ) );
         }
 
-        return exportService.getMetadataWithDependenciesAsNode( dataElementGroup );
+        return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dataElementGroup, download );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -44,17 +44,17 @@ import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.descriptors.ProgramSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
@@ -122,7 +122,7 @@ public class ProgramController
     }
 
     @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
-    public @ResponseBody RootNode getProgramWithDependencies( @PathVariable( "uid" ) String pvUid, HttpServletResponse response ) throws WebMessageException, IOException
+    public ResponseEntity<RootNode> getProgramWithDependencies( @PathVariable( "uid" ) String pvUid, @RequestParam( required = false, defaultValue = "false" ) boolean download ) throws WebMessageException
     {
         Program program = programService.getProgram( pvUid );
 
@@ -131,6 +131,6 @@ public class ProgramController
             throw new WebMessageException( WebMessageUtils.notFound( "Program not found for uid: " + pvUid ) );
         }
 
-        return metadataExportService.getMetadataWithDependenciesAsNode( program );
+        return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, program, download );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportController.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.webapi.controller.metadata;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
@@ -38,14 +39,13 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.Locale;
 
@@ -70,8 +70,9 @@ public class MetadataExportController
     private UserSettingService userSettingService;
 
     @RequestMapping( value = "", method = RequestMethod.GET )
-    public @ResponseBody RootNode getMetadata(
-        @RequestParam( required = false, defaultValue = "false" ) boolean translate, @RequestParam( required = false ) String locale )
+    public ResponseEntity<RootNode> getMetadata(
+        @RequestParam( required = false, defaultValue = "false" ) boolean translate, @RequestParam( required = false ) String locale,
+        @RequestParam( required = false, defaultValue = "false" ) boolean download )
     {
         if ( translate )
         {
@@ -81,8 +82,8 @@ public class MetadataExportController
 
         MetadataExportParams params = metadataExportService.getParamsFromMap( contextService.getParameterValuesMap() );
         metadataExportService.validate( params );
-
-        return metadataExportService.getMetadataAsNode( params );
+        RootNode rootNode = metadataExportService.getMetadataAsNode( params );
+        return MetadataExportControllerUtils.createResponseEntity( rootNode, download );
     }
 
     private void setUserContext( User user, TranslateParams translateParams )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtils.java
@@ -1,0 +1,94 @@
+package org.hisp.dhis.webapi.controller.metadata;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import javax.annotation.Nonnull;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Utilities for metadata export controllers.
+ *
+ * @author Volker Schmidt
+ */
+public abstract class MetadataExportControllerUtils
+{
+    /**
+     * Returns the response entity for metadata download with dependencies.
+     *
+     * @param contextService     the context service that is used to retrieve request parameters.
+     * @param exportService      the export service that is used to export metadata with dependencies.
+     * @param identifiableObject the identifiable object that should be exported with dependencies.
+     * @param download           <code>true</code> if the data should be downloaded (as attachment),
+     *                           <code>false</code> otherwise.
+     * @return the response with the metadata.
+     */
+    @Nonnull
+    public static ResponseEntity<RootNode> getWithDependencies( @Nonnull ContextService contextService, @Nonnull MetadataExportService exportService, @Nonnull IdentifiableObject identifiableObject, boolean download )
+    {
+        final MetadataExportParams exportParams = exportService.getParamsFromMap( contextService.getParameterValuesMap() );
+        exportService.validate( exportParams );
+
+        RootNode rootNode = exportService.getMetadataWithDependenciesAsNode( identifiableObject, exportParams );
+        return createResponseEntity( rootNode, download );
+    }
+
+    /**
+     * Creates the response entity for the root node. Optionally it can be specified that the data
+     * should be downloaded.
+     *
+     * @param rootNode the root node for which the response entity should be created.
+     * @param download <code>true</code> if the data should be downloaded (as attachment),
+     *                 <code>false</code> otherwise.
+     * @return the response with the metadata.
+     */
+    @Nonnull
+    public static ResponseEntity<RootNode> createResponseEntity( @Nonnull RootNode rootNode, boolean download )
+    {
+        HttpHeaders headers = new HttpHeaders();
+        if ( download )
+        {
+            // triggers that corresponding message converter adds also a file name with a correct extension
+            headers.add( HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=metadata" );
+        }
+        return new ResponseEntity<>( rootNode, headers, HttpStatus.OK );
+    }
+
+    private MetadataExportControllerUtils()
+    {
+        super();
+    }
+}


### PR DESCRIPTION
- Backport from 2.32
- The same export parameters that are used for normal export are now
  used for export with dependencies (even if just some of the options
  are used). This enables future extensions.
- The download parameter can be added to all endpoints in order to
  get the metadata as an attachment.
- All fields will be excluded in all skip sharing exports:
  "user", "publicAccess", "userGroupAccesses", "!userAccesses",
  "externalAccess" (at the moment just some of them, caused by filter).