### PR TITLE
add: bump cache2k version to 1.2.4

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1290,12 +1290,12 @@
       <dependency>
         <groupId>org.cache2k</groupId>
         <artifactId>cache2k-api</artifactId>
-        <version>1.2.3.Final</version>
+        <version>1.2.4.Final</version>
       </dependency>
       <dependency>
        <groupId>org.cache2k</groupId>
        <artifactId>cache2k-core</artifactId>
-       <version>1.2.3.Final</version>
+       <version>1.2.4.Final</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.jsmpp</groupId>


### PR DESCRIPTION
  Bumped cache2k to latest version to avoid stacktrace at application
startup (bug fixed in 1.2.4)

  https://github.com/cache2k/cache2k/issues/130