### PR TITLE
feat: Log sessionid in log4j logs [DHIS2-7963]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -95,6 +95,9 @@ public enum ConfigurationKey
     MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "off", false ),
     MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "off", false ),
     MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "off", false ),
+    MONITORING_LOG_REQUESTID_ENABLED("monitoring.requestidlog.enabled", "off", false),
+    MONITORING_LOG_REQUESTID_HASHALGO("monitoring.requestidlog.hash", "SHA-256", false),
+    MONITORING_LOG_REQUESTID_MAXSIZE("monitoring.requestidlog.maxsize", "-1", false),
     APP_STORE_URL( "appstore.base.url", "https://play.dhis2.org/appstore", false ),
     APP_STORE_API_URL( "appstore.api.url", "https://play.dhis2.org/appstore/api", false );
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -95,9 +95,9 @@ public enum ConfigurationKey
     MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "off", false ),
     MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "off", false ),
     MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "off", false ),
-    MONITORING_LOG_REQUESTID_ENABLED("monitoring.requestidlog.enabled", "off", false),
-    MONITORING_LOG_REQUESTID_HASHALGO("monitoring.requestidlog.hash", "SHA-256", false),
-    MONITORING_LOG_REQUESTID_MAXSIZE("monitoring.requestidlog.maxsize", "-1", false),
+    MONITORING_LOG_REQUESTID_ENABLED( "monitoring.requestidlog.enabled", "off", false ),
+    MONITORING_LOG_REQUESTID_HASHALGO( "monitoring.requestidlog.hash", "SHA-256", false ),
+    MONITORING_LOG_REQUESTID_MAXSIZE( "monitoring.requestidlog.maxsize", "-1", false ),
     APP_STORE_URL( "appstore.base.url", "https://play.dhis2.org/appstore", false ),
     APP_STORE_API_URL( "appstore.api.url", "https://play.dhis2.org/appstore/api", false );
 

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
@@ -1,29 +1,5 @@
 package org.hisp.dhis.servlet.filter;
 
-import static org.hamcrest.Matchers.is;
-import static org.hisp.dhis.external.conf.ConfigurationKey.*;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.junit.MockitoJUnit.rule;
-
-import java.io.IOException;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoRule;
-import org.slf4j.MDC;
-
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -51,6 +27,30 @@ import org.slf4j.MDC;
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.external.conf.ConfigurationKey.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoRule;
+import org.slf4j.MDC;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
@@ -1,0 +1,164 @@
+package org.hisp.dhis.servlet.filter;
+
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.external.conf.ConfigurationKey.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoRule;
+import org.slf4j.MDC;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class RequestIdentifierFilterTest
+{
+    @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
+    private RequestIdentifierFilter subject;
+
+    @Rule
+    public MockitoRule mockitoRule = rule();
+
+    private static final String DEFAULT_HASH_ALGO = MONITORING_LOG_REQUESTID_HASHALGO.getDefaultValue();
+
+    @Before
+    public void setUp()
+    {
+        MDC.clear();
+    }
+
+    @Test
+    public void testHashSessionIdNoTruncate()
+        throws ServletException,
+        IOException
+    {
+        init( -1, DEFAULT_HASH_ALGO, true );
+
+        doFilter();
+
+        assertThat( MDC.get( "sessionId" ), is( "IDJShqHVoTDIhlsHjr7eIvUrMsMM7Gs2LYGjog1W6nQFo=" ) );
+
+    }
+
+    @Test
+    public void testHashSessionIdWithTruncate()
+        throws ServletException,
+        IOException
+    {
+        init( 5, DEFAULT_HASH_ALGO, true );
+
+        doFilter();
+
+        assertThat( MDC.get( "sessionId" ), is( "IDJShqH" ) );
+
+    }
+
+    @Test
+    public void testHashSessionIdWithMd5()
+        throws ServletException,
+        IOException
+    {
+        init( -1, "MD5", true );
+        doFilter();
+
+        assertThat( MDC.get( "sessionId" ), is( "IDrBKUxIZl6blN7EtczRa7fQ==" ) );
+
+    }
+
+    @Test
+    public void testHashSessionIdWithInvalidAlgorithm()
+        throws ServletException,
+        IOException
+    {
+        init( -1, "RIJKA", true );
+        doFilter();
+
+        assertNull( MDC.get( "sessionId" ) );
+
+    }
+
+    @Test
+    public void testisDisabled()
+            throws ServletException,
+            IOException
+    {
+        init( -1, "SHA-256", false );
+        doFilter();
+
+        assertNull( MDC.get( "sessionId" ) );
+
+    }
+
+    private void doFilter()
+        throws ServletException,
+        IOException
+    {
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        HttpServletResponse res = mock( HttpServletResponse.class );
+        FilterChain filterChain = mock( FilterChain.class );
+
+        HttpSession session = mock( HttpSession.class );
+
+        when( req.getSession() ).thenReturn( session );
+        when( session.getId() ).thenReturn( "ABCDEFGHILMNO" );
+
+        subject.doFilter( req, res, filterChain );
+    }
+
+    private void init( int maxSize, String hashAlgo, boolean enabled )
+    {
+
+        when( dhisConfigurationProvider.getProperty( MONITORING_LOG_REQUESTID_MAXSIZE ) )
+            .thenReturn( Integer.toString( maxSize ) );
+        when( dhisConfigurationProvider.isEnabled( MONITORING_LOG_REQUESTID_ENABLED ) ).thenReturn( enabled );
+        when( dhisConfigurationProvider.getProperty( MONITORING_LOG_REQUESTID_HASHALGO ) ).thenReturn( hashAlgo );
+
+        subject = new RequestIdentifierFilter( dhisConfigurationProvider );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -6,7 +6,7 @@ log4j.rootLogger = WARN, stdout
 # Std out appender
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern = * %-5p %d{ISO8601} %m (%F [%t])%n
+log4j.appender.stdout.layout.ConversionPattern = * %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId}
 
 # File appender
 log4j.appender.file = org.apache.log4j.RollingFileAppender
@@ -14,7 +14,7 @@ log4j.appender.file.File = dhis.log
 log4j.appender.file.MaxFileSize = 25MB
 log4j.appender.file.MaxBackupIndex = 3
 log4j.appender.file.layout = org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern = * %-5p %d{ISO8601} %m (%F [%t])%n
+log4j.appender.file.layout.ConversionPattern = * %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId}
 
 # Log levels
 log4j.logger.org.hisp.dhis = INFO

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/HttpRedirectFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/HttpRedirectFilter.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
@@ -48,7 +47,7 @@ import org.apache.commons.logging.LogFactory;
 public class HttpRedirectFilter
     implements Filter
 {
-    public static final String REDIRECT_PATH_KEY = "redirectPath";
+    private static final String REDIRECT_PATH_KEY = "redirectPath";
 
     private static final Log log = LogFactory.getLog( HttpRedirectFilter.class );
     
@@ -60,15 +59,13 @@ public class HttpRedirectFilter
 
     @Override
     public void init( FilterConfig config )
-        throws ServletException
     {
         redirectPath = config.getInitParameter( REDIRECT_PATH_KEY );
     }
 
     @Override
     public void doFilter( ServletRequest request, ServletResponse response, FilterChain chain )
-        throws IOException, ServletException
-    {
+        throws IOException {
         log.debug( "Redirecting to: " + redirectPath );
         
         HttpServletResponse httpResponse = (HttpServletResponse) response;
@@ -87,7 +84,6 @@ public class HttpRedirectFilter
 
         httpResponse.sendRedirect( redirectPath );
 
-        return;
     }
 
     @Override

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilter.java
@@ -1,0 +1,127 @@
+package org.hisp.dhis.servlet.filter;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.external.conf.ConfigurationKey.*;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * This filter places an hashed version of the Session ID in the Log4j Mapped
+ * Diagnostic Context (MDC) of log4j. The session id is then logged in all log
+ * statements and can be used to correlate different requests.
+ *
+ * @author Luciano Fiandesio
+ */
+@Component
+public class RequestIdentifierFilter
+    extends
+    OncePerRequestFilter
+{
+    private final DhisConfigurationProvider dhisConfig;
+
+    private final static String SESSION_ID_KEY = "sessionId";
+
+    private static final Log log = LogFactory.getLog( RequestIdentifierFilter.class );
+
+    /**
+     * The hash algorithm to use (default is SHA-256)
+     */
+    private String HASH_ALGO;
+
+    /**
+     * Set the maximum length of the String used as request id
+     */
+    private int MAX_SIZE;
+
+    private final static String IDENTIFIER_PREFIX = "ID";
+
+    private boolean enabled;
+
+    public RequestIdentifierFilter( DhisConfigurationProvider dhisConfig )
+    {
+        this.dhisConfig = dhisConfig;
+
+        this.HASH_ALGO = dhisConfig.getProperty( MONITORING_LOG_REQUESTID_HASHALGO );
+        this.MAX_SIZE = Integer.parseInt( dhisConfig.getProperty( MONITORING_LOG_REQUESTID_MAXSIZE ) );
+
+        this.enabled = dhisConfig.isEnabled( MONITORING_LOG_REQUESTID_ENABLED );
+    }
+
+    @Override
+    protected void doFilterInternal( HttpServletRequest req, HttpServletResponse res, FilterChain chain )
+        throws ServletException,
+        IOException
+    {
+        if ( enabled )
+        {
+            try
+            {
+                MDC.put( SESSION_ID_KEY, IDENTIFIER_PREFIX + truncate( hashToBase64( req.getSession().getId() ) ) );
+
+            }
+            catch ( NoSuchAlgorithmException e )
+            {
+                log.error( String.format( "Invalid Hash algorithm provided (%s)", HASH_ALGO ), e );
+            }
+        }
+
+        chain.doFilter( req, res );
+    }
+
+    private String truncate( String id )
+    {
+        // only truncate if MAX SIZE <> -1
+        return id.substring( 0, (this.MAX_SIZE == -1 ? id.length() : this.MAX_SIZE) );
+    }
+
+    private String hashToBase64( String sessionId )
+        throws NoSuchAlgorithmException
+    {
+        byte[] data = sessionId.getBytes();
+        MessageDigest digester = MessageDigest.getInstance( HASH_ALGO );
+        digester.update( data );
+        return Base64.getEncoder().encodeToString( digester.digest() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-portal/src/main/webapp/WEB-INF/web.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/src/main/webapp/WEB-INF/web.xml
@@ -85,12 +85,23 @@
     <filter-name>springSessionRepositoryFilter</filter-name>
 	<filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
   </filter>
+
   <filter-mapping>
 	<filter-name>springSessionRepositoryFilter</filter-name>
 	<url-pattern>/*</url-pattern>
 	<dispatcher>REQUEST</dispatcher>
 	<dispatcher>ERROR</dispatcher>
   </filter-mapping>
+
+  <filter>
+    <filter-name>requestIdentifierFilter</filter-name>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    <init-param>
+      <param-name>targetBeanName</param-name>
+      <param-value>requestIdentifierFilter</param-value>
+    </init-param>
+  </filter>
+
   <filter>
     <filter-name>webMetricsFilter</filter-name>
     <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
@@ -148,6 +159,11 @@
     <filter-name>appCacheFilter</filter-name>
     <url-pattern>*.appcache</url-pattern>
   </filter-mapping>
+  <filter-mapping>
+    <filter-name>requestIdentifierFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
   <filter-mapping>
     <filter-name>webMetricsFilter</filter-name>
     <url-pattern>/api/*</url-pattern>


### PR DESCRIPTION
Logs an hashed version of the Session Id as part of a log entry.
The Session Id is placed into the log4J MDC framework (based on thread
local) and passed to the logs.
This feature is *disabled* by default. To enable set:
`monitoring.requestidlog.enabled = on` in DHIS2 configuration.

Additional parameters:

`monitoring.requestidlog.hash` : controls the default hash algorithm
(defaultL SHA-256)
`monitoring.requestidlog.maxsize`: controls the max size of the request
id (default: no max size)