### PR TITLE
[2.32] fix: renders Geometry FEATURE TYPE as String

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -303,8 +303,7 @@ public class OrganisationUnitController
         generator.writeStringField( "id", organisationUnit.getUid() );
 
         generator.writeObjectFieldStart( "geometry" );
-        generator.writeObjectField( "type",
-            FeatureType.getTypeFromName( organisationUnit.getGeometry().getGeometryType() ) );
+        generator.writeObjectField( "type", organisationUnit.getGeometry().getGeometryType() );
 
         generator.writeFieldName( "coordinates" );
         generator.writeRawValue( getCoordinatesFromGeometry( organisationUnit.getGeometry() ) );


### PR DESCRIPTION
- DHIS2-7189
- When rendering `/api/33/organisationUnits.geojson` the system tries
to serialize to JSON the Geometry "Feature Type" object without declaring a serializer.
This throws an exception. The fix is simply to serialize the nam