### PR TITLE
fix: (2.32) transactionRollback for addAndPruneOptionCombos()

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DefaultDeletionManager.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DefaultDeletionManager.java
@@ -66,17 +66,29 @@ public class DefaultDeletionManager
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( noRollbackFor = DeleteNotAllowedException.class )
+    public void executeNoRollback( Object object )
+    {
+        deletionCheck( object );
+    }
+
+    @Override
     @Transactional
     public void execute( Object object )
+    {
+        deletionCheck( object );
+    }
+
+    private void deletionCheck( Object object )
     {
         if ( deletionHandlers == null || deletionHandlers.isEmpty() )
         {
             log.info( "No deletion handlers registered, aborting deletion handling" );
             return;
         }
-        
+
         log.debug( "Deletion handlers detected: " + deletionHandlers.size() );
-        
+
         Class<?> clazz = getClazz( object );
 
         String className = clazz.getSimpleName();
@@ -109,7 +121,7 @@ public class DefaultDeletionManager
                         handler.getClassName() + ( hint.isEmpty() ? hint : ( " (" + hint + ")" ) );
 
                     log.info( "Delete was not allowed by " + currentHandler + ": " + message );
-                    
+
                     throw new DeleteNotAllowedException( DeleteNotAllowedException.ERROR_ASSOCIATED_BY_OTHER_OBJECTS, message );
                 }
             }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionInterceptor.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionInterceptor.java
@@ -51,7 +51,15 @@ public class DeletionInterceptor
     {
         if ( joinPoint.getArgs() != null && joinPoint.getArgs().length > 0 )
         {
-            deletionManager.execute( joinPoint.getArgs()[0] );
+            if ( joinPoint.getSignature().getName().matches( "^.*NoRollback" ) )
+            {
+                deletionManager.executeNoRollback( joinPoint.getArgs()[0] );
+            }
+            else
+            {
+                deletionManager.execute( joinPoint.getArgs()[0] );
+
+            }
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionManager.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionManager.java
@@ -34,6 +34,8 @@ package org.hisp.dhis.system.deletion;
 public interface DeletionManager
 {
     String ID = DeletionManager.class.getName();
-    
+
+    void executeNoRollback( Object object );
+
     void execute( Object object );
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7256

I had a different fix for 2.34 and 2.33  ( https://github.com/dhis2/dhis2-core/pull/3796 ) but it can't be backported due to utilisation of https://github.com/dhis2/dhis2-core/pull/3547

So this is to fix same issue for 2.32 and older versions



