### PR TITLE
[2.33] fix: Invalid equals result on DataElement class

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -747,22 +747,4 @@ public class DataElement extends BaseDimensionalItemObject
     {
         this.fieldMask = fieldMask;
     }
-
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( !(super.equals( o )) )
-        {
-            return false;
-        }
-
-        DataElement that = (DataElement) o;
-        return super.id == that.getId();
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash( super.hashCode(), super.id );
-    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -28,23 +28,15 @@ package org.hisp.dhis.dataelement;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import static org.hisp.dhis.dataset.DataSet.NO_EXPIRY;
+
+import java.util.*;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.BaseDimensionalItemObject;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DimensionItemType;
-import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
-import org.hisp.dhis.common.ObjectStyle;
-import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.dataset.comparator.DataSetApprovalFrequencyComparator;
@@ -59,16 +51,13 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.translation.TranslationProperty;
 import org.joda.time.DateTime;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.dataset.DataSet.NO_EXPIRY;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 
 /**
  * A DataElement is a definition (meta-information about) of the entities that
@@ -762,38 +751,18 @@ public class DataElement extends BaseDimensionalItemObject
     @Override
     public boolean equals( Object o )
     {
-        if ( this == o )
-        {
-            return true;
-        }
-
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-
-        if ( !super.equals( o ) )
+        if ( !(super.equals( o )) )
         {
             return false;
         }
 
         DataElement that = (DataElement) o;
-
-        return zeroIsSignificant == that.zeroIsSignificant && valueType == that.valueType
-            && Objects.equals( uid, that.uid )
-            && Objects.equals( formName, that.formName ) && Objects.equals( displayFormName, that.displayFormName )
-            && domainType == that.domainType && Objects.equals( categoryCombo, that.categoryCombo )
-            && Objects.equals( url, that.url )
-            && Objects.equals( aggregationLevels, that.aggregationLevels )
-            && Objects.equals( optionSet, that.optionSet ) && Objects.equals( commentOptionSet, that.commentOptionSet )
-            && Objects.equals( style, that.style ) && Objects.equals( fieldMask, that.fieldMask );
+        return super.id == that.getId();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( super.hashCode(), uid, valueType, formName, displayFormName, domainType, categoryCombo, url,
-            aggregationLevels, zeroIsSignificant, optionSet, commentOptionSet, style,
-            fieldMask );
+        return Objects.hash( super.hashCode(), super.id );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -35,13 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.common.AccessLevel;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.BaseNameableObject;
-import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.MetadataObject;
-import org.hisp.dhis.common.ObjectStyle;
-import org.hisp.dhis.common.VersionedObject;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeDeserializer;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeSerializer;
 import org.hisp.dhis.dataelement.DataElement;
@@ -323,7 +317,7 @@ public class Program
         {
             for ( ProgramStageDataElement element : stage.getProgramStageDataElements() )
             {
-                if ( dataElement.equals( element.getDataElement() ) )
+                if ( dataElement.getUid().equals( element.getDataElement().getUid() ) )
                 {
                     return true;
                 }


### PR DESCRIPTION
- DHIS2-7789
- Changed `equals` and `hashCode` on DataElement to only check the
"business key" for equality, and using the getId method to trigger the
proxy bypassing