### PR TITLE
Fix bug TransientObjectException when import MapView

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -1003,6 +1004,18 @@ public class DefaultPreheatService implements PreheatService
 
     private boolean skipConnect( Class<?> klass )
     {
-        return klass != null && (UserCredentials.class.isAssignableFrom( klass ) || EmbeddedObject.class.isAssignableFrom( klass ));
+        return klass != null && (UserCredentials.class.isAssignableFrom( klass ) || isEmbeddedObject( klass ));
+    }
+
+    private boolean isEmbeddedObject( Class<?> klass )
+    {
+        if ( AnalyticalObject.class.isAssignableFrom( klass ) || MetadataObject.class.isAssignableFrom( klass ) )
+        {
+            return false;
+        }
+        else
+        {
+            return  EmbeddedObject.class.isAssignableFrom( klass ) ;
+        }
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7225

- MapView was marked as both Analytic and Embedded object
- Preheat.connectReferences() will skip embedded object
- Preheat.skipConnect() return true if an object implemented EmbeddedObject interface, even if it also implement AnalyticObject. The result is MapView object's references are not connected, hence TransientObjectException is thrown when session is flushed. 

-> Fix: update skipConnect to make it return true if object only implement Embedded interface 