### PR TITLE
fix: don't try to extract a non-existent zip file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
-
 set -e
-if [ "$(id -u)" = "0" ]; then
-    unzip /usr/local/tomcat/webapps/ROOT.war -d /usr/local/tomcat/webapps/ROOT
-    rm /usr/local/tomcat/webapps/ROOT.war
-    chown -R root:tomcat /usr/local/tomcat
-    chmod -R u+rwX,g+rX,o-rwx /usr/local/tomcat
-    chown -R tomcat:tomcat /usr/local/tomcat/temp \
-        /usr/local/tomcat/work \
-        /usr/local/tomcat/logs
 
-    chown -R tomcat:tomcat /DHIS2_home
+WARFILE=/usr/local/tomcat/webapps/ROOT.war
+TOMCATDIR=/usr/local/tomcat
+DHIS2HOME=/DHIS2_home
+
+if [ "$(id -u)" = "0" ] then
+    if [ -f $WARFILE ]; then
+        unzip $WARFILE -d $TOMCATDIR/webapps/ROOT
+        rm $WARFILE
+    fi
+    
+    chown -R root:tomcat $TOMCATDIR
+    chmod -R u+rwX,g+rX,o-rwx $TOMCATDIR
+    chown -R tomcat:tomcat $TOMCATDIR/temp \
+        $TOMCATDIR/work \
+        $TOMCATDIR/logs
+
+    chown -R tomcat:tomcat $DHIS2HOME
     exec su-exec tomcat "$0" "$@"
 fi
 


### PR DESCRIPTION
When the container is restarted (not re-created) it crashes because the WAR file has already been unzipped and removed.  Only try to explode the WAR file if it exists.

Also extract some commonly-used directories and files to variables for easier editing in the future.