### PR TITLE
[DHIS2-7658][2.32] Tracker 1-1-1 performance improvements

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -230,7 +230,7 @@ public class HibernateProgramInstanceStore
     @Override
     public List<String> getUidsIncludingDeleted( List<String> uids )
     {
-        String hql = "select te.uid from TrackedEntityInstance as te where te.uid in (:uids)";
+        String hql = "select pi.uid from ProgramInstance as pi where pi.uid in (:uids)";
         List<String> resultUids = new ArrayList<>();
         List<List<String>> uidsPartitions = Lists.partition( Lists.newArrayList( uids ), 20000 );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -413,7 +413,6 @@ public abstract class AbstractEnrollmentService
         }
 
         ImportSummaries eventImportSummaries = eventService.processEventImport( events, importOptions, null );
-        System.err.println( "ev: " + eventImportSummaries );
         linkEventSummaries( importSummaries, eventImportSummaries, events );
 
         return importSummaries;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -400,7 +400,7 @@ public abstract class AbstractEnrollmentService
                 ImportSummary importSummary = addEnrollment( enrollment, importOptions, daoTrackedEntityInstance, false );
                 importSummaries.addImportSummary( importSummary );
 
-                if ( importSummary.getConflicts().isEmpty() )
+                if ( importSummary.isStatus( ImportStatus.SUCCESS ) )
                 {
                     events.addAll( enrollment.getEvents() );
                 }
@@ -413,6 +413,7 @@ public abstract class AbstractEnrollmentService
         }
 
         ImportSummaries eventImportSummaries = eventService.processEventImport( events, importOptions, null );
+        System.err.println( "ev: " + eventImportSummaries );
         linkEventSummaries( importSummaries, eventImportSummaries, events );
 
         return importSummaries;
@@ -660,7 +661,7 @@ public abstract class AbstractEnrollmentService
                 ImportSummary importSummary = updateEnrollment( enrollment, importOptions, false );
                 importSummaries.addImportSummary( importSummary );
 
-                if ( importSummary.getConflicts().isEmpty() )
+                if ( importSummary.isStatus( ImportStatus.SUCCESS ) )
                 {
                     events.addAll( enrollment.getEvents() );
                 }
@@ -936,6 +937,8 @@ public abstract class AbstractEnrollmentService
     private void linkEventSummaries( ImportSummaries importSummaries, ImportSummaries eventImportSummaries,
         List<Event> events )
     {
+        importSummaries.getImportSummaries().forEach( is -> is.setEvents( new ImportSummaries() ) );
+
         Map<String, List<Event>> eventsGroupedByEnrollment = events.stream()
             .filter( ev -> !StringUtils.isEmpty( ev.getEnrollment() ) )
             .collect( Collectors.groupingBy( Event::getEnrollment ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -375,7 +375,8 @@ public abstract class AbstractEnrollmentService
     }
 
     @Override
-    public ImportSummaries addEnrollments( List<Enrollment> enrollments, ImportOptions importOptions, org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance, boolean clearSession )
+    public ImportSummaries addEnrollments( List<Enrollment> enrollments, ImportOptions importOptions,
+        org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance, boolean clearSession )
     {
         importOptions = updateImportOptions( importOptions );
         ImportSummaries importSummaries = new ImportSummaries();
@@ -387,6 +388,7 @@ public abstract class AbstractEnrollmentService
             .collect( Collectors.toList() );
 
         List<List<Enrollment>> partitions = Lists.partition( validEnrollments, FLUSH_FREQUENCY );
+        List<Event> events = new ArrayList<>();
 
         for ( List<Enrollment> _enrollments : partitions )
         {
@@ -395,7 +397,13 @@ public abstract class AbstractEnrollmentService
 
             for ( Enrollment enrollment : _enrollments )
             {
-                importSummaries.addImportSummary( addEnrollment( enrollment, importOptions, daoTrackedEntityInstance ) );
+                ImportSummary importSummary = addEnrollment( enrollment, importOptions, daoTrackedEntityInstance, false );
+                importSummaries.addImportSummary( importSummary );
+
+                if ( importSummary.getConflicts().isEmpty() )
+                {
+                    events.addAll( enrollment.getEvents() );
+                }
             }
 
             if ( clearSession && enrollments.size() >= FLUSH_FREQUENCY )
@@ -403,6 +411,9 @@ public abstract class AbstractEnrollmentService
                 clearSession();
             }
         }
+
+        ImportSummaries eventImportSummaries = eventService.processEventImport( events, importOptions, null );
+        linkEventSummaries( importSummaries, eventImportSummaries, events );
 
         return importSummaries;
     }
@@ -429,7 +440,14 @@ public abstract class AbstractEnrollmentService
     }
 
     @Override
-    public ImportSummary addEnrollment( Enrollment enrollment, ImportOptions importOptions, org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance )
+    public ImportSummary addEnrollment( Enrollment enrollment, ImportOptions importOptions,
+        org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance )
+    {
+        return addEnrollment( enrollment, importOptions, daoTrackedEntityInstance, true );
+    }
+
+    private ImportSummary addEnrollment( Enrollment enrollment, ImportOptions importOptions,
+        org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance, boolean handleEvents )
     {
         importOptions = updateImportOptions( importOptions );
 
@@ -503,7 +521,19 @@ public abstract class AbstractEnrollmentService
         importSummary.setReference( programInstance.getUid() );
         importSummary.getImportCount().incrementImported();
 
-        importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        if ( handleEvents )
+        {
+            importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        }
+        else
+        {
+            for ( Event event : enrollment.getEvents() )
+            {
+                event.setEnrollment( enrollment.getEnrollment() );
+                event.setProgram( programInstance.getProgram().getUid() );
+                event.setTrackedEntityInstance( enrollment.getTrackedEntityInstance() );
+            }
+        }
 
         return importSummary;
     }
@@ -618,6 +648,7 @@ public abstract class AbstractEnrollmentService
         List<List<Enrollment>> partitions = Lists.partition( enrollments, FLUSH_FREQUENCY );
         importOptions = updateImportOptions( importOptions );
         ImportSummaries importSummaries = new ImportSummaries();
+        List<Event> events = new ArrayList<>();
 
         for ( List<Enrollment> _enrollments : partitions )
         {
@@ -626,7 +657,13 @@ public abstract class AbstractEnrollmentService
 
             for ( Enrollment enrollment : _enrollments )
             {
-                importSummaries.addImportSummary( updateEnrollment( enrollment, importOptions ) );
+                ImportSummary importSummary = updateEnrollment( enrollment, importOptions, false );
+                importSummaries.addImportSummary( importSummary );
+
+                if ( importSummary.getConflicts().isEmpty() )
+                {
+                    events.addAll( enrollment.getEvents() );
+                }
             }
 
             if ( clearSession && enrollments.size() >= FLUSH_FREQUENCY )
@@ -635,11 +672,19 @@ public abstract class AbstractEnrollmentService
             }
         }
 
+        ImportSummaries eventImportSummaries = eventService.processEventImport( events, importOptions, null );
+        linkEventSummaries( importSummaries, eventImportSummaries, events );
+
         return importSummaries;
     }
 
     @Override
     public ImportSummary updateEnrollment( Enrollment enrollment, ImportOptions importOptions )
+    {
+        return updateEnrollment( enrollment, importOptions, true );
+    }
+
+    private ImportSummary updateEnrollment( Enrollment enrollment, ImportOptions importOptions, boolean handleEvents )
     {
         importOptions = updateImportOptions( importOptions );
 
@@ -737,7 +782,19 @@ public abstract class AbstractEnrollmentService
         ImportSummary importSummary = new ImportSummary( enrollment.getEnrollment() ).incrementUpdated();
         importSummary.setReference( enrollment.getEnrollment() );
 
-        importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        if ( handleEvents )
+        {
+            importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        }
+        else
+        {
+            for ( Event event : enrollment.getEvents() )
+            {
+                event.setEnrollment( enrollment.getEnrollment() );
+                event.setProgram( programInstance.getProgram().getUid() );
+                event.setTrackedEntityInstance( enrollment.getTrackedEntityInstance() );
+            }
+        }
 
         return importSummary;
     }
@@ -875,6 +932,51 @@ public abstract class AbstractEnrollmentService
     // -------------------------------------------------------------------------
     // HELPERS
     // -------------------------------------------------------------------------
+
+    private void linkEventSummaries( ImportSummaries importSummaries, ImportSummaries eventImportSummaries,
+        List<Event> events )
+    {
+        Map<String, List<Event>> eventsGroupedByEnrollment = events.stream()
+            .filter( ev -> !StringUtils.isEmpty( ev.getEnrollment() ) )
+            .collect( Collectors.groupingBy( Event::getEnrollment ) );
+
+        Map<String, List<ImportSummary>> summariesGroupedByReference = importSummaries.getImportSummaries().stream()
+            .filter( ev -> !StringUtils.isEmpty( ev.getReference() ) )
+            .collect( Collectors.groupingBy( ImportSummary::getReference ) );
+
+        Map<String, List<ImportSummary>> eventSummariesGroupedByReference = eventImportSummaries.getImportSummaries().stream()
+            .filter( ev -> !StringUtils.isEmpty( ev.getReference() ) )
+            .collect( Collectors.groupingBy( ImportSummary::getReference ) );
+
+        for ( Map.Entry<String, List<Event>> set : eventsGroupedByEnrollment.entrySet() )
+        {
+            if ( !summariesGroupedByReference.containsKey( set.getKey() ) )
+            {
+                continue;
+            }
+
+            ImportSummary importSummary = summariesGroupedByReference.get( set.getKey() ).get( 0 );
+            ImportSummaries eventSummaries = new ImportSummaries();
+
+            for ( Event event : set.getValue() )
+            {
+                if ( !eventSummariesGroupedByReference.containsKey( event.getEvent() ) )
+                {
+                    continue;
+                }
+
+                ImportSummary enrollmentSummary = eventSummariesGroupedByReference.get( event.getEvent() ).get( 0 );
+                eventSummaries.addImportSummary( enrollmentSummary );
+            }
+
+            if ( eventImportSummaries.getImportSummaries().isEmpty() )
+            {
+                continue;
+            }
+
+            importSummary.setEvents( eventSummaries );
+        }
+    }
 
     private ImportSummaries handleEvents( Enrollment enrollment, ProgramInstance programInstance, ImportOptions importOptions )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/EnrollmentService.java
@@ -73,6 +73,8 @@ public interface EnrollmentService
     // CREATE
     // -------------------------------------------------------------------------
 
+    ImportSummaries addEnrollmentList( List<Enrollment> enrollments, ImportOptions importOptions );
+
     ImportSummaries addEnrollmentsJson( InputStream inputStream, ImportOptions importOptions ) throws IOException;
 
     ImportSummaries addEnrollmentsXml( InputStream inputStream, ImportOptions importOptions ) throws IOException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
@@ -202,7 +202,8 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
         return enrollments;
     }
 
-    private ImportSummaries addEnrollmentList( List<Enrollment> enrollments, ImportOptions importOptions )
+    @Override
+    public ImportSummaries addEnrollmentList( List<Enrollment> enrollments, ImportOptions importOptions )
     {
         ImportSummaries importSummaries = new ImportSummaries();
         importOptions = updateImportOptions( importOptions );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -784,15 +784,15 @@ public abstract class AbstractTrackedEntityInstanceService
         importSummaries.getImportSummaries().forEach( is -> is.setEnrollments( new ImportSummaries() ) );
 
         Map<String, List<Enrollment>> enrollmentsGroupedByTe = enrollments.stream()
-            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
+            .filter( en -> !StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
             .collect( Collectors.groupingBy( Enrollment::getTrackedEntityInstance ) );
 
         Map<String, List<ImportSummary>> summariesGroupedByReference = importSummaries.getImportSummaries().stream()
-            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getReference() ) )
+            .filter( en -> !StringUtils.isEmpty( en.getReference() ) )
             .collect( Collectors.groupingBy( ImportSummary::getReference ) );
 
         Map<String, List<ImportSummary>> enrollmentSummariesGroupedByReference = enrollmentImportSummaries.getImportSummaries().stream()
-            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getReference() ) )
+            .filter( en -> !StringUtils.isEmpty( en.getReference() ) )
             .collect( Collectors.groupingBy( ImportSummary::getReference ) );
 
         for ( Map.Entry<String, List<Enrollment>> set : enrollmentsGroupedByTe.entrySet() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -177,7 +177,7 @@ public abstract class AbstractTrackedEntityInstanceService
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityInstanceParams params, boolean skipAccessValidation )
     {
@@ -237,7 +237,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public int getTrackedEntityInstanceCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation,
         boolean skipSearchScopeValidation )
     {
@@ -245,21 +245,21 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance( String uid )
     {
         return getTrackedEntityInstance( teiService.getTrackedEntityInstance( uid ) );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance( String uid, TrackedEntityInstanceParams params )
     {
         return getTrackedEntityInstance( teiService.getTrackedEntityInstance( uid ), params );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance(
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance )
     {
@@ -267,7 +267,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance(
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance,
         TrackedEntityInstanceParams params )
@@ -276,7 +276,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance( org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance,
         TrackedEntityInstanceParams params, User user )
     {
@@ -298,7 +298,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     private org.hisp.dhis.trackedentity.TrackedEntityInstance createDAOTrackedEntityInstance(
-            TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions, ImportSummary importSummary)
+        TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions, ImportSummary importSummary )
     {
         if ( StringUtils.isEmpty( dtoEntityInstance.getOrgUnit() ) )
         {
@@ -400,7 +400,7 @@ public abstract class AbstractTrackedEntityInstanceService
                 ImportSummary importSummary = addTrackedEntityInstance( trackedEntityInstance, importOptions, false );
                 importSummaries.addImportSummary( importSummary );
 
-                if ( importSummary.getConflicts().isEmpty() )
+                if ( importSummary.isStatus( ImportStatus.SUCCESS ) )
                 {
                     enrollments.addAll( trackedEntityInstance.getEnrollments() );
                 }
@@ -542,7 +542,7 @@ public abstract class AbstractTrackedEntityInstanceService
                 ImportSummary importSummary = updateTrackedEntityInstance( trackedEntityInstance, null, importOptions, false, false );
                 importSummaries.addImportSummary( importSummary );
 
-                if ( importSummary.getConflicts().isEmpty() )
+                if ( importSummary.isStatus( ImportStatus.SUCCESS ) )
                 {
                     enrollments.addAll( trackedEntityInstance.getEnrollments() );
                 }
@@ -658,7 +658,7 @@ public abstract class AbstractTrackedEntityInstanceService
         importSummary.setReference( daoEntityInstance.getUid() );
         importSummary.getImportCount().incrementUpdated();
 
-        if ( singleUpdate && ( !importOptions.isIgnoreEmptyCollection() || !dtoEntityInstance.getRelationships().isEmpty() ))
+        if ( singleUpdate && (!importOptions.isIgnoreEmptyCollection() || !dtoEntityInstance.getRelationships().isEmpty()) )
         {
             importSummary.setRelationships( handleRelationships( dtoEntityInstance, daoEntityInstance, importOptions ) );
         }
@@ -781,6 +781,8 @@ public abstract class AbstractTrackedEntityInstanceService
     private void linkEnrollmentSummaries( ImportSummaries importSummaries, ImportSummaries enrollmentImportSummaries,
         List<Enrollment> enrollments )
     {
+        importSummaries.getImportSummaries().forEach( is -> is.setEnrollments( new ImportSummaries() ) );
+
         Map<String, List<Enrollment>> enrollmentsGroupedByTe = enrollments.stream()
             .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
             .collect( Collectors.groupingBy( Enrollment::getTrackedEntityInstance ) );
@@ -837,25 +839,25 @@ public abstract class AbstractTrackedEntityInstanceService
         List<Relationship> delete = new ArrayList<>( daoEntityInstance.getRelationshipItems().stream()
             .map( RelationshipItem::getRelationship )
 
-                // Remove items we cant write to
-                .filter(
-                    relationship -> trackerAccessManager.canWrite( importOptions.getUser(), relationship ).isEmpty() )
-                .filter(
-                    relationship -> relationship.getFrom().getTrackedEntityInstance().getUid().equals( daoEntityInstance.getUid() )
-                )
-                .map( org.hisp.dhis.relationship.Relationship::getUid )
+            // Remove items we cant write to
+            .filter(
+                relationship -> trackerAccessManager.canWrite( importOptions.getUser(), relationship ).isEmpty() )
+            .filter(
+                relationship -> relationship.getFrom().getTrackedEntityInstance().getUid().equals( daoEntityInstance.getUid() )
+            )
+            .map( org.hisp.dhis.relationship.Relationship::getUid )
 
-                // Remove items we are already referencing
-                .filter( ( uid ) -> !relationshipUids.contains( uid ) )
+            // Remove items we are already referencing
+            .filter( ( uid ) -> !relationshipUids.contains( uid ) )
 
-                // Create Relationships for these uids
-                .map( uid -> {
-                    Relationship relationship = new Relationship();
-                    relationship.setRelationship( uid );
-                    return relationship;
-                } )
+            // Create Relationships for these uids
+            .map( uid -> {
+                Relationship relationship = new Relationship();
+                relationship.setRelationship( uid );
+                return relationship;
+            } )
 
-                .collect( Collectors.toList() )
+            .collect( Collectors.toList() )
         );
 
         for ( Relationship relationship : dtoEntityInstance.getRelationships() )
@@ -882,7 +884,7 @@ public abstract class AbstractTrackedEntityInstanceService
 
                 if ( fromUid.equals( daoEntityInstance.getUid() ) )
                 {
-                    if ( _relationshipService.relationshipExists( relationship.getRelationship() ))
+                    if ( _relationshipService.relationshipExists( relationship.getRelationship() ) )
                     {
                         update.add( relationship );
                     }
@@ -1019,7 +1021,7 @@ public abstract class AbstractTrackedEntityInstanceService
 
         if ( program != null )
         {
-            for( TrackedEntityAttribute att : program.getTrackedEntityAttributes() )
+            for ( TrackedEntityAttribute att : program.getTrackedEntityAttributes() )
             {
                 TrackedEntityAttributeValue attVal = teiAttributeToValueMap.get( att.getUid() );
 
@@ -1192,7 +1194,7 @@ public abstract class AbstractTrackedEntityInstanceService
                 {
                     importConflicts.add( new ImportConflict( "Attribute.value",
                         String.format( "File resource with uid '%s' has already been assigned to a different object",
-                        attribute.getValue() ) ) );
+                            attribute.getValue() ) ) );
                 }
             }
         }


### PR DESCRIPTION
When import multiple TEIs, splits out enrollments/events into its own list so that caches can still be effective.