### PR TITLE
fix: prevent too many Validation Rules errors

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -95,6 +95,10 @@
       <artifactId>jsoup</artifactId>
       <version>1.11.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
 
   </dependencies>
   <properties>

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -189,19 +189,18 @@ public class DataValidationTask
                 {
                     orgUnit = ou;
                     orgUnitId = ou.getId();
-                    if ( dataMap.containsKey( orgUnitId ) )
-                    {
-                        for (ValidationRuleExtended r : periodTypeX.getRuleXs()) {
-                            ruleX = r;
 
-                            if ( context.isAnalysisComplete() )
-                            {
-                                break loop;
-                            }
-                            validationResults = new HashSet<>();
-                            validateRule();
-                            addValidationResultsToContext();
+                    for ( ValidationRuleExtended r : periodTypeX.getRuleXs() )
+                    {
+                        ruleX = r;
+
+                        if ( context.isAnalysisComplete() )
+                        {
+                            break loop;
                         }
+                        validationResults = new HashSet<>();
+                        validateRule();
+                        addValidationResultsToContext();
                     }
                 }
             }
@@ -228,17 +227,11 @@ public class DataValidationTask
 
         Set<String> attributeOptionCombos = Sets.union( leftSideValues.keySet(), rightSideValues.keySet() );
 
-        if ( attributeOptionCombos.isEmpty() )
-        {
-            attributeOptionCombos = Sets.newHashSet( context.getDefaultAttributeCombo().getUid() );
-        }
-
-        loop:
         for ( String optionCombo : attributeOptionCombos )
         {
             if ( context.isAnalysisComplete() )
             {
-                break loop;
+                break;
             }
 
             if ( NON_AOC.compareTo( optionCombo ) == 0 )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -189,18 +189,19 @@ public class DataValidationTask
                 {
                     orgUnit = ou;
                     orgUnitId = ou.getId();
-
-                    for ( ValidationRuleExtended r : periodTypeX.getRuleXs() )
+                    if ( dataMap.containsKey( orgUnitId ) )
                     {
-                        ruleX = r;
+                        for (ValidationRuleExtended r : periodTypeX.getRuleXs()) {
+                            ruleX = r;
 
-                        if ( context.isAnalysisComplete() )
-                        {
-                            break loop;
+                            if ( context.isAnalysisComplete() )
+                            {
+                                break loop;
+                            }
+                            validationResults = new HashSet<>();
+                            validateRule();
+                            addValidationResultsToContext();
                         }
-                        validationResults = new HashSet<>();
-                        validateRule();
-                        addValidationResultsToContext();
                     }
                 }
             }
@@ -326,7 +327,6 @@ public class DataValidationTask
         String test = leftSide
             + ruleX.getRule().getOperator().getMathematicalOperator()
             + rightSide;
-
         return ! (Boolean) expressionService.getExpressionValue( test, SIMPLE_TEST );
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRuleExtended.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRuleExtended.java
@@ -42,7 +42,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * overhead of having to compute them during the processing of every
  * organisation unit. For some of these properties this is also important
  * because they should be copied from Hibernate lazy collections before the
- * multithreaded part of the run starts, otherwise the threads may not be able
+ * multi-threaded part of the run starts, otherwise the threads may not be able
  * to access these values.
  * 
  * @author Jim Grace

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
@@ -62,8 +62,7 @@ public class Validator
     public static Collection<ValidationResult> validate( ValidationRunContext context,
         ApplicationContext applicationContext, AnalyticsService analyticsService )
     {
-        CategoryService categoryService = (CategoryService)
-            applicationContext.getBean( CategoryService.class );
+        CategoryService categoryService = applicationContext.getBean( CategoryService.class );
                 
         int threadPoolSize = getThreadPoolSize( context );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.validation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.hisp.dhis.expression.ParseType.SIMPLE_TEST;
+import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.hisp.dhis.analytics.AnalyticsService;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.constant.Constant;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.datavalue.DataExportParams;
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.datavalue.DeflatedDataValue;
+import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.expression.MissingValueStrategy;
+import org.hisp.dhis.expression.Operator;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DataValidationTaskTest
+{
+    @Mock
+    private ExpressionService expressionService;
+
+    @Mock
+    private DataValueService dataValueService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PeriodService periodService;
+
+    @Mock
+    private AnalyticsService analyticsService;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
+    private PeriodType MONTHLY = PeriodType.getPeriodTypeFromIsoString( "201901" );
+    private DataValidationTask subject;
+    private DataElement deA;
+    private List<OrganisationUnit> organisationUnits;
+    private OrganisationUnit ouA;
+    private OrganisationUnit ouB;
+    private OrganisationUnit ouZ;
+
+    private Period p1;
+    private Period p2;
+    private Period p3;
+    private Map<String, Constant> constantMap;
+    @Before
+    public void setUp()
+    {
+        subject = new DataValidationTask( expressionService, dataValueService, categoryService, periodService );
+
+        deA = createDataElement('A');
+
+        organisationUnits = new ArrayList<>();
+
+        ouA = createOu( 'A' );
+        ouB = createOu( 'B' );
+        OrganisationUnit ouC = createOu( 'C' );
+        OrganisationUnit ouD = createOu( 'D' );
+
+        organisationUnits.add( ouA );
+        organisationUnits.add( ouB );
+        organisationUnits.add( ouC );
+        organisationUnits.add( ouD );
+
+        ouZ = createOu( 'Z' );
+
+        p1 = createPeriod( "201901" );
+        p2 = createPeriod( "201902" );
+        p3 = createPeriod( "201903" );
+
+        constantMap = new HashMap<>();
+        constantMap.put( "Gfd3ppDfq8E", new Constant( "a", 5.0 ) );
+        constantMap.put( "bCqvfPR02Im", new Constant( "pi", 3.14 ) );
+
+    }
+
+    /**
+     * Verify that a single rule passes against a Data Element
+     */
+    @Test
+    public void verifySimpleValidation_oneRule_noErrors()
+    {
+        Expression leftExpression = createExpression2( 'A', "#{FUrCpcvMAmC.OrDRjJL9bTS}" );
+        Expression rightExpression = createExpression2( 'B', "-10" );
+        
+        ValidationRuleExtended vre = createValidationRuleExtended( leftExpression, rightExpression, Operator.not_equal_to );
+        
+        List<PeriodTypeExtended> periodTypes = new ArrayList<>();
+        PeriodTypeExtended periodType = createPeriodTypeExtended( vre );
+        periodType.addDataElement( deA );
+        periodTypes.add( periodType );
+
+        CategoryOptionCombo categoryOptionCombo = createCategoryOptionCombo( 'A', 'B' );
+
+        ValidationRunContext ctx = ValidationRunContext.newBuilder()
+            .withOrgUnits( organisationUnits )
+            .withConstantMap( constantMap )
+            .withDefaultAttributeCombo( categoryOptionCombo )
+            .withPeriodTypeXs( periodTypes )
+            .withMaxResults( 500 )
+            .build();
+
+        List<DeflatedDataValue> deflatedDataValues = new ArrayList<>();
+
+        DataValue dv = createDataValue(deA, createPeriod("201901"), ouA, "12.4", createCategoryOptionCombo('B', 'C'));
+
+        DeflatedDataValue ddv = new DeflatedDataValue(dv);
+        deflatedDataValues.add(ddv);
+
+        when( dataValueService.getDeflatedDataValues( any( DataExportParams.class ) ) )
+            .thenReturn( deflatedDataValues );
+        
+        Map<DimensionalItemObject, Double> vals = new HashMap<>();
+        vals.put( deA, 12.4 );
+
+        mockExpressionService(leftExpression, vals, ctx, 8.4);
+        mockExpressionService(rightExpression, vals, ctx, -10.0);
+
+        when( expressionService.getExpressionValue( "8.4!=-10.0", SIMPLE_TEST ) ).thenReturn( true );
+
+        subject.init( organisationUnits, ctx, analyticsService );
+        subject.run();
+
+        assertThat( ctx.getValidationResults().size(), is( 0 ) );
+    }
+
+    /**
+     * This test is for DHIS-7966
+     *
+     * The test creates 2 rules for one period type (composed of 3 months)
+     * and verifies that the rules are only executed on data that is related to the
+     * selected org units
+     */
+    @Test
+    public void verifySimpleValidation_twoRules_noErrors()
+    {
+        Expression leftExpression1 = createExpression( 'A', "#{FUrCpcvMAmC.OrDRjJL9bTS}", MissingValueStrategy.NEVER_SKIP );
+        Expression rightExpression1 = createExpression( 'B', "-10", MissingValueStrategy.NEVER_SKIP );
+
+        Expression leftExpression2 = createExpression( 'A', "#{FUrCpcvMAmC.OrDRjJL9bTS}", MissingValueStrategy.NEVER_SKIP );
+        Expression rightExpression2 = createExpression( 'B', "5", MissingValueStrategy.NEVER_SKIP );
+
+        ValidationRuleExtended vre1 = createValidationRuleExtended( leftExpression1, rightExpression1, Operator.not_equal_to );
+        ValidationRuleExtended vre2 = createValidationRuleExtended( leftExpression2, rightExpression2, Operator.greater_than );
+
+        List<PeriodTypeExtended> periodTypes = new ArrayList<>();
+        PeriodTypeExtended periodType1 = createPeriodTypeExtended( vre1, vre2 );
+
+        periodType1.addDataElement( deA );
+
+        periodTypes.add( periodType1 );
+
+        CategoryOptionCombo categoryOptionCombo = createCategoryOptionCombo( 'A', 'B' );
+
+        ValidationRunContext ctx = ValidationRunContext.newBuilder()
+            .withOrgUnits( organisationUnits )
+            .withConstantMap( constantMap )
+            .withDefaultAttributeCombo( categoryOptionCombo )
+            .withPeriodTypeXs( periodTypes )
+            .withMaxResults( 500 )
+            .build();
+
+        List<DeflatedDataValue> deflatedDataValues = new ArrayList<>();
+
+        DataValue dv1 = createDataValue(deA, createPeriod("201901"), ouA, "12.4", createCategoryOptionCombo('B', 'C'));
+        // this data value should be ignored, because it's outside the list of OUs
+        DataValue dv2 = createDataValue(deA, createPeriod("201901"), ouZ, "42.4", createCategoryOptionCombo('B', 'C'));
+
+        deflatedDataValues.add( new DeflatedDataValue( dv1 ) );
+        deflatedDataValues.add( new DeflatedDataValue( dv2 ) );
+
+        when( dataValueService.getDeflatedDataValues( any( DataExportParams.class ) ) )
+                .thenReturn( deflatedDataValues );
+
+        Map<DimensionalItemObject, Double> vals = new HashMap<>();
+        vals.put( deA, 12.4 );
+
+        mockExpressionService(leftExpression1, vals, ctx, 8.4);
+        mockExpressionService(leftExpression2, vals, ctx, 8.4);
+
+        mockExpressionService(rightExpression1, vals, ctx, -10.0);
+        mockExpressionService(rightExpression2, vals, ctx, 5.0);
+
+        when( expressionService.getExpressionValue( "8.4!=-10.0", SIMPLE_TEST ) ).thenReturn( true );
+        when( expressionService.getExpressionValue( "8.4>5.0", SIMPLE_TEST ) ).thenReturn( true );
+        when( expressionService.getExpressionValue( "0.0!=0.0", SIMPLE_TEST ) ).thenReturn( false );
+        when( expressionService.getExpressionValue( "0.0>0.0", SIMPLE_TEST ) ).thenReturn( false );
+
+        subject.init( organisationUnits, ctx, analyticsService );
+        subject.run();
+
+        assertThat( ctx.getValidationResults().size(), is( 0 ) );
+    }
+
+    private void mockExpressionService(Expression expression, Map<DimensionalItemObject, Double> vals, ValidationRunContext ctx, Double val) {
+
+        when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
+                ctx.getConstantMap(), null, p1.getDaysInPeriod(), expression.getMissingValueStrategy() ) ).thenReturn( val );
+
+        when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
+                ctx.getConstantMap(), null, p2.getDaysInPeriod(), expression.getMissingValueStrategy() ) ).thenReturn( val );
+
+        when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
+                ctx.getConstantMap(), null, p3.getDaysInPeriod(), expression.getMissingValueStrategy() ) ).thenReturn( val );
+
+    }
+    
+    
+    private ValidationRuleExtended createValidationRuleExtended(Expression left, Expression right, Operator op ) {
+        return new ValidationRuleExtended( createValidationRule( 'A', op, left, right, MONTHLY ) );
+    }
+
+    private PeriodTypeExtended createPeriodTypeExtended( ValidationRuleExtended... validationRuleExtended )
+    {
+        PeriodTypeExtended pt = new PeriodTypeExtended( MONTHLY );
+        // add three months
+        pt.addPeriod( p1 );
+        pt.addPeriod( p2 );
+        pt.addPeriod( p3 );
+        // add the actual validation rule
+        for ( ValidationRuleExtended ruleExtended : validationRuleExtended )
+        {
+            pt.getRuleXs().add( ruleExtended );
+
+        }
+        pt.setSlidingWindows( false );
+        return pt;
+    }
+
+    private OrganisationUnit createOu( char uniqueCharacter )
+    {
+        OrganisationUnit organisationUnit = createOrganisationUnit( uniqueCharacter );
+        organisationUnit.setId( RandomUtils.nextLong() );
+        return organisationUnit;
+    }
+    
+    private Expression createExpression( char uniqueCharacter, String expressionString, MissingValueStrategy mvs )
+    {
+        Expression exp = createExpression2( uniqueCharacter, expressionString );
+        exp.setMissingValueStrategy( mvs );
+        return exp;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -1193,7 +1193,6 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodA, sourceA, defaultCombo, 0.0, 0.0, dayInPeriodA ) );
         reference.add( new ValidationResult( validationRule, periodB, sourceA, defaultCombo, 1.0, 1.0, dayInPeriodB ) );
         reference.add( new ValidationResult( validationRule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
 


### PR DESCRIPTION
DHIS-7966
This fix prevents a Validation Rule to run on data which is related to a
OU that is not selected by the user.
Without this fix, the rules are executed on incorrect data, which cause
the test expression to always return false.