### PR TITLE
fix(dhis2-7698): use toLanguageTag instead of toString to get short code

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -398,7 +398,7 @@ public class BaseIdentifiableObject
 
         loadTranslationsCacheIfEmpty();
 
-        String cacheKey = Translation.getCacheKey( locale.toString(), property );
+        String cacheKey = Translation.getCacheKey( locale.toLanguageTag(), property );
 
         return translationCache.getOrDefault( cacheKey, defaultValue );
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/locale/I18nLocale.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/locale/I18nLocale.java
@@ -56,7 +56,7 @@ public class I18nLocale
     public I18nLocale( Locale locale )
     {
         this.name = locale.getDisplayName();
-        this.locale = locale.toString();
+        this.locale = locale.toLanguageTag();
     }
     
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/i18n/hibernate/HibernateI18nLocaleStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/i18n/hibernate/HibernateI18nLocaleStore.java
@@ -59,7 +59,7 @@ public class HibernateI18nLocaleStore
         CriteriaBuilder builder = getCriteriaBuilder();
 
         return getSingleResult( builder, newJpaParameters()
-            .addPredicate( root -> builder.equal( root.get( "locale" ), locale.toString() ) ) );
+            .addPredicate( root -> builder.equal( root.get( "locale" ), locale.toLanguageTag() ) ) );
     }
 
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/LocaleUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/LocaleUtils.java
@@ -108,7 +108,7 @@ public class LocaleUtils
         
         if ( !locale.getVariant().isEmpty() )
         {
-            locales.add( locale.toString() );
+            locales.add( locale.toLanguageTag() );
         }
         
         return locales;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebLocale.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebLocale.java
@@ -48,7 +48,7 @@ public class WebLocale
     {
         WebLocale loc = new WebLocale();
         
-        loc.setLocale( locale.toString() );
+        loc.setLocale( locale.toLanguageTag() );
         loc.setName( locale.getDisplayName() );
         
         return loc;

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/settings/userGeneralSettings.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/settings/userGeneralSettings.vm
@@ -31,7 +31,7 @@
 <div class="setting">
 <select id="currentLocale" name="currentLocale">
 #foreach( $locale in $availableLocales )
-	<option value="$locale.toString()" #if( $locale == $currentLocale )selected="selected"#end>$locale.getDisplayName()</option>
+	<option value="$locale.toLanguageTag()" #if( $locale == $currentLocale )selected="selected"#end>$locale.getDisplayName()</option>
 #end
 </select>
 </div>
@@ -42,7 +42,7 @@
 <select id="currentLocaleDb" name="currentLocaleDb">
 	<option value="">[$i18n.getString( "use_db_locale_no_translation" )]</option>
 #foreach( $locale in $availableLocalesDb )
-	<option value="$locale.toString()" #if( $locale == $currentLocaleDb )selected="selected"#end>$locale.getDisplayName()</option>
+	<option value="$locale.toLanguageTag()" #if( $locale == $currentLocaleDb )selected="selected"#end>$locale.getDisplayName()</option>
 #end
 </select>
 </div>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/HelpAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/HelpAction.java
@@ -84,7 +84,7 @@ public class HelpAction
 
         for ( Locale locale : locales )
         {
-            String helpPage = helpPagePreLocale + locale.toString() + helpPagePostLocale;
+            String helpPage = helpPagePreLocale + locale.toLanguageTag() + helpPagePostLocale;
 
             if ( resourceLoader.getResource( helpPage ) != null )
             {

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/util/TranslationUtils.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/util/TranslationUtils.java
@@ -101,7 +101,7 @@ public class TranslationUtils
 
         for ( Translation translation : translations )
         {
-            if ( StringUtils.isNotEmpty( translation.getValue() ) && translation.getLocale().equalsIgnoreCase( locale.toString() ) )
+            if ( StringUtils.isNotEmpty( translation.getValue() ) && translation.getLocale().equalsIgnoreCase( locale.toLanguageTag() ) )
             {
                 translationMap.put( translation.getProperty().getName(), translation.getValue() );
             }


### PR DESCRIPTION
Going through a bit of history of iso-639 reveals that the 2-char
language code for Indonesia used to be "in", but in later revisions they
changed it to "id".

Java has a policy of always being backwards compatible, so they have get
"in" intact. So if we do:

```
java.util.Locale locale = new java.util.Locale("id");
System.out.println(locale.toString());
```

It prints "in".

However, if we do this instead:

```
System.out.println(locale.toLanguageTag());
```

It prints "id", which is what we want.

Digging through
https://www.oracle.com/technetwork/java/javase/java8locales-2095355.html
we see that this is in fact the recommendation:

> Locales can be constructed with Locale.forLanguageTag(<Language Tag>) or
> Locale(<Language>, <Country>[, <Variant>]) where <Language Tag> is the
> Language Tag column value, <Language> is the ISO 639 value, <Country> is
> the ISO 3166 value, and <Variant> is the Variant column value if it’s
> neither empty nor *.
>
> Locales can be constructed only with Locale.forLanguageTag(<Language
> Tag>) if the Variant column value is *.

The star (*) denotation here is very important, as if we look up
Indonesian in the table we see: `in-ID(*)`.

So, we either have to construct our Locale with `.forLanguageTag` or,
actually convert to the language tag with `.toLanguageTag()` instead of
`.toString()`.