### PR TITLE
ci: attach logs from web container if tests fails

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,7 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
+                    DOCKER_IMAGE_TAG = "test"
                 }
             }
         }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -102,6 +102,17 @@ pipeline {
                     }
                 }
             }
+
+            post {
+                failure {
+                    script {
+                        dir("dhis-2/dhis-e2e-test") {
+                            sh "docker-compose logs web > logs.txt"
+                            archiveArtifacts artifacts: 'logs.txt'
+                        }
+                    }
+                }
+            }
         }
 
         stage('Publish image') {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -107,7 +107,7 @@ pipeline {
                 failure {
                     script {
                         dir("dhis-2/dhis-e2e-test") {
-                            sh "docker-compose logs web > logs.txt"
+                            sh "docker-compose -p ${COMPOSE_PARAMETER} logs web > logs.txt"
                             archiveArtifacts artifacts: 'logs.txt'
                         }
                     }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,7 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "test"
+                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
                 }
             }
         }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -115,6 +115,14 @@ pipeline {
             }
         }
 
+        stage('Publish image') {
+            steps {
+                withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                    sh "docker push ${DOCKER_BASE_IMAGE_FULL_NAME}"
+                    sh "./docker/publish-containers.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
+                }
+            }
+        }
     }
 
     post {
@@ -128,6 +136,14 @@ pipeline {
             sh "./docker/cleanup-images.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
 
             sh "docker image prune --force --filter label=identifier=${DOCKER_IMAGE_TAG}"
+        }
+
+        failure {
+            slackSend(
+                color: '#ff0000',
+                message: 'Publishing of docker images for branch ' + env.BRANCH_NAME + ' failed. Visit ' + env.BUILD_URL + ' for more information',
+                channel: 'jenkins'
+            )
         }
     }
 }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -115,14 +115,6 @@ pipeline {
             }
         }
 
-        stage('Publish image') {
-            steps {
-                withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
-                    sh "docker push ${DOCKER_BASE_IMAGE_FULL_NAME}"
-                    sh "./docker/publish-containers.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
-                }
-            }
-        }
     }
 
     post {
@@ -136,14 +128,6 @@ pipeline {
             sh "./docker/cleanup-images.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
 
             sh "docker image prune --force --filter label=identifier=${DOCKER_IMAGE_TAG}"
-        }
-
-        failure {
-            slackSend(
-                color: '#ff0000',
-                message: 'Publishing of docker images for branch ' + env.BRANCH_NAME + ' failed. Visit ' + env.BUILD_URL + ' for more information',
-                channel: 'jenkins'
-            )
         }
     }
 }

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -4,4 +4,4 @@ services:
   e2e-test:
     stdin_open: true
     image: "${IMAGE_NAME}"
-    command: ./wait-for-it.sh e2e-test-web:8080 -t 0 -- mvn test -DbaseUrl=http://e2e-test-web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?
+    command: ./wait-for-it.sh web:8080 -t 0 -- mvn test -DbaseUrl=http://web:8080/api -DsuperUserUsername=taadmin -DsuperUserPsw=Test1212?

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_DB: dhis2
       POSTGRES_PASSOWRD: dhis
 
-  e2e-test-web:
+  web:
     image: "${IMAGE_NAME}"
     build:
       dockerfile: Dockerfile


### PR DESCRIPTION
https://jira.dhis2.org/browse/AUTO-49

Adds a conditional post-failure stage to the jenkins pipeline which will attach the logs from web container if tests fail. This will help with debugging why the server doesn't start up or tests fail. 