### PR TITLE
Fixes issues with dots in URI for pager links (4896)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/DefaultLinkService.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/DefaultLinkService.java
@@ -261,7 +261,15 @@ public class DefaultLinkService implements LinkService
             return StringUtils.EMPTY;
         }
 
-        int index = requestUri.indexOf( '.' );
+        int index = requestUri.lastIndexOf( '/' );
+
+        if ( index >= 0 )
+        {
+            // the request URI itself may have dots inside
+            requestUri = requestUri.substring( index );
+        }
+
+        index = requestUri.indexOf( '.' );
 
         if ( index < 0 )
         {

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/DefaultLinkServiceTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/DefaultLinkServiceTest.java
@@ -198,6 +198,33 @@ public class DefaultLinkServiceTest
     }
 
     @Test
+    public void nextLinkWithDotsInPath()
+    {
+        Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) ).thenAnswer( invocation -> {
+            Schema schema = new Schema( OrganisationUnit.class, "organisationUnit", "organisationUnits" );
+            schema.setRelativeApiEndpoint( "/organizationUnits" );
+            return schema;
+        } );
+
+        request.setRequestURI( "https://play.dhis2.org/2.30/api/30/organizationUnits.xml.gz" );
+        Mockito.when( contextService.getRequest() ).thenReturn( request );
+
+        Mockito.when( contextService.getApiPath() ).thenReturn( "/2.30/api/30" );
+
+        Mockito.when( contextService.getParameterValuesMap() ).thenAnswer( invocation -> {
+            final Map<String, List<String>> map = new HashMap<>();
+            map.put( "page", Collections.singletonList( "1" ) );
+            map.put( "pageSize", Collections.singletonList( "55" ) );
+            return map;
+        } );
+
+        final Pager pager = new Pager( 2, 60 );
+        service.generatePagerLinks( pager, OrganisationUnit.class );
+        Assert.assertEquals( "/2.30/api/30/organizationUnits.xml.gz", pager.getPrevPage() );
+        Assert.assertNull( pager.getNextPage() );
+    }
+
+    @Test
     public void prevLinkParameters()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) ).thenAnswer( invocation -> {


### PR DESCRIPTION
When there are dots in the URI path (e.g. version numbers on play
environments) the resulting pager URL is invalid.