### PR TITLE
fix: use HEADLESS mode for Java AWT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mvn clean install -T1C -U -f /src/dhis-2/dhis-web/pom.xml -DskipTests
 ##########
 FROM tomcat:8.5.34-jre8-alpine as serve
 
-ENV DHIS2_HOME=/DHIS2_home
+ENV DHIS2_HOME=/DHIS2_home JAVA_OPTIONS="-Djava.awt.headless=true"
 
 COPY docker-entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
(Note: haven't tested this yet)

I believe this should solve the 500 errors @erikarenhill reported when accessing /api/31/charts/sWaHIJkVNh4/data.html+css on a dockerized DHIS2 core.

@vilkg should we put this on a separate line with a comment or keep it with the existing ENV command to reduce the number of Docker layers?