### PR TITLE
revert: use context.path if available

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     build:
       dockerfile: Dockerfile
       context: ../..
-    environment:
-      CATALINA_OPTS: "-Dcontext.path=''"
     volumes:
       - ./config/dhis2_home/dhis.conf:/DHIS2_home/dhis.conf
     depends_on:

--- a/server.xml
+++ b/server.xml
@@ -151,11 +151,8 @@
           name="localhost"
           appBase="webapps"
           unpackWARs="true"
-          autoDeploy="false"
-          deployOnStartup="false"
+          autoDeploy="true"
       >
-
-        <Context path="${context.path}" docBase="ROOT/" />
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->


### PR DESCRIPTION
As #3284 had unintended consequences I think it is prudent to revert this to allow the image to be consistent with a default DHIS2 Tomcat configuration.