### PR TITLE
perf: reduced queries from ~17000 to 700 when fetching TEIs

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -28,23 +28,15 @@ package org.hisp.dhis.dataelement;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import static org.hisp.dhis.dataset.DataSet.NO_EXPIRY;
+
+import java.util.*;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.BaseDimensionalItemObject;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DimensionItemType;
-import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
-import org.hisp.dhis.common.ObjectStyle;
-import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.dataset.comparator.DataSetApprovalFrequencyComparator;
@@ -59,10 +51,13 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.translation.TranslationProperty;
 import org.joda.time.DateTime;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.dataset.DataSet.NO_EXPIRY;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 
 /**
  * A DataElement is a definition (meta-information about) of the entities that
@@ -752,5 +747,39 @@ public class DataElement
     public void setFieldMask( String fieldMask )
     {
         this.fieldMask = fieldMask;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        if ( !super.equals( o ) )
+        {
+            return false;
+        }
+        DataElement that = (DataElement) o;
+        return uid.equals( that.uid ) && zeroIsSignificant == that.zeroIsSignificant && valueType == that.valueType
+            && Objects.equals( formName, that.formName ) && Objects.equals( displayFormName, that.displayFormName )
+            && domainType == that.domainType && Objects.equals( categoryCombo, that.categoryCombo )
+            && Objects.equals( url, that.url ) && Objects.equals( groups, that.groups )
+            && Objects.equals( dataSetElements, that.dataSetElements )
+            && Objects.equals( aggregationLevels, that.aggregationLevels )
+            && Objects.equals( optionSet, that.optionSet ) && Objects.equals( commentOptionSet, that.commentOptionSet )
+            && Objects.equals( style, that.style ) && Objects.equals( fieldMask, that.fieldMask );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( super.hashCode(), valueType, formName, displayFormName, domainType, categoryCombo, url,
+            groups, dataSetElements, aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
+            fieldMask );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -756,20 +756,22 @@ public class DataElement
         {
             return true;
         }
+
         if ( o == null || getClass() != o.getClass() )
         {
             return false;
         }
+
         if ( !super.equals( o ) )
         {
             return false;
         }
+
         DataElement that = (DataElement) o;
         return uid.equals( that.uid ) && zeroIsSignificant == that.zeroIsSignificant && valueType == that.valueType
             && Objects.equals( formName, that.formName ) && Objects.equals( displayFormName, that.displayFormName )
             && domainType == that.domainType && Objects.equals( categoryCombo, that.categoryCombo )
             && Objects.equals( url, that.url ) && Objects.equals( groups, that.groups )
-            && Objects.equals( dataSetElements, that.dataSetElements )
             && Objects.equals( aggregationLevels, that.aggregationLevels )
             && Objects.equals( optionSet, that.optionSet ) && Objects.equals( commentOptionSet, that.commentOptionSet )
             && Objects.equals( style, that.style ) && Objects.equals( fieldMask, that.fieldMask );
@@ -779,7 +781,7 @@ public class DataElement
     public int hashCode()
     {
         return Objects.hash( super.hashCode(), valueType, formName, displayFormName, domainType, categoryCombo, url,
-            groups, dataSetElements, aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
+            groups,aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
             fieldMask );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -768,20 +768,21 @@ public class DataElement
         }
 
         DataElement that = (DataElement) o;
-        return uid.equals( that.uid ) && zeroIsSignificant == that.zeroIsSignificant && valueType == that.valueType
-            && Objects.equals( formName, that.formName ) && Objects.equals( displayFormName, that.displayFormName )
-            && domainType == that.domainType && Objects.equals( categoryCombo, that.categoryCombo )
-            && Objects.equals( url, that.url )
-            && Objects.equals( aggregationLevels, that.aggregationLevels )
-            && Objects.equals( optionSet, that.optionSet ) && Objects.equals( commentOptionSet, that.commentOptionSet )
-            && Objects.equals( style, that.style ) && Objects.equals( fieldMask, that.fieldMask );
+        return zeroIsSignificant == that.zeroIsSignificant && valueType == that.valueType
+                && Objects.equals( uid, that.uid )
+                && Objects.equals( formName, that.formName ) && Objects.equals( displayFormName, that.displayFormName )
+                && domainType == that.domainType && Objects.equals( categoryCombo, that.categoryCombo )
+                && Objects.equals( url, that.url )
+                && Objects.equals( aggregationLevels, that.aggregationLevels )
+                && Objects.equals( optionSet, that.optionSet ) && Objects.equals( commentOptionSet, that.commentOptionSet )
+                && Objects.equals( style, that.style ) && Objects.equals( fieldMask, that.fieldMask );
     }
 
     @Override
     public int hashCode()
     {
         return Objects.hash( super.hashCode(), uid, valueType, formName, displayFormName, domainType, categoryCombo, url,
-            aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
-            fieldMask );
+                aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
+                fieldMask );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -771,7 +771,7 @@ public class DataElement
         return uid.equals( that.uid ) && zeroIsSignificant == that.zeroIsSignificant && valueType == that.valueType
             && Objects.equals( formName, that.formName ) && Objects.equals( displayFormName, that.displayFormName )
             && domainType == that.domainType && Objects.equals( categoryCombo, that.categoryCombo )
-            && Objects.equals( url, that.url ) && Objects.equals( groups, that.groups )
+            && Objects.equals( url, that.url )
             && Objects.equals( aggregationLevels, that.aggregationLevels )
             && Objects.equals( optionSet, that.optionSet ) && Objects.equals( commentOptionSet, that.commentOptionSet )
             && Objects.equals( style, that.style ) && Objects.equals( fieldMask, that.fieldMask );
@@ -780,8 +780,8 @@ public class DataElement
     @Override
     public int hashCode()
     {
-        return Objects.hash( super.hashCode(), valueType, formName, displayFormName, domainType, categoryCombo, url,
-            groups,aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
+        return Objects.hash( super.hashCode(), uid, valueType, formName, displayFormName, domainType, categoryCombo, url,
+            aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
             fieldMask );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -288,7 +288,7 @@ public class Program
     public List<TrackedEntityAttribute> getTrackedEntityAttributes()
     {
         return programAttributes.stream()
-            .map( at -> at.getAttribute() )
+            .map(ProgramTrackedEntityAttribute::getAttribute)
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceService.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.i18n.I18nFormat;
@@ -169,8 +170,9 @@ public interface ProgramStageInstanceService
      * @param programStageInstance programStageInstance to which the EventDataValues belongs to
      * @param singleValue specifies whether the update is a single value update
      */
-    void auditDataValuesChangesAndHandleFileDataValues( Set<EventDataValue> newDataValues, Set<EventDataValue> updatedDataValues,Set<EventDataValue> removedDataValues,
-        Map<String, DataElement> dataElementsCache, ProgramStageInstance programStageInstance, boolean singleValue );
+    void auditDataValuesChangesAndHandleFileDataValues( Set<EventDataValue> newDataValues,
+        Set<EventDataValue> updatedDataValues, Set<EventDataValue> removedDataValues,
+        Cache<DataElement> dataElementsCache, ProgramStageInstance programStageInstance, boolean singleValue );
 
     /**
      * Validates EventDataValues, handles files for File EventDataValues and creates audit logs for the upcoming create/save changes.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
@@ -28,13 +28,11 @@ package org.hisp.dhis.program;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.*;
+
+import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
@@ -55,8 +53,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.google.common.collect.Sets;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Abyot Asalefew
@@ -293,7 +289,7 @@ public class DefaultProgramStageInstanceService
     @Transactional
     public void auditDataValuesChangesAndHandleFileDataValues( Set<EventDataValue> newDataValues,
         Set<EventDataValue> updatedDataValues, Set<EventDataValue> removedDataValues,
-        Map<String, DataElement> dataElementsCache, ProgramStageInstance programStageInstance, boolean singleValue )
+        Cache<DataElement> dataElementsCache, ProgramStageInstance programStageInstance, boolean singleValue )
     {
         Set<EventDataValue> updatedOrNewDataValues = Sets.union( newDataValues, updatedDataValues );
 
@@ -324,7 +320,7 @@ public class DefaultProgramStageInstanceService
         Map<DataElement, EventDataValue> dataElementEventDataValueMap )
     {
         validateEventDataValues( dataElementEventDataValueMap );
-        Set<EventDataValue> eventDataValues = new HashSet<EventDataValue>( dataElementEventDataValueMap.values() );
+        Set<EventDataValue> eventDataValues = new HashSet<>(dataElementEventDataValueMap.values());
         programStageInstance.setEventDataValues( eventDataValues );
         addProgramStageInstance( programStageInstance );
 
@@ -380,22 +376,26 @@ public class DefaultProgramStageInstanceService
     }
 
     // ---- Audit ----
+    
     private void auditDataValuesChanges( Set<EventDataValue> newDataValues, Set<EventDataValue> updatedDataValues,
-        Set<EventDataValue> removedDataValues, Map<String, DataElement> dataElementsCache,
+        Set<EventDataValue> removedDataValues, Cache<DataElement> dataElementsCache,
         ProgramStageInstance programStageInstance )
     {
 
-        newDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ),
+        newDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ),
             programStageInstance, AuditType.CREATE ) );
-        updatedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ),
+        updatedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ),
             programStageInstance, AuditType.UPDATE ) );
-        removedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ),
+        removedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ),
             programStageInstance, AuditType.DELETE ) );
     }
 
     private void createAndAddAudit( EventDataValue dataValue, DataElement dataElement,
         ProgramStageInstance programStageInstance, AuditType auditType )
     {
+        if (dataElement == null) {
+            return;
+        }
         TrackedEntityDataValueAudit dataValueAudit = new TrackedEntityDataValueAudit( dataElement, programStageInstance,
             dataValue.getValue(), dataValue.getStoredBy(), dataValue.getProvidedElsewhere(), auditType );
         dataValueAuditService.addTrackedEntityDataValueAudit( dataValueAudit );
@@ -403,17 +403,21 @@ public class DefaultProgramStageInstanceService
 
     // ---- File Data Values Handling ----
     private void handleFileDataValueChanges( Set<EventDataValue> newDataValues, Set<EventDataValue> updatedDataValues,
-        Set<EventDataValue> removedDataValues, Map<String, DataElement> dataElementsCache )
+        Set<EventDataValue> removedDataValues, Cache<DataElement> dataElementsCache )
     {
         removedDataValues
-            .forEach( dv -> handleFileDataValueDelete( dv, dataElementsCache.get( dv.getDataElement() ) ) );
+            .forEach( dv -> handleFileDataValueDelete( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ) ) );
         updatedDataValues
-            .forEach( dv -> handleFileDataValueUpdate( dv, dataElementsCache.get( dv.getDataElement() ) ) );
-        newDataValues.forEach( dv -> handleFileDataValueSave( dv, dataElementsCache.get( dv.getDataElement() ) ) );
+            .forEach( dv -> handleFileDataValueUpdate( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ) ) );
+        newDataValues.forEach( dv -> handleFileDataValueSave( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ) ) );
     }
 
     private void handleFileDataValueUpdate( EventDataValue dataValue, DataElement dataElement )
     {
+        if ( dataElement == null )
+        {
+            return;
+        }
         String previousFileResourceUid = dataValue.getAuditValue();
 
         if ( previousFileResourceUid == null || previousFileResourceUid.equals( dataValue.getValue() ) )
@@ -438,6 +442,11 @@ public class DefaultProgramStageInstanceService
      */
     private void handleFileDataValueSave( EventDataValue dataValue, DataElement dataElement )
     {
+        if ( dataElement == null )
+        {
+            return;
+        }
+
         FileResource fileResource = fetchFileResource( dataValue, dataElement );
 
         if ( fileResource == null )
@@ -451,8 +460,11 @@ public class DefaultProgramStageInstanceService
     /**
      * Delete associated FileResource if it exists.
      */
-    private void handleFileDataValueDelete( EventDataValue dataValue, DataElement dataElement )
-    {
+    private void handleFileDataValueDelete( EventDataValue dataValue, DataElement dataElement ) {
+        if ( dataElement == null )
+        {
+            return;
+        }
         FileResource fileResource = fetchFileResource( dataValue, dataElement );
 
         if ( fileResource == null )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
@@ -393,7 +393,8 @@ public class DefaultProgramStageInstanceService
     private void createAndAddAudit( EventDataValue dataValue, DataElement dataElement,
         ProgramStageInstance programStageInstance, AuditType auditType )
     {
-        if (dataElement == null) {
+        if ( dataElement == null )
+        {
             return;
         }
         TrackedEntityDataValueAudit dataValueAudit = new TrackedEntityDataValueAudit( dataElement, programStageInstance,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/PreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/PreheatServiceTest.java
@@ -28,17 +28,20 @@ package org.hisp.dhis.preheat;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
@@ -52,14 +55,8 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.*;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -490,12 +487,9 @@ public class PreheatServiceTest
 
         List<DataElement> members = new ArrayList<>( dataElementGroup.getMembers() );
 
-        assertEquals( "DataElementA", members.get( 0 ).getName() );
-        assertEquals( "DataElementCodeA", members.get( 0 ).getCode() );
-        assertEquals( "DataElementB", members.get( 1 ).getName() );
-        assertEquals( "DataElementCodeB", members.get( 1 ).getCode() );
-        assertEquals( "DataElementC", members.get( 2 ).getName() );
-        assertEquals( "DataElementCodeC", members.get( 2 ).getCode() );
+        assertContains(members, "DataElementA", "DataElementCodeA");
+        assertContains(members, "DataElementB", "DataElementCodeB");
+        assertContains(members, "DataElementC", "DataElementCodeC");
 
         assertEquals( "FirstNameA", dataElementGroup.getUser().getFirstName() );
         assertEquals( "SurnameA", dataElementGroup.getUser().getSurname() );
@@ -519,12 +513,9 @@ public class PreheatServiceTest
 
         List<DataElement> members = new ArrayList<>( dataElementGroup.getMembers() );
 
-        assertEquals( "DataElementA", members.get( 0 ).getName() );
-        assertEquals( "DataElementCodeA", members.get( 0 ).getCode() );
-        assertEquals( "DataElementB", members.get( 1 ).getName() );
-        assertEquals( "DataElementCodeB", members.get( 1 ).getCode() );
-        assertEquals( "DataElementC", members.get( 2 ).getName() );
-        assertEquals( "DataElementCodeC", members.get( 2 ).getCode() );
+        assertContains(members, "DataElementA", "DataElementCodeA");
+        assertContains(members, "DataElementB", "DataElementCodeB");
+        assertContains(members, "DataElementC", "DataElementCodeC");
 
         assertEquals( "FirstNameA", dataElementGroup.getUser().getFirstName() );
         assertEquals( "SurnameA", dataElementGroup.getUser().getSurname() );
@@ -548,12 +539,9 @@ public class PreheatServiceTest
 
         List<DataElement> members = new ArrayList<>( dataElementGroup.getMembers() );
 
-        assertEquals( "DataElementA", members.get( 0 ).getName() );
-        assertEquals( "DataElementCodeA", members.get( 0 ).getCode() );
-        assertEquals( "DataElementB", members.get( 1 ).getName() );
-        assertEquals( "DataElementCodeB", members.get( 1 ).getCode() );
-        assertEquals( "DataElementC", members.get( 2 ).getName() );
-        assertEquals( "DataElementCodeC", members.get( 2 ).getCode() );
+        assertContains(members, "DataElementA", "DataElementCodeA");
+        assertContains(members, "DataElementB", "DataElementCodeB");
+        assertContains(members, "DataElementC", "DataElementCodeC");
 
         assertEquals( "FirstNameA", dataElementGroup.getUser().getFirstName() );
         assertEquals( "SurnameA", dataElementGroup.getUser().getSurname() );
@@ -668,5 +656,20 @@ public class PreheatServiceTest
 
         User user = createUser( 'A' );
         manager.save( user );
+    }
+
+    private void assertContains( List<DataElement> dataElements, String name, String code )
+    {
+
+        for ( DataElement dataElement : dataElements )
+        {
+
+            if ( dataElement.getCode().equals( code ) && dataElement.getName().equals( name ) )
+            {
+
+                return;
+            }
+        }
+        fail( "The collection does not contain a DataElement with name: [" + name + "] and code: [" + code + "]" );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -43,6 +43,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.TestCache;
 import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
@@ -164,7 +166,7 @@ public class ProgramStageInstanceServiceTest
     private EventDataValue eventDataValueC;
     private EventDataValue eventDataValueD;
 
-    private Map<String, DataElement> dataElementMap = new HashMap<>();
+    private Cache<DataElement> dataElementMap = new TestCache<>();
 
     private List<DataElement> dataElements;
 
@@ -239,7 +241,7 @@ public class ProgramStageInstanceServiceTest
         programStageDataElementService.addProgramStageDataElement( stageDataElementC );
         programStageDataElementService.addProgramStageDataElement( stageDataElementD );
 
-        /**
+        /*
          * Program B
          */
 
@@ -301,7 +303,7 @@ public class ProgramStageInstanceServiceTest
         programStageInstanceD2.setDueDate( enrollmentDate );
         programStageInstanceD2.setUid( "UID-D2" );
 
-        /**
+        /*
          * Prepare data for EventDataValues manipulation tests
          */
 
@@ -323,7 +325,7 @@ public class ProgramStageInstanceServiceTest
         dataElementMap.put( dataElementC.getUid(), dataElementC );
         dataElementMap.put( dataElementD.getUid(), dataElementD );
 
-        dataElements = new ArrayList<>( dataElementMap.values() );
+        dataElements = new ArrayList<>( dataElementMap.getAll() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -28,31 +28,25 @@ package org.hisp.dhis.dxf2.events.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.AssignedUserSelectionMode;
-import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.IdScheme;
-import org.hisp.dhis.common.IdSchemes;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IdentifiableProperty;
-import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.QueryFilter;
-import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -82,18 +76,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.program.EventSyncService;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageDataElement;
-import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.program.ProgramStageService;
-import org.hisp.dhis.program.ProgramStatus;
-import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.program.*;
 import org.hisp.dhis.program.notification.event.ProgramStageCompletionNotificationEvent;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.engine.DataValueUpdatedEvent;
@@ -122,32 +105,18 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Transactional
 public abstract class AbstractEventService
     implements EventService
 {
@@ -163,91 +132,134 @@ public abstract class AbstractEventService
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @Autowired
-    protected ProgramService programService;
+    protected final ProgramService programService;
 
-    @Autowired
-    protected ProgramStageService programStageService;
+    protected final ProgramStageService programStageService;
 
-    @Autowired
-    protected ProgramInstanceService programInstanceService;
+    protected final ProgramInstanceService programInstanceService;
 
-    @Autowired
-    protected ProgramStageInstanceService programStageInstanceService;
+    protected final ProgramStageInstanceService programStageInstanceService;
 
-    @Autowired
-    protected OrganisationUnitService organisationUnitService;
+    protected final OrganisationUnitService organisationUnitService;
 
-    @Autowired
-    protected DataElementService dataElementService;
+    protected final DataElementService dataElementService;
 
-    @Autowired
-    protected CurrentUserService currentUserService;
+    protected final CurrentUserService currentUserService;
 
-    @Autowired
-    protected EventDataValueService eventDataValueService;
+    private final EventDataValueService eventDataValueService;
 
-    @Autowired
-    protected TrackedEntityInstanceService entityInstanceService;
+    private final TrackedEntityInstanceService entityInstanceService;
 
-    @Autowired
-    protected TrackedEntityCommentService commentService;
+    private final TrackedEntityCommentService commentService;
 
-    @Autowired
-    protected EventStore eventStore;
+    private final EventStore eventStore;
 
-    @Autowired
-    protected I18nManager i18nManager;
+    protected final I18nManager i18nManager;
 
-    @Autowired
-    protected Notifier notifier;
+    protected final Notifier notifier;
 
-    @Autowired
-    protected SessionFactory sessionFactory;
+    protected final SessionFactory sessionFactory;
 
-    @Autowired
-    protected DbmsManager dbmsManager;
+    private final DbmsManager dbmsManager;
 
-    @Autowired
-    protected IdentifiableObjectManager manager;
+    protected final IdentifiableObjectManager manager;
 
-    @Autowired
-    protected CategoryService categoryService;
+    protected final CategoryService categoryService;
 
-    @Autowired
-    protected FileResourceService fileResourceService;
+    protected final FileResourceService fileResourceService;
 
-    @Autowired
-    protected SchemaService schemaService;
+    protected final SchemaService schemaService;
 
-    @Autowired
-    protected QueryService queryService;
+    protected final QueryService queryService;
 
-    @Autowired
-    protected TrackerAccessManager trackerAccessManager;
+    private final TrackerAccessManager trackerAccessManager;
 
-    @Autowired
-    protected TrackerOwnershipManager trackerOwnershipAccessManager;
+    private final TrackerOwnershipManager trackerOwnershipAccessManager;
 
-    @Autowired
-    protected AclService aclService;
+    protected final AclService aclService;
 
-    @Autowired
-    private ApplicationEventPublisher eventPublisher;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Autowired
-    protected RelationshipService relationshipService;
+    private final RelationshipService relationshipService;
 
-    @Autowired
-    protected UserService userService;
+    protected final UserService userService;
 
-    @Autowired
-    protected EventSyncService eventSyncService;
+    private final EventSyncService eventSyncService;
 
-    @Autowired
-    private ProgramRuleVariableService ruleVariableService;
+    private final ProgramRuleVariableService ruleVariableService;
 
-    protected static final int FLUSH_FREQUENCY = 100;
+    private static final int FLUSH_FREQUENCY = 100;
+
+    public AbstractEventService( ProgramService programService, ProgramStageService programStageService,
+        ProgramInstanceService programInstanceService, ProgramStageInstanceService programStageInstanceService,
+        OrganisationUnitService organisationUnitService, DataElementService dataElementService,
+        CurrentUserService currentUserService, EventDataValueService eventDataValueService,
+        TrackedEntityInstanceService entityInstanceService, TrackedEntityCommentService commentService,
+        EventStore eventStore, I18nManager i18nManager, Notifier notifier, SessionFactory sessionFactory,
+        DbmsManager dbmsManager, IdentifiableObjectManager manager, CategoryService categoryService,
+        FileResourceService fileResourceService, SchemaService schemaService, QueryService queryService,
+        TrackerAccessManager trackerAccessManager, TrackerOwnershipManager trackerOwnershipAccessManager,
+        AclService aclService, ApplicationEventPublisher eventPublisher, RelationshipService relationshipService,
+        UserService userService, EventSyncService eventSyncService, ProgramRuleVariableService ruleVariableService )
+    {
+
+        checkNotNull( programService );
+        checkNotNull( programStageService );
+        checkNotNull( programInstanceService );
+        checkNotNull( programStageInstanceService );
+        checkNotNull( organisationUnitService );
+        checkNotNull( dataElementService );
+        checkNotNull( currentUserService );
+        checkNotNull( eventDataValueService );
+        checkNotNull( entityInstanceService );
+        checkNotNull( commentService );
+        checkNotNull( eventStore );
+        checkNotNull( i18nManager );
+        checkNotNull( notifier );
+        checkNotNull( sessionFactory );
+        checkNotNull( dbmsManager );
+        checkNotNull( manager );
+        checkNotNull( categoryService );
+        checkNotNull( fileResourceService );
+        checkNotNull( schemaService );
+        checkNotNull( queryService );
+        checkNotNull( trackerAccessManager );
+        checkNotNull( trackerOwnershipAccessManager );
+        checkNotNull( aclService );
+        checkNotNull( eventPublisher );
+        checkNotNull( userService );
+        checkNotNull( eventSyncService );
+        checkNotNull( ruleVariableService );
+
+        this.programService = programService;
+        this.programStageService = programStageService;
+        this.programInstanceService = programInstanceService;
+        this.programStageInstanceService = programStageInstanceService;
+        this.organisationUnitService = organisationUnitService;
+        this.dataElementService = dataElementService;
+        this.currentUserService = currentUserService;
+        this.eventDataValueService = eventDataValueService;
+        this.entityInstanceService = entityInstanceService;
+        this.commentService = commentService;
+        this.eventStore = eventStore;
+        this.i18nManager = i18nManager;
+        this.notifier = notifier;
+        this.sessionFactory = sessionFactory;
+        this.dbmsManager = dbmsManager;
+        this.manager = manager;
+        this.categoryService = categoryService;
+        this.fileResourceService = fileResourceService;
+        this.schemaService = schemaService;
+        this.queryService = queryService;
+        this.trackerAccessManager = trackerAccessManager;
+        this.trackerOwnershipAccessManager = trackerOwnershipAccessManager;
+        this.aclService = aclService;
+        this.eventPublisher = eventPublisher;
+        this.relationshipService = relationshipService;
+        this.userService = userService;
+        this.eventSyncService = eventSyncService;
+        this.ruleVariableService = ruleVariableService;
+    }
 
     // -------------------------------------------------------------------------
     // Caches
@@ -258,8 +270,6 @@ public abstract class AbstractEventService
     private CachingMap<String, Program> programCache = new CachingMap<>();
 
     private CachingMap<String, ProgramStage> programStageCache = new CachingMap<>();
-
-    private CachingMap<String, DataElement> dataElementCache = new CachingMap<>();
 
     private CachingMap<String, CategoryOption> categoryOptionCache = new CachingMap<>();
 
@@ -281,10 +291,18 @@ public abstract class AbstractEventService
 
     private CachingMap<String, User> userCache = new CachingMap<>();
 
+    private static Cache<DataElement> DATA_ELEM_CACHE = new SimpleCacheBuilder<DataElement>()
+            .forRegion( "dataElementCache" )
+            .expireAfterAccess( 60, TimeUnit.MINUTES )
+            .withInitialCapacity( 1000 )
+            .withMaximumSize( 50000 )
+            .build();
+
     // -------------------------------------------------------------------------
     // CREATE
     // -------------------------------------------------------------------------
 
+    @Transactional
     @Override
     public ImportSummaries processEventImport( List<Event> events, ImportOptions importOptions, JobConfiguration jobId )
     {
@@ -367,6 +385,7 @@ public abstract class AbstractEventService
         return importSummaries;
     }
 
+    @Transactional
     @Override
     public ImportSummaries addEvents( List<Event> events, ImportOptions importOptions, boolean clearSession )
     {
@@ -395,6 +414,7 @@ public abstract class AbstractEventService
         return importSummaries;
     }
 
+    @Transactional
     @Override
     public ImportSummaries addEvents( List<Event> events, ImportOptions importOptions, JobConfiguration jobId )
     {
@@ -420,6 +440,7 @@ public abstract class AbstractEventService
         }
     }
 
+    @Transactional
     @Override
     public ImportSummary addEvent( Event event, ImportOptions importOptions, boolean bulkImport )
     {
@@ -587,6 +608,7 @@ public abstract class AbstractEventService
     // READ
     // -------------------------------------------------------------------------
 
+    @Transactional(readOnly = true)
     @Override
     public Events getEvents( EventSearchParams params )
     {
@@ -632,7 +654,7 @@ public abstract class AbstractEventService
 
         return events;
     }
-
+    @Transactional(readOnly = true)
     @Override
     public Grid getEventsGrid( EventSearchParams params )
     {
@@ -754,6 +776,7 @@ public abstract class AbstractEventService
         return grid;
     }
 
+    @Transactional(readOnly = true)
     @Override
     public int getAnonymousEventReadyForSynchronizationCount( Date skipChangedBefore )
     {
@@ -785,6 +808,7 @@ public abstract class AbstractEventService
         return anonymousEvents;
     }
 
+    @Transactional(readOnly = true)
     @Override
     public EventRows getEventRows( EventSearchParams params )
     {
@@ -809,12 +833,14 @@ public abstract class AbstractEventService
         return eventRows;
     }
 
+    @Transactional(readOnly = true)
     @Override
     public Event getEvent( ProgramStageInstance programStageInstance )
     {
         return getEvent( programStageInstance, false, false );
     }
 
+    @Transactional(readOnly = true)
     @Override
     public Event getEvent( ProgramStageInstance programStageInstance, boolean isSynchronizationQuery, boolean skipOwnershipCheck )
     {
@@ -908,24 +934,32 @@ public abstract class AbstractEventService
 
         for ( EventDataValue dataValue : dataValues )
         {
+
             DataElement dataElement = getDataElement( IdScheme.UID, dataValue.getDataElement() );
-
-            errors = trackerAccessManager.canRead( user, programStageInstance, dataElement, true );
-
-            if ( !errors.isEmpty() )
+            
+            if ( dataElement != null )
             {
-                continue;
+                errors = trackerAccessManager.canRead( user, programStageInstance, dataElement, true );
+
+                if ( !errors.isEmpty() )
+                {
+                    continue;
+                }
+
+                DataValue value = new DataValue();
+                value.setCreated( DateUtils.getIso8601NoTz( dataValue.getCreated() ) );
+                value.setLastUpdated( DateUtils.getIso8601NoTz( dataValue.getLastUpdated() ) );
+                value.setDataElement( dataValue.getDataElement() );
+                value.setValue( dataValue.getValue() );
+                value.setProvidedElsewhere( dataValue.getProvidedElsewhere() );
+                value.setStoredBy( dataValue.getStoredBy() );
+
+                event.getDataValues().add( value );
             }
-
-            DataValue value = new DataValue();
-            value.setCreated( DateUtils.getIso8601NoTz( dataValue.getCreated() ) );
-            value.setLastUpdated( DateUtils.getIso8601NoTz( dataValue.getLastUpdated() ) );
-            value.setDataElement( dataValue.getDataElement() );
-            value.setValue( dataValue.getValue() );
-            value.setProvidedElsewhere( dataValue.getProvidedElsewhere() );
-            value.setStoredBy( dataValue.getStoredBy() );
-
-            event.getDataValues().add( value );
+            else
+            {
+                log.info( "Can not find a Data Element having UID [" + dataValue.getDataElement() + "]" );
+            }
         }
 
         List<TrackedEntityComment> comments = programStageInstance.getComments();
@@ -950,6 +984,7 @@ public abstract class AbstractEventService
         return event;
     }
 
+    @Transactional(readOnly = true)
     @Override
     public EventSearchParams getFromUrl( String program, String programStage, ProgramStatus programStatus,
         Boolean followUp, String orgUnit, OrganisationUnitSelectionMode orgUnitSelectionMode,
@@ -1094,6 +1129,7 @@ public abstract class AbstractEventService
     // UPDATE
     // -------------------------------------------------------------------------
 
+    @Transactional
     @Override
     public ImportSummaries updateEvents( List<Event> events, ImportOptions importOptions, boolean singleValue, boolean clearSession )
     {
@@ -1122,12 +1158,14 @@ public abstract class AbstractEventService
         return importSummaries;
     }
 
+    @Transactional
     @Override
     public ImportSummary updateEvent( Event event, boolean singleValue, boolean bulkUpdate )
     {
         return updateEvent( event, singleValue, null, bulkUpdate );
     }
 
+    @Transactional
     @Override
     public ImportSummary updateEvent( Event event, boolean singleValue, ImportOptions importOptions, boolean bulkUpdate )
     {
@@ -1327,7 +1365,8 @@ public abstract class AbstractEventService
 
         saveTrackedEntityComment( programStageInstance, event, storedBy );
         preheatDataElementsCache( event, importOptions );
-        eventDataValueService.processDataValues( programStageInstance, event, singleValue, importOptions, importSummary, dataElementCache );
+        
+        eventDataValueService.processDataValues( programStageInstance, event, singleValue, importOptions, importSummary, DATA_ELEM_CACHE );
 
         programStageInstanceService.updateProgramStageInstance( programStageInstance );
 
@@ -1339,7 +1378,7 @@ public abstract class AbstractEventService
 
         for ( DataValue dv :  event.getDataValues() )
         {
-            DataElement dataElement = dataElementCache.get( dv.getDataElement() );
+            DataElement dataElement = DATA_ELEM_CACHE.get( dv.getDataElement() ).orElse( null );
 
             if ( dataElement != null )
             {
@@ -1392,7 +1431,7 @@ public abstract class AbstractEventService
             List<DataElement> dataElements = manager.getObjects( DataElement.class, IdentifiableProperty.UID,
                 dataElementIdentificators );
 
-            dataElements.forEach( de -> dataElementCache.put( de.getUid(), de ) );
+            dataElements.forEach( de -> DATA_ELEM_CACHE.put( de.getUid(), de ) );
         }
         else
         {
@@ -1401,6 +1440,7 @@ public abstract class AbstractEventService
         }
     }
 
+    @Transactional
     @Override
     public void updateEventForNote( Event event )
     {
@@ -1420,6 +1460,7 @@ public abstract class AbstractEventService
         updateTrackedEntityInstance( programStageInstance, currentUser, false );
     }
 
+    @Transactional
     @Override
     public void updateEventForEventDate( Event event )
     {
@@ -1472,6 +1513,7 @@ public abstract class AbstractEventService
         programStageInstanceService.updateProgramStageInstance( programStageInstance );
     }
 
+    @Transactional
     @Override
     public void updateEventsSyncTimestamp( List<String> eventsUIDs, Date lastSynchronized )
     {
@@ -1482,6 +1524,7 @@ public abstract class AbstractEventService
     // DELETE
     // -------------------------------------------------------------------------
 
+    @Transactional
     @Override
     public ImportSummary deleteEvent( String uid )
     {
@@ -1516,6 +1559,7 @@ public abstract class AbstractEventService
         }
     }
 
+    @Transactional
     @Override
     public ImportSummaries deleteEvents( List<String> uids, boolean clearSession )
     {
@@ -1576,7 +1620,10 @@ public abstract class AbstractEventService
 
                     for ( ProgramStage programStage : program.getProgramStages() )
                     {
-                        dataElementCache.putAll( programStage.getDataElements().stream().collect( Collectors.toMap( DataElement::getUid, de -> de ) ) );
+                        for ( DataElement dataElement : programStage.getDataElements() )
+                        {
+                            DATA_ELEM_CACHE.put( dataElement.getUid(), dataElement );
+                        }
                     }
                 }
             }
@@ -1862,12 +1909,12 @@ public abstract class AbstractEventService
             programStageInstance.setAutoFields();
             programStageInstanceService.addProgramStageInstance( programStageInstance );
 
-            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary, dataElementCache );
+            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary, DATA_ELEM_CACHE );
             programStageInstanceService.updateProgramStageInstance( programStageInstance );
         }
         else
         {
-            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary, dataElementCache );
+            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary, DATA_ELEM_CACHE );
             programStageInstanceService.updateProgramStageInstance( programStageInstance );
         }
     }
@@ -2015,16 +2062,24 @@ public abstract class AbstractEventService
 
                 programStageCache.putAll( program.getProgramStages().stream().collect( Collectors.toMap( ProgramStage::getUid, ps -> ps ) ) );
 
-                for ( ProgramStage programStage : program.getProgramStages() )
-                {
-                    dataElementCache.putAll( programStage.getDataElements().stream().collect( Collectors.toMap( DataElement::getUid, de -> de ) ) );
-                }
+                cacheDataElements( program.getProgramStages() );
             }
         }
 
         return program;
     }
 
+    private void cacheDataElements( Set<ProgramStage> programStages )
+    {
+        for ( ProgramStage programStage : programStages )
+        {
+            for ( DataElement dataElement : programStage.getDataElements() )
+            {
+                DATA_ELEM_CACHE.put( dataElement.getUid(), dataElement );
+            }
+        }
+    }
+    
     private ProgramStage getProgramStage( IdScheme idScheme, String id )
     {
         if ( id == null )
@@ -2042,7 +2097,7 @@ public abstract class AbstractEventService
             {
                 programStageCache.put( id, programStage );
 
-                dataElementCache.putAll( programStage.getDataElements().stream().collect( Collectors.toMap( DataElement::getUid, de -> de ) ) );
+                cacheDataElements( Sets.newHashSet( programStage ) );
             }
         }
 
@@ -2051,7 +2106,7 @@ public abstract class AbstractEventService
 
     private DataElement getDataElement( IdScheme idScheme, String id )
     {
-        return dataElementCache.get( id, () -> manager.getObject( DataElement.class, idScheme, id ) );
+        return DATA_ELEM_CACHE.get( id, s -> manager.getObject( DataElement.class, idScheme, id ) ).orElse( null );
     }
 
     private CategoryOption getCategoryOption( IdScheme idScheme, String id )
@@ -2073,9 +2128,8 @@ public abstract class AbstractEventService
 
     private List<ProgramInstance> getActiveProgramInstances( String key, Program program )
     {
-        return activeProgramInstanceCache.get( key, () -> {
-            return programInstanceService.getProgramInstances( program, ProgramStatus.ACTIVE );
-        } );
+        return activeProgramInstanceCache.get( key,
+            () -> programInstanceService.getProgramInstances( program, ProgramStatus.ACTIVE ) );
     }
 
     private IdentifiableObject getDefaultObject( Class<? extends IdentifiableObject> key )
@@ -2279,7 +2333,7 @@ public abstract class AbstractEventService
         programInstanceCache.clear();
         activeProgramInstanceCache.clear();
         trackedEntityInstanceCache.clear();
-        dataElementCache.clear();
+        DATA_ELEM_CACHE.invalidateAll();
         categoryOptionCache.clear();
         categoryOptionComboCache.clear();
         attributeOptionComboCache.clear();
@@ -2445,7 +2499,7 @@ public abstract class AbstractEventService
         return importOptions;
     }
 
-    protected void reloadUser( ImportOptions importOptions )
+    private void reloadUser(ImportOptions importOptions)
     {
         if ( importOptions == null || importOptions.getUser() == null )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -2499,7 +2499,7 @@ public abstract class AbstractEventService
         return importOptions;
     }
 
-    private void reloadUser(ImportOptions importOptions)
+    private void reloadUser( ImportOptions importOptions )
     {
         if ( importOptions == null || importOptions.getUser() == null )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
@@ -35,24 +35,42 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.events.TrackerAccessManager;
+import org.hisp.dhis.dxf2.events.eventdatavalue.EventDataValueService;
+import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
+import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.hibernate.objectmapper.EmptyStringToNullStdDeserializer;
 import org.hisp.dhis.hibernate.objectmapper.ParseDateStdDeserializer;
 import org.hisp.dhis.hibernate.objectmapper.WriteDateStdSerializer;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.*;
+import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.UserService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StreamUtils;
 
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
@@ -65,7 +83,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
  */
 @Service( "org.hisp.dhis.dxf2.events.event.EventService" )
 @Scope( value = "prototype", proxyMode = ScopedProxyMode.INTERFACES )
-@Transactional
 public class JacksonEventService extends AbstractEventService
 {
     // -------------------------------------------------------------------------
@@ -75,6 +92,26 @@ public class JacksonEventService extends AbstractEventService
     private final static ObjectMapper XML_MAPPER = new XmlMapper();
 
     private final static ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    public JacksonEventService( ProgramService programService, ProgramStageService programStageService,
+        ProgramInstanceService programInstanceService, ProgramStageInstanceService programStageInstanceService,
+        OrganisationUnitService organisationUnitService, DataElementService dataElementService,
+        CurrentUserService currentUserService, EventDataValueService eventDataValueService,
+        TrackedEntityInstanceService entityInstanceService, TrackedEntityCommentService commentService,
+        EventStore eventStore, I18nManager i18nManager, Notifier notifier, SessionFactory sessionFactory,
+        DbmsManager dbmsManager, IdentifiableObjectManager manager, CategoryService categoryService,
+        FileResourceService fileResourceService, SchemaService schemaService, QueryService queryService,
+        TrackerAccessManager trackerAccessManager, TrackerOwnershipManager trackerOwnershipAccessManager,
+        AclService aclService, ApplicationEventPublisher eventPublisher, RelationshipService relationshipService,
+        UserService userService, EventSyncService eventSyncService, ProgramRuleVariableService ruleVariableService )
+    {
+        super( programService, programStageService, programInstanceService, programStageInstanceService,
+            organisationUnitService, dataElementService, currentUserService, eventDataValueService,
+            entityInstanceService, commentService, eventStore, i18nManager, notifier, sessionFactory, dbmsManager,
+            manager, categoryService, fileResourceService, schemaService, queryService, trackerAccessManager,
+            trackerOwnershipAccessManager, aclService, eventPublisher, relationshipService, userService,
+            eventSyncService, ruleVariableService );
+    }
 
     @SuppressWarnings( "unchecked" )
     private static <T> T fromXml( String input, Class<?> clazz ) throws IOException

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/eventdatavalue/DefaultEventDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/eventdatavalue/DefaultEventDataValueService.java
@@ -27,7 +27,12 @@ package org.hisp.dhis.dxf2.events.eventdatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Sets;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -52,15 +57,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.collect.Sets;
 
 /**
  * @author David Katuscak
@@ -85,14 +82,14 @@ public class DefaultEventDataValueService implements EventDataValueService
     }
 
     @Override
-    public void processDataValues( ProgramStageInstance programStageInstance, Event event, boolean singleValue,
-        ImportOptions importOptions, ImportSummary importSummary, Map<String, DataElement> dataElementsCache ) {
+    public void processDataValues(ProgramStageInstance programStageInstance, Event event, boolean singleValue,
+                                  ImportOptions importOptions, ImportSummary importSummary, Cache<DataElement> dataElementCache) {
 
         Map<String, EventDataValue> dataElementValueMap = getDataElementToEventDataValueMap( programStageInstance.getEventDataValues() );
 
         boolean validateMandatoryAttributes = doValidationOfMandatoryAttributes( importOptions.getUser() );
         if ( validateMandatoryAttributes && !validatePresenceOfMandatoryDataElements( event, programStageInstance,
-            dataElementsCache, importOptions, importSummary, singleValue ) )
+            dataElementCache, importOptions, importSummary, singleValue ) )
         {
             importSummary.setStatus( ImportStatus.ERROR );
             importSummary.incrementIgnored();
@@ -103,6 +100,7 @@ public class DefaultEventDataValueService implements EventDataValueService
         Set<EventDataValue> newDataValues = new HashSet<>();
         Set<EventDataValue> updatedDataValues = new HashSet<>();
         Set<EventDataValue> removedDataValuesDueToEmptyValue = new HashSet<>();
+
         String fallbackStoredBy =
             AbstractEventService.getValidUsername( event.getStoredBy(), importSummary,
                 importOptions.getUser() != null ? importOptions.getUser().getUsername() : "[Unknown]" );
@@ -110,7 +108,7 @@ public class DefaultEventDataValueService implements EventDataValueService
         for ( DataValue dataValue : event.getDataValues() )
         {
             String storedBy = !StringUtils.isEmpty( dataValue.getStoredBy() ) ? dataValue.getStoredBy() : fallbackStoredBy;
-            DataElement dataElement = dataElementsCache.get( dataValue.getDataElement() );
+            DataElement dataElement = dataElementCache.get( dataValue.getDataElement() ).orElse( null );
 
             if ( dataElement == null )
             {
@@ -125,7 +123,7 @@ public class DefaultEventDataValueService implements EventDataValueService
             }
         }
 
-        programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( newDataValues, updatedDataValues, removedDataValuesDueToEmptyValue, dataElementsCache, programStageInstance, singleValue );
+        programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( newDataValues, updatedDataValues, removedDataValuesDueToEmptyValue, dataElementCache, programStageInstance, singleValue );
     }
 
     private void prepareDataValueForStorage( Map<String, EventDataValue> dataElementToValueMap, DataValue dataValue,
@@ -180,7 +178,7 @@ public class DefaultEventDataValueService implements EventDataValueService
     }
 
     private boolean validatePresenceOfMandatoryDataElements( Event event, ProgramStageInstance programStageInstance,
-        Map<String, DataElement> dataElementsCache, ImportOptions importOptions, ImportSummary importSummary,
+                                                             Cache<DataElement> dataElementsCache, ImportOptions importOptions, ImportSummary importSummary,
         boolean isSingleValueUpdate )
     {
         ValidationStrategy validationStrategy = programStageInstance.getProgramStage().getValidationStrategy();
@@ -196,7 +194,7 @@ public class DefaultEventDataValueService implements EventDataValueService
 
             Set<String> presentDataElements = event.getDataValues().stream()
                 .filter( dv -> dv != null && dv.getValue() != null && !dv.getValue().trim().isEmpty() && !dv.getValue().trim().equals( "null" ) )
-                .map( dv -> dataElementsCache.get( dv.getDataElement() ).getUid() )
+                .map( dv -> dataElementsCache.get( dv.getDataElement() ).get().getUid() )
                 .collect( Collectors.toSet() );
 
             // When the request is update, then only changed data values can be in the payload and so I should take into
@@ -216,7 +214,7 @@ public class DefaultEventDataValueService implements EventDataValueService
             if ( notPresentMandatoryDataElements.size() > 0 )
             {
                 notPresentMandatoryDataElements.stream()
-                    .map( dataElementsCache::get )
+                    .map( i -> dataElementsCache.get( i ).get() )
                     .forEach( de -> importSummary.getConflicts().add(
                         new ImportConflict( getDataElementIdentificator( de, importOptions.getIdSchemes().getDataElementIdScheme() ),
                             "value_required_but_not_provided" ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/repository/TrackedEntityAttributeRepository.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/repository/TrackedEntityAttributeRepository.java
@@ -28,54 +28,71 @@
 
 package org.hisp.dhis.dxf2.events.repository;
 
-import com.google.common.collect.Sets;
+import java.util.*;
+
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.springframework.stereotype.Repository;
 
-import java.util.*;
-
-import static java.util.stream.Collectors.groupingBy;
+import com.google.common.collect.Sets;
 
 /**
  * @author Luciano Fiandesio
  */
 @Repository
-public class TrackedEntityAttributeRepository {
+public class TrackedEntityAttributeRepository
+{
 
     private final SessionFactory sessionFactory;
 
-    public TrackedEntityAttributeRepository(SessionFactory sessionFactory) {
+    public TrackedEntityAttributeRepository( SessionFactory sessionFactory )
+    {
         this.sessionFactory = sessionFactory;
     }
 
+    /**
+     * Fetches all {@see TrackedEntityAttribute} linked to all
+     * {@see TrackedEntityType} present in the system
+     * 
+     * @return a Set of {@see TrackedEntityAttribute}
+     */
+    @SuppressWarnings("unchecked")
     public Set<TrackedEntityAttribute> getTrackedEntityAttributesByTrackedEntityTypes()
     {
         Query query = sessionFactory.getCurrentSession()
             .createQuery( "select tet.trackedEntityTypeAttributes from TrackedEntityType tet" );
+
         return new HashSet<>( query.list() );
     }
 
-    public Map<Program, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByProgram() {
 
+    /**
+     * Fetches all {@see TrackedEntityAttribute} and groups them by {@see Program}
+     *
+     * @return a Map, where the key is the {@see Program} and the values is a Set of {@see TrackedEntityAttribute} associated
+     * to the {@see Program} in the key
+     */
+    @SuppressWarnings("unchecked")
+    public Map<Program, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByProgram()
+    {
         Map<Program, Set<TrackedEntityAttribute>> result = new HashMap<>();
-        Query query = sessionFactory.getCurrentSession()
-                .createQuery("select p.programAttributes from Program p");
 
-        List<ProgramTrackedEntityAttribute> pteas = query.list();
-        for ( ProgramTrackedEntityAttribute ptea : pteas )
+        Query query = sessionFactory.getCurrentSession().createQuery( "select p.programAttributes from Program p");
+
+        List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes = (List<ProgramTrackedEntityAttribute>) query.list();
+
+        for ( ProgramTrackedEntityAttribute programTrackedEntityAttribute : programTrackedEntityAttributes )
         {
-            if ( !result.containsKey( ptea.getProgram() ) )
+            if ( !result.containsKey( programTrackedEntityAttribute.getProgram() ) )
             {
-                result.put( ptea.getProgram(), Sets.newHashSet( ptea.getAttribute() ) );
+                result.put( programTrackedEntityAttribute.getProgram(), Sets.newHashSet( programTrackedEntityAttribute.getAttribute() ) );
             }
             else
             {
-                result.get( ptea.getProgram() ).add( ptea.getAttribute() );
+                result.get( programTrackedEntityAttribute.getProgram() ).add( programTrackedEntityAttribute.getAttribute() );
             }
         }
         return result;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/repository/TrackedEntityAttributeRepository.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/repository/TrackedEntityAttributeRepository.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.dxf2.events.repository;
+
+import com.google.common.collect.Sets;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.groupingBy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Repository
+public class TrackedEntityAttributeRepository {
+
+    private final SessionFactory sessionFactory;
+
+    public TrackedEntityAttributeRepository(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    public Set<TrackedEntityAttribute> getTrackedEntityAttributesByTrackedEntityTypes()
+    {
+        Query query = sessionFactory.getCurrentSession()
+            .createQuery( "select tet.trackedEntityTypeAttributes from TrackedEntityType tet" );
+        return new HashSet<>( query.list() );
+    }
+
+    public Map<Program, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByProgram() {
+
+        Map<Program, Set<TrackedEntityAttribute>> result = new HashMap<>();
+        Query query = sessionFactory.getCurrentSession()
+                .createQuery("select p.programAttributes from Program p");
+
+        List<ProgramTrackedEntityAttribute> pteas = query.list();
+        for ( ProgramTrackedEntityAttribute ptea : pteas )
+        {
+            if ( !result.containsKey( ptea.getProgram() ) )
+            {
+                result.put( ptea.getProgram(), Sets.newHashSet( ptea.getAttribute() ) );
+            }
+            else
+            {
+                result.get( ptea.getProgram() ).add( ptea.getAttribute() );
+            }
+        }
+        return result;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -28,8 +28,12 @@ package org.hisp.dhis.dxf2.events.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
-import com.vividsolutions.jts.geom.Geometry;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -72,12 +76,7 @@ import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.GeoUtils;
 import org.hisp.dhis.textpattern.TextPatternValidationUtils;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
-import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
+import org.hisp.dhis.trackedentity.*;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.CurrentUserService;
@@ -88,17 +87,8 @@ import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -180,10 +170,21 @@ public abstract class AbstractTrackedEntityInstanceService
     // READ
     // -------------------------------------------------------------------------
 
-    private Set<TrackedEntityAttribute> mergeIf( Set<TrackedEntityAttribute> set1, Set<TrackedEntityAttribute> set2, boolean condition )
+    /**
+     * Merges the two sets, if the passed condition is true
+     *
+     * @param set1 a Set
+     * @param set2 a second Set
+     * @param condition a boolean condition
+     * @return if condition is true, a new Set consisting of the first and second
+     *         set. If false, the first set
+     */
+    private Set<TrackedEntityAttribute> mergeIf( Set<TrackedEntityAttribute> set1, Set<TrackedEntityAttribute> set2,
+        boolean condition )
     {
-        if (condition) {
-            set1.addAll(set2);
+        if ( condition )
+        {
+            set1.addAll( set2 );
         }
         return set1;
     }
@@ -202,8 +203,7 @@ public abstract class AbstractTrackedEntityInstanceService
         List<TrackedEntityType> trackedEntityTypes = manager.getAll( TrackedEntityType.class );
 
         Set<TrackedEntityAttribute> trackedEntityTypeAttributes = trackedEntityAttributeRepository.getTrackedEntityAttributesByTrackedEntityTypes();
-        //trackedEntityTypes.stream().collect( Collectors.toList() )
-            //.stream().map( TrackedEntityType::getTrackedEntityAttributes ).flatMap( Collection::stream ).collect( Collectors.toSet() );
+
         Map<Program, Set<TrackedEntityAttribute>> teaByProgram = trackedEntityAttributeRepository.getTrackedEntityAttributesByProgram();
 
         if ( queryParams != null && queryParams.isIncludeAllAttributes() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/repository/TrackedEntityAttributeRepositoryTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/repository/TrackedEntityAttributeRepositoryTest.java
@@ -1,0 +1,148 @@
+package org.hisp.dhis.dxf2.events.repository;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.trackedentity.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class TrackedEntityAttributeRepositoryTest
+    extends
+    DhisSpringTest
+{
+
+    @Autowired
+    private TrackedEntityAttributeRepository trackedEntityAttributeRepository;
+
+    @Autowired
+    private TrackedEntityTypeService trackedEntityTypeService;
+
+    @Autowired
+    private TrackedEntityAttributeService attributeService;
+
+    @Autowired
+    private ProgramService programService;
+
+    private final static int A = 65;
+
+    private final static int T = 85;
+
+    private Program programB;
+
+    @Before
+    public void setUp()
+    {
+
+        Program program = createProgram( 'A' );
+        programService.addProgram( program );
+
+        TrackedEntityType trackedEntityTypeA = createTrackedEntityType( 'A' );
+        trackedEntityTypeA.setPublicAccess( AccessStringHelper.FULL );
+        trackedEntityTypeService.addTrackedEntityType( trackedEntityTypeA );
+
+        TrackedEntityType trackedEntityTypeB = createTrackedEntityType( 'B' );
+        trackedEntityTypeB.setPublicAccess( AccessStringHelper.FULL );
+        trackedEntityTypeService.addTrackedEntityType( trackedEntityTypeB );
+
+        // Create 20 Tracked Entity Attributes (named A .. O)
+        IntStream.range( A, T ).mapToObj( i -> Character.toString( (char) i ) ).forEach( c -> attributeService
+            .addTrackedEntityAttribute( createTrackedEntityAttribute( c.charAt( 0 ), ValueType.TEXT ) ) );
+        
+        // Transform the Tracked Entity Attributes into a List of TrackedEntityTypeAttribute
+        List<TrackedEntityTypeAttribute> teatList = IntStream.range( A, T )
+            .mapToObj( i -> Character.toString( (char) i ) )
+            .map( s -> new TrackedEntityTypeAttribute( trackedEntityTypeA,
+                attributeService.getTrackedEntityAttributeByName( "Attribute" + s ) ) )
+            .collect( Collectors.toList() );
+        
+        // Assign 10 TrackedEntityTypeAttribute to Tracked Entity Type A
+        trackedEntityTypeA.setTrackedEntityTypeAttributes( teatList.subList( 0, 10 ) );
+        trackedEntityTypeService.updateTrackedEntityType( trackedEntityTypeA );
+
+        // Assign 10 TrackedEntityTypeAttribute to Tracked Entity Type B
+        trackedEntityTypeB.setTrackedEntityTypeAttributes( teatList.subList( 10, 20 ) );
+        trackedEntityTypeService.updateTrackedEntityType( trackedEntityTypeB );
+        
+        // Setup for second test
+        
+        programB = createProgram( 'B' );
+        programService.addProgram( programB );
+
+        List<ProgramTrackedEntityAttribute> pteaList = IntStream.range( A, T )
+            .mapToObj( i -> Character.toString( (char) i ) ).map( s -> new ProgramTrackedEntityAttribute( programB,
+                attributeService.getTrackedEntityAttributeByName( "Attribute" + s ) ) )
+            .collect( Collectors.toList() );
+
+        programB.setProgramAttributes( pteaList );
+        programService.updateProgram( program );
+
+    }
+
+    @Test
+    public void verifyGetTrackedEntityAttributesByTrackedEntityTypes()
+    {
+
+        Set<TrackedEntityAttribute> trackedEntityAttributes = trackedEntityAttributeRepository
+            .getTrackedEntityAttributesByTrackedEntityTypes();
+
+        assertThat( trackedEntityAttributes, hasSize( 20 ) );
+    }
+
+    @Test
+    public void verifyGetTrackedEntityAttributesByProgram()
+    {
+
+        Map<Program, Set<TrackedEntityAttribute>> trackedEntityAttributes = trackedEntityAttributeRepository
+            .getTrackedEntityAttributesByProgram();
+
+        assertThat( trackedEntityAttributes.size(), is( 1 ) );
+        assertThat( trackedEntityAttributes.get( programB ), hasSize( 20 ) );
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
@@ -1,4 +1,5 @@
-package org.hisp.dhis.dxf2.events.eventdatavalue;
+package org.hisp.dhis.cache;
+
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -27,30 +28,74 @@ package org.hisp.dhis.dxf2.events.eventdatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dxf2.common.ImportOptions;
-import org.hisp.dhis.dxf2.events.event.Event;
-import org.hisp.dhis.dxf2.importsummary.ImportSummary;
-import org.hisp.dhis.program.ProgramStageInstance;
-
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
- * @author David Katuscak
+ * @author Luciano Fiandesio
  */
-public interface EventDataValueService
+public class TestCache<V>
+    implements
+    Cache<V>
 {
-    /**
-     * Process the data values: validates and then saves/updates/deletes data values.
-     *
-     * @param programStageInstance The ProgramStageInstance the EventDataValues are related to
-     * @param event Event that holds the data values to process
-     * @param singleValue Specifies whether request updates only a single value or not
-     * @param importOptions ImportOptions
-     * @param importSummary ImportSummary
-     * @param dataElementsCache Cache with DataElements related to EventDataValues that are being updated
-     */
-    void processDataValues(ProgramStageInstance programStageInstance, Event event, boolean singleValue,
-                           ImportOptions importOptions, ImportSummary importSummary, Cache<DataElement> dataElementsCache);
+
+    private Map<String, V> mapCache = new HashMap<>();
+
+    @Override
+    public Optional<V> getIfPresent( String key )
+    {
+        if ( mapCache.containsKey( key ) )
+        {
+            return get( key );
+        }
+        else
+        {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<V> get( String key )
+    {
+        return Optional.ofNullable( mapCache.get( key ) );
+    }
+
+    @Override
+    public Optional<V> get( String key, Function<String, V> mappingFunction )
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<V> getAll()
+    {
+        return mapCache.values();
+    }
+
+    @Override
+    public void put( String key, V value )
+    {
+        mapCache.put( key, value );
+    }
+
+    @Override
+    public void invalidate( String key )
+    {
+        mapCache.remove( key );
+    }
+
+    @Override
+    public void invalidateAll()
+    {
+        mapCache = new HashMap<>();
+    }
+
+    @Override
+    public CacheType getCacheType()
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
Original issue: DHIS2-7336

This PR reduces the number of queries required to fetch a "page" of TEIs from ~17000 to ~700. Speed increase is around 75%.

This is the query I have been using for testing - the same query used by Android devices: 

```
/api/trackedEntityInstances?ou=DiszpKrYNg8&ouMode=DESCENDANTS&fields=trackedEntityInstance,created,lastUpdated,orgUnit,trackedEntityType,coordinates,featureType,deleted,attributes%5Battribute,value,created,lastUpdated%5D,relationships%5BtrackedEntityInstanceA,trackedEntityInstanceB,relationship,relationshipName,relationshipType,created,lastUpdated,from%5BtrackedEntityInstance%5BtrackedEntityInstance%5D,enrollment%5Benrollment%5D,event%5Bevent%5D%5D,to%5BtrackedEntityInstance%5BtrackedEntityInstance%5D,enrollment%5Benrollment%5D,event%5Bevent%5D%5D,relative%5D,enrollments%5Benrollment,created,lastUpdated,orgUnit,program,enrollmentDate,incidentDate,followup,status,deleted,trackedEntityInstance,coordinate,events%5Bevent,enrollment,created,lastUpdated,status,coordinate,program,programStage,orgUnit,eventDate,completedDate,deleted,dueDate,attributeOptionCombo,dataValues%5BdataElement,storedBy,value,created,lastUpdated,providedElsewhere%5D%5D,notes%5Bnote,value,storedBy,storedDate%5D%5D&paging=true&page=1&pageSize=50&includeAllAttributes=true&includeDeleted=true
```

The main factor in reducing the query was to use a `static` cache for `DataElement`, rather than a Map that was flushed at every invocation. There are also some minor optimizations, namely using "smarter" queries that fetch more data in one "go" (see TrackedEntityAttributeRepository)

One question is: is it OK to use `static` caches here? The cache expires after 60 minutes, so some data may be not up-to-date during cache refresh (usual trade-off when using a cache).  

