### PR TITLE
[2.30] Fix invalid value returned from TEI query when TEA is OrgUnit type

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -151,6 +151,11 @@ public enum ValueType
         return GEO_TYPES.contains( this );
     }
 
+    public boolean isOrganisationUnit()
+    {
+        return ORGANISATION_UNIT == this;
+    }
+
     /**
      * Includes integer and decimal types.
      */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/dhis/beans.xml
@@ -615,6 +615,7 @@
     <property name="sessionFactory" ref="sessionFactory" />
     <property name="jdbcTemplate" ref="jdbcTemplate" />
     <property name="statementBuilder" ref="statementBuilder" />
+    <property name="organisationUnitStore" ref="org.hisp.dhis.organisationunit.OrganisationUnitStore"/>
   </bean>
 
   <bean id="org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerStore"


### PR DESCRIPTION
- DHIS2-7100
- Fixed query returning Tracked Entity Instances, where attributes
of type OrgUnit were returned as Org Unit UID rather than Org Unit name
- Back-port from 2.32