### PR TITLE
fix: Expire a user's active session when disabled

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -379,4 +379,12 @@ public interface UserService
     List<User> getExpiringUsers();
 
     void set2FA( User user, Boolean twoFA );
+
+    /**
+     * Expire a user's active sessions retrieved from the Spring security's
+     * org.springframework.security.core.session.SessionRegistry
+     *
+     * @param credentials the user credentials
+     */
+    void expireActiveSessions( UserCredentials credentials );
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
@@ -315,4 +315,9 @@ public class MockUserService implements UserService
     public void set2FA( User user, Boolean twoFA )
     {
     }
+
+    @Override
+    public void expireActiveSessions( UserCredentials credentials )
+    {
+    }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -558,6 +558,18 @@ public class UserController
         }
     }
 
+    @Override
+    protected void postPatchEntity( User entity )
+    {
+        UserCredentials credentials = entity.getUserCredentials();
+
+        // Make sure we always expire all of the user's active sessions if we have disabled the user.
+        if ( credentials != null && credentials.isDisabled() )
+        {
+            userService.expireActiveSessions( credentials );
+        }
+    }
+
     // -------------------------------------------------------------------------
     // DELETE
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Before this change, when we disabled a user in the user admin, an already logged in user would still be "active/usable" until the session expired.
Now, when we disable a user via the user admin we retrieve the users's active session from the "SessionRegistry" and expire them.

Issue: [DHIS2-7358]