### PR TITLE
ci:wait for db before starting web

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,7 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
+                    DOCKER_IMAGE_TAG = "test"
                 }
             }
         }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,7 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "test"
+                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
                 }
             }
         }

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -4,4 +4,4 @@ services:
   e2e-test:
     stdin_open: true
     image: "${IMAGE_NAME}"
-    command: ./wait-for-it.sh e2e-test-web:8080 -t 0-- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?
+    command: ./wait-for-it.sh e2e-test-web:8080 -t 0 -- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -4,4 +4,4 @@ services:
   e2e-test:
     stdin_open: true
     image: "${IMAGE_NAME}"
-    command: ./wait-for-it.sh e2e-test-web:8080 -- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?
+    command: ./wait-for-it.sh e2e-test-web:8080 -t 0-- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -23,9 +23,10 @@ services:
       context: ../..
     volumes:
     - ./config/dhis2_home/dhis.conf:/DHIS2_home/dhis.conf
+    environment:
+      - WAIT_FOR_DB_CONTAINER=db:5432
     depends_on:
     - db
     - redis
     ports:
     - "8080"
-    command: wait-for-it.sh db:5432 -t 0 -- catalina.sh run

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -28,3 +28,4 @@ services:
     - redis
     ports:
     - "8080"
+    command: wait-for-it.sh db:5432 -- catalina.sh run

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
     - ./config/dhis2_home/dhis.conf:/DHIS2_home/dhis.conf
     environment:
-      - WAIT_FOR_DB_CONTAINER=db:5432
+      - WAIT_FOR_DB_CONTAINER=db:5432 -t 0
     depends_on:
     - db
     - redis

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -28,4 +28,4 @@ services:
     - redis
     ports:
     - "8080"
-    command: wait-for-it.sh db:5432 -- catalina.sh run
+    command: wait-for-it.sh db:5432 -t 0 -- catalina.sh run

--- a/docker/shared/wait-for-it.sh
+++ b/docker/shared/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/docker/tomcat-alpine/Dockerfile
+++ b/docker/tomcat-alpine/Dockerfile
@@ -7,10 +7,12 @@ LABEL identifier=${IDENTIFIER}
 ENV DHIS2_HOME=/DHIS2_home
 
 COPY ./tomcat-alpine/docker-entrypoint.sh /usr/local/bin/
+COPY ./shared/wait-for-it.sh /usr/local/bin/
 
 RUN rm -rf /usr/local/tomcat/webapps/* && \
     mkdir /usr/local/tomcat/webapps/ROOT && \
     chmod +rx /usr/local/bin/docker-entrypoint.sh && \
+    chmod +rx /usr/local/bin/wait-for-it.sh && \
     mkdir $DHIS2_HOME && \
     addgroup -S tomcat && \
     addgroup root tomcat && \

--- a/docker/tomcat-alpine/Dockerfile
+++ b/docker/tomcat-alpine/Dockerfile
@@ -4,15 +4,12 @@ FROM $TOMCAT_IMAGE
 ARG IDENTIFIER=unknown
 LABEL identifier=${IDENTIFIER}
 
-ENV DHIS2_HOME=/DHIS2_home
+ENV WAIT_FOR_DB_CONTAINER=""
 
-COPY ./tomcat-alpine/docker-entrypoint.sh /usr/local/bin/
-COPY ./shared/wait-for-it.sh /usr/local/bin/
+ENV DHIS2_HOME=/DHIS2_home
 
 RUN rm -rf /usr/local/tomcat/webapps/* && \
     mkdir /usr/local/tomcat/webapps/ROOT && \
-    chmod +rx /usr/local/bin/docker-entrypoint.sh && \
-    chmod +rx /usr/local/bin/wait-for-it.sh && \
     mkdir $DHIS2_HOME && \
     addgroup -S tomcat && \
     addgroup root tomcat && \
@@ -20,10 +17,15 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
     echo 'tomcat' >> /etc/cron.deny && \
     echo 'tomcat' >> /etc/at.deny
 
-
 RUN apk add --update --no-cache \
         bash  \
         su-exec
+
+COPY ./shared/wait-for-it.sh /usr/local/bin/
+COPY ./tomcat-alpine/docker-entrypoint.sh /usr/local/bin/
+
+RUN chmod +rx /usr/local/bin/docker-entrypoint.sh && \
+    chmod +rx /usr/local/bin/wait-for-it.sh
 
 COPY ./shared/server.xml /usr/local/tomcat/conf
 COPY ./artifacts/dhis.war /usr/local/tomcat/webapps/ROOT.war

--- a/docker/tomcat-alpine/docker-entrypoint.sh
+++ b/docker/tomcat-alpine/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 WARFILE=/usr/local/tomcat/webapps/ROOT.war
+BINDIR=/usr/local/bin
 TOMCATDIR=/usr/local/tomcat
 DHIS2HOME=/DHIS2_home
 
@@ -19,6 +20,10 @@ if [ "$(id -u)" = "0" ]; then
 
     chown -R tomcat:tomcat $DHIS2HOME
     exec su-exec tomcat "$0" "$@"
+fi
+
+if [[ ! -z "$WAIT_FOR_DB_CONTAINER" ]]; then
+    $BINDIR/wait-for-it.sh $WAIT_FOR_DB_CONTAINER
 fi
 
 exec "$@"

--- a/docker/tomcat-debian/Dockerfile
+++ b/docker/tomcat-debian/Dockerfile
@@ -4,15 +4,12 @@ FROM $TOMCAT_IMAGE
 ARG IDENTIFIER=unknown
 LABEL identifier=${IDENTIFIER}
 
-ENV DHIS2_HOME=/DHIS2_home
+ENV WAIT_FOR_DB_CONTAINER=""
 
-COPY ./tomcat-debian/docker-entrypoint.sh /usr/local/bin/
-COPY ./shared/wait-for-it.sh /usr/local/bin/
+ENV DHIS2_HOME=/DHIS2_home
 
 RUN rm -rf /usr/local/tomcat/webapps/* && \
     mkdir /usr/local/tomcat/webapps/ROOT && \
-    chmod +rx /usr/local/bin/docker-entrypoint.sh && \
-    chmod +rx /usr/local/bin/wait-for-it.sh && \
     mkdir $DHIS2_HOME && \
     adduser --system --disabled-password --group tomcat && \
     echo 'tomcat' >> /etc/cron.deny && \
@@ -23,6 +20,12 @@ RUN apt-get update && \
         util-linux \
         bash \
         unzip
+
+COPY ./shared/wait-for-it.sh /usr/local/bin/
+COPY ./tomcat-debian/docker-entrypoint.sh /usr/local/bin/
+
+RUN chmod +rx /usr/local/bin/docker-entrypoint.sh && \
+    chmod +rx /usr/local/bin/wait-for-it.sh
 
 COPY ./shared/server.xml /usr/local/tomcat/conf
 COPY ./artifacts/dhis.war /usr/local/tomcat/webapps/ROOT.war

--- a/docker/tomcat-debian/Dockerfile
+++ b/docker/tomcat-debian/Dockerfile
@@ -7,10 +7,12 @@ LABEL identifier=${IDENTIFIER}
 ENV DHIS2_HOME=/DHIS2_home
 
 COPY ./tomcat-debian/docker-entrypoint.sh /usr/local/bin/
+COPY ./shared/wait-for-it.sh /usr/local/bin/
 
 RUN rm -rf /usr/local/tomcat/webapps/* && \
     mkdir /usr/local/tomcat/webapps/ROOT && \
     chmod +rx /usr/local/bin/docker-entrypoint.sh && \
+    chmod +rx /usr/local/bin/wait-for-it.sh && \
     mkdir $DHIS2_HOME && \
     adduser --system --disabled-password --group tomcat && \
     echo 'tomcat' >> /etc/cron.deny && \

--- a/docker/tomcat-debian/docker-entrypoint.sh
+++ b/docker/tomcat-debian/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 WARFILE=/usr/local/tomcat/webapps/ROOT.war
+BINDIR=/usr/local/bin
 TOMCATDIR=/usr/local/tomcat
 DHIS2HOME=/DHIS2_home
 
@@ -19,6 +20,10 @@ if [ "$(id -u)" = "0" ]; then
 
     chown -R tomcat:tomcat $DHIS2HOME
     exec setpriv --reuid=tomcat --regid=tomcat --init-groups "$0" "$@"
+fi
+
+if [[ ! -z "$WAIT_FOR_DB_CONTAINER" ]]; then
+    $BINDIR/wait-for-it.sh $WAIT_FOR_DB_CONTAINER
 fi
 
 exec "$@"


### PR DESCRIPTION
This fixes the race condition issue we have been having on CI when db is not ready by the time web starts. 

- Introduces WAIT_FOR_DB_CONTAINER enviroment variable. 
- Reorganisies dockerfile a bit to use the cache in the better way: changes in scripts should not invalidate all the other docker layers. 

NOTE: this fixes the immediate problem, but is not ideal. I will introduce the timeout and possible extensions to the wait_for_db_container variable later