### PR TITLE
fix: Check if username is locked in 2FA auth

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -108,7 +108,7 @@ public class TwoFactorAuthenticationProvider
             String ip = authDetails.getIp();
             String code = StringUtils.deleteWhitespace( authDetails.getCode() );
 
-            if ( securityService.isLocked( ip ) )
+            if ( securityService.isLocked( username ) )
             {
                 log.info( String.format( "Temporary lockout for user: %s and IP: %s", username, ip ) );
 
@@ -129,7 +129,7 @@ public class TwoFactorAuthenticationProvider
 
         Authentication result = super.authenticate( auth );
 
-        // Put detached state of the user credentials into the session as user 
+        // Put detached state of the user credentials into the session as user
         // credentials must not be updated during session execution
 
         userCredentials = SerializationUtils.clone( userCredentials );


### PR DESCRIPTION
Before this fix, the ip was used to check if the username was locked due to too many failed login attempts, enabled via the config variable "keyLockMultipleFailedLogins" (default value is false)
This would not work since only username is added to the failed login counter cache when a failed login attempts occur.

Issue: [DHIS2-7861]