### PR TITLE
Adding label to docker build stage for cleaning up intermediate images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@
 # Build the DHIS2 Core server from source (Maven)
 ##########
 FROM maven:3.5.3-jdk-8-slim as build
+LABEL stage=intermediate
 #NB - maven-frontend-plugin breaks on Alpine linux, so we use Debian Slim instead
 #NB - maven-surefire-plugin fails with maven:3.5.4-jdk-8-slim and later.
 #     This is a recent issue possibly traced to an OpenJDK bug - https://github.com/carlossg/docker-maven/issues/90


### PR DESCRIPTION
Problem: Jenkins jobs on jenkins which uses docker (api tests, integration tests) fails with OOM error almost every day - https://jira.dhis2.org/browse/AUTO-34

Multi-stage docker builds create image for every stage to achieve cacheing. In our case, early stage (build) image is 5.7gb, so after several builds, if not removed, makes docker struggle with memory. Dangling images can be removed by running `docker image prune`, but on shared environments like jenkins this can cause race conditions and remove needed images. 

Solution for now is to tag intermediate images and remove old ones by running 
`docker image prune --filter label=stage=intermediate`. 