### PR TITLE
fix: DHIS2-7744 Fix parsing error on predictor expressions

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
@@ -70,7 +70,7 @@ public class ExpressionController
     {
         I18n i18n = i18nManager.getI18n();
 
-        ExpressionValidationOutcome result = expressionService.validationRuleExpressionIsValid( expression );
+        ExpressionValidationOutcome result = expressionService.predictorExpressionIsValid( expression );
 
         DescriptiveWebMessage message = new DescriptiveWebMessage();
         message.setStatus( result.isValid() ? Status.OK : Status.ERROR );


### PR DESCRIPTION
This is a 2.32-only problem. In 2.31 and prior, the endpoint GET api/expressions/description allowed all predictor functions as valid. In 2.33 and following, there are separate endpoints for indicators, validation rules, and predictors, and these endpoints are used by the front end.

In 2.32 this endpoint had been disallowing predictor functions. This patch brings it in line with previous versions of this endpoint, and recognizes predictor functions as valid.