### PR TITLE
Removing stopped containers with compose down

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -93,7 +93,7 @@ pipeline {
     post {
         always {
             dir("dhis-2/dhis-e2e-test") {
-                sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down"
+                sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down --rmi all --remove-orphans"
                 sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down"
                 sh "docker image prune --force --filter 'until=20m' --filter label=stage=intermediate"
             }


### PR DESCRIPTION
Jenkins agent we run docker pipelines on frequently runs out of memory, because dangling images are not removed correctly. That is because stopped containers were sometimes not removed and images were not pruned. Hopefully this will fix it - if yes, I will back-port to all versions. 