### PR TITLE
fix: DHIS2-7676: Mismatch between headers and rows / analytics API

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -131,6 +131,7 @@ public class DataQueryParams
     public static final String DEFAULT_ORG_UNIT_FIELD = "ou";
 
     public static final int DX_INDEX = 0;
+    public static final int NUMERATOR_DENOMINATOR_PROPERTIES_COUNT = 5;
 
     public static final ImmutableSet<Class<? extends IdentifiableObject>> DYNAMIC_DIM_CLASSES = ImmutableSet.of(
         OrganisationUnitGroupSet.class, DataElementGroupSet.class, CategoryOptionGroupSet.class, Category.class );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -590,7 +590,7 @@ public class DefaultAnalyticsService
 
                 if ( params.isIncludeNumDen() )
                 {
-                    grid.addNullValues( 5 );
+                    grid.addNullValues( NUMERATOR_DENOMINATOR_PROPERTIES_COUNT );
                 }
             }
         }
@@ -670,7 +670,7 @@ public class DefaultAnalyticsService
 
             if ( params.isIncludeNumDen() )
             {
-                grid.addNullValues( 5 );
+                grid.addNullValues( NUMERATOR_DENOMINATOR_PROPERTIES_COUNT );
             }
         }
     }
@@ -1059,7 +1059,7 @@ public class DefaultAnalyticsService
 
             if ( params.isIncludeNumDen() )
             {
-                grid.addNullValues( 3 );
+                grid.addNullValues( NUMERATOR_DENOMINATOR_PROPERTIES_COUNT );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
  */
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ORG_UNIT_STRUCT_ALIAS;
@@ -396,7 +397,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
 
             if ( params.isIncludeNumDen() )
             {
-                grid.addNullValues( 5 );
+                grid.addNullValues( NUMERATOR_DENOMINATOR_PROPERTIES_COUNT );
             }
         }
     }


### PR DESCRIPTION
Fixing the response result rows to match the same quantity of headers when "includeNumDen"  is set to true and there are no numerator/denominator data.