### PR TITLE
chore: modify dockerfile to use official tomcat images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN mvn clean install -T1C -U -f /src/dhis-2/dhis-web/pom.xml -DskipTests
 # Serve the packaged .war file (Tomcat)
 # Use a second build stage in a fresh container so we don't bloat it with the Maven build tools
 ##########
-FROM tomcat:8.5.34-jre8-alpine as serve
+FROM tomcat:8.5.46-jdk8-openjdk-slim as serve
 
 ENV DHIS2_HOME=/DHIS2_home
 
@@ -62,13 +62,13 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
     mkdir /usr/local/tomcat/webapps/ROOT && \
     chmod +rx /usr/local/bin/docker-entrypoint.sh && \
     mkdir $DHIS2_HOME && \
-    addgroup -S tomcat && \
-    addgroup root tomcat && \
-    adduser -S -D -G tomcat tomcat
+    adduser --system --disabled-password --group tomcat
 
-RUN apk add --update --no-cache \
-        bash  \
-        su-exec
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        util-linux \
+        bash \
+        unzip
 
 COPY server.xml /usr/local/tomcat/conf
 COPY --from=build /src/dhis-2/dhis-web/dhis-web-portal/target/dhis.war /usr/local/tomcat/webapps/ROOT.war
@@ -76,5 +76,3 @@ COPY --from=build /src/dhis-2/dhis-web/dhis-web-portal/target/dhis.war /usr/loca
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["catalina.sh", "run"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,9 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
     mkdir /usr/local/tomcat/webapps/ROOT && \
     chmod +rx /usr/local/bin/docker-entrypoint.sh && \
     mkdir $DHIS2_HOME && \
-    adduser --system --disabled-password --group tomcat
+    adduser --system --disabled-password --group tomcat && \
+    echo 'tomcat' >> /etc/cron.deny && \
+    echo 'tomcat' >> /etc/at.deny
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$(id -u)" = "0" ]; then
         $TOMCATDIR/logs
 
     chown -R tomcat:tomcat $DHIS2HOME
-    exec su-exec tomcat "$0" "$@"
+    exec setpriv --reuid=tomcat --regid=tomcat --init-groups "$0" "$@"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,7 +12,7 @@ if [ "$(id -u)" = "0" ]; then
     fi
     
     chown -R root:tomcat $TOMCATDIR
-    chmod -R u+rwX,g+rX,o-rwx $TOMCATDIR
+    chmod -R u=rwX,g=rX,o-rwx $TOMCATDIR
     chown -R tomcat:tomcat $TOMCATDIR/temp \
         $TOMCATDIR/work \
         $TOMCATDIR/logs


### PR DESCRIPTION
This changes the Tomcat image we use in the second phase of the build to one of the officially supported Tomcat Docker images: https://hub.docker.com/_/tomcat

This makes it easier to just change the line:

```dockerfile
FROM tomcat:8.5.46-jdk8-openjdk-slim as serve
```

This allows us to test e.g. that DHIS2 works on Tomcat 9 quite easily:

```dockerfile
FROM tomcat:9.0.26-jdk8-openjdk-slim as serve
```

### Nota bene

⚠️ This does increase the image size to **587 MB** from **372 MB**.

Not sure what optimizations we can do though, I ran a couple of analysis tools on it to catch obvious stuff:

This Debian Slim image:

```
Total Image size: 587 MB
Potential wasted space: 6.8 MB
Image efficiency score: 99 %
```

Existing Alpine based image:

```
Total Image size: 372 MB
Potential wasted space: 1.4 MB
Image efficiency score: 99 %
```

ℹ️ _However_ it is important to note that the real value of this change is to be able to test the DHIS2 software against different versions of Tomcat.

### PR Updates

- [x] Fix so the permissions on the `temp/` dir matches the previous Alpine image
- [x] Add tomcat system-user to `at.deny` and `cron.deny`