### PR TITLE
optimize: added new monitoring metrics and optimized db pool metrics

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -96,7 +96,9 @@ public enum ConfigurationKey
     MONITORING_API_ENABLED( "monitoring.api.enabled", "false", false ),
     MONITORING_JVM_ENABLED( "monitoring.jvm.enabled", "false", false ),
     MONITORING_DBPOOL_ENABLED( "monitoring.dbpool.enabled", "false", false ),
-    MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "false", false );
+    MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "false", false ),
+    MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "false", false ),
+    MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "false", false );
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -93,12 +93,12 @@ public enum ConfigurationKey
     LOGGING_FILE_MAX_ARCHIVES( "logging.file.max_archives", "0" ),
     SERVER_BASE_URL( "server.base.url", "", false ),
     MONITORING_PROVIDER( "monitoring.provider", "prometheus" ),
-    MONITORING_API_ENABLED( "monitoring.api.enabled", "false", false ),
-    MONITORING_JVM_ENABLED( "monitoring.jvm.enabled", "false", false ),
-    MONITORING_DBPOOL_ENABLED( "monitoring.dbpool.enabled", "false", false ),
-    MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "false", false ),
-    MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "false", false ),
-    MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "false", false );
+    MONITORING_API_ENABLED( "monitoring.api.enabled", "off", false ),
+    MONITORING_JVM_ENABLED( "monitoring.jvm.enabled", "off", false ),
+    MONITORING_DBPOOL_ENABLED( "monitoring.dbpool.enabled", "off", false ),
+    MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "off", false ),
+    MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "off", false ),
+    MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "off", false );
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
@@ -241,7 +241,7 @@ public class DefaultHibernateConfigurationProvider
         }
 
         // Enable Hibernate statistics if Hibernate Monitoring is enabled
-        if ( configurationProvider.getProperty( ConfigurationKey.MONITORING_HIBERNATE_ENABLED ).equals( "true" ) )
+        if ( configurationProvider.isEnabled( ConfigurationKey.MONITORING_HIBERNATE_ENABLED ) )
         {
             props.put( Environment.GENERATE_STATISTICS, true );
         }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
@@ -240,6 +240,12 @@ public class DefaultHibernateConfigurationProvider
             putIfExists( "false", "hibernate.cache.use_query_cache", props );
         }
 
+        // Enable Hibernate statistics if Hibernate Monitoring is enabled
+        if ( configurationProvider.getProperty( ConfigurationKey.MONITORING_HIBERNATE_ENABLED ).equals( "true" ) )
+        {
+            props.put( Environment.GENERATE_STATISTICS, true );
+        }
+    
         return props;
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/PropertiesAwareConfigurationCondition.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/PropertiesAwareConfigurationCondition.java
@@ -66,6 +66,6 @@ public abstract class PropertiesAwareConfigurationCondition
 
     protected boolean getBooleanValue( ConfigurationKey key )
     {
-        return getConfiguration().getProperty( key ).equalsIgnoreCase( "true" );
+        return getConfiguration().isEnabled(key);
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/HibernateMetricsConfig.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/HibernateMetricsConfig.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceException;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.SessionFactory;
@@ -54,26 +55,27 @@ public class HibernateMetricsConfig
 {
     private static final String ENTITY_MANAGER_FACTORY_SUFFIX = "entityManagerFactory";
 
-    private final MeterRegistry registry;
-
-    public HibernateMetricsConfig( MeterRegistry registry )
-    {
-        this.registry = registry;
-    }
-
     @Autowired
-    public void bindEntityManagerFactoriesToRegistry( Map<String, EntityManagerFactory> entityManagerFactories )
+    public void bindEntityManagerFactoriesToRegistry( Map<String, EntityManagerFactory> entityManagerFactories,
+        MeterRegistry registry )
     {
-        entityManagerFactories.forEach( this::bindEntityManagerFactoryToRegistry );
+        entityManagerFactories
+            .forEach( ( name, factory ) -> bindEntityManagerFactoryToRegistry( name, factory, registry ) );
     }
 
-    private void bindEntityManagerFactoryToRegistry( String beanName, EntityManagerFactory entityManagerFactory )
+    private void bindEntityManagerFactoryToRegistry( String beanName, EntityManagerFactory entityManagerFactory,
+        MeterRegistry registry )
     {
         String entityManagerFactoryName = getEntityManagerFactoryName( beanName );
-
-        SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-        new HibernateMetrics( sessionFactory, entityManagerFactoryName, Collections.emptyList() )
-            .bindTo( this.registry );
+        try
+        {
+            new HibernateMetrics( entityManagerFactory.unwrap( SessionFactory.class ), entityManagerFactoryName,
+                Collections.emptyList() ).bindTo( registry );
+        }
+        catch ( PersistenceException ex )
+        {
+            // Continue
+        }
     }
 
     /**
@@ -94,7 +96,8 @@ public class HibernateMetricsConfig
     }
 
     static class HibernateMetricsEnabledCondition
-        extends MetricsEnabler
+        extends
+        MetricsEnabler
     {
         @Override
         protected ConfigurationKey getConfigKey()

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/MetricsEnabler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/MetricsEnabler.java
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.monitoring.metrics;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.condition.PropertiesAwareConfigurationCondition;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.springframework.context.annotation.ConditionContext;
@@ -39,6 +41,8 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 public abstract class MetricsEnabler
     extends PropertiesAwareConfigurationCondition
 {
+    private static final Log log = LogFactory.getLog( MetricsEnabler.class );
+
     @Override
     public ConfigurationPhase getConfigurationPhase()
     {
@@ -48,7 +52,12 @@ public abstract class MetricsEnabler
     @Override
     public boolean matches( ConditionContext conditionContext, AnnotatedTypeMetadata annotatedTypeMetadata )
     {
-        return !isTestRun( conditionContext ) && getBooleanValue( getConfigKey() );
+        ConfigurationKey key = getConfigKey();
+
+        boolean isEnabled = !isTestRun( conditionContext ) && getBooleanValue( getConfigKey() );
+        log.info(
+            String.format( "Monitoring metric for key %s is %s", key.getKey(), isEnabled ? "enabled" : "disabled" ) );
+        return isEnabled;
     }
 
     protected abstract ConfigurationKey getConfigKey();

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/ProcessorMetricsConfig.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/ProcessorMetricsConfig.java
@@ -26,83 +26,46 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.monitoring.metrics.jdbc;
+package org.hisp.dhis.monitoring.metrics;
 
-import java.sql.SQLException;
+import static org.hisp.dhis.external.conf.ConfigurationKey.MONITORING_CPU_ENABLED;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 
 /**
  * @author Luciano Fiandesio
  */
-public class C3p0MetadataProvider
-    extends
-    AbstractDataSourcePoolMetadata<ComboPooledDataSource>
+@Configuration
+@Conditional( ProcessorMetricsConfig.ProcessorMetricsConfigEnabledCondition.class )
+public class ProcessorMetricsConfig
 {
-    private static final Log log = LogFactory.getLog( C3p0MetadataProvider.class );
-
-    /**
-     * Create an instance with the data source to use.
-     *
-     * @param dataSource the data source
-     */
-    public C3p0MetadataProvider( ComboPooledDataSource dataSource )
+    @Bean
+    public ProcessorMetrics processorMetrics()
     {
-        super( dataSource );
+        return new ProcessorMetrics();
     }
 
-    @Override
-    public Integer getActive()
+    @Autowired
+    public void bindToRegistry( MeterRegistry registry, ProcessorMetrics processorMetrics )
     {
-        try
+        processorMetrics.bindTo( registry );
+    }
+
+    static class ProcessorMetricsConfigEnabledCondition
+        extends
+        MetricsEnabler
+    {
+        @Override
+        protected ConfigurationKey getConfigKey()
         {
-            return getDataSource().getNumBusyConnections();
-        }
-        catch ( SQLException e )
-        {
-            log.error( "An error occurred while fetching number of busy connection from the DataSource", e );
-            return 0;
-        }
-    }
-
-    @Override
-    public Integer getMax()
-    {
-        return getDataSource().getMaxPoolSize();
-    }
-
-    @Override
-    public Integer getMin()
-    {
-        return getDataSource().getMinPoolSize();
-    }
-
-    @Override
-    public String getValidationQuery()
-    {
-        return "";
-    }
-
-    @Override
-    public Boolean getDefaultAutoCommit()
-    {
-        return getDataSource().isAutoCommitOnClose();
-    }
-
-    @Override
-    public Integer getIdle()
-    {
-        try
-        {
-            return getDataSource().getNumIdleConnections();
-        }
-        catch ( SQLException e )
-        {
-            log.error( "An error occurred while fetching number of idle connection from the DataSource", e );
-            return 0;
+            return MONITORING_CPU_ENABLED;
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/DataSourcePoolMetadata.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/DataSourcePoolMetadata.java
@@ -61,6 +61,17 @@ public interface DataSourcePoolMetadata {
     Integer getActive();
 
     /**
+     * Return the number of established but idle connections. Can also return {@code null}
+     * if that information is not available.
+     * @return the number of established but idle connections or {@code null}
+     * @since 2.2.0
+     * @see #getActive()
+     */
+    default Integer getIdle() {
+        return null;
+    }
+
+    /**
      * Return the maximum number of active connections that can be allocated at the same
      * time or {@code -1} if there is no limit. Can also return {@code null} if that
      * information is not available.

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/DataSourcePoolMetrics.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/DataSourcePoolMetrics.java
@@ -30,45 +30,104 @@ package org.hisp.dhis.monitoring.metrics.jdbc;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
 import javax.sql.DataSource;
 import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author Jon Schneider
  */
 public class DataSourcePoolMetrics
-    implements MeterBinder
+    implements
+    MeterBinder
 {
     private final DataSource dataSource;
 
-    private final String name;
+    private final CachingDataSourcePoolMetadataProvider metadataProvider;
 
     private final Iterable<Tag> tags;
 
-    private final DataSourcePoolMetadata poolMetadata;
-
-    public DataSourcePoolMetrics( DataSource dataSource,
-        @Nullable Collection<DataSourcePoolMetadataProvider> metadataProviders, String name, Iterable<Tag> tags )
+    public DataSourcePoolMetrics( DataSource dataSource, Collection<DataSourcePoolMetadataProvider> metadataProviders,
+        String dataSourceName, Iterable<Tag> tags )
     {
-        this.name = name;
-        this.tags = tags;
+        this( dataSource, new CompositeDataSourcePoolMetadataProvider( metadataProviders ), dataSourceName, tags );
+    }
+
+    public DataSourcePoolMetrics( DataSource dataSource, DataSourcePoolMetadataProvider metadataProvider, String name,
+        Iterable<Tag> tags )
+    {
+        Assert.notNull( dataSource, "DataSource must not be null" );
+        Assert.notNull( metadataProvider, "MetadataProvider must not be null" );
         this.dataSource = dataSource;
-        DataSourcePoolMetadataProvider provider = new DataSourcePoolMetadataProviders( metadataProviders );
-        this.poolMetadata = provider.getDataSourcePoolMetadata( dataSource );
+        this.metadataProvider = new CachingDataSourcePoolMetadataProvider( metadataProvider );
+        this.tags = Tags.concat( tags, "name", name );
     }
 
     @Override
     public void bindTo( MeterRegistry registry )
     {
-        if ( poolMetadata != null )
+        if ( this.metadataProvider.getDataSourcePoolMetadata( this.dataSource ) != null )
         {
-            registry.gauge( name + ".connections.active", tags, dataSource,
-                dataSource -> poolMetadata.getActive() != null ? poolMetadata.getActive() : 0 );
-            registry.gauge( name + ".connections.max", tags, dataSource, dataSource -> poolMetadata.getMax() );
-            registry.gauge( name + ".connections.min", tags, dataSource, dataSource -> poolMetadata.getMin() );
+            bindPoolMetadata( registry, "active", DataSourcePoolMetadata::getActive );
+            bindPoolMetadata( registry, "idle", DataSourcePoolMetadata::getIdle );
+            bindPoolMetadata( registry, "max", DataSourcePoolMetadata::getMax );
+            bindPoolMetadata( registry, "min", DataSourcePoolMetadata::getMin );
         }
+    }
+
+    private <N extends Number> void bindPoolMetadata( MeterRegistry registry, String metricName,
+        Function<DataSourcePoolMetadata, N> function )
+    {
+        bindDataSource( registry, metricName, this.metadataProvider.getValueFunction( function ) );
+    }
+
+    private <N extends Number> void bindDataSource( MeterRegistry registry, String metricName,
+        Function<DataSource, N> function )
+    {
+        if ( function.apply( this.dataSource ) != null )
+        {
+            registry.gauge( "jdbc.connections." + metricName, this.tags, this.dataSource,
+                ( m ) -> function.apply( m ).doubleValue() );
+        }
+    }
+
+    private static class CachingDataSourcePoolMetadataProvider
+        implements
+        DataSourcePoolMetadataProvider
+    {
+
+        private static final Map<DataSource, DataSourcePoolMetadata> cache = new ConcurrentReferenceHashMap<>();
+
+        private final DataSourcePoolMetadataProvider metadataProvider;
+
+        CachingDataSourcePoolMetadataProvider( DataSourcePoolMetadataProvider metadataProvider )
+        {
+            this.metadataProvider = metadataProvider;
+        }
+
+        <N extends Number> Function<DataSource, N> getValueFunction( Function<DataSourcePoolMetadata, N> function )
+        {
+            return ( dataSource ) -> function.apply( getDataSourcePoolMetadata( dataSource ) );
+        }
+
+        @Override
+        public DataSourcePoolMetadata getDataSourcePoolMetadata( DataSource dataSource )
+        {
+            DataSourcePoolMetadata metadata = cache.get( dataSource );
+            if ( metadata == null )
+            {
+                metadata = this.metadataProvider.getDataSourcePoolMetadata( dataSource );
+                cache.put( dataSource, metadata );
+            }
+            return metadata;
+        }
+
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/config/WebMvcMetricsConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/config/WebMvcMetricsConfig.java
@@ -68,13 +68,11 @@ public class WebMvcMetricsConfig
     }
 
     @Bean
+    @SuppressWarnings("deprecation")
     public WebMvcMetricsFilter webMetricsFilter( MeterRegistry registry, WebMvcTagsProvider tagsProvider,
         WebApplicationContext ctx )
     {
-        HandlerMappingIntrospector handlerMappingIntrospector = new HandlerMappingIntrospector();
-        handlerMappingIntrospector.setApplicationContext( ctx );
-        
-        return new WebMvcMetricsFilter( registry, tagsProvider, "dhis2", true, handlerMappingIntrospector );
+        return new WebMvcMetricsFilter( registry, tagsProvider, "http_server_requests", true, new HandlerMappingIntrospector(ctx) );
     }
 
     @Configuration

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1406,13 +1406,13 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-spring-legacy</artifactId>
-        <version>1.1.4</version>
+        <version>1.2.0</version>
       </dependency>
 
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>1.1.4</version>
+        <version>1.2.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Bumped micrometer to version 1.2.0
- Added uptime and cpu metrics
- Optimized DB Pool metrics to show idle connections and use tags for datasource names
- Reverted to use deprecated constructor for `WebMvcMetricsFilter`, since the non-deprecated one
does not work
- Changed prefix of API metrics to `http_server_requests` to be in-sync with spring boot