### PR TITLE
Increases performance for category options with many assigned organisation units

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -50,6 +50,7 @@ import java.beans.PropertyDescriptor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -78,7 +79,7 @@ public class DefaultFieldFilterServiceTest
     @Before
     public void setUp() throws Exception
     {
-        service = new DefaultFieldFilterService( fieldParser, schemaService, aclService, currentUserService );
+        service = new DefaultFieldFilterService( fieldParser, schemaService, aclService, currentUserService, new HashSet<>() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-node/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-node/pom.xml
@@ -2,19 +2,19 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
     <version>2.33-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>dhis-service-node</artifactId>
   <packaging>jar</packaging>
   <name>DHIS Node service</name>
-  
+
   <dependencies>
-        
+
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-schema</artifactId>
@@ -31,7 +31,7 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-system</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
@@ -40,7 +40,12 @@
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-node/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-node/pom.xml
@@ -45,6 +45,10 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
 
   </dependencies>
   <properties>

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -91,8 +91,7 @@ public class DefaultFieldFilterService implements FieldFilterService
 
     private final CurrentUserService currentUserService;
 
-    @Autowired( required = false )
-    private Set<NodeTransformer> nodeTransformers = new HashSet<>();
+    private Set<NodeTransformer> nodeTransformers;
 
     private ImmutableMap<String, Preset> presets = ImmutableMap.of();
 
@@ -101,12 +100,13 @@ public class DefaultFieldFilterService implements FieldFilterService
     private Property baseIdentifiableIdProperty;
 
     public DefaultFieldFilterService( FieldParser fieldParser, SchemaService schemaService, AclService aclService,
-        CurrentUserService currentUserService )
+        CurrentUserService currentUserService, @Autowired( required = false ) Set<NodeTransformer> nodeTransformers )
     {
         this.fieldParser = fieldParser;
         this.schemaService = schemaService;
         this.aclService = aclService;
         this.currentUserService = currentUserService;
+        this.nodeTransformers = nodeTransformers == null ? new HashSet<>() : nodeTransformers;
     }
 
     @PostConstruct
@@ -487,6 +487,7 @@ public class DefaultFieldFilterService implements FieldFilterService
                 String fieldName = matcher.group( "field" );
 
                 FieldMap value = new FieldMap();
+                value.putAll( fieldMap.get( fieldKey ) );
 
                 matcher = TRANSFORMER_PATTERN.matcher( fieldKey );
 

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -58,7 +58,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -96,6 +98,8 @@ public class DefaultFieldFilterService implements FieldFilterService
 
     private ImmutableMap<String, NodeTransformer> transformers = ImmutableMap.of();
 
+    private Property baseIdentifiableIdProperty;
+
     public DefaultFieldFilterService( FieldParser fieldParser, SchemaService schemaService, AclService aclService,
         CurrentUserService currentUserService )
     {
@@ -125,6 +129,8 @@ public class DefaultFieldFilterService implements FieldFilterService
         }
 
         transformers = transformerBuilder.build();
+
+        baseIdentifiableIdProperty = schemaService.getDynamicSchema( BaseIdentifiableObject.class ).getProperty( "id" );
     }
 
     @Override
@@ -211,6 +217,12 @@ public class DefaultFieldFilterService implements FieldFilterService
         return buildNode( fieldMap, klass, object, user, schema.getName(), defaults );
     }
 
+    private boolean mayExclude( Class<?> klass, Defaults defaults )
+    {
+        return Defaults.EXCLUDE == defaults && IdentifiableObject.class.isAssignableFrom( klass ) &&
+            ( Preheat.isDefaultClass( klass ) || klass.isInterface() || ( klass.getModifiers() & Modifier.ABSTRACT ) != 0 );
+    }
+
     private boolean shouldExclude( Object object, Defaults defaults )
     {
         return Defaults.EXCLUDE == defaults && IdentifiableObject.class.isInstance( object ) &&
@@ -287,14 +299,16 @@ public class DefaultFieldFilterService implements FieldFilterService
                 {
                     Collection<?> collection = (Collection<?>) returnValue;
 
-                    child = new CollectionNode( property.getCollectionName() );
+                    child = new CollectionNode( property.getCollectionName(), collection.size() );
                     child.setNamespace( property.getNamespace() );
 
                     if ( property.isIdentifiableObject() && isProperIdObject( property.getItemKlass() ) )
                     {
+                        final boolean mayExclude = collection.isEmpty() || mayExclude( property.getItemKlass(), defaults );
+
                         for ( Object collectionObject : collection )
                         {
-                            if ( !shouldExclude( collectionObject, defaults ) )
+                            if ( !mayExclude || !shouldExclude( collectionObject, defaults ) )
                             {
                                 child.addChild( getProperties( property, collectionObject, fields ) );
                             }
@@ -392,6 +406,11 @@ public class DefaultFieldFilterService implements FieldFilterService
 
     private void updateFields( FieldMap fieldMap, Class<?> klass )
     {
+        if ( fieldMap.isEmpty() )
+        {
+            return;
+        }
+
         // we need two run this (at least) two times, since some of the presets might contain other presets
         updateFields( fieldMap, klass, true );
         updateFields( fieldMap, klass, false );
@@ -399,6 +418,11 @@ public class DefaultFieldFilterService implements FieldFilterService
 
     private void updateFields( FieldMap fieldMap, Class<?> klass, boolean expandOnly )
     {
+        if ( fieldMap.isEmpty() )
+        {
+            return;
+        }
+
         Schema schema = schemaService.getDynamicSchema( klass );
         List<String> cleanupFields = Lists.newArrayList();
 
@@ -523,6 +547,12 @@ public class DefaultFieldFilterService implements FieldFilterService
             return null;
         }
 
+        // performance optimization for ID only queries on base identifiable objects
+        if ( isBaseIdentifiableObjectIdOnly( object, fields ) )
+        {
+            return createBaseIdentifiableObjectIdNode( currentProperty, object );
+        }
+
         ComplexNode complexNode = new ComplexNode( currentProperty.getName() );
         complexNode.setNamespace( currentProperty.getNamespace() );
         complexNode.setProperty( currentProperty );
@@ -559,6 +589,17 @@ public class DefaultFieldFilterService implements FieldFilterService
         }
 
         return complexNode;
+    }
+
+    private boolean isBaseIdentifiableObjectIdOnly( @Nonnull Object object, @Nonnull List<String> fields )
+    {
+        return fields.size() == 1 && fields.get( 0 ).equals( "id" ) && object instanceof BaseIdentifiableObject;
+    }
+
+    private ComplexNode createBaseIdentifiableObjectIdNode( @Nonnull Property currentProperty, @Nonnull Object object )
+    {
+        return new ComplexNode( currentProperty, new SimpleNode(
+            "id", baseIdentifiableIdProperty, ( (BaseIdentifiableObject) object ).getUid() ) );
     }
 
     private boolean isProperIdObject( Class<?> klass )

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldParser.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldParser.java
@@ -79,11 +79,10 @@ public class DefaultFieldParser implements FieldParser
                     }
                     else if ( (insideParameters && c.equals( ")" )) ) // end
                     {
-                        insideParameters = false;
                         builder.append( c );
                         break;
                     }
-                    else if ( c.equals( "," ) ) // rewind and break
+                    else if ( c.equals( "," ) || ( c.equals( "[" ) && !insideParameters ) ) // rewind and break
                     {
                         i--;
                         break;

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/AbstractNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/AbstractNode.java
@@ -58,7 +58,7 @@ public abstract class AbstractNode implements Node
 
     protected String comment;
 
-    protected List<Node> children = Lists.newArrayList();
+    protected List<Node> children;
 
     protected ImmutableList<Node> sortedChildren;
 
@@ -76,6 +76,19 @@ public abstract class AbstractNode implements Node
         this.name = name;
         this.nodeType = nodeType;
         this.property = property;
+    }
+
+    protected AbstractNode( String name, NodeType nodeType, Property property, AbstractNode child )
+    {
+        this.name = name;
+        this.nodeType = nodeType;
+        this.property = property;
+
+        if ( child != null && child.getName() != null )
+        {
+            children = Lists.newArrayList( child );
+            child.setParent( this );
+        }
     }
 
     @Override
@@ -188,6 +201,11 @@ public abstract class AbstractNode implements Node
             return null;
         }
 
+        if ( children == null )
+        {
+            children = Lists.newArrayList();
+        }
+
         children.add( child );
         ((AbstractNode) child).setParent( this );
 
@@ -199,7 +217,7 @@ public abstract class AbstractNode implements Node
     @Override
     public <T extends Node> void removeChild( T child )
     {
-        if ( children.contains( child ) )
+        if ( children != null && children.contains( child ) )
         {
             children.remove( child );
         }
@@ -217,13 +235,32 @@ public abstract class AbstractNode implements Node
     }
 
     @Override
+    public List<Node> getUnorderedChildren()
+    {
+        return children == null ? Collections.emptyList() : children;
+    }
+
+    @Override
     public List<Node> getChildren()
     {
         if ( sortedChildren == null )
         {
-            List<Node> clone = Lists.newArrayList( children );
-            Collections.sort( clone, OrderComparator.INSTANCE );
-            sortedChildren = ImmutableList.copyOf( clone );
+            final int size = children == null ? 0 : children.size();
+
+            if ( size > 1 )
+            {
+                List<Node> clone = Lists.newArrayList( children );
+                Collections.sort( clone, OrderComparator.INSTANCE );
+                sortedChildren = ImmutableList.copyOf( clone );
+            }
+            else if ( size == 1 )
+            {
+                sortedChildren = ImmutableList.of( children.get( 0 ) );
+            }
+            else
+            {
+                sortedChildren = ImmutableList.of();
+            }
         }
 
         return sortedChildren;

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/Node.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/Node.java
@@ -155,4 +155,9 @@ public interface Node extends Ordered
      * @return List of child nodes associated with this node
      */
     List<Node> getChildren();
+
+    /**
+     * @return the unordered children that are associated with this node.
+     */
+    List<Node> getUnorderedChildren();
 }

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/serializers/Jackson2JsonNodeSerializer.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/serializers/Jackson2JsonNodeSerializer.java
@@ -28,10 +28,12 @@ package org.hisp.dhis.node.serializers;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.io.OutputStream;
-import java.util.Date;
-import java.util.List;
-
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Geometry;
 import org.hisp.dhis.node.AbstractNodeSerializer;
 import org.hisp.dhis.node.types.CollectionNode;
 import org.hisp.dhis.node.types.ComplexNode;
@@ -42,12 +44,9 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
-import com.bedatadriven.jackson.datatype.jts.JtsModule;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.collect.Lists;
-import com.vividsolutions.jts.geom.Geometry;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.List;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -119,7 +118,7 @@ public class Jackson2JsonNodeSerializer extends AbstractNodeSerializer
 
         if ( Date.class.isAssignableFrom( simpleNode.getValue().getClass() ) )
         {
-            value = DateUtils.getIso8601NoTz( (Date) simpleNode.getValue() );
+            value = DateUtils.getIso8601NoTz( (Date) value );
         }
 
         if ( Geometry.class.isAssignableFrom( simpleNode.getValue().getClass() ) )
@@ -132,6 +131,10 @@ public class Jackson2JsonNodeSerializer extends AbstractNodeSerializer
         if ( simpleNode.getParent().isCollection() )
         {
             generator.writeObject( value );
+        }
+        else if ( value instanceof String )
+        {
+            generator.writeStringField( simpleNode.getName(), (String) value );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/transformers/PluckNodeTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/transformers/PluckNodeTransformer.java
@@ -1,0 +1,93 @@
+package org.hisp.dhis.node.transformers;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.node.Node;
+import org.hisp.dhis.node.NodeTransformer;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.hisp.dhis.schema.Property;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Transforms a collection node with complex nodes to a list with the
+ * the first field values of the includes simple nodes.
+ *
+ * @author Volker Schmidt
+ */
+@Component
+public class PluckNodeTransformer implements NodeTransformer
+{
+    @Override
+    public String name()
+    {
+        return "pluck";
+    }
+
+    @Override
+    public Node transform( Node node, List<String> args )
+    {
+        checkNotNull( node );
+        checkNotNull( node.getProperty() );
+
+        Property property = node.getProperty();
+
+        if ( property.isCollection() )
+        {
+            final String fieldName = ( args == null || args.isEmpty() ) ? null : StringUtils.defaultIfEmpty( args.get( 0 ), null );
+
+            final CollectionNode collectionNode = new CollectionNode( node.getName(), node.getUnorderedChildren().size() );
+            collectionNode.setNamespace( node.getNamespace() );
+
+            for ( final Node objectNode : node.getUnorderedChildren() )
+            {
+                for ( final Node fieldNode : objectNode.getUnorderedChildren() )
+                {
+                    if ( fieldNode instanceof SimpleNode && ( fieldName == null || fieldName.equals( fieldNode.getName() ) ) )
+                    {
+                        final SimpleNode childNode = new SimpleNode( fieldNode.getName(), ( (SimpleNode) fieldNode ).getValue() );
+                        childNode.setProperty( collectionNode.getProperty() );
+                        collectionNode.addChild( childNode );
+
+                        break;
+                    }
+                }
+            }
+
+            return collectionNode;
+        }
+
+        return node;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/CollectionNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/CollectionNode.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.node.types;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.Lists;
 import org.hisp.dhis.node.AbstractNode;
 import org.hisp.dhis.node.NodeType;
 
@@ -46,6 +47,16 @@ public class CollectionNode extends AbstractNode
     public CollectionNode( String name )
     {
         super( name, NodeType.COLLECTION );
+    }
+
+    public CollectionNode( String name, int initialChildSize )
+    {
+        super( name, NodeType.COLLECTION );
+
+        if ( initialChildSize > 0 )
+        {
+            children = Lists.newArrayListWithCapacity( initialChildSize );
+        }
     }
 
     public CollectionNode( String name, boolean wrapping )

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/SimpleNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/SimpleNode.java
@@ -28,12 +28,13 @@ package org.hisp.dhis.node.types;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Objects;
-
 import org.hisp.dhis.node.AbstractNode;
 import org.hisp.dhis.node.Node;
 import org.hisp.dhis.node.NodeType;
 import org.hisp.dhis.node.exception.InvalidTypeException;
+import org.hisp.dhis.schema.Property;
+
+import java.util.Objects;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -57,6 +58,15 @@ public class SimpleNode
         super( name, NodeType.SIMPLE );
         this.value = value;
         this.attribute = false;
+    }
+
+    public SimpleNode( String name, Property property, Object value )
+    {
+        super( name, NodeType.SIMPLE );
+        this.value = value;
+        this.attribute = property.isAttribute();
+        this.namespace = property.getNamespace();
+        this.property = property;
     }
 
     public SimpleNode( String name, Object value, boolean attribute )

--- a/dhis-2/dhis-services/dhis-service-node/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/resources/META-INF/dhis/beans.xml
@@ -16,6 +16,8 @@
 
   <bean class="org.hisp.dhis.node.transformers.SizeNodeTransformer" />
 
+  <bean class="org.hisp.dhis.node.transformers.PluckNodeTransformer" />
+
   <bean class="org.hisp.dhis.node.serializers.CsvNodeSerializer" scope="prototype">
     <aop:scoped-proxy proxy-target-class="false" />
   </bean>

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -1,0 +1,262 @@
+package org.hisp.dhis.fieldfilter;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hamcrest.Matchers;
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.node.Node;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.ComplexNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.schema.DefaultSchemaService;
+import org.hisp.dhis.schema.Jackson2PropertyIntrospectorService;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DefaultFieldFilterService}.
+ *
+ * @author Volker Schmidt
+ */
+public class DefaultFieldFilterServiceTest
+{
+    @Mock
+    private SessionFactory sessionFactory;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    private DefaultFieldFilterService service;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp()
+    {
+        final SchemaService schemaService = new DefaultSchemaService( new Jackson2PropertyIntrospectorService()
+        {
+            @Override
+            protected Map<String, Property> getPropertiesFromHibernate( Class<?> klass )
+            {
+                return Collections.emptyMap();
+            }
+        }, sessionFactory );
+        service = new DefaultFieldFilterService( new DefaultFieldParser(), schemaService, aclService, currentUserService );
+        service.init();
+    }
+
+    @Test
+    public void baseIdentifiableIdOnly()
+    {
+        final OrganisationUnit ou1 = new OrganisationUnit();
+        ou1.setUid( "abc1" );
+
+        final OrganisationUnit ou2 = new OrganisationUnit();
+        ou2.setUid( "abc2" );
+
+        final CategoryOption option = new CategoryOption();
+        option.setUid( "def1" );
+        option.getOrganisationUnits().add( ou1 );
+        option.getOrganisationUnits().add( ou2 );
+
+        final FieldFilterParams params = new FieldFilterParams( Collections.singletonList( option ), Arrays.asList( "id", "organisationUnits" ) );
+        final ComplexNode node = service.toComplexNode( params );
+
+        Assert.assertEquals( "categoryOption", node.getName() );
+        Assert.assertTrue( getNamedNode( node.getUnorderedChildren(), "id" ) instanceof SimpleNode );
+        Assert.assertEquals( "def1", ( (SimpleNode) getNamedNode( node.getUnorderedChildren(), "id" ) ).getValue() );
+        Assert.assertTrue( getNamedNode( node.getUnorderedChildren(), "organisationUnits" ) instanceof CollectionNode );
+
+        final CollectionNode collectionNode = (CollectionNode) getNamedNode( node.getUnorderedChildren(), "organisationUnits" );
+        Assert.assertEquals( 2, collectionNode.getUnorderedChildren().size() );
+        final List<String> ouIds = new ArrayList<>();
+
+        Assert.assertTrue( collectionNode.getUnorderedChildren().get( 0 ) instanceof ComplexNode );
+        ComplexNode complexNode = (ComplexNode) collectionNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "organisationUnit", complexNode.getName() );
+        Assert.assertEquals( 1, complexNode.getUnorderedChildren().size() );
+        Assert.assertTrue( complexNode.getUnorderedChildren().get( 0 ) instanceof SimpleNode );
+        SimpleNode simpleNode = (SimpleNode) complexNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        ouIds.add( String.valueOf( simpleNode.getValue() ) );
+
+        Assert.assertTrue( collectionNode.getUnorderedChildren().get( 1 ) instanceof ComplexNode );
+        complexNode = (ComplexNode) collectionNode.getUnorderedChildren().get( 1 );
+        Assert.assertEquals( "organisationUnit", complexNode.getName() );
+        Assert.assertEquals( 1, complexNode.getUnorderedChildren().size() );
+        Assert.assertTrue( complexNode.getUnorderedChildren().get( 0 ) instanceof SimpleNode );
+        simpleNode = (SimpleNode) complexNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        ouIds.add( String.valueOf( simpleNode.getValue() ) );
+
+        Assert.assertThat( ouIds, Matchers.containsInAnyOrder( "abc1", "abc2" ) );
+    }
+
+    @Test
+    public void defaultClass()
+    {
+        final CategoryOption co1 = new CategoryOption();
+        co1.setUid( "abc1" );
+
+        final CategoryOption co2 = new CategoryOption();
+        co2.setUid( "abc2" );
+        co2.setName( "default" );
+
+        final CategoryOption co3 = new CategoryOption();
+        co3.setUid( "abc3" );
+
+        final Category category = new Category();
+        category.setUid( "def1" );
+        category.getCategoryOptions().add( co1 );
+        category.getCategoryOptions().add( co2 );
+        category.getCategoryOptions().add( co3 );
+
+        final FieldFilterParams params = new FieldFilterParams( Collections.singletonList( category ), Arrays.asList( "id", "categoryOptions" ) );
+        params.setDefaults( Defaults.EXCLUDE );
+
+        final ComplexNode node = service.toComplexNode( params );
+
+        Assert.assertEquals( "category", node.getName() );
+        Assert.assertTrue( getNamedNode( node.getUnorderedChildren(), "id" ) instanceof SimpleNode );
+        Assert.assertEquals( "def1", ( (SimpleNode) getNamedNode( node.getUnorderedChildren(), "id" ) ).getValue() );
+        Assert.assertTrue( getNamedNode( node.getUnorderedChildren(), "categoryOptions" ) instanceof CollectionNode );
+
+        final CollectionNode collectionNode = (CollectionNode) getNamedNode( node.getUnorderedChildren(), "categoryOptions" );
+        Assert.assertEquals( 2, collectionNode.getUnorderedChildren().size() );
+        final List<String> coIds = new ArrayList<>();
+
+        Assert.assertTrue( collectionNode.getUnorderedChildren().get( 0 ) instanceof ComplexNode );
+        ComplexNode complexNode = (ComplexNode) collectionNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "categoryOption", complexNode.getName() );
+        Assert.assertEquals( 1, complexNode.getUnorderedChildren().size() );
+        Assert.assertTrue( complexNode.getUnorderedChildren().get( 0 ) instanceof SimpleNode );
+        SimpleNode simpleNode = (SimpleNode) complexNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        coIds.add( String.valueOf( simpleNode.getValue() ) );
+
+        Assert.assertTrue( collectionNode.getUnorderedChildren().get( 1 ) instanceof ComplexNode );
+        complexNode = (ComplexNode) collectionNode.getUnorderedChildren().get( 1 );
+        Assert.assertEquals( "categoryOption", complexNode.getName() );
+        Assert.assertEquals( 1, complexNode.getUnorderedChildren().size() );
+        Assert.assertTrue( complexNode.getUnorderedChildren().get( 0 ) instanceof SimpleNode );
+        simpleNode = (SimpleNode) complexNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        coIds.add( String.valueOf( simpleNode.getValue() ) );
+
+        Assert.assertThat( coIds, Matchers.containsInAnyOrder( "abc1", "abc3" ) );
+    }
+
+    @Test
+    public void baseIdentifiable()
+    {
+        final OrganisationUnit ou1 = new OrganisationUnit();
+        ou1.setUid( "abc1" );
+        ou1.setName( "Test 1" );
+
+        final OrganisationUnit ou2 = new OrganisationUnit();
+        ou2.setUid( "abc2" );
+        ou2.setName( "Test 2" );
+
+        final CategoryOption option = new CategoryOption();
+        option.setUid( "def1" );
+        option.getOrganisationUnits().add( ou1 );
+        option.getOrganisationUnits().add( ou2 );
+
+        final FieldFilterParams params = new FieldFilterParams( Collections.singletonList( option ), Arrays.asList( "id", "organisationUnits[id,name]" ) );
+        final ComplexNode node = service.toComplexNode( params );
+
+        Assert.assertEquals( "categoryOption", node.getName() );
+        Assert.assertTrue( getNamedNode( node.getUnorderedChildren(), "id" ) instanceof SimpleNode );
+        Assert.assertEquals( "def1", ( (SimpleNode) getNamedNode( node.getUnorderedChildren(), "id" ) ).getValue() );
+        Assert.assertTrue( getNamedNode( node.getUnorderedChildren(), "organisationUnits" ) instanceof CollectionNode );
+
+        final CollectionNode collectionNode = (CollectionNode) getNamedNode( node.getUnorderedChildren(), "organisationUnits" );
+        Assert.assertEquals( 2, collectionNode.getUnorderedChildren().size() );
+        final List<String> ouIds = new ArrayList<>();
+        final List<String> ouNames = new ArrayList<>();
+
+        Assert.assertTrue( collectionNode.getUnorderedChildren().get( 0 ) instanceof ComplexNode );
+        ComplexNode complexNode = (ComplexNode) collectionNode.getUnorderedChildren().get( 0 );
+        Assert.assertEquals( "organisationUnit", complexNode.getName() );
+        Assert.assertEquals( 2, complexNode.getUnorderedChildren().size() );
+        Assert.assertTrue( getNamedNode( complexNode.getUnorderedChildren(), "id" ) instanceof SimpleNode );
+        SimpleNode simpleNode = (SimpleNode) getNamedNode( complexNode.getUnorderedChildren(), "id" );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        ouIds.add( String.valueOf( simpleNode.getValue() ) );
+        Assert.assertTrue( getNamedNode( complexNode.getUnorderedChildren(), "name" ) instanceof SimpleNode );
+        simpleNode = (SimpleNode) getNamedNode( complexNode.getUnorderedChildren(), "name" );
+        Assert.assertEquals( "name", simpleNode.getName() );
+        ouNames.add( String.valueOf( simpleNode.getValue() ) );
+
+        Assert.assertTrue( collectionNode.getUnorderedChildren().get( 1 ) instanceof ComplexNode );
+        complexNode = (ComplexNode) collectionNode.getUnorderedChildren().get( 1 );
+        Assert.assertEquals( "organisationUnit", complexNode.getName() );
+        Assert.assertEquals( 2, complexNode.getUnorderedChildren().size() );
+        Assert.assertTrue( getNamedNode( complexNode.getUnorderedChildren(), "id" ) instanceof SimpleNode );
+        simpleNode = (SimpleNode) getNamedNode( complexNode.getUnorderedChildren(), "id" );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        ouIds.add( String.valueOf( simpleNode.getValue() ) );
+        Assert.assertTrue( getNamedNode( complexNode.getUnorderedChildren(), "name" ) instanceof SimpleNode );
+        simpleNode = (SimpleNode) getNamedNode( complexNode.getUnorderedChildren(), "name" );
+        Assert.assertEquals( "name", simpleNode.getName() );
+        ouNames.add( String.valueOf( simpleNode.getValue() ) );
+
+        Assert.assertThat( ouIds, Matchers.containsInAnyOrder( "abc1", "abc2" ) );
+        Assert.assertThat( ouNames, Matchers.containsInAnyOrder( "Test 1", "Test 2" ) );
+    }
+
+    private Node getNamedNode( @Nonnull Collection<? extends Node> nodes, @Nonnull String name )
+    {
+        return nodes.stream().filter( n -> name.equals( n.getName() ) ).findFirst().orElse( null );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldParserTest.java
@@ -1,0 +1,64 @@
+package org.hisp.dhis.fieldfilter;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DefaultFieldParser}.
+ *
+ * @author Volker Schmidt
+ */
+public class DefaultFieldParserTest
+{
+    private final DefaultFieldParser parser = new DefaultFieldParser();
+
+    @Test
+    public void parseWithTransformer()
+    {
+        final FieldMap fieldMap = parser.parse( "id,organisationUnits~pluck" );
+        Assert.assertEquals( 2, fieldMap.size() );
+        Assert.assertTrue( fieldMap.containsKey( "id" ) );
+        Assert.assertTrue( fieldMap.containsKey( "organisationUnits~pluck" ) );
+    }
+
+    @Test
+    public void parseWithTransformerArgAndFields()
+    {
+        final FieldMap fieldMap = parser.parse( "id,organisationUnits~pluck(name)[id,name]" );
+        Assert.assertEquals( 2, fieldMap.size() );
+        Assert.assertTrue( fieldMap.containsKey( "id" ) );
+        Assert.assertTrue( fieldMap.containsKey( "organisationUnits~pluck(name)" ) );
+
+        final FieldMap innerFieldMap = fieldMap.get( "organisationUnits~pluck(name)" );
+        Assert.assertTrue( innerFieldMap.containsKey( "id" ) );
+        Assert.assertTrue( innerFieldMap.containsKey( "name" ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/AbstractNodeTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/AbstractNodeTest.java
@@ -1,7 +1,7 @@
-package org.hisp.dhis.node.types;
+package org.hisp.dhis.node;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,23 +28,45 @@ package org.hisp.dhis.node.types;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.node.AbstractNode;
-import org.hisp.dhis.node.NodeType;
+import org.hisp.dhis.node.types.SimpleNode;
 import org.hisp.dhis.schema.Property;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Unit tests for {@link AbstractNode}.
+ *
+ * @author Volker Schmidt
  */
-public class ComplexNode extends AbstractNode
+public class AbstractNodeTest
 {
-    public ComplexNode( String name )
+    @Test
+    public void createSingleChild()
     {
-        super( name, NodeType.COMPLEX );
+        final SimpleNode simpleNode = new SimpleNode( "id", "My Test" );
+        final TestNode testNode = new TestNode( "tests", NodeType.COMPLEX, new Property( TestClass.class ), simpleNode );
+        Assert.assertEquals( "tests", testNode.getName() );
+        Assert.assertEquals( NodeType.COMPLEX, testNode.nodeType );
+        Assert.assertEquals( TestClass.class, testNode.getProperty().getKlass() );
+        Assert.assertEquals( 1, testNode.getUnorderedChildren().size() );
+        Assert.assertSame( simpleNode, testNode.getUnorderedChildren().get( 0 ) );
     }
 
-    public ComplexNode( Property property, SimpleNode child )
+    public static class TestNode extends AbstractNode
     {
-        super( property.getName(), NodeType.COMPLEX, property, child );
-        setNamespace( property.getNamespace() );
+        public TestNode( String name, NodeType nodeType )
+        {
+            super( name, nodeType );
+        }
+
+        public TestNode( String name, NodeType nodeType, Property property, AbstractNode child )
+        {
+            super( name, nodeType, property, child );
+        }
+    }
+
+    public static class TestClass
+    {
+        // nothing to define
     }
 }

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/transformers/PluckNodeTransformerTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/transformers/PluckNodeTransformerTest.java
@@ -1,0 +1,148 @@
+package org.hisp.dhis.node.transformers;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.node.Node;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.ComplexNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.hisp.dhis.schema.DefaultSchemaService;
+import org.hisp.dhis.schema.Jackson2PropertyIntrospectorService;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.SchemaService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link PluckNodeTransformer}.
+ *
+ * @author Volker Schmidt
+ */
+public class PluckNodeTransformerTest
+{
+    private final PluckNodeTransformer transformer = new PluckNodeTransformer();
+
+    @Mock
+    private SessionFactory sessionFactory;
+
+    private SchemaService schemaService;
+
+    private CollectionNode collectionNode;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp()
+    {
+        schemaService = new DefaultSchemaService( new Jackson2PropertyIntrospectorService()
+        {
+            @Override
+            protected Map<String, Property> getPropertiesFromHibernate( Class<?> klass )
+            {
+                return Collections.emptyMap();
+            }
+        }, sessionFactory );
+
+        collectionNode = new CollectionNode( "organisationUnits", 2 );
+        collectionNode.setNamespace( "testUrn" );
+        collectionNode.setProperty( schemaService.getDynamicSchema( CategoryOption.class ).getProperty( "organisationUnits" ) );
+
+        ComplexNode complexNode = new ComplexNode( "organisationUnit" );
+        SimpleNode simpleNode = new SimpleNode( "id", schemaService.getDynamicSchema( Category.class ).getProperty( "id" ), "abc1" );
+        complexNode.addChild( simpleNode );
+        simpleNode = new SimpleNode( "name", schemaService.getDynamicSchema( Category.class ).getProperty( "id" ), "OU 1" );
+        complexNode.addChild( simpleNode );
+        collectionNode.addChild( complexNode );
+
+        complexNode = new ComplexNode( "organisationUnit" );
+        simpleNode = new SimpleNode( "id", schemaService.getDynamicSchema( Category.class ).getProperty( "id" ), "abc2" );
+        complexNode.addChild( simpleNode );
+        simpleNode = new SimpleNode( "name", schemaService.getDynamicSchema( Category.class ).getProperty( "id" ), "OU 2" );
+        complexNode.addChild( simpleNode );
+        collectionNode.addChild( complexNode );
+    }
+
+    @Test
+    public void name()
+    {
+        Assert.assertEquals( "pluck", transformer.name() );
+    }
+
+    @Test
+    public void withoutArg()
+    {
+        Node result = transformer.transform( collectionNode, null );
+        Assert.assertTrue( result instanceof CollectionNode );
+
+        CollectionNode collection = (CollectionNode) result;
+        Assert.assertEquals( "organisationUnits", collection.getName() );
+        Assert.assertEquals( "testUrn", collection.getNamespace() );
+        Assert.assertEquals( 2, collection.getUnorderedChildren().size() );
+
+        Assert.assertEquals( "id", collection.getUnorderedChildren().get( 0 ).getName() );
+        Assert.assertTrue( collection.getUnorderedChildren().get( 0 ) instanceof SimpleNode );
+        Assert.assertEquals( "abc1", ( (SimpleNode) collection.getUnorderedChildren().get( 0 ) ).getValue() );
+
+        Assert.assertEquals( "id", collection.getUnorderedChildren().get( 1 ).getName() );
+        Assert.assertTrue( collection.getUnorderedChildren().get( 1 ) instanceof SimpleNode );
+        Assert.assertEquals( "abc2", ( (SimpleNode) collection.getUnorderedChildren().get( 1 ) ).getValue() );
+    }
+
+    @Test
+    public void withArg()
+    {
+        Node result = transformer.transform( collectionNode, Collections.singletonList( "name" ) );
+        Assert.assertTrue( result instanceof CollectionNode );
+
+        CollectionNode collection = (CollectionNode) result;
+        Assert.assertEquals( "organisationUnits", collection.getName() );
+        Assert.assertEquals( "testUrn", collection.getNamespace() );
+        Assert.assertEquals( 2, collection.getUnorderedChildren().size() );
+
+        Assert.assertEquals( "name", collection.getUnorderedChildren().get( 0 ).getName() );
+        Assert.assertTrue( collection.getUnorderedChildren().get( 0 ) instanceof SimpleNode );
+        Assert.assertEquals( "OU 1", ( (SimpleNode) collection.getUnorderedChildren().get( 0 ) ).getValue() );
+
+        Assert.assertEquals( "name", collection.getUnorderedChildren().get( 1 ).getName() );
+        Assert.assertTrue( collection.getUnorderedChildren().get( 1 ) instanceof SimpleNode );
+        Assert.assertEquals( "OU 2", ( (SimpleNode) collection.getUnorderedChildren().get( 1 ) ).getValue() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/CollectionNodeTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/CollectionNodeTest.java
@@ -1,0 +1,110 @@
+package org.hisp.dhis.node.types;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CollectionNodeTest}.
+ *
+ * @author Volker Schmidt
+ */
+public class CollectionNodeTest
+{
+    @Test
+    public void createEmpty()
+    {
+        final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
+        Assert.assertEquals( "tests", collectionNode.getName() );
+        Assert.assertEquals( 0, collectionNode.getUnorderedChildren().size() );
+    }
+
+    @Test
+    public void createNonEmpty()
+    {
+        final CollectionNode collectionNode = new CollectionNode( "tests", 10 );
+        Assert.assertEquals( "tests", collectionNode.getName() );
+        Assert.assertEquals( 0, collectionNode.getUnorderedChildren().size() );
+    }
+
+    @Test
+    public void getChildren()
+    {
+        final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
+
+        final SimpleNode simpleNode1 = new SimpleNode( "id", "My Test 1" )
+        {
+            @Override
+            public int getOrder()
+            {
+                return 10;
+            }
+        };
+        final SimpleNode simpleNode2 = new SimpleNode( "id", "My Test 2" )
+        {
+            @Override
+            public int getOrder()
+            {
+                return 5;
+            }
+        };
+        final SimpleNode simpleNode3 = new SimpleNode( "id", "My Test 3" )
+        {
+            @Override
+            public int getOrder()
+            {
+                return 15;
+            }
+        };
+
+        collectionNode.addChild( simpleNode1 );
+        collectionNode.addChild( simpleNode2 );
+        collectionNode.addChild( simpleNode3 );
+
+        Assert.assertThat( collectionNode.getChildren(), Matchers.contains( simpleNode2, simpleNode1, simpleNode3 ) );
+    }
+
+    @Test
+    public void getEmptyChildren()
+    {
+        final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
+        Assert.assertEquals( 0, collectionNode.getChildren().size() );
+    }
+
+    @Test
+    public void getSingleChildren()
+    {
+        final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
+        final SimpleNode simpleNode1 = new SimpleNode( "id", "My Test 1" );
+        collectionNode.addChild( simpleNode1 );
+        Assert.assertThat( collectionNode.getChildren(), Matchers.contains( simpleNode1 ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/ComplexNodeTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/ComplexNodeTest.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.node.types;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,23 +28,32 @@ package org.hisp.dhis.node.types;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.node.AbstractNode;
-import org.hisp.dhis.node.NodeType;
+import org.hisp.dhis.node.AbstractNodeTest;
 import org.hisp.dhis.schema.Property;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Unit tests for {@link ComplexNode}.
+ *
+ * @author Volker Schmidt
  */
-public class ComplexNode extends AbstractNode
+public class ComplexNodeTest
 {
-    public ComplexNode( String name )
+    @Test
+    public void createSingleChild()
     {
-        super( name, NodeType.COMPLEX );
-    }
+        final Property property = new Property( AbstractNodeTest.TestClass.class );
+        property.setName( "tests" );
+        property.setNamespace( "testUri" );
 
-    public ComplexNode( Property property, SimpleNode child )
-    {
-        super( property.getName(), NodeType.COMPLEX, property, child );
-        setNamespace( property.getNamespace() );
+        final SimpleNode simpleNode = new SimpleNode( "id", "My Test" );
+
+        final ComplexNode testNode = new ComplexNode( property, simpleNode );
+        Assert.assertEquals( "tests", testNode.getName() );
+        Assert.assertEquals( "testUri", testNode.getNamespace() );
+        Assert.assertEquals( AbstractNodeTest.TestClass.class, testNode.getProperty().getKlass() );
+        Assert.assertEquals( 1, testNode.getUnorderedChildren().size() );
+        Assert.assertSame( simpleNode, testNode.getUnorderedChildren().get( 0 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/SimpleNodeTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/SimpleNodeTest.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.node.types;
 
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,23 +28,30 @@ package org.hisp.dhis.node.types;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.node.AbstractNode;
-import org.hisp.dhis.node.NodeType;
+import org.hisp.dhis.node.AbstractNodeTest;
 import org.hisp.dhis.schema.Property;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Unit tests for {@link SimpleNode}.
+ *
+ * @author Volker Schmidt
  */
-public class ComplexNode extends AbstractNode
+public class SimpleNodeTest
 {
-    public ComplexNode( String name )
+    @Test
+    public void createWithProperty()
     {
-        super( name, NodeType.COMPLEX );
-    }
+        final Property property = new Property( AbstractNodeTest.TestClass.class );
+        property.setName( "test" );
+        property.setNamespace( "testUri" );
+        property.setAttribute( true );
 
-    public ComplexNode( Property property, SimpleNode child )
-    {
-        super( property.getName(), NodeType.COMPLEX, property, child );
-        setNamespace( property.getNamespace() );
+        final SimpleNode simpleNode = new SimpleNode( "id", property, "My Test" );
+        Assert.assertEquals( "id", simpleNode.getName() );
+        Assert.assertEquals( "testUri", simpleNode.getNamespace() );
+        Assert.assertTrue( simpleNode.isAttribute() );
+        Assert.assertEquals( "My Test", simpleNode.getValue() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/Schema.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/Schema.java
@@ -618,12 +618,7 @@ public class Schema implements Ordered, Klass
     @JsonIgnore
     public Property getProperty( String name )
     {
-        if ( propertyMap.containsKey( name ) )
-        {
-            return propertyMap.get( name );
-        }
-
-        return null;
+        return propertyMap.get( name );
     }
 
     @JsonIgnore


### PR DESCRIPTION
- Issue TECH-175 (backport until 2.31)
- Performance enhancement for category options with a big amount of organisation units.
- Adds fast path for writing metadata JSON strings.
- Reduces object creation for metadata nodes.
- Removes not required contains check from Schema.getProperty().
- Adds short path for filtering ID only identifiables.
- Provides ability to transform array objects to array of specific field.