### PR TITLE
Added additional label to help to clean up intermediate stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@
 ##########
 FROM maven:3.5.3-jdk-8-slim as build
 LABEL stage=intermediate
+
+ARG IDENTIFIER=unknown
+LABEL identifier=${IDENTIFIER}
 #NB - maven-frontend-plugin breaks on Alpine linux, so we use Debian Slim instead
 #NB - maven-surefire-plugin fails with maven:3.5.4-jdk-8-slim and later.
 #     This is a recent issue possibly traced to an OpenJDK bug - https://github.com/carlossg/docker-maven/issues/90

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -55,7 +55,7 @@ pipeline {
                     DOCKER_IMAGE_FULL_NAME = "${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_TAG}"
                     echo "Will tag image as ${DOCKER_IMAGE_FULL_NAME}"
 
-                    sh "docker build -t ${DOCKER_IMAGE_FULL_NAME} ."
+                    sh "docker build -t ${DOCKER_IMAGE_FULL_NAME} --build-arg IDENTIFIER=${DOCKER_IMAGE_TAG}  ."
                 }
             }
         }
@@ -94,8 +94,8 @@ pipeline {
         always {
             dir("dhis-2/dhis-e2e-test") {
                 sh "IMAGE_NAME=${DOCKER_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down --rmi all --remove-orphans"
-                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down"
-                sh "docker image prune --force --filter 'until=20m' --filter label=stage=intermediate"
+                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down --rmi all --remove-orphans"
+                sh "docker image prune --force --filter label=stage=intermediate --filter label=identifier=${DOCKER_IMAGE_TAG}"
             }
         }
 


### PR DESCRIPTION
Continuing to fix out of space issues on jenkins: adding unique identifier specific to current build pipeline which will help when removing intermediate image leftovers. As this will be specific to current build, it's safe to remove time filter - docker will not remove intermediate images from other pipelines running at the same time. 