### PR TITLE
fix: Fix Powermock issue with JDK11

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -95,7 +95,7 @@ import com.google.common.collect.Sets;
  */
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( DefaultCompleteDataSetRegistrationExchangeService.class )
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({ "javax.management.*","javax.xml.*"})
 public class DefaultCompleteDataSetRegistrationExchangeServiceTest
 {
 


### PR DESCRIPTION
The test DefaultCompleteDataSetRegistrationExchangeServiceTest will not run without use of PowerMockIgnore on "javax.xml.*"

Without this fix running tests results in this error:
"java.lang.IllegalAccessError: Class javax/xml/stream/FactoryFinder(unnamed module 0x00000000C107C170) can not access class jdk/xml/internal/SecuritySupport(module java.xml) because module module java.xml does not export package jdk/xml/internal to module unnamed module 0x00000000C107C170"
Tested on: (Java.net) 11.0.5-open and (AdoptOpenJDK 11.0.4.j9-adpt)