### PR TITLE
fix: Fix metadata import to /relationshipTypes

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/RelationshipTypeActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/RelationshipTypeActions.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.actions.tracker;
+
+import org.hisp.dhis.actions.RestApiActions;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class RelationshipTypeActions
+    extends RestApiActions
+{
+    public RelationshipTypeActions()
+    {
+        super( "/relationshipTypes" );
+    }
+}

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserDisableTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserDisableTest.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.actions.UserActions;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.utils.DataGenerator;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -75,7 +76,7 @@ public class UserDisableTest
         ApiResponse preChangeResponse = userActions.get( userId );
         preChangeResponse.validate().statusCode( 200 ).body( "userCredentials.disabled", is( false ) );
 
-        ApiResponse response = userActions.post( userId + "/disable" );
+        ApiResponse response = userActions.post( userId + "/disabled" );
         response.validate().statusCode( 204 );
 
         ApiResponse getResponse = userActions.get( userId );
@@ -92,7 +93,7 @@ public class UserDisableTest
 
         loginActions.loginAsSuperUser();
 
-        ApiResponse enableResponse = userActions.post( userId + "/enable" );
+        ApiResponse enableResponse = userActions.post( userId + "/enabled" );
         enableResponse.validate().statusCode( 204 );
 
         ApiResponse getAfterEnabled = userActions.get( userId );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/teis/RelationshipsTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/teis/RelationshipsTest.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.actions.metadata.MetadataActions;
 import org.hisp.dhis.actions.tracker.EventActions;
 import org.hisp.dhis.actions.tracker.RelationshipActions;
+import org.hisp.dhis.actions.tracker.RelationshipTypeActions;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.helpers.QueryParamsBuilder;
 import org.hisp.dhis.helpers.TestCleanUp;
@@ -76,6 +77,8 @@ public class RelationshipsTest
 
     private RelationshipActions relationshipActions;
 
+    private RelationshipTypeActions relationshipTypeActions;
+
     private static Stream<Arguments> provideRelationshipData()
     {
         return Stream.of(
@@ -94,6 +97,7 @@ public class RelationshipsTest
         trackedEntityInstanceActions = new RestApiActions( "/trackedEntityInstances" );
         metadataActions = new MetadataActions();
         eventActions = new EventActions();
+        relationshipTypeActions = new RelationshipTypeActions();
 
         new LoginActions().loginAsSuperUser();
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipTypeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipTypeController.java
@@ -28,9 +28,19 @@ package org.hisp.dhis.webapi.controller.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.commons.util.StreamUtils;
+import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.schema.descriptors.RelationshipTypeSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -42,4 +52,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class RelationshipTypeController
     extends AbstractCrudController<RelationshipType>
 {
+
+    @Override
+    public void postJsonObject( HttpServletRequest request, HttpServletResponse response )
+        throws Exception
+    {
+        MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
+
+        final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects =
+            renderService.fromMetadata( StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() ), RenderFormat.JSON );
+        params.setObjects( objects );
+
+        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+
+        ImportReport importReport = importService.importMetadata( params );
+        renderService.toJson( response.getOutputStream(), importReport );
+    }
 }


### PR DESCRIPTION
This commit addresses problems when importing metadata to the /relationshipTypes endpoint.

Issue: [DHIS2-7238]