### PR TITLE
Add jackson annotation to IdSchemes and IdScheme (master)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdScheme.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdScheme.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.common;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -99,17 +101,19 @@ public class IdScheme
         this.identifiableProperty = identifiableProperty;
     }
 
-    private IdScheme( IdentifiableProperty identifiableProperty, String attribute )
+    private IdScheme( @JsonProperty( "identifiableProperty" ) IdentifiableProperty identifiableProperty, @JsonProperty( "attribute" ) String attribute )
     {
         this.identifiableProperty = identifiableProperty;
         this.attribute = attribute;
     }
 
+    @JsonProperty
     public IdentifiableProperty getIdentifiableProperty()
     {
         return identifiableProperty;
     }
 
+    @JsonIgnore
     public String getIdentifiableString()
     {
         return identifiableProperty != null ? identifiableProperty.toString() : null;
@@ -120,6 +124,7 @@ public class IdScheme
         this.identifiableProperty = identifiableProperty;
     }
 
+    @JsonProperty
     public String getAttribute()
     {
         return attribute;
@@ -130,21 +135,25 @@ public class IdScheme
         this.attribute = attribute;
     }
 
+    @JsonIgnore
     public boolean is( IdentifiableProperty identifiableProperty )
     {
         return this.identifiableProperty == identifiableProperty;
     }
 
+    @JsonIgnore
     public boolean isNull()
     {
         return null == this.identifiableProperty;
     }
 
+    @JsonIgnore
     public boolean isNotNull()
     {
         return !isNull();
     }
 
+    @JsonIgnore
     public boolean isAttribute()
     {
         return IdentifiableProperty.ATTRIBUTE == identifiableProperty && !StringUtils.isEmpty( attribute );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.common;
 
 import com.google.common.base.MoreObjects;
 import org.hisp.dhis.util.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Identifier schemes used to map meta data. The general identifier
@@ -83,7 +84,82 @@ public class IdSchemes
         this.idScheme = IdScheme.from( idScheme );
         return this;
     }
+    
+    //--------------------------------------------------------------------------
+    // Setter id schemes
+    //--------------------------------------------------------------------------
+    @JsonProperty
+    public void setIdScheme( IdScheme idScheme )
+    {
+        this.idScheme = IdScheme.from( idScheme );
+    }
 
+    @JsonProperty
+    public void setDataElementIdScheme( IdScheme dataElementIdScheme )
+    {
+        this.dataElementIdScheme = IdScheme.from( dataElementIdScheme );
+    }
+
+    @JsonProperty
+    public void setCategoryOptionComboIdScheme( IdScheme categoryOptionComboIdScheme )
+    {
+        this.categoryOptionComboIdScheme = IdScheme.from( categoryOptionComboIdScheme );
+    }
+
+    @JsonProperty
+    public void setCategoryOptionIdScheme( IdScheme categoryOptionIdScheme )
+    {
+        this.categoryOptionIdScheme = IdScheme.from( categoryOptionIdScheme );
+    }
+
+    @JsonProperty
+    public void setOrgUnitIdScheme( IdScheme orgUnitIdScheme )
+    {
+        this.orgUnitIdScheme = IdScheme.from( orgUnitIdScheme );
+    }
+
+    @JsonProperty
+    public void setProgramIdScheme( IdScheme programIdScheme )
+    {
+        this.programIdScheme = IdScheme.from( programIdScheme );
+    }
+
+    @JsonProperty
+    public void setProgramStageIdScheme( IdScheme programStageIdScheme )
+    {
+        this.programStageIdScheme = IdScheme.from( programStageIdScheme );
+    }
+
+    @JsonProperty
+    public void setTrackedEntityIdScheme( IdScheme trackedEntityIdScheme )
+    {
+        this.trackedEntityIdScheme = IdScheme.from( trackedEntityIdScheme );
+    }
+
+    @JsonProperty
+    public void setTrackedEntityAttributeIdScheme( IdScheme trackedEntityAttributeIdScheme )
+    {
+        this.trackedEntityAttributeIdScheme = IdScheme.from( trackedEntityAttributeIdScheme );
+    }
+
+    @JsonProperty
+    public void setDataSetIdScheme( IdScheme dataSetIdScheme )
+    {
+        this.dataSetIdScheme = IdScheme.from( dataSetIdScheme );
+    }
+
+    @JsonProperty
+    public void setAttributeOptionComboIdScheme( IdScheme attributeOptionComboIdScheme )
+    {
+        this.attributeOptionComboIdScheme = IdScheme.from( attributeOptionComboIdScheme );
+    }
+
+    @JsonProperty
+    public void setProgramStageInstanceIdScheme( IdScheme programStageInstanceIdScheme )
+    {
+        this.programStageInstanceIdScheme = IdScheme.from( programStageInstanceIdScheme );
+    }
+    
     //--------------------------------------------------------------------------
     // Object type id schemes
     //--------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
@@ -31,8 +31,6 @@ package org.hisp.dhis.leader.election;
 import org.hisp.dhis.scheduling.AbstractJob;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.system.notification.NotificationLevel;
-import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Service;
 
 /**
@@ -45,12 +43,9 @@ public class LeaderRenewalJob extends AbstractJob
 {
     private LeaderManager leaderManager;
 
-    private Notifier notifier;
-
-    public LeaderRenewalJob( LeaderManager leaderManager, Notifier notifier )
+    public LeaderRenewalJob( LeaderManager leaderManager )
     {
         this.leaderManager = leaderManager;
-        this.notifier = notifier;
     }
 
     // -------------------------------------------------------------------------
@@ -66,15 +61,6 @@ public class LeaderRenewalJob extends AbstractJob
     @Override
     public void execute( JobConfiguration jobConfiguration )
     {
-        try
-        {
-            leaderManager.renewLeader();
-        }
-        catch ( Exception e )
-        {
-            notifier.notify( jobConfiguration, NotificationLevel.ERROR, "Leader renewal failed:" + e.getMessage() );
-        }
-
-        notifier.notify( jobConfiguration, NotificationLevel.INFO, "Leader renewal completed", true );
+       leaderManager.renewLeader();
     }
 }


### PR DESCRIPTION
Deserialization of ImportOptions fails due to IdSchemes and IdScheme classes. Fixed it by adding necessary annotations for jackson to use. This is only used in a horizontally scaled dhis2 using redis. 