### PR TITLE
Fix bug metadata sync deleted DataSet Section

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataImportParams.java
@@ -131,6 +131,11 @@ public class MetadataImportParams
     private boolean skipValidation;
 
     /**
+     * Is this import request from Metadata Sync service.
+     */
+    private boolean metadataSyncImport;
+
+    /**
      * Name of file that was used for import (if available).
      */
     private String filename;
@@ -335,6 +340,16 @@ public class MetadataImportParams
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isMetadataSyncImport() {
+        return metadataSyncImport;
+    }
+
+    public void setMetadataSyncImport(boolean metadataSyncImport) {
+        this.metadataSyncImport = metadataSyncImport;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isSkipValidation()
     {
         return skipValidation;
@@ -491,6 +506,7 @@ public class MetadataImportParams
         params.setMergeMode( mergeMode );
         params.setFlushMode( flushMode );
         params.setImportReportMode( importReportMode );
+        params.setMetadataSyncImport( metadataSyncImport );
 
         return params;
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
@@ -129,6 +129,11 @@ public class ObjectBundle implements ObjectIndexProvider
     private final boolean skipValidation;
 
     /**
+     * Is this import request from MetadataSync service;
+     */
+    private final boolean metadataSyncImport;
+
+    /**
      * Job id to use for threaded imports.
      */
     private JobConfiguration jobId;
@@ -180,6 +185,7 @@ public class ObjectBundle implements ObjectIndexProvider
         this.skipValidation = params.isSkipValidation();
         this.jobId = params.getJobId();
         this.preheat = preheat;
+        this.metadataSyncImport = params.isMetadataSyncImport();
 
         addObject( objectMap );
     }
@@ -257,6 +263,11 @@ public class ObjectBundle implements ObjectIndexProvider
     public boolean isSkipValidation()
     {
         return skipValidation;
+    }
+
+    public boolean isMetadataSyncImport()
+    {
+        return metadataSyncImport;
     }
 
     public JobConfiguration getJobId()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleParams.java
@@ -82,6 +82,8 @@ public class ObjectBundleParams
 
     private boolean skipValidation;
 
+    private boolean metadataSyncImport;
+
     private JobConfiguration jobId;
 
     public ObjectBundleParams()
@@ -241,6 +243,14 @@ public class ObjectBundleParams
     {
         this.skipValidation = skipValidation;
         return this;
+    }
+
+    public boolean isMetadataSyncImport() {
+        return metadataSyncImport;
+    }
+
+    public void setMetadataSyncImport(boolean metadataSyncImport) {
+        this.metadataSyncImport = metadataSyncImport;
     }
 
     public JobConfiguration getJobId()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/DataSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/DataSetObjectBundleHook.java
@@ -28,9 +28,12 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.collections.CollectionUtils;
+import org.hibernate.Session;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataset.DataInputPeriod;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.Section;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -40,6 +43,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
@@ -50,12 +54,12 @@ public class DataSetObjectBundleHook extends AbstractObjectBundleHook
     @Override
     public <T extends IdentifiableObject> List<ErrorReport> validate( T object, ObjectBundle bundle )
     {
+        List<ErrorReport> errors = new ArrayList<>();
+
         if ( object == null || !object.getClass().isAssignableFrom( DataSet.class ) )
         {
-            return new ArrayList<>();
+            return errors;
         }
-
-        List<ErrorReport> errors = new ArrayList<>();
 
         DataSet dataSet = (DataSet) object;
 
@@ -72,5 +76,26 @@ public class DataSetObjectBundleHook extends AbstractObjectBundleHook
             }
         }
         return errors;
+    }
+
+    @Override
+    public <T extends IdentifiableObject> void preUpdate( T object, T persistedObject, ObjectBundle bundle )
+    {
+        if ( object == null || !object.getClass().isAssignableFrom( DataSet.class ) ) return;
+
+        deleteRemovedSection( ( DataSet ) persistedObject, ( DataSet ) object, bundle );
+    }
+
+    private void deleteRemovedSection( DataSet persistedDataSet, DataSet importDataSet, ObjectBundle bundle )
+    {
+        if ( !bundle.isMetadataSyncImport() ) return;
+
+        Session session = sessionFactory.getCurrentSession();
+
+        List<String> importIds = importDataSet.getSections().stream().map( section ->  section.getUid() ).collect( Collectors.toList() );
+
+        persistedDataSet.getSections().stream()
+                .filter( section -> !importIds.contains( section.getUid() ) )
+                .forEach( section -> session.delete( section ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
@@ -86,8 +86,10 @@ public class DefaultMetadataSyncService
     public MetadataSyncParams getParamsFromMap( Map<String, List<String>> parameters )
     {
         List<String> versionName = getVersionsFromParams( parameters );
+        MetadataImportParams importParams = new MetadataImportParams();
+        importParams.setMetadataSyncImport( true );
         MetadataSyncParams syncParams = new MetadataSyncParams();
-        syncParams.setImportParams( new MetadataImportParams() );
+        syncParams.setImportParams( importParams );
         String versionNameStr = versionName.get( 0 );
 
         if ( StringUtils.isNotEmpty( versionNameStr ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.dxf2.metadata.version;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -375,6 +376,7 @@ DefaultMetadataVersionService
                 List<String> defaultFilterList = new ArrayList<>();
                 defaultFilterList.add( "lastUpdated:gte:" + DateUtils.getLongGmtDateString( minDate ) );
                 exportParams.setDefaultFilter( defaultFilterList );
+                exportParams.setDefaultFields(Lists.newArrayList( ":all" ) );
                 metadataExportService.validate( exportParams );
             }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_all_section_removed.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_all_section_removed.json
@@ -1,0 +1,60 @@
+{
+  "dataSets": [
+    {
+      "sections" : [
+      ],
+      "dataSetElements": [
+        {
+          "id": "WTOZ7gqbASV",
+          "dataElement": {
+            "id": "nHwIqKAudKN"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        },
+        {
+          "id": "rSChycu6mOY",
+          "dataElement": {
+            "id": "VolAzjFe5zP"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        }
+      ],
+      "compulsoryDataElementOperands": [ ],
+      "timelyDays": 15,
+      "fieldCombinationRequired": false,
+      "version": 4,
+      "renderAsTabs": false,
+      "name": "Data Set",
+      "expiryDays": 0,
+      "skipOffline": false,
+      "dataElementDecoration": false,
+      "validCompleteOnly": false,
+      "publicAccess": "rw------",
+      "noValueRequiresComment": false,
+      "shortName": "Data Set",
+      "attributeValues": [ ],
+      "id": "em8Bg4LCr5k",
+      "indicators": [ ],
+      "userGroupAccesses": [ ],
+      "periodType": "Monthly",
+      "mobile": false,
+      "lastUpdated": "2016-03-08T07:32:42.146+0000",
+      "notifyCompletingUser": false,
+      "openFuturePeriods": 0,
+      "created": "2016-03-08T07:31:30.424+0000",
+      "organisationUnits": [
+        {
+          "id": "x3gVvpbVgqy"
+        }
+      ],
+      "renderHorizontally": false,
+      "user": {
+        "id": "T12jeH7KPzk"
+      }
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_removed_section.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_removed_section.json
@@ -1,0 +1,351 @@
+{
+  "dataElements": [
+    {
+      "valueType": "NUMBER",
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "aggregationLevels": [ ],
+      "publicAccess": "rw------",
+      "aggregationType": "SUM",
+      "lastUpdated": "2016-03-08T07:30:07.699+0000",
+      "created": "2016-03-08T07:30:07.698+0000",
+      "name": "Simple Value",
+      "shortName": "Simple Value",
+      "attributeValues": [ ],
+      "zeroIsSignificant": false,
+      "userGroupAccesses": [ ],
+      "domainType": "AGGREGATE",
+      "id": "nHwIqKAudKN"
+    },
+    {
+      "name": "Value with CC",
+      "created": "2016-03-08T07:30:58.416+0000",
+      "lastUpdated": "2016-03-08T07:30:58.417+0000",
+      "zeroIsSignificant": false,
+      "userGroupAccesses": [ ],
+      "id": "VolAzjFe5zP",
+      "domainType": "AGGREGATE",
+      "attributeValues": [ ],
+      "shortName": "Value with CC",
+      "aggregationLevels": [ ],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------",
+      "valueType": "NUMBER",
+      "aggregationType": "SUM",
+      "categoryCombo": {
+        "id": "faV8QvLgIwB"
+      }
+    }
+  ],
+  "categoryCombos": [
+    {
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------",
+      "lastUpdated": "2016-03-08T07:29:15.719+0000",
+      "created": "2016-03-08T07:29:07.104+0000",
+      "categories": [
+        {
+          "id": "XJGLlMAMCcn"
+        }
+      ],
+      "name": "Gender",
+      "userGroupAccesses": [ ],
+      "skipTotal": false,
+      "dataDimensionType": "DISAGGREGATION",
+      "id": "faV8QvLgIwB"
+    }
+  ],
+  "organisationUnits": [
+    {
+      "lastUpdated": "2016-03-08T07:27:17.772+0000",
+      "name": "Country",
+      "created": "2016-03-08T07:27:17.757+0000",
+      "uuid": "d981e7c4-3c72-4e0d-8995-078f16830473",
+      "shortName": "Country",
+      "description": "",
+      "id": "x3gVvpbVgqy",
+      "attributeValues": [ ],
+      "path": "/x3gVvpbVgqy",
+      "featureType": "NONE",
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "openingDate": "2016-03-08"
+    }
+  ],
+  "categoryOptions": [
+    {
+      "id": "JYiFOMKa25J",
+      "userGroupAccesses": [ ],
+      "attributeValues": [ ],
+      "shortName": "Female",
+      "name": "Female",
+      "created": "2016-03-08T07:28:50.372+0000",
+      "lastUpdated": "2016-03-08T07:28:50.374+0000",
+      "organisationUnits": [ ],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------"
+    },
+    {
+      "shortName": "Male",
+      "userGroupAccesses": [ ],
+      "id": "tdaMRD34m8o",
+      "attributeValues": [ ],
+      "lastUpdated": "2016-03-08T07:28:44.217+0000",
+      "name": "Male",
+      "created": "2016-03-08T07:28:44.214+0000",
+      "organisationUnits": [ ],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------"
+    }
+  ],
+  "userRoles": [
+    {
+      "name": "Superuser",
+      "created": "2016-03-08T07:26:51.925+0000",
+      "lastUpdated": "2016-03-08T07:26:51.925+0000",
+      "userGroupAccesses": [ ],
+      "id": "wSdzlWUHmEu",
+      "dataSets": [ ],
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_REPORTTABLE_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_MAP_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_PROGRAM_ENROLLMENT",
+        "F_REPORTTABLE_EXTERNAL",
+        "F_SQLVIEW_EXTERNAL",
+        "F_GIS_ADMIN",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_CHART_PUBLIC_ADD",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_CHART_EXTERNAL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_MAP_EXTERNAL",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE"
+      ],
+      "publicAccess": "--------",
+      "programs": [ ]
+    }
+  ],
+  "categories": [
+    {
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------",
+      "categoryOptions": [
+        {
+          "id": "JYiFOMKa25J"
+        },
+        {
+          "id": "tdaMRD34m8o"
+        }
+      ],
+      "created": "2016-03-08T07:28:58.738+0000",
+      "name": "Gender",
+      "lastUpdated": "2016-03-08T07:28:58.740+0000",
+      "dataDimension": true,
+      "dataDimensionType": "DISAGGREGATION",
+      "userGroupAccesses": [ ],
+      "id": "XJGLlMAMCcn"
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "description": "Person",
+      "id": "MDvmqCKmXQM",
+      "attributeValues": [ ],
+      "name": "Person",
+      "created": "2016-03-08T07:28:58.738+0000",
+      "lastUpdated": "2016-03-08T07:28:58.740+0000"
+    }
+  ],
+  "sections": [
+    {
+      "lastUpdated": "2016-03-08T07:32:42.140+0000",
+      "created": "2016-03-08T07:32:42.140+0000",
+      "name": "Section Gender",
+      "id": "C50M0WxaI7y",
+      "indicators": [ ],
+      "sortOrder": 0,
+      "dataElements": [
+        {
+          "id": "VolAzjFe5zP"
+        }
+      ],
+      "greyedFields": [ ],
+      "dataSet": {
+        "id": "em8Bg4LCr5k"
+      }
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "categoryOptions": [
+        {
+          "id": "JYiFOMKa25J"
+        }
+      ],
+      "categoryCombo": {
+        "id": "faV8QvLgIwB"
+      },
+      "id": "J5uZylXMmbB",
+      "ignoreApproval": false,
+      "lastUpdated": "2016-03-08T07:29:15.715+0000",
+      "name": "Female",
+      "created": "2016-03-08T07:29:15.714+0000"
+    },
+    {
+      "lastUpdated": "2016-03-08T07:29:15.717+0000",
+      "created": "2016-03-08T07:29:15.717+0000",
+      "name": "Male",
+      "categoryCombo": {
+        "id": "faV8QvLgIwB"
+      },
+      "categoryOptions": [
+        {
+          "id": "tdaMRD34m8o"
+        }
+      ],
+      "ignoreApproval": false,
+      "id": "p99yaU6mweU"
+    }
+  ],
+  "organisationUnitLevels": [
+    {
+      "id": "JEMRBUHgpqN",
+      "name": "Level 1",
+      "created": "2016-03-08T07:27:22.448+0000",
+      "level": 1,
+      "lastUpdated": "2016-03-08T07:27:22.449+0000"
+    }
+  ],
+  "dataSets": [
+    {
+      "sections" : [
+        {
+          "id" : "C50M0WxaI7y"
+        }
+      ],
+      "dataSetElements": [
+        {
+          "id": "WTOZ7gqbASV",
+          "dataElement": {
+            "id": "nHwIqKAudKN"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        },
+        {
+          "id": "rSChycu6mOY",
+          "dataElement": {
+            "id": "VolAzjFe5zP"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        }
+      ],
+      "compulsoryDataElementOperands": [ ],
+      "timelyDays": 15,
+      "fieldCombinationRequired": false,
+      "version": 4,
+      "renderAsTabs": false,
+      "name": "Data Set",
+      "expiryDays": 0,
+      "skipOffline": false,
+      "dataElementDecoration": false,
+      "validCompleteOnly": false,
+      "publicAccess": "rw------",
+      "noValueRequiresComment": false,
+      "shortName": "Data Set",
+      "attributeValues": [ ],
+      "id": "em8Bg4LCr5k",
+      "indicators": [ ],
+      "userGroupAccesses": [ ],
+      "periodType": "Monthly",
+      "mobile": false,
+      "lastUpdated": "2016-03-08T07:32:42.146+0000",
+      "notifyCompletingUser": false,
+      "openFuturePeriods": 0,
+      "created": "2016-03-08T07:31:30.424+0000",
+      "organisationUnits": [
+        {
+          "id": "x3gVvpbVgqy"
+        }
+      ],
+      "renderHorizontally": false,
+      "user": {
+        "id": "T12jeH7KPzk"
+      }
+    }
+  ],
+  "users": [
+    {
+      "organisationUnits": [
+        {
+          "id": "x3gVvpbVgqy"
+        }
+      ],
+      "dataViewOrganisationUnits": [ ],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "catDimensionConstraints": [ ],
+        "userInfo": {
+          "id": "T12jeH7KPzk"
+        },
+        "disabled": false,
+        "username": "admin",
+        "created": "2016-03-08T07:26:52.033+0000",
+        "selfRegistered": false,
+        "cogsDimensionConstraints": [ ],
+        "passwordLastUpdated": "2016-03-08T07:26:51.942+0000",
+        "userRoles": [
+          {
+            "id": "wSdzlWUHmEu"
+          }
+        ],
+        "invitation": false,
+        "externalAuth": false,
+        "lastLogin": "2016-03-08T07:26:51.942+0000"
+      },
+      "surname": "admin",
+      "attributeValues": [ ],
+      "id": "T12jeH7KPzk",
+      "created": "2016-03-08T07:26:51.909+0000",
+      "firstName": "admin",
+      "lastUpdated": "2016-03-08T07:26:51.909+0000",
+      "teiSearchOrganisationUnits": [ ]
+    }
+  ],
+  "date": "2016-03-08T07:34:13.552+0000"
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-6920

Issue : Removed Section from DataSet from central instance and do metadata sync doesn't trigger delete that section in child instance because metadata sync service currently doesn't support deletion

Fix:
- Add a parameter  isMetadataSyncImport
- In DataSetObjectBundleHook, manually scan for removed Section and delete it in preUpdate. This will only apply if isMetadataSyncImport=true
- Set isMetadataSyncImport = true when importMetadata is called from metadataSyncService.
- In method for saving new metadata snapshot, add fields=:all so that DataSet's section list is included in export DataSet and saved to the metadata version snapshot ( by default only fields owner is exported ). This is for scanning deleted section when importing to child instance

-> this is temporary solution, for long term need to support deletion for metadata sync

