### PR TITLE
Support max returned values in Dashboard endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardService.java
@@ -51,8 +51,12 @@ public interface DashboardService
 
     DashboardSearchResult search( String query );
 
+    DashboardSearchResult search( String query, Set<DashboardItemType> maxTypes, Integer count, Integer maxCount );
+
     DashboardSearchResult search( String query, Set<DashboardItemType> maxTypes );
-    
+
+    DashboardSearchResult search( Set<DashboardItemType> maxTypes, Integer count, Integer maxCount );
+
     DashboardSearchResult search( Set<DashboardItemType> maxTypes );
 
     DashboardItem addItemContent( String dashboardUid, DashboardItemType type, String contentUid );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.report.Report;
 import org.hisp.dhis.reporttable.ReportTable;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -446,7 +447,9 @@ public class DefaultDashboardService
 
     private int getMax( DashboardItemType type, Set<DashboardItemType> maxTypes, Integer count, Integer maxCount )
     {
-        return maxTypes != null && maxTypes.contains( type ) ? (maxCount == null ? MAX_HITS_PER_OBJECT : maxCount)
-            : (count == null ? HITS_PER_OBJECT : count);
+        int dashboardsMax = ObjectUtils.firstNonNull( maxCount, MAX_HITS_PER_OBJECT );
+        int dashboardsCount = ObjectUtils.firstNonNull( count, HITS_PER_OBJECT );
+
+        return maxTypes != null && maxTypes.contains( type ) ? dashboardsMax : dashboardsCount;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -70,7 +70,7 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 public class DefaultDashboardService
     implements DashboardService
 {
-    private static final int HITS_PER_OBJECT = 5;
+    private static final int HITS_PER_OBJECT = 6;
     private static final int MAX_HITS_PER_OBJECT = 25;
 
     // -------------------------------------------------------------------------
@@ -117,12 +117,12 @@ public class DefaultDashboardService
     @Transactional(readOnly = true)
     public DashboardSearchResult search( String query )
     {
-        return search( query, new HashSet<>() );
+        return search( query, new HashSet<>(), null, null );
     }
 
     @Override
     @Transactional(readOnly = true)
-    public DashboardSearchResult search( String query, Set<DashboardItemType> maxTypes )
+    public DashboardSearchResult search( String query, Set<DashboardItemType> maxTypes, Integer count, Integer maxCount )
     {
         Set<String> words = Sets.newHashSet( query.split( TextUtils.SPACE ) );
 
@@ -130,14 +130,14 @@ public class DefaultDashboardService
 
         DashboardSearchResult result = new DashboardSearchResult();
 
-        result.setUsers( userService.getAllUsersBetweenByName( query, 0, getMax( DashboardItemType.USERS, maxTypes ) ) );
-        result.setCharts( objectManager.getBetweenLikeName( Chart.class, words, 0, getMax( DashboardItemType.CHART, maxTypes ) ) );
-        result.setEventCharts( objectManager.getBetweenLikeName( EventChart.class, words, 0, getMax( DashboardItemType.EVENT_CHART, maxTypes ) ) );
-        result.setMaps( objectManager.getBetweenLikeName( Map.class, words, 0, getMax( DashboardItemType.MAP, maxTypes ) ) );
-        result.setReportTables( objectManager.getBetweenLikeName( ReportTable.class, words, 0, getMax( DashboardItemType.REPORT_TABLE, maxTypes ) ) );
-        result.setEventReports( objectManager.getBetweenLikeName( EventReport.class, words, 0, getMax( DashboardItemType.EVENT_REPORT, maxTypes ) ) );
-        result.setReports( objectManager.getBetweenLikeName( Report.class, words, 0, getMax( DashboardItemType.REPORTS, maxTypes ) ) );
-        result.setResources( objectManager.getBetweenLikeName( Document.class, words, 0, getMax( DashboardItemType.RESOURCES, maxTypes ) ) );
+        result.setUsers( userService.getAllUsersBetweenByName( query, 0, getMax( DashboardItemType.USERS, maxTypes, count, maxCount ) ) );
+        result.setCharts( objectManager.getBetweenLikeName( Chart.class, words, 0, getMax( DashboardItemType.CHART, maxTypes, count, maxCount ) ) );
+        result.setEventCharts( objectManager.getBetweenLikeName( EventChart.class, words, 0, getMax( DashboardItemType.EVENT_CHART, maxTypes, count, maxCount ) ) );
+        result.setMaps( objectManager.getBetweenLikeName( Map.class, words, 0, getMax( DashboardItemType.MAP, maxTypes, count, maxCount ) ) );
+        result.setReportTables( objectManager.getBetweenLikeName( ReportTable.class, words, 0, getMax( DashboardItemType.REPORT_TABLE, maxTypes, count, maxCount ) ) );
+        result.setEventReports( objectManager.getBetweenLikeName( EventReport.class, words, 0, getMax( DashboardItemType.EVENT_REPORT, maxTypes, count, maxCount ) ) );
+        result.setReports( objectManager.getBetweenLikeName( Report.class, words, 0, getMax( DashboardItemType.REPORTS, maxTypes, count, maxCount ) ) );
+        result.setResources( objectManager.getBetweenLikeName( Document.class, words, 0, getMax( DashboardItemType.RESOURCES, maxTypes, count, maxCount ) ) );
         result.setApps( appManager.getAppsByName( query, dashboardApps, "ilike" ) );
 
         return result;
@@ -145,20 +145,32 @@ public class DefaultDashboardService
 
     @Override
     @Transactional(readOnly = true)
-    public DashboardSearchResult search( Set<DashboardItemType> maxTypes )
+    public DashboardSearchResult search( Set<DashboardItemType> maxTypes, Integer count, Integer maxCount )
     {
         DashboardSearchResult result = new DashboardSearchResult();
 
-        result.setCharts( objectManager.getBetweenSorted( Chart.class, 0, getMax( DashboardItemType.CHART, maxTypes ) ) );
-        result.setEventCharts( objectManager.getBetweenSorted( EventChart.class, 0, getMax( DashboardItemType.EVENT_CHART, maxTypes ) ) );
-        result.setMaps( objectManager.getBetweenSorted( Map.class, 0, getMax( DashboardItemType.MAP, maxTypes ) ) );
-        result.setReportTables( objectManager.getBetweenSorted( ReportTable.class, 0, getMax( DashboardItemType.REPORT_TABLE, maxTypes ) ) );
-        result.setEventReports( objectManager.getBetweenSorted( EventReport.class, 0, getMax( DashboardItemType.EVENT_REPORT, maxTypes ) ) );
-        result.setReports( objectManager.getBetweenSorted( Report.class, 0, getMax( DashboardItemType.REPORTS, maxTypes ) ) );
-        result.setResources( objectManager.getBetweenSorted( Document.class, 0, getMax( DashboardItemType.RESOURCES, maxTypes ) ) );
-        result.setApps( appManager.getApps( AppType.DASHBOARD_WIDGET, getMax( DashboardItemType.APP, maxTypes ) ) );
+        result.setCharts( objectManager.getBetweenSorted( Chart.class, 0, getMax( DashboardItemType.CHART, maxTypes, count, maxCount ) ) );
+        result.setEventCharts( objectManager.getBetweenSorted( EventChart.class, 0, getMax( DashboardItemType.EVENT_CHART, maxTypes, count, maxCount ) ) );
+        result.setMaps( objectManager.getBetweenSorted( Map.class, 0, getMax( DashboardItemType.MAP, maxTypes, count, maxCount ) ) );
+        result.setReportTables( objectManager.getBetweenSorted( ReportTable.class, 0, getMax( DashboardItemType.REPORT_TABLE, maxTypes, count, maxCount ) ) );
+        result.setEventReports( objectManager.getBetweenSorted( EventReport.class, 0, getMax( DashboardItemType.EVENT_REPORT, maxTypes, count, maxCount ) ) );
+        result.setReports( objectManager.getBetweenSorted( Report.class, 0, getMax( DashboardItemType.REPORTS, maxTypes, count, maxCount ) ) );
+        result.setResources( objectManager.getBetweenSorted( Document.class, 0, getMax( DashboardItemType.RESOURCES, maxTypes, count, maxCount ) ) );
+        result.setApps( appManager.getApps( AppType.DASHBOARD_WIDGET, getMax( DashboardItemType.APP, maxTypes, count, maxCount ) ) );
 
         return result;
+    }
+
+    @Override
+    public DashboardSearchResult search( String query, Set<DashboardItemType> maxTypes )
+    {
+        return this.search( query, maxTypes, null, null );
+    }
+
+    @Override
+    public DashboardSearchResult search( Set<DashboardItemType> maxTypes )
+    {
+        return this.search( maxTypes, null, null );
     }
 
     @Override
@@ -432,8 +444,9 @@ public class DefaultDashboardService
     // Supportive methods
     // -------------------------------------------------------------------------
 
-    private int getMax( DashboardItemType type, Set<DashboardItemType> maxTypes )
+    private int getMax( DashboardItemType type, Set<DashboardItemType> maxTypes, Integer count, Integer maxCount )
     {
-        return maxTypes != null && maxTypes.contains( type ) ? MAX_HITS_PER_OBJECT : HITS_PER_OBJECT;
+        return maxTypes != null && maxTypes.contains( type ) ? (maxCount == null ? MAX_HITS_PER_OBJECT : maxCount)
+            : (count == null ? HITS_PER_OBJECT : count);
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
@@ -249,9 +249,7 @@ public class DashboardServiceTest
 
         });
 
-        IntStream.range(1, 30).forEach( i -> {
-            eventChartService.saveEventChart( createEventChart( prA ) );
-        });
+        IntStream.range(1, 30).forEach( i -> eventChartService.saveEventChart( createEventChart( prA ) ));
 
         DashboardSearchResult result = dashboardService.search( Sets.newHashSet( DashboardItemType.CHART ) );
 
@@ -265,9 +263,8 @@ public class DashboardServiceTest
 
         result = dashboardService.search( Sets.newHashSet( DashboardItemType.CHART ), 3, 29 );
 
-        assertThat(result.getChartCount(), is(29));
-        assertThat(result.getEventChartCount(), is(3));
-
+        assertThat( result.getChartCount(), is( 29 ) );
+        assertThat( result.getEventChartCount(), is( 3 ) );
 
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.dashboard;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.Sets;
+import org.apache.commons.lang.RandomStringUtils;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.chart.Chart;
 import org.hisp.dhis.chart.ChartService;
@@ -42,6 +44,9 @@ import org.hisp.dhis.program.Program;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class DashboardServiceTest
@@ -229,6 +234,55 @@ public class DashboardServiceTest
         result = dashboardService.search( "Z" );
         assertEquals(0, result.getChartCount() );
         assertEquals(0, result.getResourceCount() );
+    }
 
+    @Test
+    public void testSearchDashboardWithMaxCount()
+    {
+        Program prA = createProgram( 'A', null, null );
+        objectManager.save( prA );
+
+        IntStream.range(1, 30).forEach( i -> {
+            Chart chart = createChart( 'A' );
+            chart.setName( RandomStringUtils.randomAlphabetic( 5 ) );
+            chartService.addChart( createChart( ) );
+
+        });
+
+        IntStream.range(1, 30).forEach( i -> {
+            eventChartService.saveEventChart( createEventChart( prA ) );
+        });
+
+        DashboardSearchResult result = dashboardService.search( Sets.newHashSet( DashboardItemType.CHART ) );
+
+        assertThat(result.getChartCount(), is(25));
+        assertThat(result.getEventChartCount(), is(6));
+
+        result = dashboardService.search( Sets.newHashSet( DashboardItemType.CHART ), 3, null );
+
+        assertThat(result.getChartCount(), is(25));
+        assertThat(result.getEventChartCount(), is(3));
+
+        result = dashboardService.search( Sets.newHashSet( DashboardItemType.CHART ), 3, 29 );
+
+        assertThat(result.getChartCount(), is(29));
+        assertThat(result.getEventChartCount(), is(3));
+
+
+    }
+
+    private EventChart createEventChart( Program program )
+    {
+        EventChart eventChart = new EventChart( RandomStringUtils.randomAlphabetic( 5 ) );
+        eventChart.setProgram( program );
+        eventChart.setType( ChartType.COLUMN );
+        return eventChart;
+    }
+    
+    private Chart createChart( )
+    {
+        Chart chart = createChart( 'A' );
+        chart.setName( RandomStringUtils.randomAlphabetic( 5 ) );
+        return chart;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -48,6 +48,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Set;
 
 /**
@@ -67,17 +68,21 @@ public class DashboardController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/q/{query}", method = RequestMethod.GET )
-    public @ResponseBody DashboardSearchResult search( @PathVariable String query, @RequestParam( required = false ) Set<DashboardItemType> max )
+    public @ResponseBody DashboardSearchResult search( @PathVariable String query,
+        @RequestParam( required = false ) Set<DashboardItemType> max, @RequestParam( required = false ) Integer count,
+        @RequestParam( required = false ) Integer maxCount )
     {
-        return dashboardService.search( query, max );
+        return dashboardService.search( query, max, count, maxCount );
     }
 
     @RequestMapping( value = "/q", method = RequestMethod.GET )
-    public @ResponseBody DashboardSearchResult searchNoFilter( @RequestParam( required = false ) Set<DashboardItemType> max )
+    public @ResponseBody DashboardSearchResult searchNoFilter(
+        @RequestParam( required = false ) Set<DashboardItemType> max, @RequestParam( required = false ) Integer count,
+        @RequestParam( required = false ) Integer maxCount )
     {
-        return dashboardService.search( max );
+        return dashboardService.search( max, count, maxCount );
     }
-
+    
     // -------------------------------------------------------------------------
     // Metadata with dependencies
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.webapi.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.common.collect.Sets;
+import org.hisp.dhis.cache.HibernateCacheManager;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dashboard.DashboardItemType;
+import org.hisp.dhis.dashboard.DashboardService;
+import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.dxf2.metadata.MetadataImportService;
+import org.hisp.dhis.dxf2.metadata.collection.CollectionService;
+import org.hisp.dhis.fieldfilter.FieldFilterService;
+import org.hisp.dhis.patch.PatchService;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.schema.MergeService;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.UserSettingService;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.hisp.dhis.webapi.service.LinkService;
+import org.hisp.dhis.webapi.service.WebMessageService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DashboardControllerTest
+{
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private DashboardService dashboardService;
+
+    @Mock
+    protected IdentifiableObjectManager manager;
+
+    @Mock
+    protected CurrentUserService currentUserService;
+
+    @Mock
+    protected FieldFilterService fieldFilterService;
+
+    @Mock
+    protected AclService aclService;
+
+    @Mock
+    protected SchemaService schemaService;
+
+    @Mock
+    protected LinkService linkService;
+
+    @Mock
+    protected RenderService renderService;
+
+    @Mock
+    protected MetadataImportService importService;
+
+    @Mock
+    protected MetadataExportService exportService;
+
+    @Mock
+    protected ContextService contextService;
+
+    @Mock
+    protected QueryService queryService;
+
+    @Mock
+    protected WebMessageService webMessageService;
+
+    @Mock
+    protected HibernateCacheManager hibernateCacheManager;
+
+    @Mock
+    protected UserSettingService userSettingService;
+
+    @Mock
+    protected CollectionService collectionService;
+
+    @Mock
+    protected MergeService mergeService;
+
+    @Mock
+    protected PatchService patchService;
+
+    @InjectMocks
+    private DashboardController dashboardController;
+
+    private final static String ENDPOINT = "/dashboards/q";
+
+    @Before
+    public void setUp()
+    {
+        MockitoAnnotations.initMocks( this );
+        mockMvc = MockMvcBuilders.standaloneSetup( dashboardController ).build();
+    }
+
+    @Test
+    public void verifyEndpointWithNoArgs()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT ) ).andExpect( status().isOk() );
+
+        verify( dashboardService ).search( null, null, null );
+    }
+
+    @Test
+    public void verifyEndpointWithMaxArg()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT ).param( "max", "CHART" ) ).andExpect( status().isOk() );
+
+        verify( dashboardService ).search( Sets.newHashSet( DashboardItemType.CHART ), null, null );
+    }
+
+    @Test
+    public void verifyEndpointWithAllArg()
+        throws Exception
+    {
+        mockMvc.perform(
+            get( ENDPOINT )
+                .param( "max", "CHART" )
+                .param( "count", "10" )
+                .param( "maxCount", "20" ) )
+            .andExpect( status().isOk() );
+
+        verify( dashboardService ).search( Sets.newHashSet( DashboardItemType.CHART ), 10, 20 );
+    }
+
+    @Test
+    public void verifyEndpointWithSearchQueryWithNoArgs()
+            throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT + "/alfa" ) ).andExpect( status().isOk() );
+
+        verify( dashboardService ).search( "alfa" , null, null, null );
+    }
+
+    @Test
+    public void verifyEndpointWithSearchQueryWithMaxArg()
+            throws Exception
+    {
+        mockMvc.perform(
+            get( ENDPOINT + "/alfa" )
+                .param( "max", "CHART" ) )
+            .andExpect( status().isOk() );
+
+        verify( dashboardService ).search( "alfa" , Sets.newHashSet( DashboardItemType.CHART ), null, null );
+    }
+
+    @Test
+    public void verifyEndpointWithSearchQueryWithAllArg()
+            throws Exception
+    {
+        mockMvc.perform(
+            get( ENDPOINT + "/alfa"  )
+                .param( "max", "CHART" )
+                .param( "count", "10" )
+                .param( "maxCount", "20" ) )
+            .andExpect( status().isOk() );
+
+        verify( dashboardService ).search( "alfa" , Sets.newHashSet( DashboardItemType.CHART ), 10, 20 );
+    }
+
+
+}


### PR DESCRIPTION
- DHIS2-7036
- Introduced `count` and `maxCount` parameters to `/dashboard/q` endpoint
to let clients specify the number of Dashboard items returned or the max
number of Dashboard items returned when the `max` param is used
- Add tests