### PR TITLE
Add periodBatchHandler to resolve raceconditions in DataValueSetService

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.jdbc.batchhandler.DataValueAuditBatchHandler;
 import org.hisp.dhis.jdbc.batchhandler.DataValueBatchHandler;
+import org.hisp.dhis.jdbc.batchhandler.PeriodBatchHandler;
 import org.hisp.dhis.mock.MockCurrentUserService;
 import org.hisp.dhis.mock.batchhandler.MockBatchHandler;
 import org.hisp.dhis.mock.batchhandler.MockBatchHandlerFactory;
@@ -75,9 +76,6 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -90,6 +88,8 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Lars Helge Overland
@@ -164,6 +164,7 @@ public class DataValueSetServiceTest
 
     private MockBatchHandler<DataValue> mockDataValueBatchHandler = null;
     private MockBatchHandler<DataValueAudit> mockDataValueAuditBatchHandler = null;
+    private MockBatchHandler<Period> mockPeriodBatchHandler = null;
     private MockBatchHandlerFactory mockBatchHandlerFactory = null;
 
     @Override
@@ -180,9 +181,11 @@ public class DataValueSetServiceTest
 
         mockDataValueBatchHandler = new MockBatchHandler<>();
         mockDataValueAuditBatchHandler = new MockBatchHandler<>();
+        mockPeriodBatchHandler = new MockBatchHandler<>();
         mockBatchHandlerFactory = new MockBatchHandlerFactory();
         mockBatchHandlerFactory.registerBatchHandler( DataValueBatchHandler.class, mockDataValueBatchHandler );
         mockBatchHandlerFactory.registerBatchHandler( DataValueAuditBatchHandler.class, mockDataValueAuditBatchHandler );
+        mockBatchHandlerFactory.registerBatchHandler( PeriodBatchHandler.class, mockPeriodBatchHandler );
         setDependency( dataValueSetService, "batchHandlerFactory", mockBatchHandlerFactory );
 
         attribute = new Attribute( "CUSTOM_ID", ValueType.TEXT );

--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/batchhandler/PeriodBatchHandler.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/batchhandler/PeriodBatchHandler.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.system.callable;
+package org.hisp.dhis.jdbc.batchhandler;
 
 /*
  * Copyright (c) 2004-2019, University of Oslo
@@ -28,45 +28,81 @@ package org.hisp.dhis.system.callable;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodService;
-import org.hisp.dhis.period.PeriodType;
+import org.hisp.quick.JdbcConfiguration;
+import org.hisp.quick.batchhandler.AbstractBatchHandler;
 
-import java.util.concurrent.ExecutionException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
 
-/**
- * @author Lars Helge Overland
- */
-public class PeriodCallable
-    extends IdentifiableObjectCallable<Period>
+public class PeriodBatchHandler
+    extends AbstractBatchHandler<Period>
 {
-    private PeriodService periodService;
-
-    public PeriodCallable( PeriodService periodService, IdScheme idScheme, String id )
+    public PeriodBatchHandler( JdbcConfiguration configuration )
     {
-        super( null, Period.class, idScheme, id );
-        this.periodService = periodService;
+        super( configuration );
     }
 
     @Override
-    public Period call()
-        throws ExecutionException
+    public String getTableName()
     {
-        Period period = periodService.getPeriod( id );
-
-        if ( period == null )
-        {
-            period = PeriodType.getPeriodFromIsoString( id );
-        }
-
-        return period;
+        return "period";
     }
 
     @Override
-    public PeriodCallable setId( String id )
+    public String getAutoIncrementColumn()
     {
-        this.id = id;
-        return this;
+        return "periodid";
+    }
+
+    @Override
+    public boolean isInclusiveUniqueColumns()
+    {
+        return false;
+    }
+
+    @Override
+    public List<String> getIdentifierColumns()
+    {
+        return getStringList( "periodid" );
+    }
+
+    @Override
+    public List<Object> getIdentifierValues( Period period )
+    {
+        return getObjectList( period.getId() );
+    }
+
+    @Override
+    public List<String> getUniqueColumns()
+    {
+        return getStringList( "periodid" );
+    }
+
+    @Override
+    public List<Object> getUniqueValues( Period period )
+    {
+        return getObjectList( period.getId() );
+    }
+
+    @Override
+    public List<String> getColumns()
+    {
+        return getStringList( "periodtypeid", "startdate", "enddate" );
+    }
+
+    @Override
+    public List<Object> getValues( Period period )
+    {
+        return getObjectList( period.getPeriodType().getId(), period.getStartDate(), period.getEndDate() );
+    }
+
+    @Override
+    public Period mapRow( ResultSet resultSet )
+        throws SQLException
+    {
+        // We only use this class for inserting data, not retrieving.
+        return null;
     }
 }


### PR DESCRIPTION
Instead of forcing a new period with Hibernate when no period exist, create a new period and return it to the DataValueSetService, leaving the job og pushing new periods to PeriodBatchHandler. This way we avoid the intermittent race-conditions between the jdbc and hibernate queries.

Issue: DHIS2-7539