### PR TITLE
[2.33] fix: Detect missing persmission for AttributeOption on DataSet submit

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
@@ -369,6 +369,16 @@ public interface CategoryService
         Set<CategoryOption> categoryOptions );
 
     /**
+     * Retrieves the CategoryOptionCombo with the given uid and
+     * {@see IdentifiableProperty}.
+     *
+     * @param id the id of the CategoryOptionCombo.
+     * @param property the type of id to use
+     * @return the CategoryOptionCombo.
+     */
+    CategoryOptionCombo getCategoryOptionCombo( IdentifiableProperty property, String id );
+
+    /**
      * Retrieves all CategoryOptionCombos.
      *
      * @return a list of CategoryOptionCombos.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
@@ -490,6 +490,12 @@ public class DefaultCategoryService
     }
 
     @Override
+    public CategoryOptionCombo getCategoryOptionCombo( IdentifiableProperty property, String id )
+    {
+        return idObjectManager.getObject( CategoryOptionCombo.class, property, id );
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public List<CategoryOptionCombo> getAllCategoryOptionCombos()
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/AggregateAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/AggregateAccessManager.java
@@ -42,32 +42,36 @@ public interface AggregateAccessManager
 {
     /**
      * Check if given User has DATA_READ access for given DataValue
-     * @param user
-     * @param dataValue
+     * 
+     * @param user a {@see User} to check permission for
+     * @param dataValue a {@see DataValue} object
      * @return List of errors
      */
     List<String> canRead( User user, DataValue dataValue );
 
     /**
      * Check if given user has DATA_WRITE
-     * @param user
-     * @param dataSet
+     * 
+     * @param user a {@see User} to check permission for
+     * @param dataSet a {@see DataSet} object
      * @return List of errors
      */
     List<String> canWrite( User user, DataSet dataSet );
 
     /**
      * Check if given User has DATA_READ access for given DataSet
-     * @param user
-     * @param dataSet
+     * 
+     * @param user a {@see User} to check permission for
+     * @param dataSet a {@see DataValue} object
      * @return List of errors
      */
     List<String> canRead( User user, DataSet dataSet );
 
     /**
      * Check if given User has DATA_WRITE access for given CategoryOptionCombo
-     * @param user
-     * @param categoryOption
+     * 
+     * @param user a {@see User} to check permission for
+     * @param categoryOption a {@see CategoryOptionCombo} object
      * @return List of errors
      */
     List<String> canWrite( User user, CategoryOptionCombo categoryOption );
@@ -76,24 +80,26 @@ public interface AggregateAccessManager
      * Check if given User has DATA_WRITE access for given CategoryOptionCombo,
      * result is cached.
      *
-     * @param user
-     * @param categoryOption
+     * @param user a {@see User} to check permission for
+     * @param categoryOptionCombo a {@see CategoryOptionCombo} object
      * @return List of errors
      */
     List<String> canWriteCached( User user, CategoryOptionCombo categoryOptionCombo );
 
     /**
      * Check if given User has DATA_READ access for given CategoryOptionCombo
-     * @param user
-     * @param categoryOption
-     * @return
+     * 
+     * @param user a {@see User} to check permission for
+     * @param categoryOption a {@see CategoryOptionCombo} object
+     * @return List of errors
      */
     List<String> canRead( User user, CategoryOptionCombo categoryOption );
 
     /**
      * Check if given User has DATA_WRITE access for give DataElementOperand
-     * @param user
-     * @param dataElementOperand
+     * 
+     * @param user a {@see User} to check permission for
+     * @param dataElementOperand a {@see DataElementOperand} object
      * @return List of errors
      */
     List<String> canWrite( User user, DataElementOperand dataElementOperand );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultAggregateAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultAggregateAccessManager.java
@@ -45,9 +45,10 @@ import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
@@ -58,15 +59,17 @@ public class DefaultAggregateAccessManager
 {
     private static Cache<List<String>> CAN_DATA_WRITE_COC_CACHE;
     
-
     private final AclService aclService;
 
-    @Autowired
-    private Environment env;
+    private final Environment env;
 
-    public DefaultAggregateAccessManager( AclService aclService )
+    public DefaultAggregateAccessManager( AclService aclService, Environment env )
     {
+        checkNotNull( aclService );
+        checkNotNull( env );
+
         this.aclService = aclService;
+        this.env = env;
     }
 
     // ---------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeService.java
@@ -79,21 +79,17 @@ import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.render.DefaultRenderService;
 import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
-import org.hisp.dhis.system.callable.CategoryOptionComboAclCallable;
-import org.hisp.dhis.system.callable.IdentifiableObjectCallable;
-import org.hisp.dhis.system.callable.PeriodCallable;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.quick.BatchHandler;
 import org.hisp.quick.BatchHandlerFactory;
 import org.hisp.staxwax.factory.XMLFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.ImmutableSet;
 import org.springframework.stereotype.Service;
@@ -116,50 +112,60 @@ public class DefaultCompleteDataSetRegistrationExchangeService
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @Autowired
-    private CompleteDataSetRegistrationExchangeStore cdsrStore;
+    private final CompleteDataSetRegistrationExchangeStore cdsrStore;
 
-    @Autowired
-    private IdentifiableObjectManager idObjManager;
+    private final IdentifiableObjectManager idObjManager;
 
-    @Autowired
-    private OrganisationUnitService orgUnitService;
+    private final OrganisationUnitService orgUnitService;
 
-    @Autowired
-    private Notifier notifier;
+    private final Notifier notifier;
 
-    @Autowired
-    private I18nManager i18nManager;
+    private final I18nManager i18nManager;
 
-    @Autowired
-    private BatchHandlerFactory batchHandlerFactory;
+    private final BatchHandlerFactory batchHandlerFactory;
 
-    @Autowired
-    private SystemSettingManager systemSettingManager;
+    private final SystemSettingManager systemSettingManager;
 
-    @Autowired
-    private CategoryService categoryService;
+    private final CategoryService categoryService;
 
-    @Autowired
-    private PeriodService periodService;
+    private final PeriodService periodService;
 
-    @Autowired
-    private CurrentUserService currentUserService;
+    private final CurrentUserService currentUserService;
 
-    @Autowired
-    private CompleteDataSetRegistrationService registrationService;
+    private final CompleteDataSetRegistrationService registrationService;
 
-    @Autowired
-    private InputUtils inputUtils;
+    private final InputUtils inputUtils;
 
-    @Autowired
-    private AggregateAccessManager accessManager;
+    private final AggregateAccessManager accessManager;
 
-    @Autowired
-    private DataSetNotificationEventPublisher notificationPublisher;
+    private final DataSetNotificationEventPublisher notificationPublisher;
 
-    @Autowired
-    private MessageService messageService;
+    private final MessageService messageService;
+
+    public DefaultCompleteDataSetRegistrationExchangeService( CompleteDataSetRegistrationExchangeStore cdsrStore,
+        IdentifiableObjectManager idObjManager, OrganisationUnitService orgUnitService, Notifier notifier,
+        I18nManager i18nManager, BatchHandlerFactory batchHandlerFactory, SystemSettingManager systemSettingManager,
+        CategoryService categoryService, PeriodService periodService, CurrentUserService currentUserService,
+        CompleteDataSetRegistrationService registrationService, InputUtils inputUtils,
+        AggregateAccessManager accessManager, DataSetNotificationEventPublisher notificationPublisher,
+        MessageService messageService )
+    {
+        this.cdsrStore = cdsrStore;
+        this.idObjManager = idObjManager;
+        this.orgUnitService = orgUnitService;
+        this.notifier = notifier;
+        this.i18nManager = i18nManager;
+        this.batchHandlerFactory = batchHandlerFactory;
+        this.systemSettingManager = systemSettingManager;
+        this.categoryService = categoryService;
+        this.periodService = periodService;
+        this.currentUserService = currentUserService;
+        this.registrationService = registrationService;
+        this.inputUtils = inputUtils;
+        this.accessManager = accessManager;
+        this.notificationPublisher = notificationPublisher;
+        this.messageService = messageService;
+    }
 
     // -------------------------------------------------------------------------
     // CompleteDataSetRegistrationService implementation
@@ -415,14 +421,15 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
         log.info( "Import options: " + importOptions );
 
-        ImportConfig cfg = new ImportConfig( completeRegistrations, importOptions );
+        ImportConfig cfg = new ImportConfig( this.systemSettingManager, this.categoryService, completeRegistrations, importOptions );
 
         // ---------------------------------------------------------------------
         // Set up meta-data
         // ---------------------------------------------------------------------
 
         MetaDataCaches caches = new MetaDataCaches();
-        MetaDataCallables metaDataCallables = new MetaDataCallables( cfg );
+        MetaDataCallables metaDataCallables = new MetaDataCallables( cfg, this.idObjManager, this.periodService,
+            this.categoryService );
 
         if ( importOptions.isPreheatCacheDefaultFalse() )
         {
@@ -498,19 +505,19 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
                 // Constraints validation
 
-                if ( config.strictAttrOptionCombos )
+                if ( config.isStrictAttrOptionCombos() )
                 {
                     validateAocMatchesDataSetCc( mdProps );
                 }
 
                 validateAttrOptCombo( mdProps, mdCaches, config );
 
-                if ( config.strictPeriods )
+                if ( config.isStrictPeriods() )
                 {
                     validateHasMatchingPeriodTypes( mdProps );
                 }
 
-                if ( config.strictOrgUnits )
+                if ( config.isStrictOrgUnits() )
                 {
                     validateDataSetIsAssignedToOrgUnit( mdProps );
                 }
@@ -560,6 +567,18 @@ public class DefaultCompleteDataSetRegistrationExchangeService
                 }
             }
 
+            // ---------------------------------------------------------------------
+            // Data Sharing check
+            // ---------------------------------------------------------------------
+
+            List<String> errors = validateDataAccess( currentUserService.getCurrentUser(), mdProps );
+            if ( !errors.isEmpty() )
+            {
+                summary.getConflicts().addAll(
+                    errors.stream().map( s -> new ImportConflict( "dataSet", s ) ).collect( Collectors.toList() ) );
+                continue;
+            }
+            
             // -----------------------------------------------------------------
             // Create complete data set registration
             // -----------------------------------------------------------------
@@ -567,25 +586,14 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             CompleteDataSetRegistration internalCdsr = createCompleteDataSetRegistration( cdsr, mdProps, now,
                 storedBy );
 
-            CompleteDataSetRegistration existingCdsr = config.skipExistingCheck ? null
+            CompleteDataSetRegistration existingCdsr = config.isSkipExistingCheck() ? null
                 : batchHandler.findObject( internalCdsr );
+            
+            ImportStrategy strategy = config.getStrategy();
 
-            // ---------------------------------------------------------------------
-            // Data Sharing check
-            // ---------------------------------------------------------------------
+            boolean isDryRun = config.isDryRun();
 
-            List<String> errors = accessManager.canWrite( currentUserService.getCurrentUser(), internalCdsr.getDataSet() );
-            if ( !errors.isEmpty() )
-            {
-                summary.getConflicts().addAll( errors.stream().map( s -> new ImportConflict( "dataSet", s ) ).collect( Collectors.toList() ) );
-                continue;
-            }
-
-            ImportStrategy strategy = config.strategy;
-
-            boolean isDryRun = config.dryRun;
-
-            if ( !config.skipExistingCheck && existingCdsr != null )
+            if ( !config.isSkipExistingCheck() && existingCdsr != null )
             {
                 // CDSR already exists
 
@@ -683,11 +691,23 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             date, storedBy, date, cdsr.getLastUpdatedBy(), cdsr.getCompleted() );
     }
 
+    /**
+     * Check write permission for {@see DataSet} and {@see CategoryOptionCombo}
+     * @param user currently logged-in user
+     * @param metaDataProperties {@see MetaDataProperties} containing the objects to check
+     */
+    private List<String> validateDataAccess( User user, MetaDataProperties metaDataProperties )
+    {
+        List<String> errors = accessManager.canWrite( user, metaDataProperties.dataSet );
+        errors.addAll( accessManager.canWrite( user, metaDataProperties.attrOptCombo ) );
+        return errors;
+    }
+
     private static void validateOrgUnitInUserHierarchy( MetaDataCaches mdCaches, MetaDataProperties mdProps,
         final Set<OrganisationUnit> userOrgUnits, String currentUsername )
         throws ImportConflictException
     {
-        boolean inUserHierarchy = mdCaches.orgUnitInHierarchyMap.get( mdProps.orgUnit.getUid(),
+        boolean inUserHierarchy = mdCaches.getOrgUnitInHierarchyMap().get( mdProps.orgUnit.getUid(),
             () -> mdProps.orgUnit.isDescendant( userOrgUnits ) );
 
         if ( !inUserHierarchy )
@@ -699,7 +719,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
     private void sendNotifications( ImportConfig config, CompleteDataSetRegistration registration )
     {
-        if ( !config.skipNotifications )
+        if ( !config.isSkipNotifications() )
         {
             if ( registration.getDataSet() != null  && registration.getDataSet().isNotifyCompletingUser() )
             {
@@ -717,7 +737,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
         if ( mdProps.attrOptCombo == null )
         {
-            if ( config.requireAttrOptionCombos )
+            if ( config.isRequireAttrOptionCombos() )
             {
                 throw new ImportConflictException( new ImportConflict( "Attribute option combo",
                     "Attribute option combo is required but is not specified" ) );
@@ -740,7 +760,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
         final String aocOrgUnitKey = aoc.getUid() + mdProps.orgUnit.getUid();
 
-        boolean isOrgUnitValidForAoc = mdCaches.attrOptComboOrgUnitMap.get( aocOrgUnitKey, () -> {
+        boolean isOrgUnitValidForAoc = mdCaches.getAttrOptComboOrgUnitMap().get( aocOrgUnitKey, () -> {
             Set<OrganisationUnit> aocOrgUnits = aoc.getOrganisationUnits();
             return aocOrgUnits == null || mdProps.orgUnit.isDescendant( aocOrgUnits );
         } );
@@ -808,39 +828,39 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
     private void heatCaches( MetaDataCaches caches, ImportConfig config )
     {
-        if ( !caches.dataSets.isCacheLoaded() && exceedsThreshold( caches.dataSets ) )
+        if ( !caches.getDataSets().isCacheLoaded() && exceedsThreshold( caches.getDataSets() ) )
         {
-            caches.dataSets.load( idObjManager.getAll( DataSet.class ), ds -> ds.getPropertyValue( config.dsScheme ) );
+            caches.getDataSets().load( idObjManager.getAll( DataSet.class ), ds -> ds.getPropertyValue( config.getDsScheme() ) );
 
             log.info( "Data set cache heated after cache miss threshold reached" );
         }
 
-        if ( !caches.orgUnits.isCacheLoaded() && exceedsThreshold( caches.orgUnits ) )
+        if ( !caches.getOrgUnits().isCacheLoaded() && exceedsThreshold( caches.getOrgUnits() ) )
         {
-            caches.orgUnits.load( idObjManager.getAll( OrganisationUnit.class ),
-                ou -> ou.getPropertyValue( config.ouScheme ) );
+            caches.getOrgUnits().load( idObjManager.getAll( OrganisationUnit.class ),
+                ou -> ou.getPropertyValue( config.getOuScheme() ) );
 
             log.info( "Org unit cache heated after cache miss threshold reached" );
         }
 
         // TODO Consider need for checking/re-heating attrOptCombo and period caches
 
-        if ( !caches.attrOptionCombos.isCacheLoaded() && exceedsThreshold( caches.attrOptionCombos ) )
+        if ( !caches.getAttrOptionCombos().isCacheLoaded() && exceedsThreshold( caches.getAttrOptionCombos() ) )
         {
-            caches.attrOptionCombos.load( idObjManager.getAll( CategoryOptionCombo.class ),
-                aoc -> aoc.getPropertyValue( config.aocScheme ) );
+            caches.getAttrOptionCombos().load( idObjManager.getAll( CategoryOptionCombo.class ),
+                aoc -> aoc.getPropertyValue( config.getAocScheme() ) );
 
             log.info( "Attribute option combo cache heated after cache miss threshold reached" );
         }
 
-        if ( !caches.periods.isCacheLoaded() && exceedsThreshold( caches.periods ) )
+        if ( !caches.getPeriods().isCacheLoaded() && exceedsThreshold( caches.getPeriods() ) )
         {
-            caches.periods.load( idObjManager.getAll( Period.class ), pe -> pe.getPropertyValue( null ) );
+            caches.getPeriods().load( idObjManager.getAll( Period.class ), pe -> pe.getPropertyValue( null ) );
         }
     }
 
-    public MetaDataProperties initMetaDataProperties(
-        org.hisp.dhis.dxf2.dataset.CompleteDataSetRegistration cdsr, MetaDataCallables callables, MetaDataCaches cache )
+    private MetaDataProperties initMetaDataProperties(
+            org.hisp.dhis.dxf2.dataset.CompleteDataSetRegistration cdsr, MetaDataCallables callables, MetaDataCaches cache)
     {
         String ds = StringUtils.trimToNull( cdsr.getDataSet() );
         String pe = StringUtils.trimToNull( cdsr.getPeriod() );
@@ -852,11 +872,10 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo( cdsr.getCc(), cdsr.getCp(), false );
             aoc = attributeOptionCombo != null ? attributeOptionCombo.getUid() : aoc;
         }
-
-        return new MetaDataProperties( cache.dataSets.get( ds, callables.dataSetCallable.setId( ds ) ),
-            cache.periods.get( pe, callables.periodCallable.setId( pe ) ),
-            cache.orgUnits.get( ou, callables.orgUnitCallable.setId( ou ) ),
-            cache.attrOptionCombos.get( aoc, callables.optionComboCallable.setId( aoc ) ) );
+        return new MetaDataProperties( cache.getDataSets().get( ds, callables.getDataSetCallable().setId( ds ) ),
+            cache.getPeriods().get( pe, callables.getPeriodCallable().setId( pe ) ),
+            cache.getOrgUnits().get( ou, callables.getOrgUnitCallable().setId( ou ) ),
+            cache.getAttrOptionCombos().get( aoc, callables.getOptionComboCallable().setId( aoc ) ) );
     }
 
     private static boolean exceedsThreshold( CachingMap<?, ?> cachingMap )
@@ -911,104 +930,16 @@ public class DefaultCompleteDataSetRegistrationExchangeService
 
             if ( attrOptCombo == null )
             {
-                if ( config.requireAttrOptionCombos )
+                if ( config.isRequireAttrOptionCombos() )
                 {
                     throw new ImportConflictException( new ImportConflict( "Attribute option combo",
                         "Attribute option combo is required but is not specified" ) );
                 }
                 else
                 {
-                    attrOptCombo = config.fallbackCatOptCombo;
+                    attrOptCombo = config.getFallbackCatOptCombo();
                 }
             }
-        }
-    }
-
-    private class MetaDataCallables
-    {
-        final IdentifiableObjectCallable<DataSet> dataSetCallable;
-
-        final IdentifiableObjectCallable<OrganisationUnit> orgUnitCallable;
-
-        final IdentifiableObjectCallable<CategoryOptionCombo> optionComboCallable;
-
-        final IdentifiableObjectCallable<Period> periodCallable;
-
-        MetaDataCallables( ImportConfig config )
-        {
-            dataSetCallable = new IdentifiableObjectCallable<>( idObjManager, DataSet.class, config.dsScheme, null );
-            orgUnitCallable = new IdentifiableObjectCallable<>( idObjManager, OrganisationUnit.class, config.ouScheme,
-                null );
-            optionComboCallable = new CategoryOptionComboAclCallable( categoryService, config.aocScheme, null );
-            periodCallable = new PeriodCallable( periodService, null, null );
-        }
-    }
-
-    private static class MetaDataCaches
-    {
-        CachingMap<String, DataSet> dataSets = new CachingMap<>();
-
-        CachingMap<String, OrganisationUnit> orgUnits = new CachingMap<>();
-
-        CachingMap<String, Period> periods = new CachingMap<>();
-
-        CachingMap<String, CategoryOptionCombo> attrOptionCombos = new CachingMap<>();
-
-        CachingMap<String, Boolean> orgUnitInHierarchyMap = new CachingMap<>();
-
-        CachingMap<String, Boolean> attrOptComboOrgUnitMap = new CachingMap<>();
-
-        void preheat( IdentifiableObjectManager manager, final ImportConfig config )
-        {
-            dataSets.load( manager.getAll( DataSet.class ), ds -> ds.getPropertyValue( config.dsScheme ) );
-            orgUnits.load( manager.getAll( OrganisationUnit.class ), ou -> ou.getPropertyValue( config.ouScheme ) );
-            attrOptionCombos.load( manager.getAll( CategoryOptionCombo.class ),
-                oc -> oc.getPropertyValue( config.aocScheme ) );
-        }
-    }
-
-    private class ImportConfig
-    {
-        IdScheme dsScheme, ouScheme, aocScheme;
-
-        ImportStrategy strategy;
-
-        boolean dryRun, skipExistingCheck, strictPeriods, strictAttrOptionCombos, strictOrgUnits,
-            requireAttrOptionCombos, skipNotifications;
-
-        CategoryOptionCombo fallbackCatOptCombo;
-
-        ImportConfig( CompleteDataSetRegistrations cdsr, ImportOptions options )
-        {
-            dsScheme = IdScheme.from( cdsr.getDataSetIdSchemeProperty() );
-            ouScheme = IdScheme.from( cdsr.getOrgUnitIdSchemeProperty() );
-            aocScheme = IdScheme.from( cdsr.getAttributeOptionComboIdSchemeProperty() );
-
-            log.info( String.format( "Data set scheme: %s, org unit scheme: %s, attribute option combo scheme: %s",
-                dsScheme, ouScheme, aocScheme ) );
-
-            strategy = cdsr.getStrategy() != null ? ImportStrategy.valueOf( cdsr.getStrategy() )
-                : options.getImportStrategy();
-
-            dryRun = cdsr.getDryRun() != null ? cdsr.getDryRun() : options.isDryRun();
-
-            skipNotifications = options.isSkipNotifications();
-
-            skipExistingCheck = options.isSkipExistingCheck();
-
-            strictPeriods = options.isStrictPeriods()
-                || (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS );
-
-            strictAttrOptionCombos = options.isStrictAttributeOptionCombos() || (Boolean) systemSettingManager
-                .getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS );
-
-            strictOrgUnits = options.isStrictOrganisationUnits()
-                || (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS );
-
-            requireAttrOptionCombos = options.isRequireAttributeOptionCombo() || (Boolean) systemSettingManager
-                .getSystemSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO );
-
-            fallbackCatOptCombo = categoryService.getDefaultCategoryOptionCombo();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/ImportConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/ImportConfig.java
@@ -1,0 +1,136 @@
+package org.hisp.dhis.dxf2.dataset;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+
+class ImportConfig
+{
+
+    private IdScheme dsScheme;
+
+    private IdScheme ouScheme;
+
+    private IdScheme aocScheme;
+
+    private ImportStrategy strategy;
+
+    private boolean dryRun;
+
+    private boolean skipExistingCheck;
+
+    private boolean strictPeriods;
+
+    private boolean strictAttrOptionCombos;
+
+    private boolean strictOrgUnits;
+
+    private boolean requireAttrOptionCombos;
+
+    private boolean skipNotifications;
+
+    private CategoryOptionCombo fallbackCatOptCombo;
+
+    private static final Log log = LogFactory.getLog( ImportConfig.class );
+
+    ImportConfig(SystemSettingManager systemSettingManager, CategoryService categoryService,
+                 CompleteDataSetRegistrations cdsr, ImportOptions options)
+    {
+        dsScheme = IdScheme.from( cdsr.getDataSetIdSchemeProperty() );
+        ouScheme = IdScheme.from( cdsr.getOrgUnitIdSchemeProperty() );
+        aocScheme = IdScheme.from( cdsr.getAttributeOptionComboIdSchemeProperty() );
+
+        log.info( String.format( "Data set scheme: %s, org unit scheme: %s, attribute option combo scheme: %s",
+            dsScheme, ouScheme, aocScheme ) );
+
+        strategy = cdsr.getStrategy() != null ? ImportStrategy.valueOf( cdsr.getStrategy() )
+            : options.getImportStrategy();
+
+        dryRun = cdsr.getDryRun() != null ? cdsr.getDryRun() : options.isDryRun();
+
+        skipNotifications = options.isSkipNotifications();
+
+        skipExistingCheck = options.isSkipExistingCheck();
+
+        strictPeriods = options.isStrictPeriods()
+            || (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS );
+
+        strictAttrOptionCombos = options.isStrictAttributeOptionCombos()
+            || (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS );
+
+        strictOrgUnits = options.isStrictOrganisationUnits()
+            || (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS );
+
+        requireAttrOptionCombos = options.isRequireAttributeOptionCombo()
+            || (Boolean) systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO );
+
+        fallbackCatOptCombo = categoryService.getDefaultCategoryOptionCombo();
+    }
+
+    IdScheme getDsScheme()
+    {
+        return dsScheme;
+    }
+
+    IdScheme getOuScheme()
+    {
+        return ouScheme;
+    }
+
+    IdScheme getAocScheme()
+    {
+        return aocScheme;
+    }
+
+    ImportStrategy getStrategy()
+
+    {
+        return strategy;
+    }
+
+    boolean isDryRun()
+    {
+        return dryRun;
+    }
+
+    boolean isSkipExistingCheck()
+    {
+        return skipExistingCheck;
+    }
+
+    boolean isStrictPeriods()
+    {
+        return strictPeriods;
+    }
+
+    boolean isStrictAttrOptionCombos()
+    {
+        return strictAttrOptionCombos;
+    }
+
+    boolean isStrictOrgUnits()
+    {
+        return strictOrgUnits;
+    }
+
+    boolean isRequireAttrOptionCombos()
+    {
+        return requireAttrOptionCombos;
+    }
+
+    boolean isSkipNotifications()
+    {
+        return skipNotifications;
+    }
+
+    CategoryOptionCombo getFallbackCatOptCombo()
+    {
+        return fallbackCatOptCombo;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/MetaDataCaches.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/MetaDataCaches.java
@@ -1,0 +1,62 @@
+package org.hisp.dhis.dxf2.dataset;
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.commons.collection.CachingMap;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+
+public class MetaDataCaches
+{
+    private CachingMap<String, DataSet> dataSets = new CachingMap<>();
+
+    private CachingMap<String, OrganisationUnit> orgUnits = new CachingMap<>();
+
+    private CachingMap<String, Period> periods = new CachingMap<>();
+
+    private CachingMap<String, CategoryOptionCombo> attrOptionCombos = new CachingMap<>();
+
+    private CachingMap<String, Boolean> orgUnitInHierarchyMap = new CachingMap<>();
+
+    private CachingMap<String, Boolean> attrOptComboOrgUnitMap = new CachingMap<>();
+
+    public void preheat( IdentifiableObjectManager manager,
+        final ImportConfig config )
+    {
+        dataSets.load( manager.getAll( DataSet.class ), ds -> ds.getPropertyValue( config.getDsScheme() ) );
+        orgUnits.load( manager.getAll( OrganisationUnit.class ), ou -> ou.getPropertyValue( config.getOuScheme() ) );
+        attrOptionCombos.load( manager.getAll( CategoryOptionCombo.class ),
+            oc -> oc.getPropertyValue( config.getAocScheme() ) );
+    }
+
+    public CachingMap<String, DataSet> getDataSets()
+    {
+        return dataSets;
+    }
+
+    public CachingMap<String, OrganisationUnit> getOrgUnits()
+    {
+        return orgUnits;
+    }
+
+    public CachingMap<String, Period> getPeriods()
+    {
+        return periods;
+    }
+
+    public CachingMap<String, CategoryOptionCombo> getAttrOptionCombos()
+    {
+        return attrOptionCombos;
+    }
+
+    public CachingMap<String, Boolean> getOrgUnitInHierarchyMap()
+    {
+        return orgUnitInHierarchyMap;
+    }
+
+    public CachingMap<String, Boolean> getAttrOptComboOrgUnitMap()
+    {
+        return attrOptComboOrgUnitMap;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/MetaDataCallables.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/MetaDataCallables.java
@@ -1,0 +1,53 @@
+package org.hisp.dhis.dxf2.dataset;
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.system.callable.CategoryOptionComboCallable;
+import org.hisp.dhis.system.callable.IdentifiableObjectCallable;
+import org.hisp.dhis.system.callable.PeriodCallable;
+
+class MetaDataCallables
+{
+    private final IdentifiableObjectCallable<DataSet> dataSetCallable;
+
+    private final IdentifiableObjectCallable<OrganisationUnit> orgUnitCallable;
+
+    private final IdentifiableObjectCallable<CategoryOptionCombo> optionComboCallable;
+
+    private final IdentifiableObjectCallable<Period> periodCallable;
+
+    MetaDataCallables( ImportConfig config, IdentifiableObjectManager idObjManager, PeriodService periodService,
+        CategoryService categoryService )
+    {
+        dataSetCallable = new IdentifiableObjectCallable<>( idObjManager, DataSet.class, config.getDsScheme(), null );
+        orgUnitCallable = new IdentifiableObjectCallable<>( idObjManager, OrganisationUnit.class, config.getOuScheme(),
+            null );
+        optionComboCallable = new CategoryOptionComboCallable( categoryService, config.getAocScheme(), null );
+        periodCallable = new PeriodCallable( periodService, null, null );
+    }
+
+    IdentifiableObjectCallable<DataSet> getDataSetCallable()
+    {
+        return dataSetCallable;
+    }
+
+    IdentifiableObjectCallable<OrganisationUnit> getOrgUnitCallable()
+    {
+        return orgUnitCallable;
+    }
+
+    IdentifiableObjectCallable<CategoryOptionCombo> getOptionComboCallable()
+    {
+        return optionComboCallable;
+    }
+
+    IdentifiableObjectCallable<Period> getPeriodCallable()
+    {
+        return periodCallable;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/utils/InputUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/utils/InputUtils.java
@@ -40,7 +40,6 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -57,17 +56,22 @@ public class InputUtils
 {
     private static Cache<Long> ATTR_OPTION_COMBO_ID_CACHE;
 
-    @Autowired
-    private CategoryService categoryService;
+    private final CategoryService categoryService;
 
-    @Autowired
-    private IdentifiableObjectManager idObjectManager;
+    private final IdentifiableObjectManager idObjectManager;
 
-    @Autowired
-    private Environment env;
+    private final Environment env;
     
-    @Autowired
-    private CacheProvider cacheProvider;
+    private final CacheProvider cacheProvider;
+
+    public InputUtils( CategoryService categoryService, IdentifiableObjectManager idObjectManager, Environment env,
+        CacheProvider cacheProvider )
+    {
+        this.categoryService = categoryService;
+        this.idObjectManager = idObjectManager;
+        this.env = env;
+        this.cacheProvider = cacheProvider;
+    }
 
     @PostConstruct
     public void init()
@@ -136,7 +140,7 @@ public class InputUtils
             throw new IllegalQueryException( "Illegal category combo identifier: " + cc );
         }
 
-        if ( categoryCombo == null && opts == null )
+        if ( categoryCombo == null )
         {
             if ( skipFallback )
             {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -1,0 +1,268 @@
+package org.hisp.dhis.dxf2.dataset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.cache.DefaultCacheProvider;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.commons.collection.CachingMap;
+import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.notifications.DataSetNotificationEventPublisher;
+import org.hisp.dhis.datavalue.DefaultAggregateAccessManager;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.dxf2.utils.InputUtils;
+import org.hisp.dhis.i18n.I18n;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.jdbc.batchhandler.CompleteDataSetRegistrationBatchHandler;
+import org.hisp.dhis.message.MessageService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.MonthlyPeriodType;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.notification.NotificationLevel;
+import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.quick.BatchHandler;
+import org.hisp.quick.BatchHandlerFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.env.Environment;
+
+import com.google.common.collect.Sets;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( DefaultCompleteDataSetRegistrationExchangeService.class )
+public class DefaultCompleteDataSetRegistrationExchangeServiceTest
+{
+
+    @Mock
+    private CompleteDataSetRegistrationExchangeStore cdsrStore;
+
+    @Mock
+    private IdentifiableObjectManager idObjManager;
+
+    @Mock
+    private OrganisationUnitService orgUnitService;
+
+    @Mock
+    private Notifier notifier;
+
+    @Mock
+    private I18nManager i18nManager;
+
+    @Mock
+    private BatchHandlerFactory batchHandlerFactory;
+
+    @Mock
+    private SystemSettingManager systemSettingManager;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PeriodService periodService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private CompleteDataSetRegistrationService registrationService;
+
+    @Mock
+    private DataSetNotificationEventPublisher notificationPublisher;
+
+    @Mock
+    private MessageService messageService;
+
+    @Mock
+    private I18n i18n;
+
+    @Mock
+    private BatchHandler batchHandler;
+
+    @Mock
+    private MetaDataCaches metaDataCaches;
+
+    // Cache mocks //
+
+    @Mock
+    private CachingMap<String, DataSet> datasetCache;
+
+    @Mock
+    private CachingMap<String, Period> periodCache;
+
+    @Mock
+    private CachingMap<String, OrganisationUnit> orgUnitCache;
+
+    @Mock
+    private CachingMap<String, Boolean> orgUnitInHierarchyCache;
+
+    @Mock
+    private CachingMap<String, Boolean> attrOptComboOrgUnitCache;
+
+    // this one is not a mock, because we are interested in triggering
+    // the actual fetching of the cache element from the database
+    private CachingMap<String, CategoryOptionCombo> aocCache;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private AclService aclService;
+
+    private User user;
+
+    private DefaultCompleteDataSetRegistrationExchangeService subject;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private CategoryOptionCombo DEFAULT_COC;
+
+    @Before
+    @SuppressWarnings( "unchecked" )
+    public void setUp()
+    {
+        user = new User();
+
+        when( environment.getActiveProfiles() ).thenReturn( new String[] { "test" } );
+        when( currentUserService.getCurrentUser() ).thenReturn( user );
+        CacheProvider cacheProvider = new DefaultCacheProvider();
+
+        InputUtils inputUtils = new InputUtils( categoryService, idObjManager, environment, cacheProvider );
+        inputUtils.init();
+
+        DefaultAggregateAccessManager aggregateAccessManager = new DefaultAggregateAccessManager( aclService,
+            environment );
+
+        subject = new DefaultCompleteDataSetRegistrationExchangeService( cdsrStore, idObjManager, orgUnitService,
+            notifier, i18nManager, batchHandlerFactory, systemSettingManager, categoryService, periodService,
+            currentUserService, registrationService, inputUtils, aggregateAccessManager, notificationPublisher,
+            messageService );
+
+        DEFAULT_COC = new CategoryOptionCombo();
+
+        when( notifier.clear( null ) ).thenReturn( notifier );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS ) ).thenReturn( false );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS ) )
+            .thenReturn( false );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS ) )
+            .thenReturn( false );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO ) )
+            .thenReturn( false );
+
+        when( currentUserService.getCurrentUsername() ).thenReturn( "john1" );
+        when( currentUserService.getCurrentUserOrganisationUnits() )
+            .thenReturn( Collections.singleton( createOrganisationUnit( 'A' ) ) );
+        when( i18nManager.getI18n() ).thenReturn( i18n );
+
+        when( categoryService.getDefaultCategoryOptionCombo() ).thenReturn( DEFAULT_COC );
+        when( batchHandlerFactory.createBatchHandler( CompleteDataSetRegistrationBatchHandler.class ) )
+            .thenReturn( batchHandler );
+        when( batchHandler.init() ).thenReturn( batchHandler );
+
+        // caches
+        when( metaDataCaches.getDataSets() ).thenReturn( datasetCache );
+        when( metaDataCaches.getPeriods() ).thenReturn( periodCache );
+        when( metaDataCaches.getOrgUnits() ).thenReturn( orgUnitCache );
+        aocCache = new CachingMap<>();
+        when( metaDataCaches.getAttrOptionCombos() ).thenReturn( aocCache );
+        when( metaDataCaches.getOrgUnitInHierarchyMap() ).thenReturn( orgUnitInHierarchyCache );
+        when( metaDataCaches.getAttrOptComboOrgUnitMap() ).thenReturn( attrOptComboOrgUnitCache );
+
+        //
+        when( notifier.notify( null, NotificationLevel.INFO, "Import done", true ) ).thenReturn( notifier );
+    }
+
+    @Test
+    public void verifyUserHasNoWritePermissionOnCategoryOption()
+        throws Exception
+    {
+        OrganisationUnit organisationUnit = createOrganisationUnit( 'A' );
+        DataSet dataSetA = createDataSet( 'A', new MonthlyPeriodType() );
+        CategoryCombo categoryCombo = createCategoryCombo( 'A' );
+        CategoryOption categoryOptionA = createCategoryOption( 'A' );
+        CategoryOption categoryOptionB = createCategoryOption( 'B' );
+        CategoryOptionCombo categoryOptionCombo = createCategoryOptionCombo( categoryCombo, categoryOptionA,
+            categoryOptionB );
+        Period period = createPeriod( "201907" );
+
+        String payload = cretePayload( period, organisationUnit, dataSetA, categoryCombo, categoryOptionA, categoryOptionB );
+
+        whenNew( MetaDataCaches.class ).withNoArguments().thenReturn( metaDataCaches );
+
+        when( idObjManager.get( CategoryCombo.class, categoryCombo.getUid() ) ).thenReturn( categoryCombo );
+        when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionA.getUid() ) )
+            .thenReturn( categoryOptionA );
+        when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionB.getUid() ) )
+            .thenReturn( categoryOptionB );
+
+        when( categoryService.getCategoryOptionCombo( categoryCombo,
+            Sets.newHashSet( categoryOptionA, categoryOptionB ) ) ).thenReturn( categoryOptionCombo );
+
+        when( datasetCache.get( eq( dataSetA.getUid() ), any() ) ).thenReturn( dataSetA );
+        when( periodCache.get( eq( period.getIsoDate() ), any() ) ).thenReturn( period );
+        when( orgUnitCache.get( eq( organisationUnit.getUid() ), any() ) ).thenReturn( createOrganisationUnit( 'A' ) );
+
+        when( orgUnitInHierarchyCache.get( eq( organisationUnit.getUid() ), any() ) ).thenReturn( Boolean.TRUE );
+        when( attrOptComboOrgUnitCache.get( eq( categoryOptionCombo.getUid() + organisationUnit.getUid() ), any() ) )
+            .thenReturn( Boolean.TRUE );
+        when( categoryService.getCategoryOptionCombo( categoryOptionCombo.getUid() ) )
+            .thenReturn( categoryOptionCombo );
+
+        // force error on access check for Category Option Combo
+        when( aclService.canDataWrite( user, dataSetA ) ).thenReturn( true );
+        when( aclService.canDataWrite( user, categoryOptionA ) ).thenReturn( false );
+        when( aclService.canDataWrite( user, categoryOptionB ) ).thenReturn( true );
+
+        // call method under test
+        ImportSummary summary = subject.saveCompleteDataSetRegistrationsJson(
+            new ByteArrayInputStream( payload.getBytes() ), new ImportOptions() );
+
+        assertThat( summary.getStatus(), is( ImportStatus.ERROR ) );
+        assertThat( summary.getImportCount().getIgnored(), is( 1 ) );
+        assertThat( summary.getConflicts(), hasSize( 1 ) );
+        assertThat( summary.getConflicts().iterator().next().getValue(),
+            is( "User has no data write access for CategoryOption: " + categoryOptionA.getUid() ) );
+    }
+
+    private String cretePayload( Period period, OrganisationUnit organisationUnit, DataSet dataSet,
+        CategoryCombo categoryCombo, CategoryOption... categoryOptions )
+    {
+        return "{\"completeDataSetRegistrations\":[{\"cc\":\"" + categoryCombo.getUid() + "\","
+            + "\"cp\":\"" + Arrays.stream( categoryOptions ).map( CategoryOption::getUid ).collect( Collectors.joining( ";" ) )
+            + "\"," + "\"dataSet\":\"" + dataSet.getUid() + "\"," + "\"period\":\"" + period.getIsoDate() + "\","
+            + "\"organisationUnit\":\"" + organisationUnit.getUid() + "\"," + "\"completed\":true}]}";
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -54,6 +54,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.core.env.Environment;
@@ -62,6 +63,7 @@ import com.google.common.collect.Sets;
 
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( DefaultCompleteDataSetRegistrationExchangeService.class )
+@PowerMockIgnore("javax.management.*")
 public class DefaultCompleteDataSetRegistrationExchangeServiceTest
 {
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/callable/CategoryOptionComboCallable.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/callable/CategoryOptionComboCallable.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.cache;
+package org.hisp.dhis.system.callable;
 
 /*
  * Copyright (c) 2004-2019, University of Oslo
@@ -28,22 +28,40 @@ package org.hisp.dhis.cache;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.concurrent.ExecutionException;
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdScheme;
+
 /**
- * Provides cache builder to build instances.
- * 
- * @author Ameen Mohamed
+ * Retrieves the category option combination with the given identifier and
+ * id scheme. Checks that the current user has {@code data write} access.
+ *
+ * @author Lars Helge Overland
  */
-public interface CacheProvider
+public class CategoryOptionComboCallable
+    extends IdentifiableObjectCallable<CategoryOptionCombo>
 {
-    /**
-     * Creates a new {@link ExtendedCacheBuilder} that can be used to build a cache that
-     * stores the valueType specified.
-     * 
-     * 
-     * @param valueType The class type of values to be stored in cache.
-     * @return A cache builder instance for the specified value type. Returns a
-     *         {@link ExtendedCacheBuilder}
-     */
-    <V> CacheBuilder<V> newCacheBuilder(Class<V> valueType);
-    
+    private CategoryService categoryService;
+
+    public CategoryOptionComboCallable(CategoryService categoryService, IdScheme idScheme, String id )
+    {
+        super( null, CategoryOptionCombo.class, idScheme, id );
+        this.categoryService = categoryService;
+    }
+
+    @Override
+    public CategoryOptionCombo call()
+        throws ExecutionException
+    {
+        return categoryService.getCategoryOptionCombo( id );
+    }
+
+    @Override
+    public CategoryOptionComboCallable setId(String id )
+    {
+        this.id = id;
+        return this;
+    }
 }


### PR DESCRIPTION
- DHIS-1534
- Refactored DefaultCompleteDataRegistrationExchangeService for simplifying
testing
- Add new method to fetch `CategoryOptionCombo` from `CategoryService`
- Added unit test

(cherry picked from commit 8fc69300a11d1967f0bade5eb63c192e0dcc5012)