### PR TITLE
feat: Inject data into db from integration tests

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationTestData.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationTestData.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used within a Docker-based integration test to inject data into the
+ * Dockerized Postgresql database.
+ * The annotation expects a "path" property to point to the actual SQL file containing the INSERT/UPDATE/DELETE
+ * statements to run prior to each test. The file must be present in the classpath (e.g. src/main/resources/)
+ * The data file is going to be injected only once per each test class.
+ *
+ * <pre>{@code
+ *
+ * @org.junit.experimental.categories.Category( IntegrationTest.class )
+ * @IntegrationTestData(path = "sql/mydata.sql")
+ * public class DefaultTrackedEntityInstanceStoreTest
+ *     extends
+ *     IntegrationTestBase
+ * {
+ *   ...
+ * }
+ * }</pre>
+ *
+ *
+ * @author Luciano Fiandesio
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.TYPE )
+public @interface IntegrationTestData
+{
+    String path();
+}


### PR DESCRIPTION
Introduced annotation `IntegrationTestData` that can be used on
Docker-based integration tests to inject SQL into the Dockerized
database prior to start executing the test class.