### PR TITLE
[2.31] fix: display org unit in Event Report for OU DataValue

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -122,7 +122,8 @@ public abstract class AbstractEventJdbcTableManager
         }
         else if ( valueType.isOrganisationUnit() )
         {
-            return "ou.name from organisationunit ou where ou.uid = (select value " ;
+            // org unit is persisted like: /abcd/efgh/djkj so we only extract the last segment using substring
+            return "ou.name from organisationunit ou where ou.uid = (select substring(value, '[^/]*$') " ;
         }
         else
         {


### PR DESCRIPTION
- DHIS2-7157
- In 2.31, DataValues of type OrgUnit are persisted storing the entire
OU UID tree (abcd/efgg/ilmnd/pqrs). For Event Report we need only the
last segment of the "tree" to resolve the OU name during analytics table
population.