### PR TITLE
Fix circular dependency issue when importing UserRole-User-UserGroup with sharing enabled

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/amqp/RabbitMQAmqpService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/amqp/RabbitMQAmqpService.java
@@ -44,6 +44,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -67,6 +68,7 @@ public class RabbitMQAmqpService implements AmqpService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean isEnabled()
     {
         if ( enabled == null )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
@@ -55,6 +55,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
 import java.io.IOException;
@@ -119,6 +120,7 @@ public class DefaultSystemService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public SystemInfo getSystemInfo()
     {
         SystemInfo info = systemInfo != null ? systemInfo.instance() : null;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.dxf2.metadata;
 import com.google.api.client.util.Lists;
 import com.google.common.base.Enums;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.amqp.AmqpService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -94,6 +95,9 @@ public class DefaultMetadataImportService implements MetadataImportService
     @Autowired
     private Notifier notifier;
 
+    @Autowired
+    private AmqpService amqpService;
+
     @Override
     public ImportReport importMetadata( MetadataImportParams params )
     {
@@ -122,6 +126,9 @@ public class DefaultMetadataImportService implements MetadataImportService
         }
 
         ObjectBundleParams bundleParams = params.toObjectBundleParams();
+
+        bundleParams.setAmqpServiceEnabled( amqpService.isEnabled() );
+
         ObjectBundle bundle = objectBundleService.create( bundleParams );
 
         prepareBundle( bundle, bundleParams );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -273,7 +273,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
             audit.setCode( object.getCode() );
             audit.setType( AuditType.CREATE );
 
-            if ( amqpService.isEnabled() )
+            if ( bundle.isAmqpServiceEnabled() )
             {
                 audit.setValue( renderService.toJsonAsString( object ) );
                 amqpService.publish( audit );
@@ -390,7 +390,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
             audit.setCode( object.getCode() );
             audit.setType( AuditType.UPDATE );
 
-            if ( amqpService.isEnabled() )
+            if ( bundle.isAmqpServiceEnabled() )
             {
                 audit.setValue( renderService.toJsonAsString( patch ) );
                 amqpService.publish( audit );
@@ -482,7 +482,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
             audit.setCode( object.getCode() );
             audit.setType( AuditType.DELETE );
 
-            if ( amqpService.isEnabled() )
+            if ( bundle.isAmqpServiceEnabled() )
             {
                 audit.setValue( renderService.toJsonAsString( object ) );
                 amqpService.publish( audit );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAuthorityGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -424,6 +425,18 @@ public class DefaultObjectBundleService implements ObjectBundleService
 
             if ( FlushMode.OBJECT == bundle.getFlushMode() ) session.flush();
         }
+
+        objects.forEach( object -> {
+//            if ( UserAuthorityGroup.class.isAssignableFrom( object.getClass() ) )
+//            {
+                UserAuthorityGroup o = (UserAuthorityGroup) object;
+                o.getUsers().forEach( user -> {
+                    user.getGroups().forEach( group -> {
+                            System.out.println( "group = " + group.getId());
+                    } );
+                } );
+//            }
+        } );
 
         session.flush();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -63,7 +63,6 @@ import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserAuthorityGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -425,18 +424,6 @@ public class DefaultObjectBundleService implements ObjectBundleService
 
             if ( FlushMode.OBJECT == bundle.getFlushMode() ) session.flush();
         }
-
-        objects.forEach( object -> {
-//            if ( UserAuthorityGroup.class.isAssignableFrom( object.getClass() ) )
-//            {
-                UserAuthorityGroup o = (UserAuthorityGroup) object;
-                o.getUsers().forEach( user -> {
-                    user.getGroups().forEach( group -> {
-                            System.out.println( "group = " + group.getId());
-                    } );
-                } );
-//            }
-        } );
 
         session.flush();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
@@ -128,6 +128,8 @@ public class ObjectBundle implements ObjectIndexProvider
      */
     private final boolean skipValidation;
 
+    private final boolean amqpServiceEnabled;
+
     /**
      * Job id to use for threaded imports.
      */
@@ -180,6 +182,7 @@ public class ObjectBundle implements ObjectIndexProvider
         this.skipValidation = params.isSkipValidation();
         this.jobId = params.getJobId();
         this.preheat = preheat;
+        this.amqpServiceEnabled = params.isAmqpServiceEnabled();
 
         addObject( objectMap );
     }
@@ -272,6 +275,11 @@ public class ObjectBundle implements ObjectIndexProvider
     public ObjectBundleStatus getObjectBundleStatus()
     {
         return objectBundleStatus;
+    }
+
+    public boolean isAmqpServiceEnabled()
+    {
+        return amqpServiceEnabled;
     }
 
     public void setObjectBundleStatus( ObjectBundleStatus objectBundleStatus )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleParams.java
@@ -82,6 +82,8 @@ public class ObjectBundleParams
 
     private boolean skipValidation;
 
+    private boolean amqpServiceEnabled;
+
     private JobConfiguration jobId;
 
     public ObjectBundleParams()
@@ -251,6 +253,17 @@ public class ObjectBundleParams
     public ObjectBundleParams setJobId( JobConfiguration jobId )
     {
         this.jobId = jobId;
+        return this;
+    }
+
+    public boolean isAmqpServiceEnabled()
+    {
+        return amqpServiceEnabled;
+    }
+
+    public ObjectBundleParams setAmqpServiceEnabled( boolean amqpServiceEnabled )
+    {
+        this.amqpServiceEnabled = amqpServiceEnabled;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserAuthorityGroupObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserAuthorityGroupObjectBundleHook.java
@@ -1,0 +1,57 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.collections.CollectionUtils;
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.user.UserAuthorityGroup;
+import org.hisp.dhis.user.UserGroup;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UserAuthorityGroupObjectBundleHook
+    extends AbstractObjectBundleHook
+{
+    private SessionFactory sessionFactory;
+
+    public UserAuthorityGroupObjectBundleHook( SessionFactory sessionFactory )
+    {
+        Preconditions.checkNotNull( sessionFactory );
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    @Transactional
+    public void preCommit( ObjectBundle bundle )
+    {
+        bundle.getObjects( UserAuthorityGroup.class, false ).forEach( object -> saveNotPersistedUserGroup( object, bundle ) );
+        bundle.getObjects( UserAuthorityGroup.class, true ).forEach( object -> saveNotPersistedUserGroup( object, bundle ) );
+    }
+
+    private void saveNotPersistedUserGroup( IdentifiableObject object, ObjectBundle bundle )
+    {
+        UserAuthorityGroup userAuthorityGroup = (UserAuthorityGroup) object;
+
+        if ( !CollectionUtils.isEmpty( userAuthorityGroup.getUserGroupAccesses() ) )
+        {
+            userAuthorityGroup.getUserGroupAccesses().forEach( uga -> {
+                if ( uga.getUserGroup().getId() == 0 )
+                {
+                    UserGroup userGroup = uga.getUserGroup();
+                    userGroup.getMembers().clear();
+                    sessionFactory.getCurrentSession().save( userGroup );
+
+                    if ( bundle.getPreheat().containsKey( bundle.getPreheatIdentifier(), UserGroup.class, bundle.getPreheatIdentifier().getIdentifier( userGroup ) ) )
+                    {
+                        bundle.getPreheat().replace( bundle.getPreheatIdentifier(), userGroup );
+                    }
+                    else
+                    {
+                        bundle.getPreheat().put( PreheatIdentifier.UID, userGroup );
+                    }
+                }
+            } );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/resources/META-INF/dhis/beans.xml
@@ -44,6 +44,8 @@
 
   <bean class="org.hisp.dhis.dxf2.metadata.objectbundle.hooks.ProgramStageObjectBundleHook" />
 
+  <bean class="org.hisp.dhis.dxf2.metadata.objectbundle.hooks.UserAuthorityGroupObjectBundleHook" />
+
   <bean class="org.hisp.dhis.dxf2.metadata.objectbundle.hooks.OptionObjectBundleHook" />
 
   <bean class="org.hisp.dhis.dxf2.metadata.objectbundle.hooks.JobConfigurationObjectBundleHook">

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MergeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MergeServiceTest.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.dxf2.metadata;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.Sets;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.dxf2.metadata.merge.Simple;
@@ -39,12 +40,17 @@ import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.schema.MergeParams;
 import org.hisp.dhis.schema.MergeService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAuthorityGroup;
+import org.hisp.dhis.user.UserGroup;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Date;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -179,5 +185,14 @@ public class MergeServiceTest
         assertEquals( indicator.getUid(), clone.getUid() );
         assertEquals( indicator.getCode(), clone.getCode() );
         assertEquals( indicator.getIndicatorType(), clone.getIndicatorType() );
+    }
+
+    public void testMergeNotOwnerCollection()
+    {
+        User userA = createUser( 'A' );
+        User userB = createUser( 'B' );
+        UserAuthorityGroup role = createUserAuthorityGroup( 'A' );
+        UserGroup userGroup = createUserGroup( 'A', Sets.newHashSet( userA, userB ) );
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -75,8 +75,13 @@ public class DefaultMergeService implements MergeService
                 continue;
             }
 
-            if ( property.isCollection() )
+            if ( property.isCollection()  )
             {
+                if ( !property.isOwner() )
+                {
+                    continue;
+                }
+
                 Collection<T> sourceObject = ReflectionUtils.invokeMethod( source, property.getGetterMethod() );
                 Collection<T> targetObject = ReflectionUtils.invokeMethod( target, property.getGetterMethod() );
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -31,9 +31,7 @@ package org.hisp.dhis.schema;
 import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.system.util.ReflectionUtils;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -81,6 +79,7 @@ public class DefaultMergeService implements MergeService
             {
                 Collection<T> sourceObject = ReflectionUtils.invokeMethod( source, property.getGetterMethod() );
                 Collection<T> targetObject = ReflectionUtils.invokeMethod( target, property.getGetterMethod() );
+
 
                 if ( sourceObject == null )
                 {

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -75,16 +75,10 @@ public class DefaultMergeService implements MergeService
                 continue;
             }
 
-            if ( property.isCollection()  )
+            if ( property.isCollection() )
             {
-                if ( !property.isOwner() )
-                {
-                    continue;
-                }
-
                 Collection<T> sourceObject = ReflectionUtils.invokeMethod( source, property.getGetterMethod() );
                 Collection<T> targetObject = ReflectionUtils.invokeMethod( target, property.getGetterMethod() );
-
 
                 if ( sourceObject == null )
                 {


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7144

Issue : 
- UserRole ( schema order 100 ) , User ( 101 ) and UserGroup ( 102 ) all in one payload. With given order, UserRole will be imported first.
- UserRole has userAccesses or userGroupAccesses which linked to not existed User or UserGroup in the payload 
=> TransientObjectException will be thrown

Fix:
Add a hook for detecting not existed referenced UserGroup as describe above and save it before saving UserRole. This will only applies for importing with sharing = true
This issue will only happen to UserRole because it has lowest schema order. 

