### PR TITLE
[2.29] Fix OU name not displayed in event report

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -152,4 +152,9 @@ public enum ValueType
     {
         return aggregateable;
     }
+
+    public boolean isOrganisationUnit()
+    {
+        return ORGANISATION_UNIT == this;
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.analytics.table;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AnalyticsTablePartition;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.util.ConcurrentUtils;
@@ -120,6 +121,10 @@ public abstract class AbstractEventJdbcTableManager
         {
             return "ST_GeomFromGeoJSON('{\"type\":\"Point\", \"coordinates\":' || value || ', \"crs\":{\"type\":\"name\", \"properties\":{\"name\":\"EPSG:4326\"}}}')";
         }
+        else if ( valueType.isOrganisationUnit() )
+        {
+            return "ou.name from organisationunit ou where ou.uid = (select value";
+        }
         else
         {
             return "value";
@@ -137,5 +142,24 @@ public abstract class AbstractEventJdbcTableManager
         }
 
         return null;
+    }
+
+    String addClosingParentheses( String selectSql )
+    {
+        int open = 0;
+
+        for ( int i = 0; i < selectSql.length(); i++ )
+        {
+            if ( selectSql.charAt( i ) == '(' )
+            {
+                open++;
+            }
+            else if ( selectSql.charAt( i ) == ')' )
+            {
+                open--;
+            }
+
+        }
+        return StringUtils.repeat(")", open);
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -192,7 +192,7 @@ public class JdbcEnrollmentAnalyticsTableManager
                     "and tedv.dataelementid=" + dataElement.getId() + " " +
                     "and psi.programstageid=" + programStage.getId() + " " +
                     "order by psi.executiondate desc " +
-                    "limit 1) as " + quote( programStage.getUid() + DB_SEPARATOR_ID + dataElement.getUid() );
+                    "limit 1) " + addClosingParentheses(select) + " as " + quote( programStage.getUid() + DB_SEPARATOR_ID + dataElement.getUid() );
 
                 columns.add( new AnalyticsTableColumn( quote( programStage.getUid() + DB_SEPARATOR_ID + dataElement.getUid() ), dataType, sql, skipIndex ) );
             }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTablePartition;
@@ -236,7 +237,7 @@ public class JdbcEventAnalyticsTableManager
             boolean skipIndex = NO_INDEX_VAL_TYPES.contains( dataElement.getValueType() ) && !dataElement.hasOptionSet();
 
             String sql = "(select " + select + " from trackedentitydatavalue where programstageinstanceid=psi.programstageinstanceid " +
-                "and dataelementid=" + dataElement.getId() + dataClause + ") as " + quote( dataElement.getUid() );
+                "and dataelementid=" + dataElement.getId() + dataClause +  addClosingParentheses(select)  + ") as " + quote( dataElement.getUid() );
 
             columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() ), dataType, sql, skipIndex ) );
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.analytics.table;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataapproval.DataApprovalLevelService;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementCategoryService;
+import org.hisp.dhis.jdbc.StatementBuilder;
+import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.database.DatabaseInfo;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class JdbcEnrollmentAnalyticsTableManagerTest {
+
+    @Mock
+    private IdentifiableObjectManager idObjectManager;
+
+    @Mock
+    private DataElementCategoryService categoryService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @Mock
+    private SystemSettingManager systemSettingManager;
+
+    @Mock
+    private DataApprovalLevelService dataApprovalLevelService;
+
+    @Mock
+    private ResourceTableService resourceTableService;
+
+    @Mock
+    private AnalyticsTableHookService tableHookService;
+
+    private StatementBuilder statementBuilder = new PostgreSQLStatementBuilder();
+
+    @Mock
+    private PartitionManager partitionManager;
+
+    @Mock
+    private DatabaseInfo databaseInfo;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @InjectMocks
+    private JdbcEnrollmentAnalyticsTableManager subject;
+
+    @Before
+    public void setUp()
+    {
+        ReflectionTestUtils.setField( subject, "statementBuilder", statementBuilder );
+        when( jdbcTemplate.queryForList(
+            "select distinct(extract(year from psi.executiondate)) from programstageinstance psi inner join programinstance pi on psi.programinstanceid = pi.programinstanceid where pi.programid = 0 and psi.executiondate is not null and psi.deleted is false and psi.executiondate >= '2018-01-01'",
+            Integer.class ) ).thenReturn( Lists.newArrayList( 2018, 2019 ) );
+    }
+
+    @Test
+    public void verifyDataElementTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
+    {
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        when( databaseInfo.isSpatialSupport() ).thenReturn( true );
+        Program p1 = createProgram( 'A' );
+
+        DataElement d5 = createDataElement('G', ValueType.ORGANISATION_UNIT, AggregationType.NONE);
+        d5.setId( 150 );
+
+        ProgramStage ps1 = createProgramStage( 'A', Sets.newHashSet( d5 ) );
+
+        p1.setProgramStages( Sets.newHashSet( ps1 ) );
+
+        when( idObjectManager.getAllNoAcl( Program.class ) ).thenReturn( Lists.newArrayList( p1 ) );
+
+        subject.populateTable( PartitionUtils.getTablePartitions( subject.getAnalyticsTables( getDate( 2018, 1, 1 ) ) ).get( 0 ) );
+
+        verify(jdbcTemplate).execute(sql.capture());
+        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = " + "(select value from trackedentitydatavalue where "
+                + "programstageinstanceid=psi.programstageinstanceid and dataelementid=" + d5.getId() + ")) as \"" + d5.getUid() + "\"";
+
+        assertThat(sql.getValue(), containsString(ouQuery));
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.analytics.table;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
+import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataapproval.DataApprovalLevelService;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementCategoryService;
+import org.hisp.dhis.jdbc.StatementBuilder;
+import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.database.DatabaseInfo;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class JdbcEventAnalyticsTableManagerTest {
+
+    @Mock
+    private IdentifiableObjectManager idObjectManager;
+
+    @Mock
+    private DataElementCategoryService categoryService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @Mock
+    private SystemSettingManager systemSettingManager;
+
+    @Mock
+    private DataApprovalLevelService dataApprovalLevelService;
+
+    @Mock
+    private ResourceTableService resourceTableService;
+
+    @Mock
+    private AnalyticsTableHookService tableHookService;
+
+    private StatementBuilder statementBuilder = new PostgreSQLStatementBuilder();
+
+    @Mock
+    private PartitionManager partitionManager;
+
+    @Mock
+    private DatabaseInfo databaseInfo;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @InjectMocks
+    private JdbcEventAnalyticsTableManager subject;
+
+    @Before
+    public void setUp()
+    {
+        ReflectionTestUtils.setField( subject, "statementBuilder", statementBuilder );
+        when( jdbcTemplate.queryForList(
+            "select distinct(extract(year from psi.executiondate)) from programstageinstance psi inner join programinstance pi on psi.programinstanceid = pi.programinstanceid where pi.programid = 0 and psi.executiondate is not null and psi.deleted is false and psi.executiondate >= '2018-01-01'",
+            Integer.class ) ).thenReturn( Lists.newArrayList( 2018, 2019 ) );
+    }
+
+    @Test
+    public void verifyDataElementTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
+    {
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        when( databaseInfo.isSpatialSupport() ).thenReturn( true );
+        Program p1 = createProgram( 'A' );
+
+        DataElement d5 = createDataElement('G', ValueType.ORGANISATION_UNIT, AggregationType.NONE);
+        d5.setId( 150 );
+
+        ProgramStage ps1 = createProgramStage( 'A', Sets.newHashSet( d5 ) );
+
+        p1.setProgramStages( Sets.newHashSet( ps1 ) );
+
+        when( idObjectManager.getAllNoAcl( Program.class ) ).thenReturn( Lists.newArrayList( p1 ) );
+
+        subject.populateTable( PartitionUtils.getTablePartitions( subject.getAnalyticsTables( getDate( 2018, 1, 1 ) ) ).get( 0 ) );
+
+        verify(jdbcTemplate).execute(sql.capture());
+        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = " + "(select value from trackedentitydatavalue where "
+                + "programstageinstanceid=psi.programstageinstanceid and dataelementid=" + d5.getId() + ")) as \"" + d5.getUid() + "\"";
+
+        assertThat(sql.getValue(), containsString(ouQuery));
+    }
+
+}


### PR DESCRIPTION
- DHIS2-6885
- Altered INSERT query that populates the Event and Enrollment nalytics table to
fetch the OU name when the Data Element is type 'ORGANIZATIONALUNIT', instead
of the OU UID
- Added unit tests