### PR TITLE
fix: DHIS2-7629: DataStatistics doesn't include endDate when getting data

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -579,6 +579,25 @@ public class DateUtils
     }
 
     /**
+     * Method responsible for adding a positive or negative number based in a chronological unit.
+     *
+     * @param date the date to be modified. It's the input date for the calculation.
+     * @param addend a positive or negative integer to be added to the date.
+     * @param chronoUnit the unit of time to be used in the calculation. It's fully based in the Calendar API.
+     *                   Valid values could be: Calendar.DATE, Calendar.MILLISECOND, etc..
+     * @return the resultant date after the addition.
+     */
+    public static Date calculateDateFrom( final Date date, final int addend, final int chronoUnit) {
+        Calendar cal = Calendar.getInstance();
+
+        cal.setLenient(false);
+        cal.setTime( date );
+        cal.add( chronoUnit, addend );
+
+        return cal.getTime();
+    }
+
+    /**
      * Sets the name property of each period based on the given I18nFormat.
      */
     public static List<Period> setNames( List<Period> periods, I18nFormat format )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -587,10 +587,10 @@ public class DateUtils
      *                   Valid values could be: Calendar.DATE, Calendar.MILLISECOND, etc..
      * @return the resultant date after the addition.
      */
-    public static Date calculateDateFrom( final Date date, final int addend, final int chronoUnit) {
+    public static Date calculateDateFrom( final Date date, final int addend, final int chronoUnit ) {
         Calendar cal = Calendar.getInstance();
 
-        cal.setLenient(false);
+        cal.setLenient( false );
         cal.setTime( date );
         cal.add( chronoUnit, addend );
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
@@ -28,15 +28,16 @@ package org.hisp.dhis.util;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static java.util.Calendar.DATE;
+import static java.util.Calendar.MILLISECOND;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hisp.dhis.util.DateUtils.dateIsValid;
 import static org.hisp.dhis.util.DateUtils.dateTimeIsValid;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.util.DateUtils.getMediumDate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -46,7 +47,6 @@ import java.util.Calendar;
 import java.util.TimeZone;
 
 import org.hisp.dhis.calendar.impl.NepaliCalendar;
-import org.hisp.dhis.util.DateUtils;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
@@ -101,7 +101,8 @@ public class DateUtilsTest
     @Test
     public void testDaysBetween()
     {
-        Assert.assertEquals( 6, DateUtils.daysBetween( new DateTime( 2014, 3, 1, 0, 0 ).toDate(), new DateTime( 2014, 3, 7, 0, 0 ).toDate() ) );
+        Assert.assertEquals( 6, DateUtils.daysBetween( new DateTime( 2014, 3, 1, 0, 0 ).toDate(),
+            new DateTime( 2014, 3, 7, 0, 0 ).toDate() ) );
     }
 
     @Test
@@ -110,9 +111,9 @@ public class DateUtilsTest
         java.util.Calendar cal = java.util.Calendar.getInstance();
 
         Date today = cal.getTime();
-        cal.add( java.util.Calendar.DATE, -1 );
+        cal.add( DATE, -1 );
         Date yesterday = cal.getTime();
-        cal.add( java.util.Calendar.DATE, +2 );
+        cal.add( DATE, +2 );
         Date tomorrow = cal.getTime();
 
         assertTrue( DateUtils.isToday( today ) );
@@ -295,7 +296,7 @@ public class DateUtilsTest
         int month = 4;
         int day = 14;
 
-        String dateString = "" + year + "-" + ( month < 10 ? "0" : "" ) + month + "-"  + ( day < 10 ? "0" : "" ) + day;
+        String dateString = "" + year + "-" + (month < 10 ? "0" : "") + month + "-" + (day < 10 ? "0" : "") + day;
 
         assertTrue( dateTimeIsValid( dateString + "T00:00" ) );
 
@@ -320,9 +321,10 @@ public class DateUtilsTest
         int month = 5;
         int day = 24;
 
-        String dateString = "" + year + "-" + ( month < 10 ? "0" : "" ) + month + "-"  + ( day < 10 ? "0" : "" ) + day + "T00:00Z";
+        String dateString = "" + year + "-" + (month < 10 ? "0" : "") + month + "-" + (day < 10 ? "0" : "") + day
+            + "T00:00Z";
 
-        assertTrue( dateTimeIsValid( dateString  ) );
+        assertTrue( dateTimeIsValid( dateString ) );
 
         Date dateParsed = parseDate( dateString );
         cal.setTime( dateParsed );
@@ -331,5 +333,57 @@ public class DateUtilsTest
         assertEquals( month, cal.get( Calendar.MONTH ) + 1 );
         assertEquals( day, cal.get( Calendar.DAY_OF_MONTH ) );
         assertEquals( 0, cal.get( Calendar.HOUR_OF_DAY ) );
+    }
+
+    @Test
+    public void testCalculateDateFromUsingPositiveDays()
+    {
+        // Given
+        final Date anyInitialDate = new Date();
+
+        // When
+        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, 1, DATE );
+
+        // Then
+        assertThat( theNewDate, is( greaterThan( anyInitialDate ) ) );
+    }
+
+    @Test
+    public void testCalculateDateFromUsingNegativeDays()
+    {
+        // Given
+        final Date anyInitialDate = new Date();
+
+        // When
+        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, -1, DATE );
+
+        // Then
+        assertThat( theNewDate, is( lessThan( anyInitialDate ) ) );
+    }
+
+    @Test
+    public void testCalculateDateFromUsingPositiveMilis()
+    {
+        // Given
+        final Date anyInitialDate = new Date();
+
+        // When
+        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, 1, MILLISECOND );
+
+        // Then
+        assertThat( theNewDate, is( greaterThan( anyInitialDate ) ) );
+    }
+
+    @Test
+    public void testCalculateDateFromUsingNegativeMilis()
+    {
+        // Given
+        final Date anyInitialDate = new Date();
+
+        // When
+        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, -1, MILLISECOND );
+
+        // Then
+        assertThat( theNewDate, is( lessThan( anyInitialDate ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsStore.java
@@ -254,7 +254,7 @@ public class HibernateDataStatisticsStore
             "cast(round(cast(sum(indicators) as numeric),0) as int) as savedIndicators," +
             "cast(round(cast(sum(datavalues) as numeric),0) as int) as savedDataValues," +
             "max(users) as users from datastatistics " +
-            "where created >= '" + DateUtils.getMediumDateString( start ) + "' " +
-            "and created <= '" + DateUtils.getMediumDateString( end ) + "' ";
+            "where created >= '" + DateUtils.getLongDateString( start ) + "' " +
+            "and created <= '" + DateUtils.getLongDateString( end ) + "' ";
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.datastatistics.FavoriteStatistics;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -55,6 +56,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.servlet.http.HttpServletResponse;
 
+import static java.util.Calendar.DATE;
+import static java.util.Calendar.MILLISECOND;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.Date;
@@ -96,6 +99,10 @@ public class DataStatisticsController
         {
             throw new WebMessageException( WebMessageUtils.conflict( "Start date is after end date" ) );
         }
+
+        // The endDate is arriving as: "2019-09-28". After the conversion below it will become: "2019-09-28 23:59:59.999"
+        endDate = DateUtils.calculateDateFrom( endDate, 1, DATE );
+        endDate = DateUtils.calculateDateFrom( endDate, -1, MILLISECOND );
 
         setNoStore( response );
         return dataStatisticsService.getReports( startDate, endDate, interval );


### PR DESCRIPTION
The endDate is being formatted to medium format and is losing the hour/time, missing valid result rows when querying the DB.