### PR TITLE
(2.30) Add username and password validation with http post

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
@@ -57,6 +57,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -66,6 +67,8 @@ import static org.junit.Assert.*;
  */
 public class ProgramRuleEngineTest extends DhisSpringTest
 {
+    private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat( "yyyy-MM-dd" );
+
     private Program programA;
 
     private Program programS;
@@ -181,6 +184,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
     private String ageExpression = "d2:yearsBetween(#{DOB}, V{event_date})";
 
+    private Date psEventDate;
+
     @Autowired
     ProgramRuleEngine programRuleEngine;
 
@@ -242,7 +247,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
     private ProgramNotificationTemplateStore programNotificationTemplateStore;
 
     @Override
-    public void setUpTest()
+    public void setUpTest() throws Exception
     {
         dataElementA = createDataElement( 'A', ValueType.TEXT, AggregationType.NONE, DataElementDomain.TRACKER );
         dataElementB = createDataElement( 'B', ValueType.TEXT, AggregationType.NONE, DataElementDomain.TRACKER );
@@ -264,6 +269,12 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         attributeService.addTrackedEntityAttribute( attributeA );
         attributeService.addTrackedEntityAttribute( attributeB );
+
+        Calendar cal = Calendar.getInstance();
+        cal.setTime( SIMPLE_DATE_FORMAT.parse( dob ) );
+        cal.add( Calendar.YEAR, 10 );
+
+        psEventDate = cal.getTime();
 
         setupEvents();
         setupProgramRuleEngine();
@@ -357,8 +368,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         List<RuleEffect> ruleEffects = programRuleEngine.evaluateEvent( programStageInstance );
 
         assertNotNull( ruleEffects );
-        assertFalse( ruleEffects.isEmpty() );
-        assertEquals( ruleEffects.get( 0 ).data(), "34" );
+        assertEquals( ruleEffects.get( 0 ).data(), "10" );
     }
 
     @Test
@@ -371,7 +381,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         List<RuleEffect> ruleEffects = programRuleEngine.evaluateEvent( programStageInstance );
 
         assertNotNull( ruleEffects );
-        assertEquals( ruleEffects.get( 0 ).data(), "34" );
+        assertEquals( ruleEffects.get( 0 ).data(), "10" );
     }
 
     private void setupEvents()
@@ -520,13 +530,13 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         programStageInstanceAge = new ProgramStageInstance( programInstanceA, programStageAge );
         programStageInstanceAge.setDueDate( enrollmentDate );
-        programStageInstanceAge.setExecutionDate( new Date() );
+        programStageInstanceAge.setExecutionDate( psEventDate );
         programStageInstanceAge.setUid( "UID-PS12" );
         programStageInstanceService.addProgramStageInstance( programStageInstanceAge );
 
         programStageInstanceDate = new ProgramStageInstance( programInstanceA, programStageAge );
         programStageInstanceDate.setDueDate( enrollmentDate );
-        programStageInstanceDate.setExecutionDate( new Date() );
+        programStageInstanceDate.setExecutionDate( psEventDate );
         programStageInstanceDate.setUid( "UID-PS13" );
         programStageInstanceService.addProgramStageInstance( programStageInstanceDate );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -487,7 +487,7 @@ public class AccountController
     }
 
     @RequestMapping( value = "/validateUsername", method = RequestMethod.POST )
-    public void validateUserNameGetPost( @RequestParam String username, HttpServletResponse response ) throws IOException
+    public void validateUserNamePost( @RequestParam String username, HttpServletResponse response ) throws IOException
     {
         Map<String, String> result = validateUserName( username );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -479,7 +479,42 @@ public class AccountController
     }
 
     @RequestMapping( value = "/username", method = RequestMethod.GET )
-    public void validateUserName( @RequestParam String username, HttpServletResponse response ) throws IOException
+    public void validateUserNameGet( @RequestParam String username, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validateUserName( username );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    @RequestMapping( value = "/validateUsername", method = RequestMethod.POST )
+    public void validateUserNameGetPost( @RequestParam String username, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validateUserName( username );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    @RequestMapping( value = "/password", method = RequestMethod.GET )
+    public void validatePasswordGet( @RequestParam String password, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validatePassword( password );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    @RequestMapping( value = "/validatePassword", method = RequestMethod.POST )
+    public void validatePasswordPost( @RequestParam String password, HttpServletResponse response ) throws IOException
+    {
+        Map<String, String> result = validatePassword( password );
+
+        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+    }
+
+    // ---------------------------------------------------------------------
+    // Supportive methods
+    // ---------------------------------------------------------------------
+
+    private Map<String, String> validateUserName( String username )
     {
         boolean valid = username != null && userService.getUserCredentialsByUsername( username ) == null;
 
@@ -490,11 +525,10 @@ public class AccountController
         result.put( "response", valid ? "success" : "error" );
         result.put( "message", valid ? "" : "Username is already taken" );
 
-        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+        return result;
     }
 
-    @RequestMapping( value = "/password", method = RequestMethod.GET )
-    public void validatePassword( @RequestParam String password, HttpServletResponse response ) throws IOException
+    private Map<String, String> validatePassword( String password )
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( password, true );
 
@@ -507,12 +541,8 @@ public class AccountController
         result.put( "response", passwordValidationResult.isValid() ? "success" : "error" );
         result.put( "message", passwordValidationResult.isValid() ? "" : passwordValidationResult.getErrorMessage() );
 
-        ContextUtils.okResponse( response, objectMapper.writeValueAsString( result ) );
+        return result;
     }
-
-    // ---------------------------------------------------------------------
-    // Supportive methods
-    // ---------------------------------------------------------------------
 
     private void authenticate( String username, String rawPassword, Collection<GrantedAuthority> authorities, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/useraccount/account.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/useraccount/account.js
@@ -11,14 +11,17 @@ var validationRules = {
     username: {
       required: true,
       rangelength: [4, 80],
-      remote: "../../api/account/username"
+      remote: {
+            url: "../../api/account/validateUsername",
+            type: "post"}
     },
     password: {
       required: true,
       rangelength: [8, 40],
       password: true,
-      remote: "../../api/account/password"
-
+      remote: {
+            url: "../../api/account/validatePassword",
+            type: "post"}
     },
     retypePassword: {
       required: true,

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -138,6 +138,8 @@
     <sec:intercept-url pattern="/api/account/recovery" access="permitAll()" />
     <sec:intercept-url pattern="/api/account/restore" access="permitAll()" />
     <sec:intercept-url pattern="/api/account/password" access="permitAll()" />
+    <sec:intercept-url pattern="/api/account/validatePassword" method="POST" access="permitAll()" />
+    <sec:intercept-url pattern="/api/account/validateUsername" method="POST" access="permitAll()" />
     <sec:intercept-url pattern="/api/account" access="permitAll()" />
     <sec:intercept-url pattern="/api/staticContent/*" method="GET" access="permitAll()" />
     <sec:intercept-url pattern="/api/externalFileResources/*" method="GET" access="permitAll()" />


### PR DESCRIPTION
While user creation through self-registration or email invitation, username and password validation was performed via http get. A new endpoint has been added to use http post. 
Fix will be backported all the way till 2.29.

PR #3728