### PR TITLE
AUTO-37: pipeline for pushing docker images

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -12,6 +12,7 @@ pipeline {
         DOCKER_IMAGE_TAG = ''
         DOCKER_IMAGE_FULL_NAME = ''
         COMPOSE_PARAMETER = ''
+        TESTS_IMAGE_FULL_NAME = ''
     }
 
     stages {
@@ -46,8 +47,13 @@ pipeline {
 
         stage('Run api tests') {
             steps {
-                dir("dhis-2/dhis-e2e-test") {
-                    sh "IMAGE_TAG=${DOCKER_IMAGE_TAG} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --build --exit-code-from e2e-test"
+                script {
+                    TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}"
+
+                    dir("dhis-2/dhis-e2e-test") {
+                        sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
+                        sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                    }
                 }
             }
         }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -8,7 +8,7 @@ pipeline {
 
     environment {
         DHIS2_VERSION = ''
-        DOCKER_HUB_REPOSITORY = "${DOCKER_HUB_OWNER}/core"
+        DOCKER_HUB_REPOSITORY = "${DOCKER_HUB_OWNER}/core-dev"
         DOCKER_IMAGE_TAG = ''
         DOCKER_IMAGE_FULL_NAME = ''
         COMPOSE_PARAMETER = ''
@@ -16,18 +16,41 @@ pipeline {
     }
 
     stages {
+        stage('Prepare env for release deployment') {
+            when{
+                buildingTag()
+            }
+            steps {
+                script {
+                    DOCKER_HUB_REPOSITORY = "${DOCKER_HUB_OWNER}/core"
+                    pom = readMavenPom file: 'dhis-2/pom.xml'
+                    DHIS2_VERSION = pom.version.toLowerCase()
+
+                    echo "DHIS2 version: ${DHIS2_VERSION}"
+
+                    DOCKER_IMAGE_TAG = "${DHIS2_VERSION}"
+                }
+            }
+        }
+
+        stage('Prepare env for dev deployment') {
+            when {
+                not {
+                    buildingTag()
+                }
+            }
+
+            steps {
+                script {
+                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
+                }
+            }
+        }
         stage('Build image') {
             steps {
                 script {
-                    pom = readMavenPom file: 'dhis-2/pom.xml'
-
-                    DHIS2_VERSION = pom.version.toLowerCase()
-                    echo "DHIS2 version: ${DHIS2_VERSION}"
-
                     COMPOSE_PARAMETER = "${env.JOB_NAME}"
                     echo "Docker compose parameter: ${COMPOSE_PARAMETER}"
-
-                    DOCKER_IMAGE_TAG = "${DHIS2_VERSION}-alpine"
 
                     DOCKER_IMAGE_FULL_NAME = "${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_TAG}"
                     echo "Will tag image as ${DOCKER_IMAGE_FULL_NAME}"

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -71,7 +71,7 @@ pipeline {
         always {
             dir("dhis-2/dhis-e2e-test") {
                 sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down"
-                sh "IMAGE_TAG=${DOCKER_IMAGE_TAG} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down"
+                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down"
                 sh "docker image prune --force --filter 'until=2h' --filter label=stage=intermediate"
             }
         }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'master'
+        label 'large'
     }
     options {
         disableConcurrentBuilds()

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -1,0 +1,73 @@
+pipeline {
+    agent {
+        label 'master'
+    }
+    options {
+        disableConcurrentBuilds()
+    }
+
+    environment {
+        DHIS2_VERSION = ''
+        DOCKER_HUB_REPOSITORY = "${DOCKER_HUB_OWNER}/core"
+        DOCKER_IMAGE_TAG = ''
+        DOCKER_IMAGE_FULL_NAME = ''
+        COMPOSE_PARAMETER = ''
+    }
+
+    stages {
+        stage('Build image') {
+            steps {
+                script {
+                    pom = readMavenPom file: 'dhis-2/pom.xml'
+
+                    DHIS2_VERSION = pom.version.toLowerCase()
+                    echo "DHIS2 version: ${DHIS2_VERSION}"
+
+                    COMPOSE_PARAMETER = "${env.JOB_NAME}"
+                    echo "Docker compose parameter: ${COMPOSE_PARAMETER}"
+
+                    DOCKER_IMAGE_TAG = "${DHIS2_VERSION}-alpine"
+
+                    DOCKER_IMAGE_FULL_NAME = "${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_TAG}"
+                    echo "Will tag image as ${DOCKER_IMAGE_FULL_NAME}"
+
+                    sh "docker build -t ${DOCKER_IMAGE_FULL_NAME} ."
+                }
+            }
+        }
+
+        stage('Start instance') {
+            steps {
+                dir("dhis-2/dhis-e2e-test") {
+                    sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} up -d"
+                }
+            }
+        }
+
+        stage('Run api tests') {
+            steps {
+                dir("dhis-2/dhis-e2e-test") {
+                    sh "IMAGE_TAG=${DOCKER_IMAGE_TAG} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --build --exit-code-from e2e-test"
+                }
+            }
+        }
+
+        stage('Publish image') {
+            steps {
+                withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                    sh "docker push ${DOCKER_IMAGE_FULL_NAME}"
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            dir("dhis-2/dhis-e2e-test") {
+                sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down"
+                sh "IMAGE_TAG=${DOCKER_IMAGE_TAG} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down"
+                sh "docker image prune --force --filter 'until=2h' --filter label=stage=intermediate"
+            }
+        }
+    }
+}

--- a/dhis-2/dhis-e2e-test/Dockerfile
+++ b/dhis-2/dhis-e2e-test/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.5.3-jdk-8-slim
+
+COPY pom.xml wait-for-it.sh /
+RUN mvn dependency:go-offline
+
+COPY config/dhis2_home/dhis.conf /config/dhis2_home/dhis.conf
+COPY src /src
+
+VOLUME /target
+
+RUN chmod +x wait-for-it.sh
+RUN mvn compile

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -3,9 +3,5 @@ version: '3'
 services:
   e2e-test:
     stdin_open: true
-    image: ${IMAGE_NAME}
-    build:
-      dockerfile: Dockerfile
-      context: .
-
+    image: "${IMAGE_NAME}"
     command: ./wait-for-it.sh e2e-test-web:8080 -- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  e2e-test:
+    stdin_open: true
+    image: core-api-tests:${IMAGE_TAG}
+    build:
+      dockerfile: Dockerfile
+      context: .
+
+    command: ./wait-for-it.sh e2e-test-web:8080 -- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   e2e-test:
     stdin_open: true
-    image: core-api-tests:${IMAGE_TAG}
+    image: ${IMAGE_NAME}
     build:
       dockerfile: Dockerfile
       context: .

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -10,13 +10,15 @@ services:
       POSTGRES_PASSOWRD: dhis
 
   e2e-test-web:
-    image: dhis2/dhis2-core:dev-latest
+    image: "${IMAGE_NAME}"
+    logging:
+      driver: "json-file"
     build:
       dockerfile: Dockerfile
       context: ../..
     volumes:
-      - ./config/dhis2_home/dhis.conf:/DHIS2_home/dhis.conf
+    - ./config/dhis2_home/dhis.conf:/DHIS2_home/dhis.conf
     depends_on:
-      - db
+    - db
     ports:
-      - 8070:8080
+    - "8080"

--- a/dhis-2/dhis-e2e-test/wait-for-it.sh
+++ b/dhis-2/dhis-e2e-test/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
This PR enables parallel test execution on CI server:

- avoiding port collisions by running tests in a docker container. This way port doesn´t have to be expose to host machine and tests can communicate with backend in isolated network;

Adds Jenkinsfile with the pipeline for publishing docker images. For testing I used my docker hub account, but as soon as everything works I will use dhis2 account - it's only a matter of configuring "$DOCKER_HUB_OWNER" variable in jenkins and changing credentials in credentials manager.

- Multibranch pipeline requires "jenkins-as-code" pipeline definition, hence the Jenkinsfile.