### PR TITLE
[2.30] Improve Jackson JSON streaming performance (#3575)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/StreamingJsonDataValueSet.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/StreamingJsonDataValueSet.java
@@ -28,11 +28,12 @@ package org.hisp.dhis.dxf2.datavalueset;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.hisp.dhis.dxf2.datavalue.DataValue;
 import org.hisp.dhis.dxf2.datavalue.StreamingJsonDataValue;
-import org.hisp.dhis.render.DefaultRenderService;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,7 +51,12 @@ public class StreamingJsonDataValueSet extends DataValueSet
     {
         try
         {
-            generator = DefaultRenderService.getJsonMapper().getFactory().createGenerator( out );
+            JsonFactory factory = new ObjectMapper().getFactory();
+            // Disables flushing every time that an object property is written to the stream
+            factory.disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
+            // Do not attempt to balance unclosed tags - small optimization
+            factory.disable( JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT );
+            generator = factory.createGenerator( out );
             generator.writeStartObject();
         }
         catch ( IOException ignored )


### PR DESCRIPTION
- DHIS2-7023
- Disable `JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM` Jackson feature
to reduce number of flushes to HTTP response stream by 5X

(cherry picked from commit c802b06720170cec164cda93d9903613b3dbe141)