### PR TITLE
[2.29] Use simplified value type in analytics metadata

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -72,26 +72,33 @@ public enum ValueType
     URL( String.class, false ),
     IMAGE( String.class, false);
 
-    public static final Set<ValueType> INTEGER_TYPES = ImmutableSet.<ValueType>builder().add(
-        INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE ).build();
+    public static final Set<ValueType> INTEGER_TYPES = ImmutableSet.of(
+        INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE );
 
-    public static final Set<ValueType> NUMERIC_TYPES = ImmutableSet.<ValueType>builder().add(
-        INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE, NUMBER, UNIT_INTERVAL, PERCENTAGE ).build();
+    public static final Set<ValueType> DECIMAL_TYPES =ImmutableSet.of(
+            NUMBER, UNIT_INTERVAL, PERCENTAGE );
 
-    public static final Set<ValueType> BOOLEAN_TYPES = ImmutableSet.<ValueType>builder().add(
-        BOOLEAN, TRUE_ONLY ).build();
+    public static final Set<ValueType> BOOLEAN_TYPES = ImmutableSet.of(
+        BOOLEAN, TRUE_ONLY );
 
-    public static final Set<ValueType> TEXT_TYPES = ImmutableSet.<ValueType>builder().add(
-        TEXT, LONG_TEXT, LETTER, COORDINATE, TIME, USERNAME, EMAIL, PHONE_NUMBER, URL ).build();
+   public static final Set<ValueType> TEXT_TYPES = ImmutableSet.of(
+        TEXT, LONG_TEXT, LETTER, TIME, USERNAME, EMAIL, PHONE_NUMBER, URL );
 
-    public static final Set<ValueType> DATE_TYPES = ImmutableSet.<ValueType>builder().add(
-        DATE, DATETIME, AGE ).build();
+    public static final Set<ValueType> DATE_TYPES = ImmutableSet.of(
+        DATE, DATETIME, AGE );
 
-    public static final Set<ValueType> FILE_TYPES = ImmutableSet.<ValueType>builder().add(
-        FILE_RESOURCE, IMAGE ).build();
+    public static final Set<ValueType> FILE_TYPES = ImmutableSet.of(
+        FILE_RESOURCE, IMAGE );
 
     public static final Set<String> VALID_IMAGE_FORMATS = ImmutableSet.<String>builder().add(
             ImageIO.getReaderFormatNames() ).build();
+
+    public static final Set<ValueType> GEO_TYPES = ImmutableSet.<ValueType>builder().add(
+        COORDINATE ).build();
+
+    public static final Set<ValueType> NUMERIC_TYPES = ImmutableSet.<ValueType>builder().addAll(
+        INTEGER_TYPES ).addAll( DECIMAL_TYPES ).build();
+
 
     private final Class<?> javaClass;
 
@@ -156,5 +163,54 @@ public enum ValueType
     public boolean isOrganisationUnit()
     {
         return ORGANISATION_UNIT == this;
+    }
+
+    public boolean isGeo()
+    {
+        return GEO_TYPES.contains( this );
+    }
+
+    /**
+     * Returns a simplified value type. As an example, if the value type is
+     * any numeric type such as integer, percentage, then {@link ValueType#NUMBER}
+     * is returned. Can return any of:
+     *
+     * <ul>
+     * <li>{@link ValueType#NUMBER} for any numeric types.</li>
+     * <li>{@link ValueType#BOOLEAN} for any boolean types.</li>
+     * <li>{@link ValueType#DATE} for any date / time types.</li>
+     * <li>{@link ValueType#FILE_RESOURCE} for any file types.</li>
+     * <li>{@link ValueType#COORDINATE} for any geometry types.</li>
+     * <li>{@link ValueType#TEXT} for any textual types.</li>
+     * </ul>
+     *
+     * @return a simplified value type.
+     */
+    public ValueType asSimplifiedValueType()
+    {
+        if ( isNumeric() )
+        {
+            return ValueType.NUMBER;
+        }
+        else if ( isBoolean() )
+        {
+            return ValueType.BOOLEAN;
+        }
+        else if ( isDate() )
+        {
+            return ValueType.DATE;
+        }
+        else if ( isFile() )
+        {
+            return ValueType.FILE_RESOURCE;
+        }
+        else if ( isGeo() )
+        {
+            return ValueType.COORDINATE;
+        }
+        else
+        {
+            return ValueType.TEXT;
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsUtils.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.FinancialPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/MetadataItem.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/MetadataItem.java
@@ -30,14 +30,19 @@ package org.hisp.dhis.analytics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import java.util.Date;
+
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.TotalAggregationType;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 /**
  * Item part of meta data analytics response.
@@ -67,6 +72,9 @@ public class MetadataItem
 
     private TotalAggregationType totalAggregationType;
 
+    private Date startDate;
+
+    private Date endDate;
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -147,6 +155,35 @@ public class MetadataItem
         this.description = dimensionalItemObject.getDescription();
         this.aggregationType = dimensionalItemObject.getAggregationType();
         this.totalAggregationType = dimensionalItemObject.getTotalAggregationType();
+
+
+        if ( dimensionalItemObject.hasLegendSet() )
+        {
+            this.legendSet = dimensionalItemObject.getLegendSet().getUid();
+        }
+
+        // TODO common interface
+
+        if ( dimensionalItemObject instanceof DataElement)
+        {
+            DataElement dataElement = (DataElement) dimensionalItemObject;
+            this.valueType = dataElement.getValueType().asSimplifiedValueType();
+        }
+
+        if ( dimensionalItemObject instanceof TrackedEntityAttribute)
+        {
+            TrackedEntityAttribute attribute = (TrackedEntityAttribute) dimensionalItemObject;
+            this.valueType = attribute.getValueType().asSimplifiedValueType();
+        }
+
+        // TODO introduce start/end date marker interface instead
+
+        if ( dimensionalItemObject instanceof Period)
+        {
+            Period period = (Period) dimensionalItemObject;
+            this.startDate = period.getStartDate();
+            this.endDate = period.getEndDate();
+        }
     }
 
     private void setDataItem( DimensionalObject dimensionalObject )


### PR DESCRIPTION
In analytics metadata response for items, the value type property can now be any of these:

- NUMBER
- BOOLEAN
- DATE
- FILE_RESOURCE
- COORDINATE
- TEXT

This to expose an appropriate level of detail to the client. More detailed value types such as "positive integer" are folded under NUMBER, etc.

(cherry picked from commit 4a4d0bcda27ea5c040732d440530d6cd1909da49)