### PR TITLE
ci(docker): add escape hatch to only build default container

### DIFF
--- a/docker/build-containers.sh
+++ b/docker/build-containers.sh
@@ -92,13 +92,14 @@ build () {
         "$DIR"
 }
 
-build_debian_containers () {
+build_default_container () {
     build "$CORE_IMAGE" "$DEFAULT_TOMCAT_TAG" "debian"
+}
 
+build_debian_containers () {
     for TOMCAT_TAG in "${TOMCAT_DEBIAN_TAGS[@]}"; do
         build "${CORE_IMAGE}-${TOMCAT_IMAGE}-${TOMCAT_TAG}" "$TOMCAT_TAG" "debian"
     done
-
 }
 
 build_alpine_containers () {
@@ -108,8 +109,13 @@ build_alpine_containers () {
 }
 
 main () {
-    build_debian_containers
-    build_alpine_containers
+    build_default_container
+
+    # checks if ONLY_DEFAULT is unset
+    if [ -z ${ONLY_DEFAULT+x} ]; then
+        build_debian_containers
+        build_alpine_containers
+    fi
 }
 
 


### PR DESCRIPTION
	ONLY_DEFAULT=1 ./docker/build-containers.sh <image> <identifier>

The above would result in only the default core image with tomcat being built,
which is handy in local testing situations where you only need to build a single
image, and want to avoid the storage overhead of building all Tomcat images we
provide.

---

`./docker/build-containers.sh core:local localident` would run:

- build_default_container
- build_debian_containers
- build_alpine_containers

`ONLY_DEFAULT=1 ./docker/build-containers.sh core:local localident` would run:

- build_default_container