### PR TITLE
fix: Role is deleted when updating without read access

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.collections.set.CompositeSet;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -35,20 +36,23 @@ import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.schema.MergeParams;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.ValidationUtils;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserCredentials;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.security.acl.Acl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -56,14 +60,25 @@ import java.util.Set;
 @Component
 public class UserObjectBundleHook extends AbstractObjectBundleHook
 {
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired
-    private FileResourceService fileResourceService;
+    private final FileResourceService fileResourceService;
 
-    @Autowired
-    private CurrentUserService currentUserService;
+    private final CurrentUserService currentUserService;
+
+    private final AclService aclService;
+
+    public UserObjectBundleHook( UserService userService, FileResourceService fileResourceService, CurrentUserService currentUserService, AclService aclService )
+    {
+        checkNotNull( userService );
+        checkNotNull( fileResourceService );
+        checkNotNull( currentUserService );
+        checkNotNull( aclService );
+        this.userService = userService;
+        this.fileResourceService = fileResourceService;
+        this.currentUserService = currentUserService;
+        this.aclService = aclService;
+    }
 
     @Override
     public <T extends IdentifiableObject> List<ErrorReport> validate( T object, ObjectBundle bundle )
@@ -83,7 +98,6 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
 
         return errorReports;
     }
-
 
     @Override
     public void preCreate( IdentifiableObject object, ObjectBundle bundle )
@@ -156,6 +170,7 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
                 fileResourceService.updateFileResource( fileResource );
             }
         }
+
     }
 
     @Override
@@ -199,7 +214,10 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
 
         for ( IdentifiableObject identifiableObject : objects )
         {
-            identifiableObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+            User user = (User) identifiableObject;
+            handleNoAccessRoles( user, bundle );
+
+            user = bundle.getPreheat().get( bundle.getPreheatIdentifier(), user );
             Map<String, Object> userReferenceMap = userReferences.get( identifiableObject.getUid() );
 
             if ( userReferenceMap == null || userReferenceMap.isEmpty() )
@@ -207,7 +225,6 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
                 continue;
             }
 
-            User user = (User) identifiableObject;
             UserCredentials userCredentials = user.getUserCredentials();
 
             if ( userCredentials == null )
@@ -233,5 +250,35 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
             user.setUserCredentials( userCredentials );
             sessionFactory.getCurrentSession().update( user );
         }
+    }
+
+    /**
+     * If currentUser doesn't have read access to a UserRole
+     * and it is included in the payload
+     * then that UserRole should not be removed from updating User
+     * @param user updating User
+     * @param bundle ObjectBundle
+     */
+    private void handleNoAccessRoles( User user, ObjectBundle bundle )
+    {
+        Set<String> preHeatedRoles = bundle.getPreheat().get( PreheatIdentifier.UID, user )
+            .getUserCredentials().getUserAuthorityGroups().stream().map( role -> role.getUid() ).collect( Collectors.toSet() );
+
+        user.getUserCredentials().getUserAuthorityGroups().stream()
+            .filter( role -> !preHeatedRoles.contains( role.getUid() ) )
+            .forEach( role -> {
+                UserAuthorityGroup persistedRole = bundle.getPreheat().get( PreheatIdentifier.UID, role );
+
+                if ( persistedRole == null )
+                {
+                    persistedRole = manager.getNoAcl( UserAuthorityGroup.class, role.getUid() );
+                }
+
+                if ( !aclService.canRead( bundle.getUser(), persistedRole ) )
+                {
+                    bundle.getPreheat().get( PreheatIdentifier.UID, user ).getUserCredentials().getUserAuthorityGroups().add( persistedRole );
+                    bundle.getPreheat().put( PreheatIdentifier.UID, persistedRole );
+                }
+            } );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/user_userrole.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/user_userrole.json
@@ -1,0 +1,175 @@
+{
+  "userRoles": [
+    {
+      "created": "2014-12-26T14:21:00.602",
+      "lastUpdated": "2018-02-19T12:04:23.711",
+      "name": "User manager",
+      "href": "https://play.dhis2.org/dev/api/userRoles/xJZBzAHI88H",
+      "id": "xJZBzAHI88H",
+      "displayName": "User manager",
+      "publicAccess": "--------",
+      "description": "User manager",
+      "externalAccess": false,
+      "favorite": false,
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "authorities": [
+        "M_dhis-web-maintenance-user",
+        "F_USER_VIEW",
+        "M_dhis-web-dashboard",
+        "F_USER_DELETE",
+        "F_USER_ADD"
+      ]
+    },
+    {
+      "created": "2014-12-26T14:21:00.602",
+      "lastUpdated": "2018-02-19T12:04:23.711",
+      "name": "Data entry clerk",
+      "href": "https://play.dhis2.org/dev/api/userRoles/xJZBzAHI88H",
+      "id": "tMYCXBU3TPD",
+      "displayName": "Data entry clerk",
+      "publicAccess": "--------",
+      "description": "Data entry clerk",
+      "externalAccess": false,
+      "favorite": false,
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "authorities": [
+        "F_DATAVALUE_DELETE",
+        "M_dhis-web-light",
+        "M_dhis-web-reporting",
+        "M_dhis-web-dataentry",
+        "M_dhis-web-mobile",
+        "M_dhis-web-validationrule",
+        "M_dhis-web-dashboard",
+        "F_DATAVALUE_ADD",
+        "M_dhis-web-maps"
+      ]
+    }
+  ],
+  "date": "2016-03-12T06:21:34.667+0000",
+  "organisationUnits": [
+    {
+      "path": "/inVD5SdytkT",
+      "openingDate": "2016-03-11T17:00:00.000+0000",
+      "lastUpdated": "2016-03-12T06:19:49.665+0000",
+      "created": "2016-03-12T06:19:49.649+0000",
+      "shortName": "Country",
+      "user": {
+        "id": "enHApD3I6Ho"
+      },
+      "attributeValues": [],
+      "id": "inVD5SdytkT",
+      "name": "Country",
+      "description": "",
+      "featureType": "NONE",
+      "uuid": "0f2d7a85-3b6e-4cae-9d5a-e2903331629b"
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "id": "xjZaLLspj2r",
+      "attributeValues": [],
+      "description": "Person",
+      "name": "Person",
+      "created": "2016-03-09T09:56:10.596+0000",
+      "lastUpdated": "2016-03-09T09:56:10.597+0000"
+    }
+  ],
+  "users": [
+    {
+      "email": "user@b.org",
+      "surname": "BB",
+      "firstName": "User",
+      "created": "2016-03-12T06:21:02.324+0000",
+      "lastUpdated": "2016-03-12T06:21:02.325+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "yqJHNnkF3SJ",
+        "user": {
+          "id": "enHApD3I6Ho"
+        },
+        "cogsDimensionConstraints": [],
+        "selfRegistered": false,
+        "catDimensionConstraints": [],
+        "lastLogin": "2016-03-12T06:21:02.226+0000",
+        "created": "2016-03-12T06:21:02.329+0000",
+        "passwordLastUpdated": "2016-03-12T06:21:02.226+0000",
+        "userInfo": {
+          "id": "MwhEJUnTHkn"
+        },
+        "userRoles": [
+          {
+            "id": "xJZBzAHI88H"
+          },
+          {
+            "id": "tMYCXBU3TPD"
+          }
+        ],
+        "username": "UserB",
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false
+      },
+      "teiSearchOrganisationUnits": [],
+      "id": "MwhEJUnTHkn",
+      "attributeValues": []
+    },
+    {
+      "firstName": "User",
+      "email": "user@a.org",
+      "surname": "AA",
+      "attributeValues": [],
+      "id": "sPWjoHSY03y",
+      "created": "2016-03-12T06:20:43.502+0000",
+      "lastUpdated": "2016-03-12T06:20:43.502+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "username": "UserAA",
+        "userRoles": [
+          {
+            "id": "xJZBzAHI88H"
+          },
+          {
+            "id": "tMYCXBU3TPD"
+          }
+        ],
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false,
+        "cogsDimensionConstraints": [],
+        "user": {
+          "id": "enHApD3I6Ho"
+        },
+        "selfRegistered": false,
+        "catDimensionConstraints": [],
+        "lastLogin": "2016-03-12T06:20:43.407+0000",
+        "created": "2016-03-12T06:20:43.508+0000",
+        "userInfo": {
+          "id": "sPWjoHSY03y"
+        },
+        "passwordLastUpdated": "2016-03-12T06:20:43.407+0000"
+      },
+      "teiSearchOrganisationUnits": []
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/user_userrole_update.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/user_userrole_update.json
@@ -1,0 +1,100 @@
+{
+
+  "date": "2016-03-12T06:21:34.667+0000",
+  "users": [
+    {
+      "email": "user@b.org",
+      "surname": "BB",
+      "firstName": "User",
+      "created": "2016-03-12T06:21:02.324+0000",
+      "lastUpdated": "2016-03-12T06:21:02.325+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "yqJHNnkF3SJ",
+        "user": {
+          "id": "enHApD3I6Ho"
+        },
+        "cogsDimensionConstraints": [],
+        "selfRegistered": false,
+        "catDimensionConstraints": [],
+        "lastLogin": "2016-03-12T06:21:02.226+0000",
+        "created": "2016-03-12T06:21:02.329+0000",
+        "passwordLastUpdated": "2016-03-12T06:21:02.226+0000",
+        "userInfo": {
+          "id": "MwhEJUnTHkn"
+        },
+        "userRoles": [
+          {
+            "id": "xJZBzAHI88H"
+          },
+          {
+            "id": "tMYCXBU3TPD"
+          }
+        ],
+        "username": "UserB",
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false
+      },
+      "teiSearchOrganisationUnits": [],
+      "id": "MwhEJUnTHkn",
+      "attributeValues": []
+    },
+    {
+      "firstName": "User",
+      "email": "user@a.org",
+      "surname": "AA",
+      "attributeValues": [],
+      "id": "sPWjoHSY03y",
+      "created": "2016-03-12T06:20:43.502+0000",
+      "lastUpdated": "2016-03-12T06:20:43.502+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "username": "UserA",
+        "userRoles": [
+          {
+            "id": "xJZBzAHI88H"
+          },
+          {
+            "id": "tMYCXBU3TPD"
+          }
+        ],
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false,
+        "cogsDimensionConstraints": [],
+        "user": {
+          "id": "enHApD3I6Ho"
+        },
+        "selfRegistered": false,
+        "catDimensionConstraints": [],
+        "lastLogin": "2016-03-12T06:20:43.407+0000",
+        "created": "2016-03-12T06:20:43.508+0000",
+        "userInfo": {
+          "id": "sPWjoHSY03y"
+        },
+        "passwordLastUpdated": "2016-03-12T06:20:43.407+0000"
+      },
+      "teiSearchOrganisationUnits": []
+    }
+  ]
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7808

This is to fix the case  as described in jira

> we want them to be user managers but not be able to assign user management authorities to other users

Example 
1) User A has User Manager role
1) User A has Role B but doesn't have read access with Role B
2) User A try to update a User C that has role B
3) Role B is removed from User C

The underlying issue is that the Preheat service can't get the UserRole without read access.
So we need to add a method in UserObjectBundleHook to call getNoAcl() and then put that role to preheat map. 

