### PR TITLE
(2.33) Add username and password validation with http post

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -488,7 +488,42 @@ public class AccountController
     }
 
     @RequestMapping( value = "/username", method = RequestMethod.GET )
-    public void validateUserName( @RequestParam String username, HttpServletResponse response ) throws IOException
+    public void validateUserNameGet( @RequestParam String username, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validateUserName( username );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    @RequestMapping( value = "/validateUsername", method = RequestMethod.POST )
+    public void validateUserNameGetPost( @RequestParam String username, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validateUserName( username );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    @RequestMapping( value = "/password", method = RequestMethod.GET )
+    public void validatePasswordGet( @RequestParam String password, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validatePassword( password );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    @RequestMapping( value = "/validatePassword", method = RequestMethod.POST )
+    public void validatePasswordPost( @RequestParam String password, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validatePassword( password );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    // ---------------------------------------------------------------------
+    // Supportive methods
+    // ---------------------------------------------------------------------
+
+    private Map<String, String> validateUserName( String username )
     {
         boolean valid = username != null && userService.getUserCredentialsByUsername( username ) == null;
 
@@ -499,11 +534,10 @@ public class AccountController
         result.put( "response", valid ? "success" : "error" );
         result.put( "message", valid ? "" : "Username is already taken" );
 
-        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+        return result;
     }
 
-    @RequestMapping( value = "/password", method = RequestMethod.GET )
-    public void validatePassword( @RequestParam String password, HttpServletResponse response ) throws IOException
+    private Map<String, String> validatePassword( String password )
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( password, true );
 
@@ -516,12 +550,8 @@ public class AccountController
         result.put( "response", passwordValidationResult.isValid() ? "success" : "error" );
         result.put( "message", passwordValidationResult.isValid() ? "" : passwordValidationResult.getErrorMessage() );
 
-        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+        return result;
     }
-
-    // ---------------------------------------------------------------------
-    // Supportive methods
-    // ---------------------------------------------------------------------
 
     private void authenticate( String username, String rawPassword, Collection<GrantedAuthority> authorities, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/useraccount/account.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/useraccount/account.js
@@ -11,14 +11,17 @@ var validationRules = {
     username: {
       required: true,
       rangelength: [4, 80],
-      remote: "../../api/account/username"
+      remote: {
+            url: "../../api/account/validateUsername",
+            type: "post"}
     },
     password: {
       required: true,
       rangelength: [8, 40],
       password: true,
-      remote: "../../api/account/password"
-
+      remote: {
+            url: "../../api/account/validatePassword",
+            type: "post"}
     },
     retypePassword: {
       required: true,

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -138,6 +138,8 @@
     <sec:intercept-url pattern="/api/account/recovery" access="permitAll()" />
     <sec:intercept-url pattern="/api/account/restore" access="permitAll()" />
     <sec:intercept-url pattern="/api/account/password" access="permitAll()" />
+    <sec:intercept-url pattern="/api/account/validatePassword" method="POST" access="permitAll()" />
+    <sec:intercept-url pattern="/api/account/validateUsername" method="POST" access="permitAll()" />
     <sec:intercept-url pattern="/api/account" access="permitAll()" />
     <sec:intercept-url pattern="/api/staticContent/*" method="GET" access="permitAll()" />
     <sec:intercept-url pattern="/api/externalFileResources/*" method="GET" access="permitAll()" />


### PR DESCRIPTION
While user creation through self-registration or email invitation, username and password validation was performed via http get. A new endpoint has been added to use http post. 
Fix will be backported all the way till 2.29.

PR #3728