### PR TITLE
Category Option Groups in indicator expressions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -81,23 +81,12 @@ import org.hisp.dhis.analytics.RawAnalyticsManager;
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.analytics.event.EventAnalyticsService;
 import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.analytics.resolver.ExpressionResolver;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.calendar.Calendar;
-import org.hisp.dhis.common.AnalyticalObject;
-import org.hisp.dhis.common.BaseDimensionalObject;
-import org.hisp.dhis.common.CombinationGenerator;
-import org.hisp.dhis.common.DataDimensionItemType;
-import org.hisp.dhis.common.DimensionType;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.DimensionalObjectUtils;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
-import org.hisp.dhis.common.ReportingRateMetric;
-import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.commons.util.SystemUtils;
@@ -167,6 +156,8 @@ public class DefaultAnalyticsService
 
     private final DataQueryService dataQueryService;
 
+    private final ExpressionResolver resolver;
+
     private final DhisConfigurationProvider dhisConfig;
 
     private final CacheProvider cacheProvider;
@@ -196,7 +187,7 @@ public class DefaultAnalyticsService
         AnalyticsSecurityManager securityManager, QueryPlanner queryPlanner, QueryValidator queryValidator,
         ConstantService constantService, ExpressionService expressionService,
         OrganisationUnitService organisationUnitService, SystemSettingManager systemSettingManager,
-        EventAnalyticsService eventAnalyticsService, DataQueryService dataQueryService,
+        EventAnalyticsService eventAnalyticsService, DataQueryService dataQueryService, ExpressionResolver resolver,
         DhisConfigurationProvider dhisConfig, CacheProvider cacheProvider, Environment environment)
     {
         checkNotNull( analyticsManager );
@@ -210,6 +201,7 @@ public class DefaultAnalyticsService
         checkNotNull( systemSettingManager );
         checkNotNull( eventAnalyticsService );
         checkNotNull( dataQueryService );
+        checkNotNull( resolver );
         checkNotNull( dhisConfig );
         checkNotNull( cacheProvider );
         checkNotNull( environment );
@@ -225,6 +217,7 @@ public class DefaultAnalyticsService
         this.systemSettingManager = systemSettingManager;
         this.eventAnalyticsService = eventAnalyticsService;
         this.dataQueryService = dataQueryService;
+        this.resolver = resolver;
         this.dhisConfig = dhisConfig;
         this.cacheProvider = cacheProvider;
         this.environment = environment;
@@ -1345,7 +1338,7 @@ public class DefaultAnalyticsService
     {
         indicators.forEach( params::addResolvedExpressionItem );
 
-        List<DimensionalItemObject> items = Lists.newArrayList( expressionService.getIndicatorDimensionalItemObjects( indicators ) );
+        List<DimensionalItemObject> items = Lists.newArrayList( expressionService.getIndicatorDimensionalItemObjects( preprocessIndicators( indicators ) ) );
 
         if ( items.isEmpty() )
         {
@@ -1368,6 +1361,16 @@ public class DefaultAnalyticsService
         Grid grid = getAggregatedDataValueGridInternal( dataSourceParams );
 
         return grid.getAsMap( grid.getWidth() - 1, DimensionalObject.DIMENSION_SEP );
+    }
+
+    private Collection<Indicator> preprocessIndicators( List<Indicator> indicators )
+    {
+        for ( Indicator indicator : indicators )
+        {
+            indicator.setNumerator( resolver.resolve( indicator.getNumerator() ) );
+            indicator.setDenominator( resolver.resolve( indicator.getDenominator() ) );
+        }
+        return indicators;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.analytics.resolver;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT_OPERAND;
+import static org.hisp.dhis.expression.Expression.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.base.Joiner;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryOptionComboStore;
+import org.hisp.dhis.category.CategoryOptionGroup;
+import org.hisp.dhis.category.CategoryOptionGroupStore;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.expression.ExpressionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Service
+public class CategoryOptionGroupResolver
+    implements
+    ExpressionResolver
+{
+    private final ExpressionService expressionService;
+
+    private final CategoryOptionGroupStore categoryOptionGroupStore;
+
+    private final CategoryOptionComboStore categoryOptionComboStore;
+
+    public CategoryOptionGroupResolver( CategoryOptionGroupStore categoryOptionGroupStore, CategoryOptionComboStore categoryOptionComboStore,
+        ExpressionService expressionService )
+    {
+        checkNotNull( categoryOptionGroupStore );
+        checkNotNull( expressionService );
+        checkNotNull( categoryOptionComboStore );
+
+        this.categoryOptionGroupStore = categoryOptionGroupStore;
+        this.categoryOptionComboStore = categoryOptionComboStore;
+        this.expressionService = expressionService;
+    }
+
+    private Set<String> resolveCoCFromCog( String categoryOptionGroupUid )
+    {
+        return categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroupUid ).stream()
+            .map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
+    }
+
+    /**
+     * Resolves a Data Element Operand expression containing one or two Category Option Group UID to an equivalent
+     * expression where the associated Category Option Combos for the given Category Option Group are "exploded" into
+     * the expression.
+     *
+     * Resolves one of the expressions below:
+     *
+     * 1) #{DEUID.COGUID.AOCUID}
+     * 2) #{DEUID.COCUID.COGUID}
+     * 3) #{DEUID.COG1UID.COG2UID}
+     *
+     * to:
+     *
+     * 1) #{DEUID.COCUID1.AOCUID} + #{DEUID.COCUID2.AOCUID} + #{DEUID.COCUID3.AOCUID}
+     * where COCUID1,2,3... are resolved by fetching all COCUID by COGUID
+     *
+     * 2) #{DEUID.COCUID} + #{DEUID.COCUID1} + #{DEUID.COCUID2} + #{DEUID.COCUID3} + #{DEUID.COCUID4}
+     * where COCUID1,2,3... are resolved by fetching all COCUID by COGUID
+     *
+     * 3) #{DEUID.COCUID1} + #{DEUID.COCUID2} + #{DEUID.COCUID3} + #{DEUID.COCUID4}
+     * where COCUID1 and COCUID2 are resolved from COG1UID and COCUID3 and COCUID4 are resolved from COGUID2
+     *
+     * DEUID = Data Element UID
+     * COCUID = Category Option Combo UID
+     * COGUID = Category Option Group UID
+     *
+     * @param expression a Data Element Expression
+     * @return an expression containing additional CategoryOptionCombos based on the given Category Option Group
+     */
+    @Override
+    @Transactional( readOnly = true )
+    public String resolve( String expression )
+    {
+        // Get a DimensionalItemId from the expression. The expression is parsed and
+        // each element placed in the DimensionalItemId
+        Set<DimensionalItemId> dimItemIds = expressionService.getDimensionalItemIdsInExpression( expression );
+        List<String> resolvedOperands = new ArrayList<>();
+        if ( isDataElementOperand( dimItemIds ) )
+        {
+            DimensionalItemId dimensionalItemId = dimItemIds.stream().findFirst().get();
+            // First element is always the Data Element Id
+            String dataElementUid = dimensionalItemId.getId0();
+
+            resolvedOperands
+                .addAll( evaluate( dataElementUid, dimensionalItemId.getId1(), dimensionalItemId.getId2() ) );
+            
+            resolvedOperands.addAll( evaluate( dataElementUid, dimensionalItemId.getId2(), null ) );
+        } 
+        if ( resolvedOperands.isEmpty() )
+        {
+            // nothing to resolve, add the expression as it is
+            resolvedOperands.add( expression );
+        }
+        return Joiner.on( "+" ).join( resolvedOperands );
+    }
+    
+    private List<String> evaluate( String dataElementUid, String uid, String uid2 )
+    {
+        List<String> resolvedExpression = new ArrayList<>();
+        Optional<String> cogUid = getCategoryOptionGroupUid( uid );
+        if ( cogUid.isPresent() )
+        {
+            Set<String> cocs = resolveCoCFromCog( cogUid.get() );
+            resolvedExpression = Arrays.asList( resolve( cocs, dataElementUid, uid2 ).split( "\\+" ) );
+        }
+        return resolvedExpression;
+    }
+    
+    private String resolve( Set<String> cocs, String dataElementUid, String third )
+    {
+        boolean isAoc = isAoc( third );
+        
+        return cocs.stream()
+            .map( coc -> EXP_OPEN + dataElementUid + SEPARATOR + coc + (isAoc ? SEPARATOR + third : "") + EXP_CLOSE )
+            .collect( Collectors.joining( "+" ) );
+    }
+
+    private boolean isAoc( String uid )
+    {
+        return (uid != null && categoryOptionComboStore.getByUid(uid) != null);
+    }
+
+    private Optional<String> getCategoryOptionGroupUid( String uid )
+    {
+        CategoryOptionGroup cog = categoryOptionGroupStore.getByUid( uid );
+
+        return cog == null ? Optional.empty() : Optional.of( cog.getUid() );
+    }
+
+    private boolean isDataElementOperand( Set<DimensionalItemId> dimensionalItemIds )
+    {
+        return dimensionalItemIds.size() == 1
+            && dimensionalItemIds.iterator().next().getDimensionItemType().equals( DATA_ELEMENT_OPERAND );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolver.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.category;
-
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -28,29 +26,14 @@ package org.hisp.dhis.category;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.common.IdentifiableObjectStore;
-
-import java.util.List;
-import java.util.Set;
+package org.hisp.dhis.analytics.resolver;
 
 /**
- * @author Lars Helge Overland
+ * A component that can analyze and resolve analytics expressions so that they
+ *
+ * @author Luciano Fiandesio
  */
-public interface CategoryOptionComboStore
-    extends IdentifiableObjectStore<CategoryOptionCombo>
+public interface ExpressionResolver
 {
-    CategoryOptionCombo getCategoryOptionCombo( CategoryCombo categoryCombo, Set<CategoryOption> categoryOptions );
-    
-    void updateNames();
-
-    /**
-     * Fetch all {@see CategoryOptionCombo} from a given {@see CategoryOptionGroup} uid.
-     *
-     * A {@see CategoryOptionGroup} is a collection of {@see CategoryOption}. Therefore, this method finds all
-     * {@see CategoryOptionCombo} for all the members of the given {@see CategoryOptionGroup}
-     *
-     * @param groupId a {@see CategoryOptionGroup} uid
-     * @return a List of {@see CategoryOptionCombo} or empty List
-     */
-    List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupId );
+    String resolve( String expression );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceBaseTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceBaseTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.data;
 
 import org.hisp.dhis.analytics.*;
 import org.hisp.dhis.analytics.event.EventAnalyticsService;
+import org.hisp.dhis.analytics.resolver.ExpressionResolver;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.expression.ExpressionService;
@@ -93,6 +94,9 @@ public abstract class AnalyticsServiceBaseTest {
     @Mock
     private Environment environment;
 
+    @Mock
+    private ExpressionResolver resolver;
+
     AnalyticsService target;
 
     @Before
@@ -102,7 +106,7 @@ public abstract class AnalyticsServiceBaseTest {
 
         target = new DefaultAnalyticsService( analyticsManager, rawAnalyticsManager, securityManager, queryPlanner,
             queryValidator, constantService, expressionService, organisationUnitService, systemSettingManager,
-            eventAnalyticsService, dataQueryService, dhisConfig, cacheProvider, environment );
+            eventAnalyticsService, dataQueryService, resolver, dhisConfig, cacheProvider, environment );
 
         when( systemSettingManager.getSystemSetting( SettingKey.ANALYTICS_MAINTENANCE_MODE ) ).thenReturn( false );
         when( dhisConfig.getAnalyticsCacheExpiration() ).thenReturn( 0L );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.analytics.resolver;
+
+import static org.hisp.dhis.DhisConvenienceTest.createCategoryOptionGroup;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.Lists;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryOptionComboStore;
+import org.hisp.dhis.category.CategoryOptionGroup;
+import org.hisp.dhis.category.CategoryOptionGroupStore;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.DimensionItemType;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.Sets;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class CategoryOptionGroupResolverTest
+{
+    @Mock
+    private CategoryOptionGroupStore categoryOptionGroupStore;
+
+    @Mock
+    private ExpressionService expressionService;
+
+    @Mock
+    private CategoryOptionComboStore categoryOptionComboStore;
+
+    private ExpressionResolver resolver;
+
+    private BeanRandomizer beanRandomizer;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private String elem1;
+
+    private String elem2;
+
+    private String elem3;
+
+    private int COCS_IN_COG = 2;
+
+    @Before
+    public void setUp()
+    {
+        elem1 = CodeGenerator.generateUid();
+        elem2 = CodeGenerator.generateUid();
+        elem3 = CodeGenerator.generateUid();
+        resolver = new CategoryOptionGroupResolver( categoryOptionGroupStore, categoryOptionComboStore,
+            expressionService );
+        beanRandomizer = new BeanRandomizer();
+    }
+
+    /**
+     * case: #{DEUID.COGUID.AOCUID} resolves to: #{DEUID.COCUID1.AOCUID} +
+     * #{DEUID.COCUID2.AOCUID} + #{DEUID.COCUID3.AOCUID}
+     *
+     */
+    @Test
+    public void verifySecondElementIsCogThirdElementIsAoc()
+    {
+        DimensionalItemId dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, elem1,
+            elem2, elem3 );
+
+        CategoryOptionGroup categoryOptionGroup = createCategoryOptionGroup( 'A' );
+
+        // #{DEUID.COGUID.AOCUID}
+        String exp = createIndicatorExp();
+
+        when( expressionService.getDimensionalItemIdsInExpression( exp ) )
+            .thenReturn( Sets.newHashSet( dimensionalItemId ) );
+
+        when( categoryOptionGroupStore.getByUid( elem2 ) ).thenReturn( categoryOptionGroup );
+
+        List<CategoryOptionCombo> cocs = beanRandomizer.randomObjects( CategoryOptionCombo.class, COCS_IN_COG );
+
+        when( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroup.getUid() ) )
+            .thenReturn( cocs );
+        when( categoryOptionComboStore.getByUid( elem3 ) )
+            .thenReturn( beanRandomizer.randomObject( CategoryOptionCombo.class ) );
+
+        String expression = resolver.resolve( exp );
+        // split resolved expression into a List of Strings
+        List<String> expressionList = Arrays.asList( expression.split( "\\+" ) );
+        assertEquals( COCS_IN_COG, expressionList.size() );
+
+        collectionsHaveIdenticalValuesIgnoreOrder( expressionList, buildExpectedExpression( elem1, cocs, elem3 ) );
+    }
+
+    /**
+     * case: #{DEUID.COGUID.COG2UID} resolves to:
+     *
+     */
+    @Test
+    public void verifySecondElementIsCogThirdElementIsCog()
+    {
+        DimensionalItemId dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, elem1,
+            elem2, elem3 );
+
+        CategoryOptionGroup categoryOptionGroup1 = createCategoryOptionGroup( 'A' );
+        CategoryOptionGroup categoryOptionGroup2 = createCategoryOptionGroup( 'B' );
+
+        // #{DEUID.COGUID.COGUID}
+        String exp = createIndicatorExp();
+
+        when( expressionService.getDimensionalItemIdsInExpression( exp ) )
+            .thenReturn( Sets.newHashSet( dimensionalItemId ) );
+
+        when( categoryOptionGroupStore.getByUid( elem2 ) ).thenReturn( categoryOptionGroup1 );
+        when( categoryOptionGroupStore.getByUid( elem3 ) ).thenReturn( categoryOptionGroup2 );
+
+        List<CategoryOptionCombo> cocs1 = beanRandomizer.randomObjects( CategoryOptionCombo.class, COCS_IN_COG );
+        List<CategoryOptionCombo> cocs2 = beanRandomizer.randomObjects( CategoryOptionCombo.class, COCS_IN_COG );
+
+        when( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroup1.getUid() ) )
+            .thenReturn( cocs1 );
+        when( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroup2.getUid() ) )
+            .thenReturn( cocs2 );
+
+        String expression = resolver.resolve( exp );
+        // split resolved expression into a List of Strings
+        List<String> expressionList = Arrays.asList( expression.split( "\\+" ) );
+        assertEquals( COCS_IN_COG * 2, expressionList.size() );
+
+        collectionsHaveIdenticalValuesIgnoreOrder( expressionList, buildExpectedExpression( elem1, cocs1, cocs2 ) );
+    }
+
+    /**
+     * case: #{DEUID.COGUID.COG2UID} resolves to:
+     *
+     */
+    @Test
+    public void verifySecondElementIsCocThirdElementIsCog()
+    {
+        DimensionalItemId dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, elem1,
+            elem2, elem3 );
+
+        CategoryOptionGroup categoryOptionGroup1 = createCategoryOptionGroup( 'A' );
+
+        // #{DEUID.COCUID.COGUID}
+        String exp = createIndicatorExp();
+
+        when( expressionService.getDimensionalItemIdsInExpression( exp ) )
+            .thenReturn( Sets.newHashSet( dimensionalItemId ) );
+
+        when( categoryOptionGroupStore.getByUid( elem3 ) ).thenReturn( categoryOptionGroup1 );
+
+        List<CategoryOptionCombo> cocs1 = beanRandomizer.randomObjects( CategoryOptionCombo.class, COCS_IN_COG );
+
+        when( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroup1.getUid() ) )
+            .thenReturn( cocs1 );
+
+        String expression = resolver.resolve( exp );
+
+        // split resolved expression into a List of Strings
+        List<String> expressionList = Arrays.asList( expression.split( "\\+" ) );
+        assertEquals( COCS_IN_COG , expressionList.size() );
+
+        collectionsHaveIdenticalValuesIgnoreOrder( expressionList, buildExpectedExpression( elem1, elem2, cocs1 ) );
+    }
+
+    @Test
+    public void verifySecondElementIsCocThirdElementIsAoc()
+    {
+        DimensionalItemId dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, elem1,
+                elem2, elem3 );
+
+        CategoryOptionGroup categoryOptionGroup1 = createCategoryOptionGroup( 'A' );
+
+        // #{DEUID.COCUID.AOCUID}
+        String exp = createIndicatorExp();
+
+        when( expressionService.getDimensionalItemIdsInExpression( exp ) )
+                .thenReturn( Sets.newHashSet( dimensionalItemId ) );
+
+        String expression = resolver.resolve( exp );
+
+        // split resolved expression into a List of Strings
+        List<String> expressionList = Arrays.asList( expression.split( "\\+" ) );
+        assertEquals( 1 , expressionList.size() );
+
+        // original expression is returned
+        collectionsHaveIdenticalValuesIgnoreOrder( expressionList, Lists.newArrayList( exp ) );
+    }
+
+    @Test
+    public void verifyExpressionIsNotDataElementOperand()
+    {
+        DimensionalItemId dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT, elem1 );
+
+        // #{DEUID}
+        String exp = "#{" + elem1 + "}";
+
+        when( expressionService.getDimensionalItemIdsInExpression( exp ) )
+                .thenReturn( Sets.newHashSet( dimensionalItemId ) );
+
+        String expression = resolver.resolve( exp );
+
+        // split resolved expression into a List of Strings
+        List<String> expressionList = Arrays.asList( expression.split( "\\+" ) );
+        assertEquals( 1 , expressionList.size() );
+
+        // original expression is returned
+        collectionsHaveIdenticalValuesIgnoreOrder( expressionList, Lists.newArrayList( exp ) );
+    }
+
+    private void collectionsHaveIdenticalValuesIgnoreOrder( List<String> listA, List<String> listB )
+    {
+
+        for ( String s : listA )
+        {
+            assertTrue( listB.contains( s ) );
+        }
+    }
+
+    private String createIndicatorExp()
+    {
+        return String.format( "#{%s.%s.%s}", elem1, elem2, elem3 );
+    }
+
+    private String buildOperand( String s1, String s2, String s3 )
+    {
+
+        return "#{" + s1 + "." + s2 + "." + s3 + "}";
+    }
+
+    private String buildOperand( String s1, String s2 )
+    {
+
+        return "#{" + s1 + "." + s2 + "}";
+    }
+
+    private List<String> buildExpectedExpression( String dataElementUid, List<CategoryOptionCombo> cocs, String aocUid )
+    {
+        List<String> expressionAsList = new ArrayList<>( cocs.size() );
+        for ( CategoryOptionCombo coc : cocs )
+        {
+            expressionAsList.add( buildOperand( dataElementUid, coc.getUid(), aocUid ) );
+        }
+        return expressionAsList;
+    }
+
+    private List<String> buildExpectedExpression( String dataElementUid, List<CategoryOptionCombo> cocs1,
+        List<CategoryOptionCombo> cocs2 )
+    {
+        return Stream.concat( cocs1.stream(), cocs2.stream() ).map( c -> buildOperand( dataElementUid, c.getUid() ) )
+            .collect( Collectors.toList() );
+
+    }
+
+    private List<String> buildExpectedExpression( String dataElementUid, String cocUid, List<CategoryOptionCombo> cocs )
+    {
+        List<String> expressionAsList = new ArrayList<>( cocs.size() );
+        for ( CategoryOptionCombo coc : cocs )
+        {
+            expressionAsList.add( buildOperand( dataElementUid, coc.getUid() ) );
+        }
+        expressionAsList.add( buildOperand( dataElementUid, cocUid ) );
+        return expressionAsList;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
@@ -44,6 +44,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.criteria.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -105,5 +107,27 @@ public class HibernateCategoryOptionComboStore
                 dbmsManager.clearSession();
             }
         }
+    }
+
+    @Override
+    public List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupUid )
+    {
+        // TODO
+        //    private final static String SQL = "SELECT coc.uid " +
+//            "FROM categoryoptioncombos_categoryoptions ccc " +
+//            "JOIN categoryoptioncombo coc ON ccc.categoryoptioncomboid = coc.categoryoptioncomboid " +
+//            "WHERE categoryoptionid IN " +
+//            "    (SELECT categoryoptionid " +
+//            "     FROM categoryoptiongroupmembers cogm " +
+//            "     JOIN categoryoptiongroup cog ON cogm.categoryoptiongroupid = cog.categoryoptiongroupid " +
+//            "     WHERE cog.uid = ?)";
+
+        CriteriaBuilder builder = getCriteriaBuilder();
+        CriteriaQuery<CategoryOptionCombo> query = builder.createQuery( CategoryOptionCombo.class );
+        Root<CategoryOptionCombo> root = query.from( CategoryOptionCombo.class );
+        Join<Object, Object> joinCatOption = root.join( "categoryOptions", JoinType.INNER );
+        Join<Object, Object> joinCatOptionGroup = joinCatOption.join( "groups", JoinType.INNER );
+        query.where( builder.equal( joinCatOptionGroup.get( "uid" ), groupUid ) );
+        return getSession().createQuery( query ).list();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
@@ -112,16 +112,6 @@ public class HibernateCategoryOptionComboStore
     @Override
     public List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupUid )
     {
-        // TODO
-        //    private final static String SQL = "SELECT coc.uid " +
-//            "FROM categoryoptioncombos_categoryoptions ccc " +
-//            "JOIN categoryoptioncombo coc ON ccc.categoryoptioncomboid = coc.categoryoptioncomboid " +
-//            "WHERE categoryoptionid IN " +
-//            "    (SELECT categoryoptionid " +
-//            "     FROM categoryoptiongroupmembers cogm " +
-//            "     JOIN categoryoptiongroup cog ON cogm.categoryoptiongroupid = cog.categoryoptiongroupid " +
-//            "     WHERE cog.uid = ?)";
-
         CriteriaBuilder builder = getCriteriaBuilder();
         CriteriaQuery<CategoryOptionCombo> query = builder.createQuery( CategoryOptionCombo.class );
         Root<CategoryOptionCombo> root = query.from( CategoryOptionCombo.class );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -714,6 +714,7 @@ public class DefaultExpressionService
                 "D".equals( key ) ? PROGRAM_DATA_ELEMENT :
                 "A".equals( key ) ? PROGRAM_ATTRIBUTE :
                 "I".equals( key ) ? PROGRAM_INDICATOR :
+                "N".equals( key ) ? INDICATOR :
                 "R".equals( key ) ? REPORTING_RATE : null;
 
             if ( itemType != null )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/category/CategoryOptionComboStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/category/CategoryOptionComboStoreTest.java
@@ -58,6 +58,9 @@ public class CategoryOptionComboStoreTest
     @Autowired
     private CategoryService categoryService;
     
+    @Autowired
+    private CategoryOptionGroupStore categoryOptionGroupStore;
+    
     private Category categoryA;
     private Category categoryB;
         
@@ -292,5 +295,20 @@ public class CategoryOptionComboStoreTest
         assertEquals( categoryOptions2, coc2.getCategoryOptions() );
         assertEquals( categoryOptions3, coc3.getCategoryOptions() );
         assertEquals( categoryOptions4, coc4.getCategoryOptions() );
+    }
+
+    @Test
+    public void testGetCategoryOptionComboByOptionGroup()
+    {
+        categoryService.generateOptionCombos( categoryComboA );
+        categoryService.generateOptionCombos( categoryComboB );
+        CategoryOptionGroup catOptionGroup = createCategoryOptionGroup( 'A' );
+        catOptionGroup.addCategoryOption( categoryOptionA );
+        catOptionGroup.addCategoryOption( categoryOptionB );
+        categoryOptionGroupStore.save( catOptionGroup );
+        List<CategoryOptionCombo> result = categoryOptionComboStore
+            .getCategoryOptionCombosByGroupUid( catOptionGroup.getUid() );
+        assertNotNull( result );
+        assertEquals( 6, result.size() );
     }
 }


### PR DESCRIPTION
Created component `CategoryOptionGroupResolver` that "explodes" CategoryOptionGroup UID into a list of CategoryOptionCombo:

```
<de>.<cog>

->

<de.coc1> + <de.coc2> + <de.coc3> + ...
```
and replaces the Indicator expression before it is processed by the analytics engine.

Some open questions, mostly around AOC (AttributeOptionCombos)
Also, class naming needs reviewing