### PR TITLE
perf: [DHIS2-7824] Speed predictors with PIs

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -34,9 +34,12 @@ import static org.hisp.dhis.parser.expression.ParserUtils.*;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.StringUtils;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.ConstantService;
@@ -85,6 +88,12 @@ public class  DefaultProgramIndicatorService
     private I18nManager i18nManager;
 
     private RelationshipTypeService relationshipTypeService;
+
+    private static Cache<String> ANALYTICS_SQL_CACHE = new SimpleCacheBuilder<String>().forRegion( "analyticsSql" )
+        .expireAfterAccess( 10, TimeUnit.HOURS )
+        .withInitialCapacity( 10000 )
+        .withMaximumSize( 50000 )
+        .build();
 
     public DefaultProgramIndicatorService( ProgramIndicatorStore programIndicatorStore,
         ProgramStageService programStageService, DataElementService dataElementService,
@@ -295,7 +304,7 @@ public class  DefaultProgramIndicatorService
     @Transactional( readOnly = true )
     public String getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate )
     {
-        return _getAnalyticsSql( expression, programIndicator, startDate, endDate, null );
+        return getAnalyticsSqlCached( expression, programIndicator, startDate, endDate, null );
     }
 
     @Override
@@ -303,16 +312,32 @@ public class  DefaultProgramIndicatorService
     public String getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate,
         String tableAlias )
     {
-        return _getAnalyticsSql( expression, programIndicator, startDate, endDate, tableAlias );
+        return getAnalyticsSqlCached( expression, programIndicator, startDate, endDate, tableAlias );
     }
-    
-    private String _getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate, String tableAlias )
+
+    private String getAnalyticsSqlCached( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate, String tableAlias )
     {
         if ( expression == null )
         {
             return null;
         }
 
+        String cacheKey = getAnalyticsSqlCacheKey( expression, programIndicator, startDate, endDate, tableAlias );
+
+        return ANALYTICS_SQL_CACHE.get( cacheKey, k -> _getAnalyticsSql( expression, programIndicator, startDate, endDate, tableAlias ) ).orElse( null );
+    }
+
+    private String getAnalyticsSqlCacheKey( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate, String tableAlias )
+    {
+        return expression
+            + "|" + programIndicator.getUid()
+            + "|" + startDate.getTime()
+            + "|" + endDate.getTime()
+            + "|" + ( tableAlias == null ? "" : tableAlias );
+    }
+
+    private String _getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate, String tableAlias )
+    {
         Set<String> uids = getDataElementAndAttributeIdentifiers( expression, programIndicator.getAnalyticsType() );
 
         CommonExpressionVisitor visitor = newVisitor( FUNCTION_GET_SQL, ITEM_GET_SQL );


### PR DESCRIPTION
From [DHIS2-7824](https://jira.dhis2.org/browse/DHIS2-7824):

In the South African IDSR/Malaria Information System test referenced [in the issue], this [pull request] reduces the amount of time spent translating the expression into SQL on a test system from about 80% of total time to about 13% of total time. The number of predictions per minute is increased by a factor of about 4.2. The approximate breakdown of times after the fix is:

Program Indicator SQL queries: 86%
Forming the SQL for PI expressions and filters: 13%
Fetching orgUnits to traverse: 1%
Batch write of predicted values 0.5%