### PR TITLE
fix: use program owner OU instead of registration ou when querying teis (master)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
@@ -99,6 +100,9 @@ public class DefaultProgramInstanceService
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;
+    
+    @Autowired
+    private TrackerOwnershipManager trackerOwnershipAccessManager;
 
     @Autowired
     private ProgramInstanceAuditService programInstanceAuditService;
@@ -526,6 +530,13 @@ public class DefaultProgramInstanceService
             incidentDate, organisationUnit, uid );
         addProgramInstance( programInstance );
 
+        // ---------------------------------------------------------------------
+        // Add program owner and overwrite if already exists.
+        // ---------------------------------------------------------------------
+
+        trackerOwnershipAccessManager.assignOwnership( trackedEntityInstance, program, organisationUnit, true, true );
+
+        
         // -----------------------------------------------------------------
         // Send enrollment notifications (if any)
         // -----------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -153,6 +153,7 @@ public class HibernateTrackedEntityInstanceStore
             .replaceFirst( "inner join fetch tei.programInstances", "inner join tei.programInstances" )
             .replaceFirst( "inner join fetch pi.programStageInstances", "inner join pi.programStageInstances" )
             .replaceFirst( "inner join fetch psi.assignedUser", "inner join psi.assignedUser" )
+            .replaceFirst( "inner join fetch tei.programOwners", "inner join tei.programOwners" )
             .replaceFirst( "order by case when pi.status = 'ACTIVE' then 1 when pi.status = 'COMPLETED' then 2 else 3 end asc, tei.lastUpdated desc ", "" )
             .replaceFirst( "order by tei.lastUpdated desc ", "" );
     }
@@ -162,10 +163,18 @@ public class HibernateTrackedEntityInstanceStore
         SqlHelper hlp = new SqlHelper( true );
 
         String hql = "select tei from TrackedEntityInstance tei ";
+        
+        //Used for switing between registration org unit or ownership org unit. Default source is registration ou.
+        String teiOuSource = "tei.organisationUnit";
+
 
         if ( params.hasProgram() )
         {
             hql += "inner join fetch tei.programInstances as pi ";
+            
+            //Joining program owners and using that as tei ou source
+            hql += "inner join fetch tei.programOwners as po ";
+            teiOuSource = "po.organisationUnit";
 
             if ( params.hasFilterForEvents() )
             {
@@ -179,6 +188,8 @@ public class HibernateTrackedEntityInstanceStore
                 hql += hlp.whereAnd() + getEventWhereClauseHql( params );
 
             }
+            
+            hql += hlp.whereAnd() + " po.program.uid = '" + params.getProgram().getUid() + "'";
 
             hql += hlp.whereAnd() + " pi.program.uid = '" + params.getProgram().getUid() + "'";
 
@@ -280,7 +291,7 @@ public class HibernateTrackedEntityInstanceStore
 
                 for ( OrganisationUnit organisationUnit : params.getOrganisationUnits() )
                 {
-                    ouClause += orHlp.or() + "tei.organisationUnit.path LIKE '" + organisationUnit.getPath() + "%'";
+                    ouClause += orHlp.or() + teiOuSource + ".path LIKE '" + organisationUnit.getPath() + "%'";
                 }
 
                 ouClause += ")";
@@ -289,7 +300,7 @@ public class HibernateTrackedEntityInstanceStore
             }
             else
             {
-                hql += hlp.whereAnd() + "tei.organisationUnit.uid in (" + getQuotedCommaDelimitedString( getUids( params.getOrganisationUnits() ) ) + ")";
+                hql += hlp.whereAnd() + teiOuSource + ".uid in (" + getQuotedCommaDelimitedString( getUids( params.getOrganisationUnits() ) ) + ")";
             }
         }
 
@@ -479,8 +490,16 @@ public class HibernateTrackedEntityInstanceStore
         String sql = "from trackedentityinstance tei "
             + "inner join trackedentitytype te on tei.trackedentitytypeid = te.trackedentitytypeid ";
 
+        String teiOuSource = "tei.organisationunitid";
+
+        
         if ( params.hasProgram() )
         {
+            //Using program owner OU instead of registration OU.
+            sql += "inner join (select trackedentityinstanceid, organisationunitid from trackedentityprogramowner where programid = ";
+            sql += params.getProgram().getId() + ") as tepo ON tei.trackedentityinstanceid = tepo.trackedentityinstanceid ";
+            teiOuSource = "tepo.organisationunitid";
+            
             sql += "inner join ("
                 + "select trackedentityinstanceid, min(case when status='ACTIVE' then 0 when status='COMPLETED' then 1 else 2 end) as status "
                 + "from programinstance pi ";
@@ -539,7 +558,7 @@ public class HibernateTrackedEntityInstanceStore
             sql += " group by trackedentityinstanceid ) as en on tei.trackedentityinstanceid = en.trackedentityinstanceid ";
         }
 
-        sql += "inner join organisationunit ou on tei.organisationunitid = ou.organisationunitid ";
+        sql += "inner join organisationunit ou on " + teiOuSource + " = ou.organisationunitid ";
 
         for ( QueryItem item : params.getAttributesAndFilters() )
         {
@@ -593,7 +612,7 @@ public class HibernateTrackedEntityInstanceStore
         }
         else // SELECTED (default)
         {
-            sql += hlp.whereAnd() + " tei.organisationunitid in ("
+            sql += hlp.whereAnd() + " " + teiOuSource + " in ("
                 + getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) ) + ") ";
         }
 


### PR DESCRIPTION
This PR modifies the sql/hql when querying teis with specific org units specified. 
1. If program is specified, teis are filtered based on program owner OUs.
2. If program is not specified, teis are filtered based on the registration OUs