### PR TITLE
refactor(app store api): use versioned end-point from code, drop config property

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/appstore/DefaultAppStoreService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/appstore/DefaultAppStoreService.java
@@ -83,7 +83,7 @@ public class DefaultAppStoreService
     public List<WebApp> getAppStore()
     {
         String appStoreApiUrl = dhisConfigurationProvider.getProperty( ConfigurationKey.APP_STORE_API_URL );
-        String allAppsUrl = appStoreApiUrl + "/v1/apps";
+        String allAppsUrl = appStoreApiUrl + "/apps";
 
         WebApp[] apps = restTemplate.getForObject( allAppsUrl, WebApp[].class );
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/appstore/DefaultAppStoreService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/appstore/DefaultAppStoreService.java
@@ -83,17 +83,7 @@ public class DefaultAppStoreService
     public List<WebApp> getAppStore()
     {
         String appStoreApiUrl = dhisConfigurationProvider.getProperty( ConfigurationKey.APP_STORE_API_URL );
-        String appStoreApiVersion = dhisConfigurationProvider.getProperty( ConfigurationKey.APP_STORE_API_VERSION );
-        String allAppsUrl;
-
-        if ( "" == appStoreApiVersion )
-        {
-            allAppsUrl = appStoreApiUrl + "/apps";
-        }
-        else
-        {
-            allAppsUrl = appStoreApiUrl + "/" + appStoreApiVersion + "/apps";
-        }
+        String allAppsUrl = appStoreApiUrl + "/v1/apps";
 
         WebApp[] apps = restTemplate.getForObject( allAppsUrl, WebApp[].class );
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -101,7 +101,7 @@ public enum ConfigurationKey
     MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "off", false ),
     MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "off", false ),
     APP_STORE_URL( "appstore.base.url", "https://play.dhis2.org/appstore", false ),
-    APP_STORE_API_URL( "appstore.api.url", "https://play.dhis2.org/appstore/api", false ),
+    APP_STORE_API_URL( "appstore.api.url", "https://play.dhis2.org/appstore/api", false );
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -102,7 +102,6 @@ public enum ConfigurationKey
     MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "off", false ),
     APP_STORE_URL( "appstore.base.url", "https://play.dhis2.org/appstore", false ),
     APP_STORE_API_URL( "appstore.api.url", "https://play.dhis2.org/appstore/api", false ),
-    APP_STORE_API_VERSION( "appstore.api.version", "", false );
 
     private final String key;
 


### PR DESCRIPTION
We are dropping the `appstore.api.version` due to that the version cannot be controlled for all end-points through a single version. Instead, it is up to the consumer of the end-point to decide.

Even though we are adding versioned end-points to the app store, we need to stay backwards compatible with the existing app store API, so we are going to alias the unversioned `/apps` end-point to `/v1/apps`, this means we can drop the ugly checks in the core too.