### PR TITLE
fix: Event count fix for not allowed categories [DHIS2-7712]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.analytics.event.data;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang.time.DateUtils.addYears;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LATITUDE;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LONGITUDE;
@@ -53,10 +54,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.math3.util.Precision;
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.analytics.event.EventAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -393,10 +397,19 @@ public class JdbcEventAnalyticsManager
         List<DimensionalObject> dynamicDimensions = params.getDimensionsAndFilters(
             Sets.newHashSet( DimensionType.ORGANISATION_UNIT_GROUP_SET, DimensionType.CATEGORY ) );
 
-        for ( DimensionalObject dim : dynamicDimensions )
+        if ( isNotEmpty( dynamicDimensions ) )
         {
-            String col = quoteAlias( dim.getDimensionName() );
-            sql += sqlHelper.whereAnd() + " " + col + " in (" + getQuotedCommaDelimitedString( getUids( dim.getItems() ) ) + ") ";
+            // Apply pre-authorized dimensions filtering
+            for ( DimensionalObject dim : dynamicDimensions )
+            {
+                String col = quoteAlias( dim.getDimensionName() );
+                sql += sqlHelper.whereAnd() + " " + col + " in ("
+                    + getQuotedCommaDelimitedString( getUids( dim.getItems() ) ) + ") ";
+            }
+        }
+        else if ( params.hasProgram() && params.getProgram().hasCategoryCombo() )
+        {
+            sql += queryOnlyAllowedCategoryOptionEvents( params.getProgram().getCategoryCombo().getCategories() );
         }
 
         // ---------------------------------------------------------------------
@@ -510,6 +523,56 @@ public class JdbcEventAnalyticsManager
         }
 
         return sql;
+    }
+
+    /**
+     * This method will generate a sql sentence responsible for filtering only the
+     * allowed category options for this program, and expects to receive only the
+     * authorized category options.
+     *
+     * @see org.hisp.dhis.analytics.AnalyticsSecurityManager#decideAccess(DataQueryParams)
+     *
+     * @param programCategories the list of program categories containing the list
+     *        of authorized category options for the current user.
+     * @return the sql statement in the format:
+     *          "and ax."mEXqxV2KIUl" in ('qNqYLugIySD') or ax."r7NDRdgj5zs" in ('qNqYLugIySD') "
+     */
+    String queryOnlyAllowedCategoryOptionEvents( final List<Category> programCategories )
+    {
+        boolean andFlag = true;
+        final StringBuilder query = new StringBuilder();
+
+        if ( isNotEmpty( programCategories ) )
+        {
+            for ( final Category category : programCategories )
+            {
+                final List<CategoryOption> categoryOptions = category.getCategoryOptions();
+
+                if ( isNotEmpty( categoryOptions ) )
+                {
+                    query.append( andFlag ? " and " : " or " );
+                    andFlag = false;
+                    query.append( buildInFilterForCategory( category, categoryOptions ) );
+                }
+            }
+        }
+        return query.toString();
+    }
+
+    /**
+     * This method will generate a "in" sql statement for the given category and
+     * category options.
+     *
+     * @param category
+     * @param categoryOptions
+     * @return a sql statement in the format: "ax."mEXqxV2KIUl" in ('qNqYLugIySD') "
+     */
+    String buildInFilterForCategory(final Category category, final List<CategoryOption> categoryOptions )
+    {
+        final String categoryColumn = quoteAlias( category.getUid() );
+        final String inFilter = categoryColumn + " in (" + getQuotedCommaDelimitedString( getUids( categoryOptions ) )
+            + ") ";
+        return inFilter;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -33,6 +33,8 @@ import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataapproval.DataApproval;
@@ -50,6 +52,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 /**
  * @author Lars Helge Overland
@@ -79,6 +83,28 @@ public class DefaultAnalyticsSecurityManager
     // -------------------------------------------------------------------------
     // AnalyticsSecurityManager implementation
     // -------------------------------------------------------------------------
+
+    /**
+     * Will remove/exclude, from DataQueryParams, any category option that the
+     * current user is not allowed to read.
+     *
+     * @param programCategories the categories related to this program.
+     */
+    void excludeNonAuthorizedCategoryOptions( final List<Category> programCategories )
+    {
+        if ( isNotEmpty( programCategories ) )
+        {
+            for ( Category category : programCategories )
+            {
+                category.getCategoryOptions().removeIf( categoryOption -> !hasDataReadPermissionFor( categoryOption ) );
+            }
+        }
+    }
+
+    private boolean hasDataReadPermissionFor( final CategoryOption categoryOption )
+    {
+        return aclService.canDataRead( currentUserService.getCurrentUser(), categoryOption );
+    }
 
     @Override
     public void decideAccess( DataQueryParams params )
@@ -126,7 +152,7 @@ public class DefaultAnalyticsSecurityManager
      * @param user the user to check.
      * @throws IllegalQueryException if user does not have access.
      */
-    private void decideAccessDataReadObjects( DataQueryParams params, User user )
+    void decideAccessDataReadObjects( DataQueryParams params, User user )
         throws IllegalQueryException
     {
         Set<IdentifiableObject> objects = new HashSet<>();
@@ -137,6 +163,12 @@ public class DefaultAnalyticsSecurityManager
         if ( params.hasProgram() )
         {
             objects.add( params.getProgram() );
+
+            if ( params.getProgram().hasCategoryCombo() )
+            {
+                final List<Category> programCategories = params.getProgram().getCategoryCombo().getCategories();
+                excludeNonAuthorizedCategoryOptions( programCategories );
+            }
         }
 
         if ( params.hasProgramStage() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
@@ -36,7 +36,7 @@ import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
 import static org.hisp.dhis.common.DimensionType.PROGRAM_ATTRIBUTE;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.junit.Assert.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.junit.MockitoJUnit.rule;
 
 import java.util.List;
 
@@ -47,25 +47,42 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicatorService;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoRule;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.google.common.collect.Lists;
 
 public class JdbcEventAnalyticsManagerTest
 {
 
-    @InjectMocks
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private StatementBuilder statementBuilder;
+
+    @Mock
+    private ProgramIndicatorService programIndicatorService;
+
+    @Rule
+    public MockitoRule mockitoRule = rule();
+
     private JdbcEventAnalyticsManager jdbcEventAnalyticsManager;
 
     @Before
     public void setUp()
     {
-        initMocks( this );
+        jdbcEventAnalyticsManager = new JdbcEventAnalyticsManager( jdbcTemplate, statementBuilder,
+            programIndicatorService );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.analytics.event.data;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hisp.dhis.common.DataDimensionType.ATTRIBUTE;
+import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.DimensionType.PROGRAM_ATTRIBUTE;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.junit.Assert.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.Program;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import com.google.common.collect.Lists;
+
+public class JdbcEventAnalyticsManagerTest
+{
+
+    @InjectMocks
+    private JdbcEventAnalyticsManager jdbcEventAnalyticsManager;
+
+    @Before
+    public void setUp()
+    {
+        initMocks( this );
+    }
+
+    @Test
+    public void testWhereClauseWhenThereAreNoDimensionsAndOneCategory()
+    {
+        // Given
+        final CategoryOption aCategoryOptionA = stubCategoryOption( "cat-option-A", "uid-opt-A" );
+        final CategoryOption aCategoryOptionB = stubCategoryOption( "cat-option-B", "uid-opt-B" );
+
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+
+        final EventQueryParams theEventQueryParams = stubEventQueryParamsWithoutDimensions(
+            newArrayList( aCategoryA ) );
+
+        final String theExpectedSql = " and ax.\"uid-cat-A\" in ('uid-opt-A', 'uid-opt-B') ";
+
+        // When
+        final String actualSql = jdbcEventAnalyticsManager.getWhereClause( theEventQueryParams );
+
+        // Then
+        assertThat( actualSql, containsString( theExpectedSql ) );
+    }
+
+    @Test
+    public void testWhereClauseWhenThereAreNoDimensionsAndMultipleCategories()
+    {
+        // Given
+        final CategoryOption aCategoryOptionA = stubCategoryOption( "cat-option-A", "uid-opt-A" );
+        final CategoryOption aCategoryOptionB = stubCategoryOption( "cat-option-B", "uid-opt-B" );
+
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+        final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+
+        final EventQueryParams theEventQueryParams = stubEventQueryParamsWithoutDimensions(
+            newArrayList( aCategoryA, aCategoryB ) );
+
+        final String theExpectedSql = " and ax.\"uid-cat-A\" in ('uid-opt-A', 'uid-opt-B')  or ax.\"uid-cat-B\" in ('uid-opt-A', 'uid-opt-B') ";
+
+        // When
+        final String actualSql = jdbcEventAnalyticsManager.getWhereClause( theEventQueryParams );
+
+        // Then
+        assertThat( actualSql, containsString( theExpectedSql ) );
+    }
+
+    @Test
+    public void testQueryOnlyAllowedCategoryOptionEvents()
+    {
+        // Given
+        final CategoryOption aCategoryOptionA = stubCategoryOption( "cat-option-A", "uid-opt-A" );
+        final CategoryOption aCategoryOptionB = stubCategoryOption( "cat-option-B", "uid-opt-B" );
+
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+        final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+
+        final String theExpectedSql = " and ax.\"uid-cat-A\" in ('uid-opt-A', 'uid-opt-B')  or ax.\"uid-cat-B\" in ('uid-opt-A', 'uid-opt-B') ";
+
+        // When
+        final String actualSql = jdbcEventAnalyticsManager
+            .queryOnlyAllowedCategoryOptionEvents( newArrayList( aCategoryA, aCategoryB ) );
+
+        // Then
+        assertThat( actualSql, containsString( theExpectedSql ) );
+    }
+
+    @Test
+    public void testQueryOnlyAllowedCategoryOptionEventsWithNoCategories()
+    {
+        // Given
+        final List<Category> emptyCategoryList = newArrayList();
+
+        // When
+        final String actualSql = jdbcEventAnalyticsManager.queryOnlyAllowedCategoryOptionEvents( emptyCategoryList );
+
+        // Then
+        assertThat( actualSql, isEmptyString() );
+    }
+
+    @Test
+    public void testQueryOnlyAllowedCategoryOptionEventsWithNoCategoryOptions()
+    {
+        // Given
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A", newArrayList() );
+        final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B", newArrayList() );
+
+        // When
+        final String actualSql = jdbcEventAnalyticsManager
+            .queryOnlyAllowedCategoryOptionEvents( newArrayList( aCategoryA, aCategoryB ) );
+
+        // Then
+        assertThat( actualSql, isEmptyString() );
+    }
+
+    private Category stubCategory( final String name, final String uid, final List<CategoryOption> categoryOptions )
+    {
+        final Category category = new Category( name, ATTRIBUTE );
+        category.setCategoryOptions( newArrayList( categoryOptions ) );
+        category.setUid( uid );
+        return category;
+    }
+
+    private CategoryOption stubCategoryOption( final String name, final String uid )
+    {
+        final CategoryOption categoryOption = new CategoryOption( name );
+        categoryOption.setUid( uid );
+        return categoryOption;
+    }
+
+    private EventQueryParams stubEventQueryParamsWithoutDimensions( final List<Category> categories )
+    {
+        final DimensionalObject doA = new BaseDimensionalObject( ORGUNIT_DIM_ID, ORGANISATION_UNIT, newArrayList() );
+        final DimensionalObject doC = new BaseDimensionalObject( "Cz3WQznvrCM", PROGRAM_ATTRIBUTE, newArrayList() );
+
+        final Period period = PeriodType.getPeriodFromIsoString( "2019Q2" );
+
+        final CategoryCombo categoryCombo = new CategoryCombo( "cat-combo", ATTRIBUTE );
+        categoryCombo.setCategories( categories );
+
+        final Program program = new Program( "program", "a program" );
+        program.setCategoryCombo( categoryCombo );
+
+        final DataQueryParams dataQueryParams = DataQueryParams.newBuilder().addDimension( doA ).addDimension( doC )
+            .withPeriods( Lists.newArrayList( period ) ).withPeriodType( period.getPeriodType().getIsoFormat() )
+            .build();
+
+        final EventQueryParams.Builder eventQueryParamsBuilder = new EventQueryParams.Builder( dataQueryParams );
+        final EventQueryParams eventQueryParams = eventQueryParamsBuilder.withProgram( program ).build();
+
+        return eventQueryParams;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.analytics.security;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hisp.dhis.common.DataDimensionType.ATTRIBUTE;
+import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.DimensionType.PROGRAM_ATTRIBUTE;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.google.common.collect.Lists;
+
+public class DefaultAnalyticsSecurityManagerTest
+{
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @InjectMocks
+    private DefaultAnalyticsSecurityManager defaultAnalyticsSecurityManager;
+
+    @Before
+    public void setUp()
+    {
+        initMocks( this );
+    }
+
+    @Test
+    public void testExcludeNonAuthorizedCategoryOptionsWhenOneCategoryOptionIsNotAllowed()
+    {
+        // Given
+        final CategoryOption aCategoryOptionNotAllowed = stubCategoryOption( "cat-option-A", "uid-opt-A" );
+        final CategoryOption aCategoryOptionAllowed = stubCategoryOption( "cat-option-B", "uid-opt-B" );
+
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A",
+            newArrayList( aCategoryOptionNotAllowed, aCategoryOptionAllowed ) );
+        final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B",
+            newArrayList( aCategoryOptionNotAllowed, aCategoryOptionAllowed ) );
+        final List<Category> categories = newArrayList( aCategoryA, aCategoryB );
+
+        final boolean canDataReadFalse = false;
+        final boolean canDataReadTrue = true;
+        final User stubUser = new User();
+
+        // When
+        when( currentUserService.getCurrentUser() ).thenReturn( stubUser );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), aCategoryOptionNotAllowed ) )
+            .thenReturn( canDataReadFalse );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), aCategoryOptionAllowed ) )
+            .thenReturn( canDataReadTrue );
+        defaultAnalyticsSecurityManager.excludeNonAuthorizedCategoryOptions( categories );
+
+        // Then
+        assertThat( aCategoryA.getCategoryOptions(), hasItems( aCategoryOptionAllowed ) );
+        assertThat( aCategoryB.getCategoryOptions(), hasItems( aCategoryOptionAllowed ) );
+        assertThat( aCategoryA.getCategoryOptions(), not( hasItems( aCategoryOptionNotAllowed ) ) );
+        assertThat( aCategoryB.getCategoryOptions(), not( hasItems( aCategoryOptionNotAllowed ) ) );
+    }
+
+    @Test
+    public void testExcludeNonAuthorizedCategoryOptionsWhenAllCategoryOptionsAreAllowed()
+    {
+        // Given
+        final CategoryOption aCategoryOptionAllowed = stubCategoryOption( "cat-option-A", "uid-opt-A" );
+        final CategoryOption anotherCategoryOptionAllowed = stubCategoryOption( "cat-option-B", "uid-opt-B" );
+
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A",
+            newArrayList( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) );
+        final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B",
+            newArrayList( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) );
+        final List<Category> categories = newArrayList( aCategoryA, aCategoryB );
+
+        final boolean canDataReadTrue = true;
+        final User aStubUser = new User();
+
+        // When
+        when( currentUserService.getCurrentUser() ).thenReturn( aStubUser );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), aCategoryOptionAllowed ) )
+            .thenReturn( canDataReadTrue );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), anotherCategoryOptionAllowed ) )
+            .thenReturn( canDataReadTrue );
+        defaultAnalyticsSecurityManager.excludeNonAuthorizedCategoryOptions( categories );
+
+        // Then
+        assertThat( aCategoryA.getCategoryOptions(), hasItems( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) );
+        assertThat( aCategoryB.getCategoryOptions(), hasItems( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) );
+    }
+
+    @Test
+    public void testDecideAccessDataReadObjects()
+    {
+        // Given
+        final CategoryOption aCategoryOptionA = stubCategoryOption( "cat-option-A", "uid-opt-A" );
+        final CategoryOption aCategoryOptionB = stubCategoryOption( "cat-option-B", "uid-opt-B" );
+
+        final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+        final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B",
+            newArrayList( aCategoryOptionA, aCategoryOptionB ) );
+
+        final DataQueryParams theEventQueryParams = stubEventQueryParamsWithProgramCategoryCombo(
+            newArrayList( aCategoryA, aCategoryB ) );
+        final User aStubUser = new User();
+        final boolean canDataReadTrue = true;
+
+        // When
+        when( currentUserService.getCurrentUser() ).thenReturn( aStubUser );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), aCategoryA ) ).thenReturn( canDataReadTrue );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), aCategoryB ) ).thenReturn( canDataReadTrue );
+        when( aclService.canDataRead( currentUserService.getCurrentUser(), theEventQueryParams.getProgram() ) )
+            .thenReturn( canDataReadTrue );
+        defaultAnalyticsSecurityManager.decideAccessDataReadObjects( theEventQueryParams, aStubUser );
+
+        // Then
+        final int oneTimeForEachCategoryOptionIteration = 2;
+        verify( aclService, times( oneTimeForEachCategoryOptionIteration ) ).canDataRead( aStubUser, aCategoryOptionA );
+        verify( aclService, times( oneTimeForEachCategoryOptionIteration ) ).canDataRead( aStubUser, aCategoryOptionB );
+    }
+
+    private Category stubCategory( final String name, final String uid, final List<CategoryOption> categoryOptions )
+    {
+        final Category category = new Category( name, ATTRIBUTE );
+        category.setCategoryOptions( newArrayList( categoryOptions ) );
+        category.setUid( uid );
+        return category;
+    }
+
+    private CategoryOption stubCategoryOption( final String name, final String uid )
+    {
+        final CategoryOption categoryOption = new CategoryOption( name );
+        categoryOption.setUid( uid );
+        categoryOption.setShortName( "short-" + name );
+        categoryOption.setDescription( "description-" + name );
+        categoryOption.setCode( "code-" + uid );
+        return categoryOption;
+    }
+
+    private DataQueryParams stubEventQueryParamsWithProgramCategoryCombo( final List<Category> categories )
+    {
+        final DimensionalObject doA = new BaseDimensionalObject( ORGUNIT_DIM_ID, ORGANISATION_UNIT, newArrayList() );
+        final DimensionalObject doC = new BaseDimensionalObject( "Cz3WQznvrCM", PROGRAM_ATTRIBUTE, newArrayList() );
+
+        final Period period = PeriodType.getPeriodFromIsoString( "2019Q2" );
+
+        final CategoryCombo categoryCombo = new CategoryCombo( "cat-combo", ATTRIBUTE );
+        categoryCombo.setCategories( categories );
+
+        final Program program = new Program( "program", "a program" );
+        program.setCategoryCombo( categoryCombo );
+
+        final DataQueryParams dataQueryParams = DataQueryParams.newBuilder().addDimension( doA ).addDimension( doC )
+            .withPeriods( Lists.newArrayList( period ) ).withPeriodType( period.getPeriodType().getIsoFormat() )
+            .build();
+
+        final EventQueryParams.Builder eventQueryParamsBuilder = new EventQueryParams.Builder( dataQueryParams );
+        final EventQueryParams eventQueryParams = eventQueryParamsBuilder.withProgram( program ).build();
+
+        return eventQueryParams;
+    }
+}


### PR DESCRIPTION
Stop counting events related to the categories that users don't have access.
Porting it to 2.32. Was already reviewed and merged into 2.30.