### PR TITLE
Update jetty plugin, adds tomcat 8 plugin

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -106,7 +106,6 @@
     <dependency>
       <groupId>com.bedatadriven</groupId>
       <artifactId>jackson-datatype-jts</artifactId>
-      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>

--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -96,6 +96,10 @@
       <artifactId>hibernate-validator</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-spatial</artifactId>
     </dependency>

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSet.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.collect.Lists;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -46,7 +46,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.comparator.ObjectStringValueComparator;
 import org.hisp.dhis.dataelement.DataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PastPeriodPredicate.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PastPeriodPredicate.java
@@ -28,20 +28,20 @@ package org.hisp.dhis.period;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.collections4.Predicate;
+
 import java.util.Calendar;
 import java.util.Date;
-
-import org.apache.commons.collections.Predicate;
 
 public class PastPeriodPredicate
     implements Predicate
 {
     private Date date;
-    
+
     protected PastPeriodPredicate()
     {
     }
-    
+
     public PastPeriodPredicate( Date d )
     {
         Calendar cal = PeriodType.createCalendarInstance( d );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.user;
 
 import java.util.*;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdentifiableObjectUtils;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAuthorityGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAuthorityGroup.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.collect.Sets;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -34,7 +34,7 @@ import io.restassured.http.ContentType;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hamcrest.Matchers;
 import org.hisp.dhis.TestRunStorage;
 import org.hisp.dhis.dto.ApiResponse;

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -6,7 +6,7 @@ import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;

--- a/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/legacy/MetadataAuditConsumer.java
+++ b/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/legacy/MetadataAuditConsumer.java
@@ -72,8 +72,8 @@ public class MetadataAuditConsumer implements AuditConsumer
         this.metadataAuditService = metadataAuditService;
         this.renderService = renderService;
 
-        this.metadataAuditPersist = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_PERSIST ), "off" );
-        this.metadataAuditLog = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_LOG ), "off" );
+        this.metadataAuditPersist = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_PERSIST ), "on" );
+        this.metadataAuditLog = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_LOG ), "on" );
     }
 
     @JmsListener( destination = Topics.METADATA_TOPIC_NAME )

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -173,6 +173,10 @@
       <artifactId>velocity</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.eHealthAfrica</groupId>
       <artifactId>dhis2-sms-compression</artifactId>
       <version>0.1.7</version>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalAuditService.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.dataapproval;
  */
 
 import com.google.common.collect.Sets;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.category.CategoryOptionGroup;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
 import org.hisp.dhis.category.Category;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalLevelService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalLevelService.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.dataapproval;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.category.CategoryOptionGroupSet;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalAuditStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalAuditStore.java
@@ -36,7 +36,7 @@ import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import javax.persistence.criteria.CriteriaBuilder;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/DefaultReservedValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/DefaultReservedValueServiceTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.reservedvalue;
  */
 
 import com.google.common.collect.Lists;
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.hisp.dhis.DhisTest;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.Objects;

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -2,21 +2,21 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
     <version>2.34-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>dhis-service-reporting</artifactId>
   <packaging>jar</packaging>
   <name>DHIS Reporting Service</name>
-  
+
   <dependencies>
-    
+
     <!-- DHIS -->
-    
+
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-api</artifactId>
@@ -41,7 +41,7 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-dxf2</artifactId>
     </dependency>
-	
+
     <!-- JasperReports -->
 
     <dependency>
@@ -64,9 +64,13 @@
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+
     <!-- GeoTools -->
-    
+
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-render</artifactId>
@@ -79,9 +83,9 @@
       <groupId>org.geotools</groupId>
       <artifactId>gt-referencing</artifactId>
     </dependency>
-    
+
     <!-- Other -->
-    
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
@@ -95,7 +99,7 @@
       <artifactId>jsoup</artifactId>
       <version>1.11.3</version>
     </dependency>
-    
+
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.analytics.AnalyticsService;

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.validation.hibernate;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>artemis-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-amqp-protocol</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-external/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-external/pom.xml
@@ -94,7 +94,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
-    
+
     <!-- Other -->
 
     <dependency>
@@ -109,13 +109,17 @@
       <groupId>org.openid4java</groupId>
       <artifactId>openid4java</artifactId>
     </dependency>
-	<dependency>
+    <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
     <!-- Test -->
-    
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
@@ -125,7 +129,7 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
@@ -117,7 +117,7 @@ public class DefaultDhisConfigurationProvider
 
         try ( InputStream jsonIn = locationManager.getInputStream( GOOGLE_AUTH_FILENAME ) )
         {
-            Map<String, String> json = new ObjectMapper().readValue( jsonIn, new TypeReference<HashMap<String,Object>>() {} );
+            HashMap<String, Object> json = new ObjectMapper().readValue( jsonIn, new TypeReference<HashMap<String,Object>>() {} );
 
             this.properties.put( ConfigurationKey.GOOGLE_SERVICE_ACCOUNT_CLIENT_ID.getKey(), json.get( "client_id" ) );
         }

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -60,6 +60,10 @@
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
 
     <!-- Jasypt -->
 

--- a/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-spatial</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -157,6 +157,10 @@
       <artifactId>commons-validator</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -75,10 +75,6 @@
       <groupId>org.geotools</groupId>
       <artifactId>gt-geojson</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.vividsolutions</groupId>
-      <artifactId>jts</artifactId>
-    </dependency>
 
     <!-- JasperReports -->
 

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -121,6 +121,10 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-spatial</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -60,6 +60,10 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hisp</groupId>
       <artifactId>quick</artifactId>
     </dependency>

--- a/dhis-2/dhis-web/dhis-web-api-mobile/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-api-mobile/src/main/webapp/WEB-INF/web.xml
@@ -45,7 +45,7 @@
   </filter>
   <filter>
     <filter-name>Struts</filter-name>
-    <filter-class>org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter</filter-class>
+    <filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
   <filter>

--- a/dhis-2/dhis-web/dhis-web-api/src/main/resources/META-INF/dhis/servlet.xml
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/resources/META-INF/dhis/servlet.xml
@@ -4,7 +4,7 @@
   xmlns:context="http://www.springframework.org/schema/context"
   xmlns:sec="http://www.springframework.org/schema/security" xmlns:mvc="http://www.springframework.org/schema/mvc"
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
+    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
   <sec:global-method-security pre-post-annotations="enabled">

--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/WEB-INF/web.xml
@@ -44,7 +44,7 @@
   </filter>
   <filter>
     <filter-name>Struts</filter-name>
-    <filter-class>org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter</filter-class>
+    <filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
   <filter>

--- a/dhis-2/dhis-web/dhis-web-commons/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/pom.xml
@@ -67,6 +67,10 @@
       <artifactId>velocity</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity-tools</artifactId>
     </dependency>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityCacheManifestResult.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityCacheManifestResult.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.result;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.struts2.dispatcher.VelocityResult;
+import org.apache.struts2.result.VelocityResult;
 
 public class VelocityCacheManifestResult
     extends VelocityResult

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityJavascriptResult.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityJavascriptResult.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.result;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.struts2.dispatcher.VelocityResult;
+import org.apache.struts2.result.VelocityResult;
 
 public class VelocityJavascriptResult
     extends VelocityResult
@@ -40,7 +40,7 @@ public class VelocityJavascriptResult
 
     @Override
     protected final String getContentType( String templateLocation )
-    {       
+    {
         return "application/javascript";
     }
 }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityJsonResult.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityJsonResult.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.result;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.struts2.dispatcher.VelocityResult;
+import org.apache.struts2.result.VelocityResult;
 
 /**
  * @author Lars Helge Overland
@@ -44,7 +44,7 @@ public class VelocityJsonResult
 
     @Override
     protected final String getContentType( String templateLocation )
-    {       
+    {
         return "application/json";
     }
 }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityXMLResult.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/result/VelocityXMLResult.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.result;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.struts2.dispatcher.VelocityResult;
+import org.apache.struts2.result.VelocityResult;
 
 /**
  * @author Hans S. Toemmerholt
@@ -44,7 +44,7 @@ public class VelocityXMLResult
 
     @Override
     protected final String getContentType( String templateLocation )
-    {       
+    {
         return "text/xml";
     }
 }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:sec="http://www.springframework.org/schema/security" xmlns:oauth="http://www.springframework.org/schema/security/oauth2"
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
+    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2.xsd">
 
   <!-- OAuth2 -->

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/WEB-INF/web.xml
@@ -52,7 +52,7 @@
   </filter>
   <filter>
     <filter-name>Struts</filter-name>
-    <filter-class>org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter</filter-class>
+    <filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
   <filter>

--- a/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-mobile/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-maintenance/dhis-web-maintenance-mobile/src/main/webapp/WEB-INF/web.xml
@@ -52,7 +52,7 @@
   </filter>
   <filter>
     <filter-name>Struts</filter-name>
-    <filter-class>org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter</filter-class>
+    <filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
   <filter>

--- a/dhis-2/dhis-web/dhis-web-portal/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/src/main/webapp/WEB-INF/web.xml
@@ -59,7 +59,7 @@
   </filter>
   <filter>
     <filter-name>Struts</filter-name>
-    <filter-class>org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter</filter-class>
+    <filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
   <filter>

--- a/dhis-2/dhis-web/dhis-web-uaa/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-uaa/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
   </filter>
   <filter>
     <filter-name>Struts</filter-name>
-    <filter-class>org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter</filter-class>
+    <filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
   <filter>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -74,6 +74,39 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-maven2-plugin</artifactId>
+        <version>1.7.7</version>
+        <configuration>
+          <container>
+            <containerId>tomcat8x</containerId>
+            <artifactInstaller>
+              <groupId>org.apache.tomcat</groupId>
+              <artifactId>tomcat</artifactId>
+              <version>${tomcat.version}</version>
+            </artifactInstaller>
+          </container>
+          <configuration>
+            <type>standalone</type>
+            <home>${project.build.directory}/apache-tomcat-${tomcat.version}</home>
+            <properties>
+              <cargo.servlet.port>8080</cargo.servlet.port>
+              <cargo.logging>low</cargo.logging>
+            </properties>
+          </configuration>
+          <deployables>
+            <deployable>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}</artifactId>
+              <type>war</type>
+              <properties>
+                <context>/</context>
+              </properties>
+            </deployable>
+          </deployables>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${maven-jetty-plugin.version}</version>
@@ -141,6 +174,7 @@
     <rootDir>../</rootDir>
     <useWarCompression>true</useWarCompression>
     <maven-jetty-plugin.version>9.4.21.v20190926</maven-jetty-plugin.version>
+    <tomcat.version>8.5.47</tomcat.version>
   </properties>
 
 </project>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -35,6 +35,7 @@
           <plugin>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
+            <version>${maven-jetty-plugin.version}</version>
             <configuration>
               <scanIntervalSeconds>0</scanIntervalSeconds>
             </configuration>
@@ -75,7 +76,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.13.v20161014</version>
+        <version>${maven-jetty-plugin.version}</version>
         <configuration>
           <systemProperties>
             <systemProperty>
@@ -135,8 +136,11 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
   <properties>
     <rootDir>../</rootDir>
     <useWarCompression>true</useWarCompression>
+    <maven-jetty-plugin.version>9.4.21.v20190926</maven-jetty-plugin.version>
   </properties>
+
 </project>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -557,12 +557,12 @@
       <dependency>
         <groupId>org.springframework.hateoas</groupId>
         <artifactId>spring-hateoas</artifactId>
-        <version>0.23.0.RELEASE</version>
+        <version>1.0.0.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.retry</groupId>
         <artifactId>spring-retry</artifactId>
-        <version>1.2.1.RELEASE</version>
+        <version>1.2.4.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>
@@ -572,7 +572,7 @@
       <dependency>
         <groupId>com.alibaba.spring</groupId>
         <artifactId>spring-webmvc-velocity</artifactId>
-        <version>1.4.3.18.RELEASE</version>
+        <version>4.3.18.RELEASE</version>
       </dependency>
       <!--Spring Security -->
       <dependency>
@@ -690,7 +690,7 @@
       <dependency>
         <groupId>org.jasypt</groupId>
         <artifactId>jasypt</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.3</version>
       </dependency>
 
       <!-- Image Processing -->
@@ -758,12 +758,12 @@
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi</artifactId>
-        <version>3.17</version>
+        <version>4.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi-ooxml</artifactId>
-        <version>3.17</version>
+        <version>4.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.hisp</groupId>
@@ -804,7 +804,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant-compress</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>javax.interceptor</groupId>
@@ -851,7 +851,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.3</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -983,7 +983,7 @@
       <dependency>
         <groupId>com.mchange</groupId>
         <artifactId>c3p0</artifactId>
-        <version>0.9.5.3</version>
+        <version>0.9.5.4</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
@@ -1068,7 +1068,7 @@
       <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jcommon</artifactId>
-        <version>1.0.23</version>
+        <version>1.0.24</version>
         <exclusions>
           <exclusion>
             <groupId>gnujaxp</groupId>
@@ -1452,13 +1452,13 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-spring-legacy</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
       </dependency>
 
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -1480,7 +1480,7 @@
     <!-- Keep in sync with Hibernate -->
     <javassist.version>3.20.0-GA</javassist.version>
     <!-- unit test dependencies-->
-    <powermock.version>2.0.0</powermock.version>
+    <powermock.version>2.0.4</powermock.version>
     <jackson.version>2.10.0</jackson.version>
     <slf4j.version>1.7.5</slf4j.version>
     <geotools.version>18.0</geotools.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1200,11 +1200,6 @@
         <artifactId>gt-geojson</artifactId>
         <version>${geotools.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.vividsolutions</groupId>
-        <artifactId>jts</artifactId>
-        <version>1.13</version>
-      </dependency>
 
       <!-- JAXB -->
       <dependency>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -640,6 +640,12 @@
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
         <version>1.22.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-jdk5</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Spring Mobile -->
@@ -898,6 +904,12 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${hibernate.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml</groupId>
+            <artifactId>classmate</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -908,6 +920,12 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernate-validator.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml</groupId>
+            <artifactId>classmate</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -1112,6 +1130,11 @@
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml</groupId>
+        <artifactId>classmate</artifactId>
+        <version>1.3.2</version>
+      </dependency>
 
       <!-- GeoTools -->
       <dependency>
@@ -1304,9 +1327,9 @@
         <version>1.2.4.Final</version>
       </dependency>
       <dependency>
-       <groupId>org.cache2k</groupId>
-       <artifactId>cache2k-core</artifactId>
-       <version>1.2.4.Final</version>
+        <groupId>org.cache2k</groupId>
+        <artifactId>cache2k-core</artifactId>
+        <version>1.2.4.Final</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.jsmpp</groupId>
@@ -1337,7 +1360,7 @@
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
-        <version>3.3.0.Final</version>
+        <version>3.4.1.Final</version>
       </dependency>
       <dependency>
         <groupId>dom4j</groupId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1271,7 +1271,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.24.Final</version>
+        <version>4.1.42.Final</version>
       </dependency>
 
       <dependency>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1427,7 +1427,7 @@
     <spring-session-data-redis.version>1.3.5.RELEASE</spring-session-data-redis.version>
     <lettuce.version>4.5.0.Final</lettuce.version>
     <spring-data-redis.version>1.8.22.RELEASE</spring-data-redis.version>
-    <struts.version>2.3.36</struts.version>
+    <struts.version>2.5.20</struts.version>
     <hibernate.version>5.2.17.Final</hibernate.version>
     <hibernate-validator.version>5.0.3.Final</hibernate-validator.version>
     <jclouds.version>2.0.3</jclouds.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -725,6 +725,12 @@
         <groupId>org.apache.velocity</groupId>
         <artifactId>velocity</artifactId>
         <version>1.7</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>
@@ -815,7 +821,22 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.1</version>
+        <version>4.4</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.4</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-digester</groupId>
+        <artifactId>commons-digester</artifactId>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -826,16 +847,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.9.3</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-digester</groupId>
-        <artifactId>commons-digester</artifactId>
-        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
@@ -851,6 +862,12 @@
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
         <version>1.6</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -934,6 +934,11 @@
         <version>${hibernate.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.bedatadriven</groupId>
+        <artifactId>jackson-datatype-jts</artifactId>
+        <version>2.4</version>
+      </dependency>
+      <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernate-validator.version}</version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -834,19 +834,19 @@
         <version>1.9.4</version>
       </dependency>
       <dependency>
-        <groupId>commons-digester</groupId>
-        <artifactId>commons-digester</artifactId>
-        <version>2.1</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-digester3</artifactId>
+        <version>3.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.6</version>
+        <version>3.9</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.1</version>
+        <version>1.8</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
@@ -856,7 +856,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-math3</artifactId>
-        <version>3.4.1</version>
+        <version>3.6.1</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>
@@ -877,7 +877,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.11</version>
+        <version>1.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -887,7 +887,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-email</artifactId>
-        <version>1.3.3</version>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -1466,9 +1466,9 @@
   <properties>
     <rootDir></rootDir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.version>5.1.9.RELEASE</spring.version>
-    <spring-security.version>5.1.6.RELEASE</spring-security.version>
-    <spring-security-oauth2.version>2.3.6.RELEASE</spring-security-oauth2.version>
+    <spring.version>5.2.0.RELEASE</spring.version>
+    <spring-security.version>5.2.0.RELEASE</spring-security.version>
+    <spring-security-oauth2.version>2.3.7.RELEASE</spring-security-oauth2.version>
     <spring-session-data-redis.version>1.3.5.RELEASE</spring-session-data-redis.version>
     <lettuce.version>4.5.0.Final</lettuce.version>
     <spring-data-redis.version>1.8.22.RELEASE</spring-data-redis.version>
@@ -1481,7 +1481,7 @@
     <javassist.version>3.20.0-GA</javassist.version>
     <!-- unit test dependencies-->
     <powermock.version>2.0.0</powermock.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
     <slf4j.version>1.7.5</slf4j.version>
     <geotools.version>18.0</geotools.version>
     <jasperreports.version>6.3.1</jasperreports.version>


### PR DESCRIPTION
* Updates `jetty-maven-plugin` to latest version.
* Adds support for running `dhis-web-portal` through Tomcat 8.5.47 (using cargo), can be tested with `mvn cargo:run`.
* Updates a bunch of dependencies since using the latest `jetty-maven-plugin` exposed lots maven dependency mismatches (multiple version of same library etc).