### PR TITLE
Revert spring-security-oauth2 to 2.3.6.RELEASE version

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1463,7 +1463,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>5.2.0.RELEASE</spring.version>
     <spring-security.version>5.2.0.RELEASE</spring-security.version>
-    <spring-security-oauth2.version>2.3.7.RELEASE</spring-security-oauth2.version>
+    <spring-security-oauth2.version>2.3.6.RELEASE</spring-security-oauth2.version>
     <spring-session-data-redis.version>2.2.0.RELEASE</spring-session-data-redis.version>
     <lettuce.version>5.2.0.RELEASE</lettuce.version>
     <spring-data-redis.version>2.2.0.RELEASE</spring-data-redis.version>


### PR DESCRIPTION
spring-security-oauth 2 2.3.7.RELEASE has a bug that prevents custom
UserCredential classes to be deserialized: [commit](https://github.com/spring-projects/spring-security-oauth/commit/b214a25fdd8eae34c8ad803e7022fd17d1c63eb6#diff-28d3f6d7939c6931299a5d3c5e632d58)

The change was actually reverted
([commit](https://github.com/spring-projects/spring-security-oauth/commit/e7c2b970000ebd298d8ad15c5347c2e8c00bad2e#diff-28d3f6d7939c6931299a5d3c5e632d58))
but has not made it into a spring-security-oauth release yet.