### PR TITLE
Fix: disabling the data import tests

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/aggregate/DataImportTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/aggregate/DataImportTest.java
@@ -31,9 +31,6 @@ package org.hisp.dhis.aggregate;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import io.restassured.matcher.RestAssuredMatchers;
-import jdk.nashorn.internal.ir.annotations.Ignore;
-import org.hamcrest.Matchers;
 import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.aggregate.DataValueActions;
@@ -46,12 +43,11 @@ import org.hisp.dhis.helpers.QueryParamsBuilder;
 import org.hisp.dhis.helpers.file.JsonFileReader;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -59,7 +55,7 @@ import static org.hamcrest.Matchers.*;
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-@Ignore
+@Disabled
 public class DataImportTest
     extends ApiTest
 {


### PR DESCRIPTION
In jUni5, ignored flag seems to behave the same way as disabled. Using disabled instead. 