### PR TITLE
[DHIS2-7658][2.31] Tracker 1-1-1 performance improvements

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -230,7 +230,7 @@ public class HibernateProgramInstanceStore
     @Override
     public List<String> getUidsIncludingDeleted( List<String> uids )
     {
-        String hql = "select te.uid from TrackedEntityInstance as te where te.uid in (:uids)";
+        String hql = "select pi.uid from ProgramInstance as pi where pi.uid in (:uids)";
         List<String> resultUids = new ArrayList<>();
         List<List<String>> uidsPartitions = Lists.partition( Lists.newArrayList( uids ), 20000 );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -189,7 +189,7 @@ public abstract class AbstractEnrollmentService
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public Enrollments getEnrollments( ProgramInstanceQueryParams params )
     {
         Enrollments enrollments = new Enrollments();
@@ -220,7 +220,7 @@ public abstract class AbstractEnrollmentService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public List<Enrollment> getEnrollments( Iterable<ProgramInstance> programInstances )
     {
         List<Enrollment> enrollments = new ArrayList<>();
@@ -239,7 +239,7 @@ public abstract class AbstractEnrollmentService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public Enrollment getEnrollment( String id )
     {
         ProgramInstance programInstance = programInstanceService.getProgramInstance( id );
@@ -247,21 +247,21 @@ public abstract class AbstractEnrollmentService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public Enrollment getEnrollment( ProgramInstance programInstance )
     {
         return getEnrollment( currentUserService.getCurrentUser(), programInstance, TrackedEntityInstanceParams.FALSE, false );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public Enrollment getEnrollment( ProgramInstance programInstance, TrackedEntityInstanceParams params )
     {
         return getEnrollment( currentUserService.getCurrentUser(), programInstance, params, false );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public Enrollment getEnrollment( User user, ProgramInstance programInstance, TrackedEntityInstanceParams params, boolean skipOwnershipCheck )
     {
         Enrollment enrollment = new Enrollment();
@@ -386,7 +386,8 @@ public abstract class AbstractEnrollmentService
 
     @Override
     @Transactional
-    public ImportSummaries addEnrollments( List<Enrollment> enrollments, ImportOptions importOptions, org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance, boolean clearSession )
+    public ImportSummaries addEnrollments( List<Enrollment> enrollments, ImportOptions importOptions,
+        org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance, boolean clearSession )
     {
         importOptions = updateImportOptions( importOptions );
         ImportSummaries importSummaries = new ImportSummaries();
@@ -398,6 +399,7 @@ public abstract class AbstractEnrollmentService
             .collect( Collectors.toList() );
 
         List<List<Enrollment>> partitions = Lists.partition( validEnrollments, FLUSH_FREQUENCY );
+        List<Event> events = new ArrayList<>();
 
         for ( List<Enrollment> _enrollments : partitions )
         {
@@ -406,7 +408,13 @@ public abstract class AbstractEnrollmentService
 
             for ( Enrollment enrollment : _enrollments )
             {
-                importSummaries.addImportSummary( addEnrollment( enrollment, importOptions, daoTrackedEntityInstance ) );
+                ImportSummary importSummary = addEnrollment( enrollment, importOptions, daoTrackedEntityInstance, false );
+                importSummaries.addImportSummary( importSummary );
+
+                if ( importSummary.getConflicts().isEmpty() )
+                {
+                    events.addAll( enrollment.getEvents() );
+                }
             }
 
             if ( clearSession && enrollments.size() >= FLUSH_FREQUENCY )
@@ -414,6 +422,9 @@ public abstract class AbstractEnrollmentService
                 clearSession();
             }
         }
+
+        ImportSummaries eventImportSummaries = eventService.processEventImport( events, importOptions, null );
+        linkEventSummaries( importSummaries, eventImportSummaries, events );
 
         return importSummaries;
     }
@@ -442,7 +453,14 @@ public abstract class AbstractEnrollmentService
 
     @Override
     @Transactional
-    public ImportSummary addEnrollment( Enrollment enrollment, ImportOptions importOptions, org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance )
+    public ImportSummary addEnrollment( Enrollment enrollment, ImportOptions importOptions,
+        org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance )
+    {
+        return addEnrollment( enrollment, importOptions, daoTrackedEntityInstance, true );
+    }
+
+    private ImportSummary addEnrollment( Enrollment enrollment, ImportOptions importOptions,
+        org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance, boolean handleEvents )
     {
         importOptions = updateImportOptions( importOptions );
 
@@ -516,7 +534,19 @@ public abstract class AbstractEnrollmentService
         importSummary.setReference( programInstance.getUid() );
         importSummary.getImportCount().incrementImported();
 
-        importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        if ( handleEvents )
+        {
+            importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        }
+        else
+        {
+            for ( Event event : enrollment.getEvents() )
+            {
+                event.setEnrollment( enrollment.getEnrollment() );
+                event.setProgram( programInstance.getProgram().getUid() );
+                event.setTrackedEntityInstance( enrollment.getTrackedEntityInstance() );
+            }
+        }
 
         return importSummary;
     }
@@ -632,6 +662,7 @@ public abstract class AbstractEnrollmentService
         List<List<Enrollment>> partitions = Lists.partition( enrollments, FLUSH_FREQUENCY );
         importOptions = updateImportOptions( importOptions );
         ImportSummaries importSummaries = new ImportSummaries();
+        List<Event> events = new ArrayList<>();
 
         for ( List<Enrollment> _enrollments : partitions )
         {
@@ -640,7 +671,13 @@ public abstract class AbstractEnrollmentService
 
             for ( Enrollment enrollment : _enrollments )
             {
-                importSummaries.addImportSummary( updateEnrollment( enrollment, importOptions ) );
+                ImportSummary importSummary = updateEnrollment( enrollment, importOptions, false );
+                importSummaries.addImportSummary( importSummary );
+
+                if ( importSummary.getConflicts().isEmpty() )
+                {
+                    events.addAll( enrollment.getEvents() );
+                }
             }
 
             if ( clearSession && enrollments.size() >= FLUSH_FREQUENCY )
@@ -649,12 +686,20 @@ public abstract class AbstractEnrollmentService
             }
         }
 
+        ImportSummaries eventImportSummaries = eventService.processEventImport( events, importOptions, null );
+        linkEventSummaries( importSummaries, eventImportSummaries, events );
+
         return importSummaries;
     }
 
     @Override
     @Transactional
     public ImportSummary updateEnrollment( Enrollment enrollment, ImportOptions importOptions )
+    {
+        return updateEnrollment( enrollment, importOptions, true );
+    }
+
+    private ImportSummary updateEnrollment( Enrollment enrollment, ImportOptions importOptions, boolean handleEvents )
     {
         importOptions = updateImportOptions( importOptions );
 
@@ -752,7 +797,19 @@ public abstract class AbstractEnrollmentService
         ImportSummary importSummary = new ImportSummary( enrollment.getEnrollment() ).incrementUpdated();
         importSummary.setReference( enrollment.getEnrollment() );
 
-        importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        if ( handleEvents )
+        {
+            importSummary.setEvents( handleEvents( enrollment, programInstance, importOptions ) );
+        }
+        else
+        {
+            for ( Event event : enrollment.getEvents() )
+            {
+                event.setEnrollment( enrollment.getEnrollment() );
+                event.setProgram( programInstance.getProgram().getUid() );
+                event.setTrackedEntityInstance( enrollment.getTrackedEntityInstance() );
+            }
+        }
 
         return importSummary;
     }
@@ -896,6 +953,51 @@ public abstract class AbstractEnrollmentService
     // -------------------------------------------------------------------------
     // HELPERS
     // -------------------------------------------------------------------------
+
+    private void linkEventSummaries( ImportSummaries importSummaries, ImportSummaries eventImportSummaries,
+        List<Event> events )
+    {
+        Map<String, List<Event>> eventsGroupedByEnrollment = events.stream()
+            .filter( ev -> !StringUtils.isEmpty( ev.getEnrollment() ) )
+            .collect( Collectors.groupingBy( Event::getEnrollment ) );
+
+        Map<String, List<ImportSummary>> summariesGroupedByReference = importSummaries.getImportSummaries().stream()
+            .filter( ev -> !StringUtils.isEmpty( ev.getReference() ) )
+            .collect( Collectors.groupingBy( ImportSummary::getReference ) );
+
+        Map<String, List<ImportSummary>> eventSummariesGroupedByReference = eventImportSummaries.getImportSummaries().stream()
+            .filter( ev -> !StringUtils.isEmpty( ev.getReference() ) )
+            .collect( Collectors.groupingBy( ImportSummary::getReference ) );
+
+        for ( Map.Entry<String, List<Event>> set : eventsGroupedByEnrollment.entrySet() )
+        {
+            if ( !summariesGroupedByReference.containsKey( set.getKey() ) )
+            {
+                continue;
+            }
+
+            ImportSummary importSummary = summariesGroupedByReference.get( set.getKey() ).get( 0 );
+            ImportSummaries eventSummaries = new ImportSummaries();
+
+            for ( Event event : set.getValue() )
+            {
+                if ( !eventSummariesGroupedByReference.containsKey( event.getEvent() ) )
+                {
+                    continue;
+                }
+
+                ImportSummary enrollmentSummary = eventSummariesGroupedByReference.get( event.getEvent() ).get( 0 );
+                eventSummaries.addImportSummary( enrollmentSummary );
+            }
+
+            if ( eventImportSummaries.getImportSummaries().isEmpty() )
+            {
+                continue;
+            }
+
+            importSummary.setEvents( eventSummaries );
+        }
+    }
 
     private ImportSummaries handleEvents( Enrollment enrollment, ProgramInstance programInstance, ImportOptions importOptions )
     {
@@ -1251,7 +1353,7 @@ public abstract class AbstractEnrollmentService
         return importOptions;
     }
 
-    private void reloadUser(ImportOptions importOptions)
+    private void reloadUser( ImportOptions importOptions )
     {
         if ( importOptions == null || importOptions.getUser() == null )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -957,6 +957,8 @@ public abstract class AbstractEnrollmentService
     private void linkEventSummaries( ImportSummaries importSummaries, ImportSummaries eventImportSummaries,
         List<Event> events )
     {
+        importSummaries.getImportSummaries().forEach( is -> is.setEvents( new ImportSummaries() ) );
+
         Map<String, List<Event>> eventsGroupedByEnrollment = events.stream()
             .filter( ev -> !StringUtils.isEmpty( ev.getEnrollment() ) )
             .collect( Collectors.groupingBy( Event::getEnrollment ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/EnrollmentService.java
@@ -73,6 +73,8 @@ public interface EnrollmentService
     // CREATE
     // -------------------------------------------------------------------------
 
+    ImportSummaries addEnrollmentList( List<Enrollment> enrollments, ImportOptions importOptions );
+
     ImportSummaries addEnrollmentsJson( InputStream inputStream, ImportOptions importOptions ) throws IOException;
 
     ImportSummaries addEnrollmentsXml( InputStream inputStream, ImportOptions importOptions ) throws IOException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
@@ -202,7 +202,8 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
         return enrollments;
     }
 
-    private ImportSummaries addEnrollmentList( List<Enrollment> enrollments, ImportOptions importOptions )
+    @Override
+    public ImportSummaries addEnrollmentList( List<Enrollment> enrollments, ImportOptions importOptions )
     {
         ImportSummaries importSummaries = new ImportSummaries();
         importOptions = updateImportOptions( importOptions );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -28,18 +28,8 @@ package org.hisp.dhis.dxf2.events.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Geometry;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -97,8 +87,17 @@ import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.collect.Lists;
-import com.vividsolutions.jts.geom.Geometry;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -178,7 +177,7 @@ public abstract class AbstractTrackedEntityInstanceService
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityInstanceParams params, boolean skipAccessValidation )
     {
@@ -241,7 +240,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public int getTrackedEntityInstanceCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation,
         boolean skipSearchScopeValidation )
     {
@@ -249,21 +248,21 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance( String uid )
     {
         return getTrackedEntityInstance( teiService.getTrackedEntityInstance( uid ) );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance( String uid, TrackedEntityInstanceParams params )
     {
         return getTrackedEntityInstance( teiService.getTrackedEntityInstance( uid ), params );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance(
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance )
     {
@@ -271,7 +270,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance(
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance,
         TrackedEntityInstanceParams params )
@@ -280,7 +279,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional( readOnly = true )
     public TrackedEntityInstance getTrackedEntityInstance( org.hisp.dhis.trackedentity.TrackedEntityInstance daoTrackedEntityInstance,
         TrackedEntityInstanceParams params, User user )
     {
@@ -302,7 +301,7 @@ public abstract class AbstractTrackedEntityInstanceService
     }
 
     private org.hisp.dhis.trackedentity.TrackedEntityInstance createDAOTrackedEntityInstance(
-            TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions, ImportSummary importSummary)
+        TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions, ImportSummary importSummary )
     {
         if ( StringUtils.isEmpty( dtoEntityInstance.getOrgUnit() ) )
         {
@@ -662,7 +661,7 @@ public abstract class AbstractTrackedEntityInstanceService
         importSummary.setReference( daoEntityInstance.getUid() );
         importSummary.getImportCount().incrementUpdated();
 
-        if ( singleUpdate && ( !importOptions.isIgnoreEmptyCollection() || !dtoEntityInstance.getRelationships().isEmpty() ))
+        if ( singleUpdate && (!importOptions.isIgnoreEmptyCollection() || !dtoEntityInstance.getRelationships().isEmpty()) )
         {
             importSummary.setRelationships( handleRelationships( dtoEntityInstance, daoEntityInstance, importOptions ) );
         }
@@ -785,6 +784,8 @@ public abstract class AbstractTrackedEntityInstanceService
     private void linkEnrollmentSummaries( ImportSummaries importSummaries, ImportSummaries enrollmentImportSummaries,
         List<Enrollment> enrollments )
     {
+        importSummaries.getImportSummaries().forEach( is -> is.setEnrollments( new ImportSummaries() ) );
+
         Map<String, List<Enrollment>> enrollmentsGroupedByTe = enrollments.stream()
             .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
             .collect( Collectors.groupingBy( Enrollment::getTrackedEntityInstance ) );
@@ -875,7 +876,7 @@ public abstract class AbstractTrackedEntityInstanceService
                 String fromUid = relationship.getFrom().getTrackedEntityInstance().getTrackedEntityInstance();
                 if ( fromUid.equals( daoEntityInstance.getUid() ) )
                 {
-                    if ( _relationshipService.relationshipExists( relationship.getRelationship() ))
+                    if ( _relationshipService.relationshipExists( relationship.getRelationship() ) )
                     {
                         update.add( relationship );
                     }
@@ -1010,7 +1011,7 @@ public abstract class AbstractTrackedEntityInstanceService
 
         if ( program != null )
         {
-            for( TrackedEntityAttribute att : program.getTrackedEntityAttributes() )
+            for ( TrackedEntityAttribute att : program.getTrackedEntityAttributes() )
             {
                 TrackedEntityAttributeValue attVal = teiAttributeToValueMap.get( att.getUid() );
 
@@ -1290,7 +1291,7 @@ public abstract class AbstractTrackedEntityInstanceService
         return importOptions;
     }
 
-    private void reloadUser(ImportOptions importOptions)
+    private void reloadUser( ImportOptions importOptions )
     {
         if ( importOptions == null || importOptions.getUser() == null )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -787,7 +787,7 @@ public abstract class AbstractTrackedEntityInstanceService
         importSummaries.getImportSummaries().forEach( is -> is.setEnrollments( new ImportSummaries() ) );
 
         Map<String, List<Enrollment>> enrollmentsGroupedByTe = enrollments.stream()
-            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
+            .filter( en -> !StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
             .collect( Collectors.groupingBy( Enrollment::getTrackedEntityInstance ) );
 
         Map<String, List<ImportSummary>> summariesGroupedByReference = importSummaries.getImportSummaries().stream()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -392,6 +392,7 @@ public abstract class AbstractTrackedEntityInstanceService
         List<List<TrackedEntityInstance>> partitions = Lists.partition( trackedEntityInstances, FLUSH_FREQUENCY );
         importOptions = updateImportOptions( importOptions );
         ImportSummaries importSummaries = new ImportSummaries();
+        List<Enrollment> enrollments = new ArrayList<>();
 
         for ( List<TrackedEntityInstance> _trackedEntityInstances : partitions )
         {
@@ -400,11 +401,20 @@ public abstract class AbstractTrackedEntityInstanceService
 
             for ( TrackedEntityInstance trackedEntityInstance : _trackedEntityInstances )
             {
-                importSummaries.addImportSummary( addTrackedEntityInstance( trackedEntityInstance, importOptions ) );
+                ImportSummary importSummary = addTrackedEntityInstance( trackedEntityInstance, importOptions, false );
+                importSummaries.addImportSummary( importSummary );
+
+                if ( importSummary.getConflicts().isEmpty() )
+                {
+                    enrollments.addAll( trackedEntityInstance.getEnrollments() );
+                }
             }
 
             clearSession();
         }
+
+        ImportSummaries enrollmentImportSummaries = enrollmentService.addEnrollmentList( enrollments, importOptions );
+        linkEnrollmentSummaries( importSummaries, enrollmentImportSummaries, enrollments );
 
         return importSummaries;
     }
@@ -440,8 +450,12 @@ public abstract class AbstractTrackedEntityInstanceService
 
     @Override
     @Transactional
-    public ImportSummary addTrackedEntityInstance( TrackedEntityInstance dtoEntityInstance,
-        ImportOptions importOptions )
+    public ImportSummary addTrackedEntityInstance( TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions )
+    {
+        return addTrackedEntityInstance( dtoEntityInstance, importOptions, true );
+    }
+
+    private ImportSummary addTrackedEntityInstance( TrackedEntityInstance dtoEntityInstance, ImportOptions importOptions, boolean handleEnrollments )
     {
         importOptions = updateImportOptions( importOptions );
 
@@ -492,7 +506,18 @@ public abstract class AbstractTrackedEntityInstanceService
         importSummary.setReference( daoEntityInstance.getUid() );
         importSummary.getImportCount().incrementImported();
 
-        importSummary.setEnrollments( handleEnrollments( dtoEntityInstance, daoEntityInstance, importOptions ) );
+        if ( handleEnrollments )
+        {
+            importSummary.setEnrollments( handleEnrollments( dtoEntityInstance, daoEntityInstance, importOptions ) );
+        }
+        else
+        {
+            for ( Enrollment enrollment : dtoEntityInstance.getEnrollments() )
+            {
+                enrollment.setTrackedEntityType( dtoEntityInstance.getTrackedEntityType() );
+                enrollment.setTrackedEntityInstance( daoEntityInstance.getUid() );
+            }
+        }
 
         return importSummary;
     }
@@ -509,6 +534,7 @@ public abstract class AbstractTrackedEntityInstanceService
         List<List<TrackedEntityInstance>> partitions = Lists.partition( trackedEntityInstances, FLUSH_FREQUENCY );
         importOptions = updateImportOptions( importOptions );
         ImportSummaries importSummaries = new ImportSummaries();
+        List<Enrollment> enrollments = new ArrayList<>();
 
         for ( List<TrackedEntityInstance> _trackedEntityInstances : partitions )
         {
@@ -517,11 +543,20 @@ public abstract class AbstractTrackedEntityInstanceService
 
             for ( TrackedEntityInstance trackedEntityInstance : _trackedEntityInstances )
             {
-                importSummaries.addImportSummary( updateTrackedEntityInstance( trackedEntityInstance, null, importOptions, false ) );
+                ImportSummary importSummary = updateTrackedEntityInstance( trackedEntityInstance, null, importOptions, false, false );
+                importSummaries.addImportSummary( importSummary );
+
+                if ( importSummary.getConflicts().isEmpty() )
+                {
+                    enrollments.addAll( trackedEntityInstance.getEnrollments() );
+                }
             }
 
             clearSession();
         }
+
+        ImportSummaries enrollmentImportSummaries = enrollmentService.addEnrollmentList( enrollments, importOptions );
+        linkEnrollmentSummaries( importSummaries, enrollmentImportSummaries, enrollments );
 
         return importSummaries;
     }
@@ -530,6 +565,12 @@ public abstract class AbstractTrackedEntityInstanceService
     @Transactional
     public ImportSummary updateTrackedEntityInstance( TrackedEntityInstance dtoEntityInstance, String programId,
         ImportOptions importOptions, boolean singleUpdate )
+    {
+        return updateTrackedEntityInstance( dtoEntityInstance, programId, importOptions, singleUpdate, true );
+    }
+
+    private ImportSummary updateTrackedEntityInstance( TrackedEntityInstance dtoEntityInstance, String programId,
+        ImportOptions importOptions, boolean singleUpdate, boolean handleEnrollments )
     {
         ImportSummary importSummary = new ImportSummary( dtoEntityInstance.getTrackedEntityInstance() );
         importOptions = updateImportOptions( importOptions );
@@ -625,7 +666,19 @@ public abstract class AbstractTrackedEntityInstanceService
         {
             importSummary.setRelationships( handleRelationships( dtoEntityInstance, daoEntityInstance, importOptions ) );
         }
-        importSummary.setEnrollments( handleEnrollments( dtoEntityInstance, daoEntityInstance, importOptions ) );
+
+        if ( handleEnrollments )
+        {
+            importSummary.setEnrollments( handleEnrollments( dtoEntityInstance, daoEntityInstance, importOptions ) );
+        }
+        else
+        {
+            for ( Enrollment enrollment : dtoEntityInstance.getEnrollments() )
+            {
+                enrollment.setTrackedEntityType( dtoEntityInstance.getTrackedEntityType() );
+                enrollment.setTrackedEntityInstance( daoEntityInstance.getUid() );
+            }
+        }
 
         return importSummary;
     }
@@ -728,6 +781,51 @@ public abstract class AbstractTrackedEntityInstanceService
     // -------------------------------------------------------------------------
     // HELPERS
     // -------------------------------------------------------------------------
+
+    private void linkEnrollmentSummaries( ImportSummaries importSummaries, ImportSummaries enrollmentImportSummaries,
+        List<Enrollment> enrollments )
+    {
+        Map<String, List<Enrollment>> enrollmentsGroupedByTe = enrollments.stream()
+            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getTrackedEntityInstance() ) )
+            .collect( Collectors.groupingBy( Enrollment::getTrackedEntityInstance ) );
+
+        Map<String, List<ImportSummary>> summariesGroupedByReference = importSummaries.getImportSummaries().stream()
+            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getReference() ) )
+            .collect( Collectors.groupingBy( ImportSummary::getReference ) );
+
+        Map<String, List<ImportSummary>> enrollmentSummariesGroupedByReference = enrollmentImportSummaries.getImportSummaries().stream()
+            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getReference() ) )
+            .collect( Collectors.groupingBy( ImportSummary::getReference ) );
+
+        for ( Map.Entry<String, List<Enrollment>> set : enrollmentsGroupedByTe.entrySet() )
+        {
+            if ( !summariesGroupedByReference.containsKey( set.getKey() ) )
+            {
+                continue;
+            }
+
+            ImportSummary importSummary = summariesGroupedByReference.get( set.getKey() ).get( 0 );
+            ImportSummaries enrollmentSummaries = new ImportSummaries();
+
+            for ( Enrollment enrollment : set.getValue() )
+            {
+                if ( !enrollmentSummariesGroupedByReference.containsKey( enrollment.getEnrollment() ) )
+                {
+                    continue;
+                }
+
+                ImportSummary enrollmentSummary = enrollmentSummariesGroupedByReference.get( enrollment.getEnrollment() ).get( 0 );
+                enrollmentSummaries.addImportSummary( enrollmentSummary );
+            }
+
+            if ( enrollmentImportSummaries.getImportSummaries().isEmpty() )
+            {
+                continue;
+            }
+
+            importSummary.setEnrollments( enrollmentSummaries );
+        }
+    }
 
     private ImportSummaries handleRelationships( TrackedEntityInstance dtoEntityInstance,
         org.hisp.dhis.trackedentity.TrackedEntityInstance daoEntityInstance, ImportOptions importOptions )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -791,11 +791,11 @@ public abstract class AbstractTrackedEntityInstanceService
             .collect( Collectors.groupingBy( Enrollment::getTrackedEntityInstance ) );
 
         Map<String, List<ImportSummary>> summariesGroupedByReference = importSummaries.getImportSummaries().stream()
-            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getReference() ) )
+            .filter( en -> !StringUtils.isEmpty( en.getReference() ) )
             .collect( Collectors.groupingBy( ImportSummary::getReference ) );
 
         Map<String, List<ImportSummary>> enrollmentSummariesGroupedByReference = enrollmentImportSummaries.getImportSummaries().stream()
-            .filter( en -> !org.springframework.util.StringUtils.isEmpty( en.getReference() ) )
+            .filter( en -> !StringUtils.isEmpty( en.getReference() ) )
             .collect( Collectors.groupingBy( ImportSummary::getReference ) );
 
         for ( Map.Entry<String, List<Enrollment>> set : enrollmentsGroupedByTe.entrySet() )


### PR DESCRIPTION
When import multiple TEIs, splits out enrollments/events into its own list so that caches can still be effective.