### PR TITLE
Fix bug lastLogin reset after updating user

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/users_update.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/users_update.json
@@ -161,7 +161,6 @@
         "cogsDimensionConstraints": [ ],
         "selfRegistered": false,
         "catDimensionConstraints": [ ],
-        "lastLogin": "2016-03-12T06:21:02.226+0000",
         "created": "2016-03-12T06:21:02.329+0000",
         "passwordLastUpdated": "2016-03-12T06:21:02.226+0000",
         "userInfo": {
@@ -216,7 +215,7 @@
         },
         "selfRegistered": false,
         "catDimensionConstraints": [ ],
-        "lastLogin": "2016-03-12T06:20:43.407+0000",
+        "lastLogin": "2016-03-13T06:20:43.407+0000",
         "created": "2016-03-12T06:20:43.508+0000",
         "userInfo": {
           "id": "sPWjoHSY03y"

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -462,6 +462,7 @@ public class UserController
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
         params.setImportReportMode( ImportReportMode.FULL );
         params.setImportStrategy( ImportStrategy.UPDATE );
+        params.setMergeMode( MergeMode.MERGE );
         params.addObject( parsed );
 
         ImportReport importReport = importService.importMetadata( params );
@@ -510,6 +511,7 @@ public class UserController
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
         params.setImportReportMode( ImportReportMode.FULL );
         params.setImportStrategy( ImportStrategy.UPDATE );
+        params.setMergeMode( MergeMode.MERGE );
         params.addObject( parsed );
 
         ImportReport importReport = importService.importMetadata( params );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/AuthenticationListener.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/AuthenticationListener.java
@@ -36,8 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
-import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
-import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.authentication.event.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -60,8 +59,8 @@ public class AuthenticationListener
     @Autowired
     private DhisConfigurationProvider config;
 
-    @EventListener
-    public void handleAuthenticationFailure( AuthenticationFailureBadCredentialsEvent event )
+    @EventListener( { AuthenticationFailureBadCredentialsEvent.class } )
+    public void handleAuthenticationFailure( AbstractAuthenticationFailureEvent event )
     {
         Authentication auth = event.getAuthentication();
 
@@ -76,8 +75,8 @@ public class AuthenticationListener
         securityService.registerFailedLogin( auth.getName() );
     }
 
-    @EventListener
-    public void handleAuthenticationSuccess( AuthenticationSuccessEvent event )
+    @EventListener( { InteractiveAuthenticationSuccessEvent.class, AuthenticationSuccessEvent.class } )
+    public void handleAuthenticationSuccess( AbstractAuthenticationEvent event )
     {
         Authentication auth = event.getAuthentication();
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7282
This is because user app is sending user payload without lastLogin property.
- Update mergeMode=MERGE to keep existed properties value.
- Add `InteractiveAuthenticationSuccessEvent` for eventListener, seems this is only needed for 2.33 as a result of upgrading spring. Will check when backport