### PR TITLE
Resolve performance issues with large category option requests

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.user;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,13 +28,12 @@ package org.hisp.dhis.user;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -51,12 +50,14 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import javax.persistence.Transient;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Nguyen Hong Duc
@@ -165,6 +166,20 @@ public class UserCredentials
      */
     private boolean disabled;
 
+    /**
+     * Cached all authorities {@link #getAllAuthorities()}.
+     */
+    @JsonIgnore
+    @Transient
+    private transient volatile Set<String> cachedAllAuthorities;
+
+    /**
+     * Cached state if user is super user {@link #isSuper()}.
+     */
+    @JsonIgnore
+    @Transient
+    private transient volatile Boolean cachedSuper;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -197,12 +212,23 @@ public class UserCredentials
      */
     public Set<String> getAllAuthorities()
     {
+        // cached all authorities can be reset to null by different thread and must be assigned before evaluation
+        final Set<String> resultingAuthorities = cachedAllAuthorities;
+
+        if ( resultingAuthorities != null )
+        {
+            return resultingAuthorities;
+        }
+
         Set<String> authorities = new HashSet<>();
 
         for ( UserAuthorityGroup group : userAuthorityGroups )
         {
             authorities.addAll( group.getAuthorities() );
         }
+
+        authorities = Collections.unmodifiableSet( authorities );
+        cachedAllAuthorities = authorities;
 
         return authorities;
     }
@@ -260,15 +286,18 @@ public class UserCredentials
      */
     public boolean isSuper()
     {
-        for ( UserAuthorityGroup group : userAuthorityGroups )
+        final Boolean superUser = cachedSuper;
+
+        if ( superUser != null )
         {
-            if ( group.isSuper() )
-            {
-                return true;
-            }
+            return superUser;
         }
 
-        return false;
+        final boolean resultingSuper = userAuthorityGroups.stream().anyMatch( UserAuthorityGroup::isSuper );
+
+        cachedSuper = resultingSuper;
+
+        return resultingSuper;
     }
 
     /**
@@ -592,6 +621,8 @@ public class UserCredentials
     public void setUserAuthorityGroups( Set<UserAuthorityGroup> userAuthorityGroups )
     {
         this.userAuthorityGroups = userAuthorityGroups;
+        this.cachedSuper = null;
+        this.cachedAllAuthorities = null;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/UserCredentialsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/UserCredentialsTest.java
@@ -1,0 +1,127 @@
+package org.hisp.dhis.user;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link UserCredentials}.
+ *
+ * @author volsch
+ */
+public class UserCredentialsTest
+{
+    private UserAuthorityGroup userAuthorityGroup1;
+
+    private UserAuthorityGroup userAuthorityGroup2;
+
+    private UserAuthorityGroup userAuthorityGroup1Super;
+
+    @Before
+    public void setUp()
+    {
+        userAuthorityGroup1 = new UserAuthorityGroup();
+        userAuthorityGroup1.setUid( "uid1" );
+        userAuthorityGroup1.setAuthorities( new HashSet<>( Arrays.asList( "x1", "x2" ) ) );
+
+        userAuthorityGroup2 = new UserAuthorityGroup();
+        userAuthorityGroup2.setUid( "uid2" );
+        userAuthorityGroup2.setAuthorities( new HashSet<>( Arrays.asList( "y1", "y2" ) ) );
+
+        userAuthorityGroup1Super = new UserAuthorityGroup();
+        userAuthorityGroup1Super.setUid( "uid4" );
+        userAuthorityGroup1Super.setAuthorities( new HashSet<>( Arrays.asList( "z1", UserAuthorityGroup.AUTHORITY_ALL ) ) );
+    }
+
+    @Test
+    public void isSuper()
+    {
+        final UserCredentials userCredentials = new UserCredentials();
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super, userAuthorityGroup2 ) ) );
+
+        Assert.assertTrue( userCredentials.isSuper() );
+        Assert.assertTrue( userCredentials.isSuper() );
+    }
+
+    @Test
+    public void isNotSuper()
+    {
+        final UserCredentials userCredentials = new UserCredentials();
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup2 ) ) );
+
+        Assert.assertFalse( userCredentials.isSuper() );
+        Assert.assertFalse( userCredentials.isSuper() );
+    }
+
+    @Test
+    public void isSuperChanged()
+    {
+        final UserCredentials userCredentials = new UserCredentials();
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super, userAuthorityGroup2 ) ) );
+
+        Assert.assertTrue( userCredentials.isSuper() );
+
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup2 ) ) );
+        Assert.assertFalse( userCredentials.isSuper() );
+    }
+
+    @Test
+    public void getAllAuthorities()
+    {
+        final UserCredentials userCredentials = new UserCredentials();
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super ) ) );
+
+        Set<String> authorities1 = userCredentials.getAllAuthorities();
+        Assert.assertThat( authorities1, Matchers.containsInAnyOrder( "x1", "x2", "z1", UserAuthorityGroup.AUTHORITY_ALL ) );
+
+        Set<String> authorities2 = userCredentials.getAllAuthorities();
+        Assert.assertSame( authorities1, authorities2 );
+    }
+
+    @Test
+    public void getAllAuthoritiesChanged()
+    {
+        final UserCredentials userCredentials = new UserCredentials();
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super ) ) );
+
+        Set<String> authorities1 = userCredentials.getAllAuthorities();
+        Assert.assertThat( authorities1, Matchers.containsInAnyOrder( "x1", "x2", "z1", UserAuthorityGroup.AUTHORITY_ALL ) );
+
+        userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup2 ) ) );
+        Set<String> authorities2 = userCredentials.getAllAuthorities();
+        Assert.assertThat( authorities2, Matchers.containsInAnyOrder( "x1", "x2", "y1", "y2" ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -94,7 +94,7 @@ public class DefaultAclService implements AclService
         Schema schema = schemaService.getSchema( klass );
         return schema != null && schema.isDataShareable();
     }
-    
+
     @Override
     public boolean canRead( User user, IdentifiableObject object )
     {
@@ -104,7 +104,7 @@ public class DefaultAclService implements AclService
         }
 
         Schema schema = schemaService.getSchema( object.getClass() );
-        
+
         if ( canAccess( user, schema.getAuthorityByType( AuthorityType.READ ) ) )
         {
             if ( object instanceof CategoryOptionCombo )
@@ -132,7 +132,7 @@ public class DefaultAclService implements AclService
         if ( readWriteCommonCheck( user, object ) ) return true;
 
         Schema schema = schemaService.getSchema( object.getClass() );
-        
+
         if ( canAccess( user, schema.getAuthorityByType( AuthorityType.DATA_READ ) ) )
         {
             if ( object instanceof CategoryOptionCombo )
@@ -169,7 +169,7 @@ public class DefaultAclService implements AclService
 
         Schema schema = schemaService.getSchema( object.getClass() );
 
-        List<String> anyAuthorities = schema.getAuthorityByType( AuthorityType.CREATE );
+        List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.CREATE ) );
 
         if ( anyAuthorities.isEmpty() )
         {
@@ -204,6 +204,7 @@ public class DefaultAclService implements AclService
 
         Schema schema = schemaService.getSchema( object.getClass() );
 
+        // returned unmodifiable list does not need to be cloned since it is not modified
         List<String> anyAuthorities = schema.getAuthorityByType( AuthorityType.DATA_CREATE );
 
         if ( canAccess( user, anyAuthorities ) )
@@ -232,7 +233,7 @@ public class DefaultAclService implements AclService
 
         Schema schema = schemaService.getSchema( object.getClass() );
 
-        List<String> anyAuthorities = schema.getAuthorityByType( AuthorityType.UPDATE );
+        List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.UPDATE ) );
 
         if ( anyAuthorities.isEmpty() )
         {
@@ -264,7 +265,7 @@ public class DefaultAclService implements AclService
 
         Schema schema = schemaService.getSchema( object.getClass() );
 
-        List<String> anyAuthorities = schema.getAuthorityByType( AuthorityType.DELETE );
+        List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.DELETE ) );
 
         if ( anyAuthorities.isEmpty() )
         {
@@ -646,7 +647,7 @@ public class DefaultAclService implements AclService
         for ( UserGroupAccess userGroupAccess : object.getUserGroupAccesses() )
         {
             /*
-             * Is the user allowed to read this object through group access? 
+             * Is the user allowed to read this object through group access?
              *
              */
             if ( AccessStringHelper.isEnabled( userGroupAccess.getAccess(), permission )
@@ -659,7 +660,7 @@ public class DefaultAclService implements AclService
         for ( UserAccess userAccess : object.getUserAccesses() )
         {
             /*
-             * Is the user allowed to read to this object through user access? 
+             * Is the user allowed to read to this object through user access?
              *
              */
             if ( AccessStringHelper.isEnabled( userAccess.getAccess(), permission )
@@ -704,7 +705,7 @@ public class DefaultAclService implements AclService
         return schemaService.getSchema( object.getClass() ) == null;
     }
 
-    private boolean writeCommonCheck(Schema schema, User user, IdentifiableObject object ) 
+    private boolean writeCommonCheck( Schema schema, User user, IdentifiableObject object )
     {
         if ( !schema.isShareable() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOption.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOption.hbm.xml
@@ -27,7 +27,7 @@
 
     <property name="translations" type="jblTranslations"/>
 
-    <set name="organisationUnits" table="categoryoption_organisationunits">
+    <set name="organisationUnits" table="categoryoption_organisationunits" batch-size="100">
       <cache usage="read-write" />
       <key column="categoryoptionid" foreign-key="fk_categoryoption_organisationunits_categoryoptionid" />
       <many-to-many column="organisationunitid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
@@ -41,7 +41,7 @@
         foreign-key="fk_categoryoption_categoryoptioncomboid" />
     </set>
 
-    <set name="categories" table="categories_categoryoptions" inverse="true">
+    <set name="categories" table="categories_categoryoptions" inverse="true" batch-size="1000">
       <cache usage="read-write" />
       <key column="categoryoptionid" />
       <many-to-many class="org.hisp.dhis.category.Category" column="categoryid" />
@@ -66,13 +66,13 @@
 
     <property name="publicAccess" length="8" />
 
-    <set name="userGroupAccesses" table="dataelementcategoryoptionusergroupaccesses" cascade="all-delete-orphan">
+    <set name="userGroupAccesses" table="dataelementcategoryoptionusergroupaccesses" cascade="all-delete-orphan" batch-size="1000">
       <cache usage="read-write" />
       <key column="categoryoptionid" />
       <many-to-many class="org.hisp.dhis.user.UserGroupAccess" column="usergroupaccessid" unique="true" />
     </set>
 
-    <set name="userAccesses" table="dataelementcategoryoptionuseraccesses" cascade="all-delete-orphan">
+    <set name="userAccesses" table="dataelementcategoryoptionuseraccesses" cascade="all-delete-orphan" batch-size="1000">
       <cache usage="read-write" />
       <key column="categoryoptionid" />
       <many-to-many class="org.hisp.dhis.user.UserAccess" column="useraccessid" unique="true" />

--- a/dhis-2/dhis-services/dhis-service-schema/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-schema/pom.xml
@@ -2,21 +2,21 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
     <version>2.33-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>dhis-service-schema</artifactId>
   <packaging>jar</packaging>
   <name>DHIS Schema service</name>
-  
+
   <dependencies>
-    
+
     <!-- DHIS -->
-    
+
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-api</artifactId>
@@ -33,7 +33,12 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-system</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/SchemaTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/SchemaTest.java
@@ -30,8 +30,17 @@ package org.hisp.dhis.schema;
 
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.SecondaryMetadataObject;
+import org.hisp.dhis.security.Authority;
+import org.hisp.dhis.security.AuthorityType;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
 
 /**
  * Unit tests for {@link Schema}.
@@ -40,6 +49,17 @@ import org.junit.Test;
  */
 public class SchemaTest
 {
+    private List<Authority> authorities;
+
+    @Before
+    public void setUp()
+    {
+        authorities = new ArrayList<>();
+        authorities.add( new Authority( AuthorityType.CREATE, Arrays.asList( "x1", "x2" ) ) );
+        authorities.add( new Authority( AuthorityType.CREATE, Arrays.asList( "y1", "y2" ) ) );
+        authorities.add( new Authority( AuthorityType.DELETE, Arrays.asList( "z1", "z2" ) ) );
+    }
+
     @Test
     public void isSecondaryMetadataObject()
     {
@@ -56,6 +76,68 @@ public class SchemaTest
     public void isSecondaryMetadataObjectNot()
     {
         Assert.assertFalse( new Schema( Metadata.class, "singular", "plural" ).isSecondaryMetadata() );
+    }
+
+    @Test
+    public void testAuthorityByType()
+    {
+        final Schema schema = new Schema( SecondaryMetadata.class, "singular", "plural" );
+        schema.setAuthorities( authorities );
+
+        List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE );
+        Assert.assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
+
+        List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE );
+        Assert.assertThat( list2, contains( "x1", "x2", "y1", "y2" ) );
+        Assert.assertSame( list1, list2 );
+    }
+
+    @Test
+    public void testAuthorityByTypeDifferent()
+    {
+        final Schema schema = new Schema( SecondaryMetadata.class, "singular", "plural" );
+        schema.setAuthorities( authorities );
+
+        List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE );
+        Assert.assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
+
+        List<String> list3 = schema.getAuthorityByType( AuthorityType.DELETE );
+        Assert.assertThat( list3, contains( "z1", "z2" ) );
+
+        List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE );
+        Assert.assertThat( list2, contains( "x1", "x2", "y1", "y2" ) );
+        Assert.assertSame( list1, list2 );
+    }
+
+    @Test
+    public void testAuthorityByTypeNotFound()
+    {
+        final Schema schema = new Schema( SecondaryMetadata.class, "singular", "plural" );
+        schema.setAuthorities( authorities );
+
+        List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE_PRIVATE );
+        Assert.assertTrue( list1.isEmpty() );
+
+        List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE_PRIVATE );
+        Assert.assertTrue( list2.isEmpty() );
+        Assert.assertSame( list1, list2 );
+    }
+
+    @Test
+    public void testAuthorityByTypeReset()
+    {
+        final Schema schema = new Schema( SecondaryMetadata.class, "singular", "plural" );
+        schema.setAuthorities( authorities );
+
+        List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE );
+        Assert.assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
+
+        authorities.add( new Authority( AuthorityType.CREATE, Arrays.asList( "a1", "a2" ) ) );
+        schema.setAuthorities( authorities );
+
+        List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE );
+        Assert.assertThat( list2, contains( "x1", "x2", "y1", "y2", "a1", "a2" ) );
+        Assert.assertNotSame( list1, list2 );
     }
 
     private static class SecondaryMetadata implements SecondaryMetadataObject

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.33/V2_33_3__Create_categories_categoryoptions_index.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.33/V2_33_3__Create_categories_categoryoptions_index.sql
@@ -1,0 +1,2 @@
+-- Creates covering index for querying categories from category options
+CREATE INDEX in_categories_categoryoptions_coid ON categories_categoryoptions(categoryoptionid, categoryid);

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -29,7 +29,7 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-db-migration</artifactId>
     </dependency>
-    
+
     <!-- Hibernate -->
 
     <dependency>
@@ -96,6 +96,11 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
     </dependency>
 
   </dependencies>

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonEventDataValueSetBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonEventDataValueSetBinaryType.java
@@ -27,16 +27,16 @@ package org.hisp.dhis.hibernate.jsonb.type;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.hibernate.HibernateException;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.hisp.dhis.eventdatavalue.EventDataValue;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * @author David Katuscak
@@ -57,6 +57,13 @@ public class JsonEventDataValueSetBinaryType extends JsonBinaryType
         returnedClass = klass;
         reader = MAPPER.readerFor( new TypeReference<Map<String, EventDataValue>>() {} );
         writer = MAPPER.writerFor( new TypeReference<Map<String, EventDataValue>>() {} );
+    }
+
+    @Override
+    public Object deepCopy( Object value ) throws HibernateException
+    {
+        String json = convertObjectToJson( value );
+        return convertJsonToObject( json );
     }
 
     /**

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonJobParametersType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonJobParametersType.java
@@ -31,44 +31,22 @@ package org.hisp.dhis.hibernate.jsonb.type;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.util.Properties;
-
 /**
  * @author Henning Håkonsen
  */
-@SuppressWarnings("rawtypes")
 public class JsonJobParametersType extends JsonBinaryType
 {
-    @Override
-    public void setParameterValues( Properties parameters )
+    static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static
     {
-        final String clazz = (String) parameters.get( "clazz" );
-
-        if ( clazz == null )
-        {
-            throw new IllegalArgumentException(
-                String.format( "Required parameter '%s' is not configured", "clazz" ) );
-        }
-
-        try
-        {
-            init( classForName( clazz ) );
-        }
-        catch ( ClassNotFoundException e )
-        {
-            throw new IllegalArgumentException( "Class: " + clazz + " is not a known class type." );
-        }
+        MAPPER.enableDefaultTyping();
+        MAPPER.setSerializationInclusion( JsonInclude.Include.NON_NULL );
     }
 
     @Override
-    protected void init( Class<?> klass )
+    protected ObjectMapper getResultingMapper()
     {
-        ObjectMapper MAPPER = new ObjectMapper();
-        MAPPER.enableDefaultTyping();
-        MAPPER.setSerializationInclusion( JsonInclude.Include.NON_NULL );
-
-        returnedClass = klass;
-        reader = MAPPER.readerFor( klass );
-        writer = MAPPER.writerFor( klass );
+        return MAPPER;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryType.java
@@ -32,14 +32,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
  * @author Abyot Asalefew Gizaw <abyota@gmail.com>
  *
  */
-public class JsonListBinaryType 
+public class JsonListBinaryType
     extends JsonBinaryType
 {
     static final ObjectMapper MAPPER = new ObjectMapper();
@@ -50,30 +49,14 @@ public class JsonListBinaryType
     }
 
     @Override
-    protected String convertObjectToJson( Object value )
+    protected ObjectMapper getResultingMapper()
     {
-        try
-        {
-            return MAPPER.writeValueAsString( value );
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return MAPPER;
     }
-    
+
     @Override
-    protected Object convertJsonToObject( String content )
+    protected JavaType getResultingJavaType( Class<?> returnedClass )
     {
-        try
-        {
-            JavaType type = MAPPER.getTypeFactory().constructCollectionType( List.class, returnedClass() );
-            
-            return MAPPER.readValue( content, type );
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return MAPPER.getTypeFactory().constructCollectionType( List.class, returnedClass );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.hibernate.jsonb.type;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,34 +28,44 @@ package org.hisp.dhis.hibernate.jsonb.type;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.Set;
+import org.hisp.dhis.translation.Translation;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
- * @author Viet Nguyen <viet@dhis2.org>
+ * Unit tests for {@link JsonBinaryType}.
+ *
+ * @author Volker Schmidt
  */
-public class JsonSetBinaryType
-    extends JsonBinaryType
+public class JsonBinaryTypeTest
 {
-    static final ObjectMapper MAPPER = new ObjectMapper();
+    private JsonBinaryType jsonBinaryType;
 
-    static
+    private Translation translation1;
+
+    @Before
+    public void setUp()
     {
-        MAPPER.setSerializationInclusion( JsonInclude.Include.NON_NULL );
+        translation1 = new Translation();
+        translation1.setLocale( "en" );
+        translation1.setValue( "English Test 1" );
+
+        jsonBinaryType = new JsonBinaryType();
+        jsonBinaryType.init( Translation.class );
     }
 
-    @Override
-    protected ObjectMapper getResultingMapper()
+    @Test
+    public void deepCopy()
     {
-        return MAPPER;
+        final Translation result = (Translation) jsonBinaryType.deepCopy( translation1 );
+        Assert.assertNotSame( translation1, result );
+        Assert.assertEquals( translation1, result );
     }
 
-    @Override
-    protected JavaType getResultingJavaType( Class<?> returnedClass )
+    @Test
+    public void deepCopyNull()
     {
-        return MAPPER.getTypeFactory().constructCollectionType( Set.class, returnedClass );
+        Assert.assertNull( jsonBinaryType.deepCopy( null ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryTypeTest.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.hibernate.jsonb.type;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,34 +28,61 @@ package org.hisp.dhis.hibernate.jsonb.type;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.hisp.dhis.translation.Translation;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * @author Viet Nguyen <viet@dhis2.org>
+ * Unit tests for {@link JsonListBinaryType}.
+ *
+ * @author Volker Schmidt
  */
-public class JsonSetBinaryType
-    extends JsonBinaryType
+public class JsonListBinaryTypeTest
 {
-    static final ObjectMapper MAPPER = new ObjectMapper();
+    private JsonListBinaryType jsonBinaryType;
 
-    static
+    private List<Translation> translations;
+
+    private Translation translation1;
+
+    private Translation translation2;
+
+    @Before
+    public void setUp()
     {
-        MAPPER.setSerializationInclusion( JsonInclude.Include.NON_NULL );
+        translation1 = new Translation();
+        translation1.setLocale( "en" );
+        translation1.setValue( "English Test 1" );
+
+        translation2 = new Translation();
+        translation2.setLocale( "no" );
+        translation2.setValue( "Norwegian Test 1" );
+
+        translations = new ArrayList<>();
+        translations.add( translation1 );
+        translations.add( translation2 );
+
+        jsonBinaryType = new JsonListBinaryType();
+        jsonBinaryType.init( Translation.class );
     }
 
-    @Override
-    protected ObjectMapper getResultingMapper()
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void deepCopy()
     {
-        return MAPPER;
+        final List<Translation> result = (List<Translation>) jsonBinaryType.deepCopy( translations );
+        Assert.assertNotSame( translations, result );
+        Assert.assertThat( result, Matchers.contains( translation1, translation2 ) );
     }
 
-    @Override
-    protected JavaType getResultingJavaType( Class<?> returnedClass )
+    @Test
+    public void deepCopyNull()
     {
-        return MAPPER.getTypeFactory().constructCollectionType( Set.class, returnedClass );
+        Assert.assertNull( jsonBinaryType.deepCopy( null ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryTypeTest.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.hibernate.jsonb.type;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,34 +28,61 @@ package org.hisp.dhis.hibernate.jsonb.type;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.hisp.dhis.translation.Translation;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
- * @author Viet Nguyen <viet@dhis2.org>
+ * Unit tests for {@link JsonSetBinaryType}.
+ *
+ * @author Volker Schmidt
  */
-public class JsonSetBinaryType
-    extends JsonBinaryType
+public class JsonSetBinaryTypeTest
 {
-    static final ObjectMapper MAPPER = new ObjectMapper();
+    private JsonSetBinaryType jsonBinaryType;
 
-    static
+    private Set<Translation> translations;
+
+    private Translation translation1;
+
+    private Translation translation2;
+
+    @Before
+    public void setUp()
     {
-        MAPPER.setSerializationInclusion( JsonInclude.Include.NON_NULL );
+        translation1 = new Translation();
+        translation1.setLocale( "en" );
+        translation1.setValue( "English Test 1" );
+
+        translation2 = new Translation();
+        translation2.setLocale( "no" );
+        translation2.setValue( "Norwegian Test 1" );
+
+        translations = new HashSet<>();
+        translations.add( translation1 );
+        translations.add( translation2 );
+
+        jsonBinaryType = new JsonSetBinaryType();
+        jsonBinaryType.init( Translation.class );
     }
 
-    @Override
-    protected ObjectMapper getResultingMapper()
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void deepCopy()
     {
-        return MAPPER;
+        final Set<Translation> result = (Set<Translation>) jsonBinaryType.deepCopy( translations );
+        Assert.assertNotSame( translations, result );
+        Assert.assertThat( result, Matchers.containsInAnyOrder( translation1, translation2 ) );
     }
 
-    @Override
-    protected JavaType getResultingJavaType( Class<?> returnedClass )
+    @Test
+    public void deepCopyNull()
     {
-        return MAPPER.getTypeFactory().constructCollectionType( Set.class, returnedClass );
+        Assert.assertNull( jsonBinaryType.deepCopy( null ) );
     }
 }


### PR DESCRIPTION
- Resolves issue DHIS2-6491.
- Adds an index for category options to their categories on specific database table.
- Reduces the amount of database queries immensely by using batch association fetches for category options.
- Frequently accessed accessed user and schema data that must be calculated is cached.
- Optimized deep copying for Hibernate PostgreSQL JSONB type.
- Not all of the commits would be backported (limiting risk) and also batch sizes would be reduced. 
