### PR TITLE
Adds missing @Component to OptionObjectBundleHook.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -32,10 +32,12 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Volker Schmidt
  */
+@Component
 public class OptionObjectBundleHook
     extends AbstractObjectBundleHook
 {


### PR DESCRIPTION
- Fixes issue DHIS2-5535 in master.
- After adding Spring annotation processing the hook was not
  discovered anymore.