### PR TITLE
2.30: removing stopped containers on jenkins

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -94,7 +94,7 @@ pipeline {
         always {
             dir("dhis-2/dhis-e2e-test") {
                 sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down"
-                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down"
+                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down --rmi all --remove-orphans"
                 sh "docker image prune --force --filter 'until=20m' --filter label=stage=intermediate"
             }
         }

--- a/dhis-2/dhis-e2e-test/Dockerfile
+++ b/dhis-2/dhis-e2e-test/Dockerfile
@@ -1,12 +1,10 @@
 FROM maven:3.5.3-jdk-8-slim
 
 COPY pom.xml wait-for-it.sh /
-RUN mvn dependency:go-offline
-
 COPY config/dhis2_home/dhis.conf /config/dhis2_home/dhis.conf
 COPY src /src
 
-VOLUME /target
+RUN chmod +x wait-for-it.sh && \
+    mvn compile
 
-RUN chmod +x wait-for-it.sh
-RUN mvn compile
+VOLUME /target


### PR DESCRIPTION
- Removed stopped containers to avoid dangling images not being cleaned up;
- Optimized e2e image tiny bit to save more space on jenkins agent