### PR TITLE
Skip min srch att restriction for unique atts

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
@@ -67,6 +67,8 @@ public class QueryItem
 
     private ProgramStage programStage;
 
+    private Boolean unique = false;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -83,6 +85,16 @@ public class QueryItem
         this.valueType = valueType;
         this.aggregationType = aggregationType;
         this.optionSet = optionSet;
+    }
+
+    public QueryItem( DimensionalItemObject item, LegendSet legendSet, ValueType valueType, AggregationType aggregationType, OptionSet optionSet, Boolean unique )
+    {
+        this.item = item;
+        this.legendSet = legendSet;
+        this.valueType = valueType;
+        this.aggregationType = aggregationType;
+        this.optionSet = optionSet;
+        this.unique = unique;
     }
 
     public QueryItem( DimensionalItemObject item, QueryOperator operator, String filter, ValueType valueType, AggregationType aggregationType, OptionSet optionSet )
@@ -423,5 +435,15 @@ public class QueryItem
     public void setProgramStage( ProgramStage programStage )
     {
         this.programStage = programStage;
+    }
+
+    public Boolean isUnique()
+    {
+        return unique;
+    }
+
+    public void setUnique( Boolean unique )
+    {
+        this.unique = unique;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -656,6 +656,27 @@ public class TrackedEntityInstanceQueryParams
     }
 
     /**
+     * Indicates whether filters are unique attributes.
+     */
+    public boolean hasUniqueFilters()
+    {
+        if ( !hasFilters() )
+        {
+            return false;
+        }
+
+        for ( QueryItem filter : filters )
+        {
+            if ( !filter.isUnique() )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Indicates whether paging is enabled.
      */
     public boolean isPaging()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -633,12 +633,22 @@ public class DefaultTrackedEntityInstanceService
 
     private boolean isProgramMinAttributesViolated( TrackedEntityInstanceQueryParams params )
     {
+        if ( params.hasUniqueFilters() )
+        {
+            return false;
+        }
+
         return (!params.hasFilters() && params.getProgram().getMinAttributesRequiredToSearch() > 0)
             || (params.hasFilters() && params.getFilters().size() < params.getProgram().getMinAttributesRequiredToSearch());
     }
 
     private boolean isTeTypeMinAttributesViolated( TrackedEntityInstanceQueryParams params )
     {
+        if ( params.hasUniqueFilters() )
+        {
+            return false;
+        }
+
         return (!params.hasFilters() && params.getTrackedEntityType().getMinAttributesRequiredToSearch() > 0)
             || (params.hasFilters() && params.getFilters().size() < params.getTrackedEntityType().getMinAttributesRequiredToSearch());
     }
@@ -796,7 +806,7 @@ public class DefaultTrackedEntityInstanceService
             throw new IllegalQueryException( "Attribute does not exist: " + item );
         }
 
-        return new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet() );
+        return new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(), at.isUnique() );
     }
 
     /**


### PR DESCRIPTION
Program and tracked entity type have minimum length of attributes users are required to fill in order to search for TEIs.
Such requirements can be skipped when users are searching using unique attributes