### PR TITLE
Places detached user credentials into session.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -82,7 +82,8 @@ public class TwoFactorAuthenticationProvider
             throw new BadCredentialsException( "Invalid username or password" );
         }
 
-        // initialize all required properties of user credentials since these will become detached
+        // Initialize all required properties of user credentials since these will become detached
+
         userCredentials.getAllAuthorities();
 
         // -------------------------------------------------------------------------
@@ -128,11 +129,13 @@ public class TwoFactorAuthenticationProvider
 
         Authentication result = super.authenticate( auth );
 
-        // Puts detached state of the user credentials into the session,
-        // since user credentials must not be updated during session execution (e.g. by metadata importer).
+        // Put detached state of the user credentials into the session as user 
+        // credentials must not be updated during session execution
+
         userCredentials = SerializationUtils.clone( userCredentials );
 
-        // initialize cached authorities
+        // Initialize cached authorities
+
         userCredentials.isSuper();
         userCredentials.getAllAuthorities();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.security.spring2fa;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.LongValidator;
 import org.hisp.dhis.security.SecurityService;
@@ -81,6 +82,9 @@ public class TwoFactorAuthenticationProvider
             throw new BadCredentialsException( "Invalid username or password" );
         }
 
+        // initialize all required properties of user credentials since these will become detached
+        userCredentials.getAllAuthorities();
+
         // -------------------------------------------------------------------------
         // Check two-factor authentication
         // -------------------------------------------------------------------------
@@ -123,6 +127,14 @@ public class TwoFactorAuthenticationProvider
         // -------------------------------------------------------------------------
 
         Authentication result = super.authenticate( auth );
+
+        // Puts detached state of the user credentials into the session,
+        // since user credentials must not be updated during session execution (e.g. by metadata importer).
+        userCredentials = SerializationUtils.clone( userCredentials );
+
+        // initialize cached authorities
+        userCredentials.isSuper();
+        userCredentials.getAllAuthorities();
 
         return new UsernamePasswordAuthenticationToken( userCredentials, result.getCredentials(), result.getAuthorities() );
     }


### PR DESCRIPTION
- Fixes issue TECH-168
- User credentials that are stored in session must not be managed since
  the managed user credentials may be changed during first request
  (especially by metadata importer) which results in unwanted behaviour.