### PR TITLE
[2.31] fix: error get Enrollments through `/api/enrollments.json` endpoint

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceAuditService.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.program;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Abyot Asalefew Gizaw <abyota@gmail.com>
@@ -44,7 +46,7 @@ public class DefaultProgramInstanceAuditService
     // Dependencies
     // -------------------------------------------------------------------------
     
-    @Autowired 
+    @Autowired
     private ProgramInstanceAuditStore programInstanceAuditStore;
     
     // -------------------------------------------------------------------------
@@ -52,24 +54,28 @@ public class DefaultProgramInstanceAuditService
     // -------------------------------------------------------------------------
     
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void addProgramInstanceAudit( ProgramInstanceAudit programInstanceAudit )
     {
         programInstanceAuditStore.addProgramInstanceAudit( programInstanceAudit );
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteProgramInstanceAudit( ProgramInstance programInstance )
     {
         programInstanceAuditStore.deleteProgramInstanceAudit( programInstance );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ProgramInstanceAudit> getProgramInstanceAudits( ProgramInstanceAuditQueryParams params )
     {
         return programInstanceAuditStore.getProgramInstanceAudits( params );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public int getProgramInstanceAuditsCount( ProgramInstanceAuditQueryParams params )
     {
         return programInstanceAuditStore.getProgramInstanceAuditsCount( params );


### PR DESCRIPTION
- DHIS2-7323
- Fixed by making Audit Service to run in its own TX context

(cherry picked from commit c118a4b013148ea11a0ce30d115cb0ccb5818401)