### PR TITLE
fix: Add event publisher, remove registerFailedLogin

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/SecurityConfig.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/SecurityConfig.java
@@ -45,6 +45,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -153,6 +154,12 @@ public class SecurityConfig
 
     @Autowired
     private DefaultClientDetailsUserDetailsService defaultClientDetailsUserDetailsService;
+
+    @Bean
+    public DefaultAuthenticationEventPublisher authenticationEventPublisher()
+    {
+        return new DefaultAuthenticationEventPublisher();
+    }
 
     @Autowired
     public void configureGlobal( AuthenticationManagerBuilder auth, UserService userService,

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/CustomExceptionMappingAuthenticationFailureHandler.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/CustomExceptionMappingAuthenticationFailureHandler.java
@@ -60,8 +60,6 @@ public class CustomExceptionMappingAuthenticationFailureHandler
 
         request.getSession().setAttribute( "username", username );
 
-        securityService.registerFailedLogin( username );
-
         I18n i18n = i18nManager.getI18n();
 
         if ( ExceptionUtils.indexOfThrowable( exception, LockedException.class ) != -1)


### PR DESCRIPTION
Adds a DefaultAuthenticationEventPublisher bean to the security config.
Remove a call to security service for failed login that becomes a duplicate after adding the DefaultAuthenticationEventPublisher, since the failed login is called in the failed login event listener instead.

Issue: DHIS2-7915