### PR TITLE
[2.30] Use simplified value type in analytics metadata

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -77,14 +77,14 @@ public enum ValueType
     public static final Set<ValueType> DECIMAL_TYPES = ImmutableSet.<ValueType>builder().add(
         NUMBER, UNIT_INTERVAL, PERCENTAGE ).build();
 
-    public static final Set<ValueType> BOOLEAN_TYPES = ImmutableSet.<ValueType>builder().add(
-        BOOLEAN, TRUE_ONLY ).build();
+    public static final Set<ValueType> BOOLEAN_TYPES = ImmutableSet.of(
+        BOOLEAN, TRUE_ONLY );
 
-    public static final Set<ValueType> TEXT_TYPES = ImmutableSet.<ValueType>builder().add(
-        TEXT, LONG_TEXT, LETTER, TIME, USERNAME, EMAIL, PHONE_NUMBER, URL ).build();
+    public static final Set<ValueType> TEXT_TYPES = ImmutableSet.of(
+        TEXT, LONG_TEXT, LETTER, TIME, USERNAME, EMAIL, PHONE_NUMBER, URL );
 
-    public static final Set<ValueType> DATE_TYPES = ImmutableSet.<ValueType>builder().add(
-        DATE, DATETIME, AGE ).build();
+    public static final Set<ValueType> DATE_TYPES = ImmutableSet.of(
+        DATE, DATETIME, AGE );
 
     public static final Set<ValueType> FILE_TYPES = ImmutableSet.<ValueType>builder().add(
         FILE_RESOURCE, IMAGE ).build();
@@ -162,5 +162,49 @@ public enum ValueType
     public boolean isAggregateable()
     {
         return aggregateable;
+    }
+
+    /**
+     * Returns a simplified value type. As an example, if the value type is
+     * any numeric type such as integer, percentage, then {@link ValueType#NUMBER}
+     * is returned. Can return any of:
+     *
+     * <ul>
+     * <li>{@link ValueType#NUMBER} for any numeric types.</li>
+     * <li>{@link ValueType#BOOLEAN} for any boolean types.</li>
+     * <li>{@link ValueType#DATE} for any date / time types.</li>
+     * <li>{@link ValueType#FILE_RESOURCE} for any file types.</li>
+     * <li>{@link ValueType#COORDINATE} for any geometry types.</li>
+     * <li>{@link ValueType#TEXT} for any textual types.</li>
+     * </ul>
+     *
+     * @return a simplified value type.
+     */
+    public ValueType asSimplifiedValueType()
+    {
+        if ( isNumeric() )
+        {
+            return ValueType.NUMBER;
+        }
+        else if ( isBoolean() )
+        {
+            return ValueType.BOOLEAN;
+        }
+        else if ( isDate() )
+        {
+            return ValueType.DATE;
+        }
+        else if ( isFile() )
+        {
+            return ValueType.FILE_RESOURCE;
+        }
+        else if ( isGeo() )
+        {
+            return ValueType.COORDINATE;
+        }
+        else
+        {
+            return ValueType.TEXT;
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/MetadataItem.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/MetadataItem.java
@@ -30,14 +30,19 @@ package org.hisp.dhis.analytics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import java.util.Date;
+
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.TotalAggregationType;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 /**
  * Item part of meta data analytics response.
@@ -66,6 +71,10 @@ public class MetadataItem
     private AggregationType aggregationType;
 
     private TotalAggregationType totalAggregationType;
+
+    private Date startDate;
+
+    private Date endDate;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -147,6 +156,34 @@ public class MetadataItem
         this.description = dimensionalItemObject.getDescription();
         this.aggregationType = dimensionalItemObject.getAggregationType();
         this.totalAggregationType = dimensionalItemObject.getTotalAggregationType();
+
+        if ( dimensionalItemObject.hasLegendSet() )
+        {
+            this.legendSet = dimensionalItemObject.getLegendSet().getUid();
+        }
+
+        // TODO common interface
+
+        if ( dimensionalItemObject instanceof DataElement )
+        {
+            DataElement dataElement = (DataElement) dimensionalItemObject;
+            this.valueType = dataElement.getValueType().asSimplifiedValueType();
+        }
+
+        if ( dimensionalItemObject instanceof TrackedEntityAttribute)
+        {
+            TrackedEntityAttribute attribute = (TrackedEntityAttribute) dimensionalItemObject;
+            this.valueType = attribute.getValueType().asSimplifiedValueType();
+        }
+
+        // TODO introduce start/end date marker interface instead
+
+        if ( dimensionalItemObject instanceof Period)
+        {
+            Period period = (Period) dimensionalItemObject;
+            this.startDate = period.getStartDate();
+            this.endDate = period.getEndDate();
+        }
     }
 
     private void setDataItem( DimensionalObject dimensionalObject )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -770,6 +770,12 @@ public class AnalyticsUtils
                 DECIMALS_NO_ROUNDING );
     }
 
+    /**
+     * Returns the base month of the year for the period type, zero-based.
+     *
+     * @param periodType the period type.
+     * @return the base month.
+     */
     public static Double getBaseMonth( PeriodType periodType )
     {
         if ( periodType instanceof FinancialPeriodType)


### PR DESCRIPTION
In analytics metadata response for items, the value type property can now be any of these:

- NUMBER
- BOOLEAN
- DATE
- FILE_RESOURCE
- COORDINATE
- TEXT

This to expose an appropriate level of detail to the client. More detailed value types such as "positive integer" are folded under NUMBER, etc.

Backport from 2.32 (DHIS2-5854)