### PR TITLE
feat: add context to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,10 @@ FROM tomcat:8.5.34-jre8-alpine as serve
 RUN rm -rf /usr/local/tomcat/webapps/*
 
 COPY server.xml /usr/local/tomcat/conf
+ARG CONTEXT
+ENV CONTEXT ${CONTEXT:-}
+RUN sed -i "s;<Context path=\"\" docBase=\"ROOT/\" />;<Context path=\"/${CONTEXT}\" docBase=\"ROOT/\" />;" /usr/local/tomcat/conf/server.xml
+
 COPY --from=build /src/dhis-2/dhis-web/dhis-web-portal/target/dhis.war /usr/local/tomcat/webapps/ROOT.war
 
 # Expose the easy-to-remember directory /DHIS2_home for Docker volume mounting to configure the CORE instance

--- a/server.xml
+++ b/server.xml
@@ -150,6 +150,8 @@
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 
+        <Context path="" docBase="ROOT/" />
+
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--


### PR DESCRIPTION
`docker build -t test/add-context --build-arg CONTEXT=dev .`

If no `CONTEXT` is passed to the build, it defaults to an empty string.

Would be nice to figure out nice context names based on the versions at build time.

Could maybe use the branch name?