### PR TITLE
Fix bug transaction rollback on addAndPruneAllOptionCombos function

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DefaultDeletionManager.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DefaultDeletionManager.java
@@ -34,7 +34,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Component;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -67,7 +66,6 @@ public class DefaultDeletionManager
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional
     public void execute( Object object )
     {
         if ( deletionHandlers == null || deletionHandlers.isEmpty() )


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7256

In `categoryManager.addAndPruneOptionCombos()`, we use `categoryService.deleteCategoryOptionComboNoRollback()` with ` @Transactional( noRollbackFor = DeleteNotAllowedException.class )`, the reason is because this is use for maintenance function in Data Admin app and the purpose of this function is to delete unused  CategoryOptionCombos or update their names if the option's names were changed.  So we don't want to rollback the whole transaction if one CategoryOptionCombo in the loop couldn't be deleted due to reference with data values. 

If `@Transactional` were put at the `DefaultDeletionManager`, we would need to add `( noRollbackFor = DeleteNotAllowedException.class )` there to make the above works. However, this is wrong as this function is also using by other functions in the system and we would need the rollback there. 

Below is the error logs

* INFO  2019-07-17 15:31:54,784 Delete was not allowed by DataValueDeletionHandler: Could not delete due to association with another object: DataValue (DefaultDeletionManager.java [qtp112049309-32])
* WARN  2019-07-17 15:31:54,785 Could not delete category option combo: {"class":"class org.hisp.dhis.category.CategoryOptionCombo", "id":"359663", "uid":"YEmiuCcgNQI", "code":"COC_359663", "categoryCombo":{"class":"class org.hisp.dhis.category.CategoryCombo", "id":"359659", "uid":"m2jTvAj5kkm", "code":"BIRTHS", "name":"Births", "created":"2011-12-24 12:24:25.203", "lastUpdated":"2016-04-18 16:04:34.745" }, "categoryOptions":[{"class":"class org.hisp.dhis.category.CategoryOption", "hashCode":"1844240452", "id":"359612", "uid":"TXGfLxZlInA", "code":"SECHN", "name":"SECHN", "shortName":"SECHN", "description":"null", "created":"2011-12-24 12:24:24.149", "lastUpdated":"2011-12-24 12:24:24.149" }, {"class":"class org.hisp.dhis.category.CategoryOption", "hashCode":"1070434135", "id":"167629", "uid":"Fp4gVHbRvEV", "code":"AT_PHU", "name":"At PHU", "shortName":"At PHU", "description":"null", "created":"2011-12-24 12:24:24.149", "lastUpdated":"2011-12-24 12:24:24.149" }]} (DefaultCategoryManager.java [qtp112049309-32])
org.springframework.transaction.UnexpectedRollbackException: Transaction rolled back because it has been marked as rollback-only
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.processRollback(AbstractPlatformTransactionManager.java:873)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.commit(AbstractPlatformTransactionManager.java:710)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.commitTransactionAfterReturning(TransactionAspectSupport.java:534)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:305)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:98)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212)
	at com.sun.proxy.$Proxy204.addAndPruneAllOptionCombos(Unknown Source)
	at org.hisp.dhis.webapi.controller.MaintenanceController.updateCategoryOptionCombos(MaintenanceController.java:222)
	at org.hisp.dhis.webapi.controller.MaintenanceController.performMaintenance(MaintenanceController.java:391)
	at org.hisp.dhis.webapi.controller.MaintenanceController$$FastClassBySpringCGLIB$$a0db5fcb.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:749)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.security.access.intercept.aopalliance.MethodSecurityInterceptor.invoke(MethodSecurityInterceptor.java:69)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:688)
	at org.hisp.dhis.webapi.controller.MaintenanceController$$EnhancerBySpringCGLIB$$9ccdd6f5.performMaintenance(<generated>)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:104)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:892)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:797)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1039)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:942)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1005)
	at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:908)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:882)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:873)