### PR TITLE
fix: [2.31] Check null reference when restoring password

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -179,12 +179,12 @@ public class AccountController
         }
 
         CredentialsInfo credentialsInfo;
-        User user = credentials.getUser();
+        User user = credentials.getUserInfo();
 
-        // In case of restoring password
+        // if user is null then something is internally wrong and request should be terminated.
         if ( user == null )
         {
-            credentialsInfo = new CredentialsInfo( username, password, "", false );
+            throw new WebMessageException( WebMessageUtils.error( String.format( "No user found for username: %s", username ) ) );
         }
         else
         {

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -178,9 +178,18 @@ public class AccountController
             throw new WebMessageException( WebMessageUtils.conflict( "User does not exist: " + username ) );
         }
 
+        CredentialsInfo credentialsInfo;
         User user = credentials.getUser();
 
-        CredentialsInfo credentialsInfo = new CredentialsInfo( username, password, user == null ? null : user.getEmail(), false );
+        // In case of restoring password
+        if ( user == null )
+        {
+            credentialsInfo = new CredentialsInfo( username, password, "", false );
+        }
+        else
+        {
+            credentialsInfo = new CredentialsInfo( username, password, user.getEmail() != null ? user.getEmail() : "", false );
+        }
 
         PasswordValidationResult result = passwordValidationService.validate( credentialsInfo );
 


### PR DESCRIPTION
While restoring password if no user is found against provided username then request should be terminated. In other cases request should proceed with password validation.