### PR TITLE
fix: Add organisationUnit path in validation result

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -673,6 +673,8 @@ public class DataAnalysisController
             {
                 validationResultView.setOrganisationUnitId( organisationUnit.getUid() );
                 validationResultView.setOrganisationUnitDisplayName( organisationUnit.getDisplayName() );
+                validationResultView.setOrganisationUnitPath( organisationUnit.getPath() );
+                validationResultView.setOrganisationUnitAncestorNames( organisationUnit.getAncestorNames() );
             }
 
             Period period = validationResult.getPeriod();

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/ValidationResultView.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/ValidationResultView.java
@@ -42,6 +42,10 @@ public class ValidationResultView
 
     private String organisationUnitDisplayName;
 
+    private String organisationUnitPath;
+
+    private String organisationUnitAncestorNames;
+
     private String periodId;
 
     private String periodDisplayName;
@@ -96,6 +100,28 @@ public class ValidationResultView
     public void setOrganisationUnitDisplayName( String organisationUnitDisplayName )
     {
         this.organisationUnitDisplayName = organisationUnitDisplayName;
+    }
+
+    @JsonProperty
+    public String getOrganisationUnitPath()
+    {
+        return organisationUnitPath;
+    }
+
+    public void setOrganisationUnitPath( String organisationUnitPath )
+    {
+        this.organisationUnitPath = organisationUnitPath;
+    }
+
+    @JsonProperty
+    public String getOrganisationUnitAncestorNames()
+    {
+        return organisationUnitAncestorNames;
+    }
+
+    public void setOrganisationUnitAncestorNames( String organisationUnitAncestorNames )
+    {
+        this.organisationUnitAncestorNames = organisationUnitAncestorNames;
     }
 
     @JsonProperty


### PR DESCRIPTION
To provide the OrganisationUnitPath property in the resulting ValidationResult payload in order to identify two organisation units with same name.