### PR TITLE
feat: add ou resolution mode when querying teis to either use registration or ownership ou (master)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OrganisationUnitResolutionMode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OrganisationUnitResolutionMode.java
@@ -1,0 +1,44 @@
+package org.hisp.dhis.common;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Defines which orgunit field is used when querying teis
+ * 
+ * <ul>
+ * <li>REGISTRATION: prgunits resolved on registration org units.</li>
+ * <li>OWNERSHIP: orgunits resolved on ownership org units.</li>
+ * </ul>
+ * 
+ * @author Ameen Mohamed
+ */
+public enum OrganisationUnitResolutionMode
+{
+    REGISTRATION, OWNERSHIP
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.trackedentity;
 import com.google.common.base.MoreObjects;
 import org.apache.commons.lang.time.DateUtils;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
+import org.hisp.dhis.common.OrganisationUnitResolutionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -159,6 +160,11 @@ public class TrackedEntityInstanceQueryParams
      * Selection mode for user assignment of events.
      */
     private AssignedUserSelectionMode assignedUserSelectionMode;
+    
+    /**
+     * Resolution mode for the specified organisation units, default is REGISTRATION.
+     */
+    private OrganisationUnitResolutionMode organisationUnitResolution;
     
     /**
      * Set of user ids to filter based on events assigned to the users.
@@ -952,6 +958,17 @@ public class TrackedEntityInstanceQueryParams
     public TrackedEntityInstanceQueryParams setOrganisationUnitMode( OrganisationUnitSelectionMode organisationUnitMode )
     {
         this.organisationUnitMode = organisationUnitMode;
+        return this;
+    }
+    
+    public OrganisationUnitResolutionMode getOrganisationUnitResolution()
+    {
+        return organisationUnitResolution;
+    }
+    
+    public TrackedEntityInstanceQueryParams setOrganisationUnitResolution( OrganisationUnitResolutionMode organisationUnitResolution )
+    {
+        this.organisationUnitResolution = organisationUnitResolution;
         return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.trackedentity;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitResolutionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
@@ -162,7 +163,7 @@ public interface TrackedEntityInstanceService
      * @return a TrackedEntityInstanceQueryParams.
      */
     TrackedEntityInstanceQueryParams getFromUrl( String query, Set<String> attribute, Set<String> filter,
-        Set<String> ou, OrganisationUnitSelectionMode ouMode, String program, ProgramStatus programStatus,
+        Set<String> ou, OrganisationUnitSelectionMode ouMode, OrganisationUnitResolutionMode ouResolution, String program, ProgramStatus programStatus,
         Boolean followUp, Date lastUpdatedStart, Date lastUpdatedEndDate, String lastUpdatedDuration,
         Date programEnrollmentStartDate, Date programEnrollmentEndDate, Date programIncidentStartDate,
         Date programIncidentEndDate, String trackedEntityType, EventStatus eventStatus, Date eventStartDate,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitResolutionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryFilter;
@@ -669,7 +670,7 @@ public class DefaultTrackedEntityInstanceService
     @Override
     @Transactional(readOnly = true)
     public TrackedEntityInstanceQueryParams getFromUrl( String query, Set<String> attribute, Set<String> filter,
-        Set<String> ou, OrganisationUnitSelectionMode ouMode, String program, ProgramStatus programStatus,
+        Set<String> ou, OrganisationUnitSelectionMode ouMode, OrganisationUnitResolutionMode ouResolution, String program, ProgramStatus programStatus,
         Boolean followUp, Date lastUpdatedStartDate, Date lastUpdatedEndDate, String lastUpdatedDuration,
         Date programEnrollmentStartDate, Date programEnrollmentEndDate, Date programIncidentStartDate,
         Date programIncidentEndDate, String trackedEntityType, EventStatus eventStatus, Date eventStartDate,
@@ -749,6 +750,11 @@ public class DefaultTrackedEntityInstanceService
             params.getOrganisationUnits().addAll( user.getOrganisationUnits() );
         }
 
+        if ( ouResolution == OrganisationUnitResolutionMode.OWNERSHIP && program == null )
+        {
+            throw new IllegalQueryException( "Program should be specified to use OWNERSHIP orgUnit resolution mode" );
+        }
+
         if ( assignedUserSelectionMode != null && assignedUsers != null && !assignedUsers.isEmpty()
             && !assignedUserSelectionMode.equals( AssignedUserSelectionMode.PROVIDED ) )
         {
@@ -768,6 +774,7 @@ public class DefaultTrackedEntityInstanceService
             .setProgramIncidentEndDate( programIncidentEndDate )
             .setTrackedEntityType( te )
             .setOrganisationUnitMode( ouMode )
+            .setOrganisationUnitResolution( ouResolution )
             .setEventStatus( eventStatus )
             .setEventStartDate( eventStartDate )
             .setEventEndDate( eventEndDate )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -193,7 +193,10 @@ public class HibernateTrackedEntityInstanceStore
 
             }
            
-            hql += hlp.whereAnd() + " po.program.uid = '" + params.getProgram().getUid() + "'";
+            if ( params.getOrganisationUnitResolution() == OrganisationUnitResolutionMode.OWNERSHIP )
+            {
+                hql += hlp.whereAnd() + " po.program.uid = '" + params.getProgram().getUid() + "'";
+            }
             
             hql += hlp.whereAnd() + " pi.program.uid = '" + params.getProgram().getUid() + "'";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -34,6 +34,7 @@ import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.query.Query;
+import org.hisp.dhis.common.OrganisationUnitResolutionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -153,6 +154,7 @@ public class HibernateTrackedEntityInstanceStore
             .replaceFirst( "inner join fetch tei.programInstances", "inner join tei.programInstances" )
             .replaceFirst( "inner join fetch pi.programStageInstances", "inner join pi.programStageInstances" )
             .replaceFirst( "inner join fetch psi.assignedUser", "inner join psi.assignedUser" )
+            .replaceFirst( "inner join fetch tei.programOwners", "inner join tei.programOwners" )
             .replaceFirst( "order by case when pi.status = 'ACTIVE' then 1 when pi.status = 'COMPLETED' then 2 else 3 end asc, tei.lastUpdated desc ", "" )
             .replaceFirst( "order by tei.lastUpdated desc ", "" );
     }
@@ -162,9 +164,20 @@ public class HibernateTrackedEntityInstanceStore
         SqlHelper hlp = new SqlHelper( true );
 
         String hql = "select tei from TrackedEntityInstance tei ";
-
+        
+        params.handleOrganisationUnits();
+        
+      //Used for switing between registration org unit or ownership org unit. Default source is registration ou.
+        String teiOuSource = "tei.organisationUnit";
+        
         if ( params.hasProgram() )
         {
+            if ( params.getOrganisationUnitResolution() == OrganisationUnitResolutionMode.OWNERSHIP )
+            {
+                hql += "inner join fetch tei.programOwners as po ";
+                teiOuSource = "po.organisationUnit";
+            }
+            
             hql += "inner join fetch tei.programInstances as pi ";
 
             if ( params.hasFilterForEvents() )
@@ -179,7 +192,9 @@ public class HibernateTrackedEntityInstanceStore
                 hql += hlp.whereAnd() + getEventWhereClauseHql( params );
 
             }
-
+           
+            hql += hlp.whereAnd() + " po.program.uid = '" + params.getProgram().getUid() + "'";
+            
             hql += hlp.whereAnd() + " pi.program.uid = '" + params.getProgram().getUid() + "'";
 
             if ( params.hasProgramStatus() )
@@ -270,8 +285,7 @@ public class HibernateTrackedEntityInstanceStore
 
         if ( params.hasOrganisationUnits() )
         {
-            params.handleOrganisationUnits();
-
+            
             if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) )
             {
                 String ouClause = "(";
@@ -280,7 +294,7 @@ public class HibernateTrackedEntityInstanceStore
 
                 for ( OrganisationUnit organisationUnit : params.getOrganisationUnits() )
                 {
-                    ouClause += orHlp.or() + "tei.organisationUnit.path LIKE '" + organisationUnit.getPath() + "%'";
+                    ouClause += orHlp.or() + teiOuSource + ".path LIKE '" + organisationUnit.getPath() + "%'";
                 }
 
                 ouClause += ")";
@@ -289,7 +303,7 @@ public class HibernateTrackedEntityInstanceStore
             }
             else
             {
-                hql += hlp.whereAnd() + "tei.organisationUnit.uid in (" + getQuotedCommaDelimitedString( getUids( params.getOrganisationUnits() ) ) + ")";
+                hql += hlp.whereAnd() + teiOuSource + ".uid in (" + getQuotedCommaDelimitedString( getUids( params.getOrganisationUnits() ) ) + ")";
             }
         }
 
@@ -479,8 +493,19 @@ public class HibernateTrackedEntityInstanceStore
         String sql = "from trackedentityinstance tei "
             + "inner join trackedentitytype te on tei.trackedentitytypeid = te.trackedentitytypeid ";
 
+        params.handleOrganisationUnits();
+        
+        //Used for switing between registration org unit or ownership org unit. Default source is registration ou.
+        String orgUnitSource = "tei.organisationunitid";
+        
         if ( params.hasProgram() )
         {
+            if ( params.getOrganisationUnitResolution() == OrganisationUnitResolutionMode.OWNERSHIP )
+            {
+                sql += "inner join (select trackedentityinstanceid, organisationunitid from trackedentityprogramowner where programid = ";
+                sql += params.getProgram().getId() + ") as tepo ON tei.trackedentityinstanceid = tepo.trackedentityinstanceid ";
+                orgUnitSource = "tepo.organisationunitid";
+            }   
             sql += "inner join ("
                 + "select trackedentityinstanceid, min(case when status='ACTIVE' then 0 when status='COMPLETED' then 1 else 2 end) as status "
                 + "from programinstance pi ";
@@ -539,7 +564,7 @@ public class HibernateTrackedEntityInstanceStore
             sql += " group by trackedentityinstanceid ) as en on tei.trackedentityinstanceid = en.trackedentityinstanceid ";
         }
 
-        sql += "inner join organisationunit ou on tei.organisationunitid = ou.organisationunitid ";
+        sql += "inner join organisationunit ou on " + orgUnitSource + " = ou.organisationunitid ";
 
         for ( QueryItem item : params.getAttributesAndFilters() )
         {
@@ -570,8 +595,6 @@ public class HibernateTrackedEntityInstanceStore
             sql += hlp.whereAnd() + " tei.trackedentitytypeid = " + params.getTrackedEntityType().getId() + " ";
         }
 
-        params.handleOrganisationUnits();
-
         if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.ALL ) )
         {
             // No restriction
@@ -593,7 +616,7 @@ public class HibernateTrackedEntityInstanceStore
         }
         else // SELECTED (default)
         {
-            sql += hlp.whereAnd() + " tei.organisationunitid in ("
+            sql += hlp.whereAnd() + " " + orgUnitSource + " in ("
                 + getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) ) + ") ";
         }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.OrganisationUnitResolutionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
@@ -175,6 +176,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) Set<String> filter,
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) OrganisationUnitResolutionMode ouResolution,
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) ProgramStatus programStatus,
         @RequestParam( required = false ) Boolean followUp,
@@ -224,7 +226,7 @@ public class TrackedEntityInstanceController
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
         TrackedEntityInstanceQueryParams queryParams = instanceService.getFromUrl( query, attribute, filter, orgUnits,
-            ouMode, program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, lastUpdatedDuration,
+            ouMode, ouResolution, program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, lastUpdatedDuration,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
             trackedEntityType, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
             page, pageSize, totalPages, skipPaging, includeDeleted, includeAllAttributes, getOrderParams( order ) );
@@ -389,6 +391,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) Set<String> filter,
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) OrganisationUnitResolutionMode ouResolution,
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) ProgramStatus programStatus,
         @RequestParam( required = false ) Boolean followUp,
@@ -424,7 +427,7 @@ public class TrackedEntityInstanceController
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
-        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
+        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode, ouResolution,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
             trackedEntityType, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
@@ -441,6 +444,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) Set<String> filter,
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) OrganisationUnitResolutionMode ouResolution,
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) ProgramStatus programStatus,
         @RequestParam( required = false ) Boolean followUp,
@@ -475,7 +479,7 @@ public class TrackedEntityInstanceController
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
-        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
+        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode, ouResolution,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
             trackedEntityType, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
@@ -493,6 +497,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) Set<String> filter,
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) OrganisationUnitResolutionMode ouResolution,
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) ProgramStatus programStatus,
         @RequestParam( required = false ) Boolean followUp,
@@ -527,7 +532,7 @@ public class TrackedEntityInstanceController
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
-        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
+        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode, ouResolution,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
             trackedEntityType, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
@@ -545,6 +550,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) Set<String> filter,
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) OrganisationUnitResolutionMode ouResolution,
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) ProgramStatus programStatus,
         @RequestParam( required = false ) Boolean followUp,
@@ -579,7 +585,7 @@ public class TrackedEntityInstanceController
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
-        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
+        TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode, ouResolution,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
             trackedEntityType, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
@@ -597,6 +603,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) Set<String> filter,
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) OrganisationUnitResolutionMode ouResolution,
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) ProgramStatus programStatus,
         @RequestParam( required = false ) Boolean followUp,
@@ -631,7 +638,7 @@ public class TrackedEntityInstanceController
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
 
         TrackedEntityInstanceQueryParams queryParams = instanceService.getFromUrl( query, attribute, filter, orgUnits,
-            ouMode, program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, lastUpdatedDuration,
+            ouMode, ouResolution, program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, lastUpdatedDuration,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
             trackedEntityType, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, true,
             TrackedEntityInstanceQueryParams.DEFAULT_PAGE, Pager.DEFAULT_PAGE_SIZE, true, true,


### PR DESCRIPTION
Added a new param in TrackedEntityInstanceQueryParams named organisationUnitResolution which is used to switch between
A) filtering defined org units based on the Registration org units of tei
B) filtering defined org units based on the Ownership org units of tei + program