### PR TITLE
fix: Consistent bean annotations for jobs

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/AnalyticsJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/AnalyticsJobParameters.java
@@ -77,6 +77,11 @@ public class AnalyticsJobParameters
         return lastYears;
     }
 
+    public void setLastYears( Integer lastYears )
+    {
+        this.lastYears = lastYears;
+    }
+
     @JsonProperty
     @JacksonXmlElementWrapper( localName = "skipTableTypes", namespace = DxfNamespaces.DXF_2_0 )
     @JacksonXmlProperty( localName = "skipTableType", namespace = DxfNamespaces.DXF_2_0 )
@@ -85,21 +90,16 @@ public class AnalyticsJobParameters
         return skipTableTypes;
     }
 
+    public void setSkipTableTypes( Set<AnalyticsTableType> skipTableTypes )
+    {
+        this.skipTableTypes = skipTableTypes;
+    }
+
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isSkipResourceTables()
     {
         return skipResourceTables;
-    }
-
-    public void setLastYears( Integer lastYears )
-    {
-        this.lastYears = lastYears;
-    }
-
-    public void setSkipTableTypes( Set<AnalyticsTableType> skipTableTypes )
-    {
-        this.skipTableTypes = skipTableTypes;
     }
 
     public void setSkipResourceTables( boolean skipResourceTables )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/EventProgramsDataSynchronizationJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/EventProgramsDataSynchronizationJobParameters.java
@@ -55,7 +55,6 @@ public class EventProgramsDataSynchronizationJobParameters implements JobParamet
 
     public EventProgramsDataSynchronizationJobParameters()
     {
-
     }
 
     public EventProgramsDataSynchronizationJobParameters( final int pageSize )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/MetadataSyncJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/MetadataSyncJobParameters.java
@@ -1,4 +1,5 @@
 package org.hisp.dhis.scheduling.parameters;
+
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -46,7 +47,6 @@ import java.util.Optional;
 @JsonDeserialize( using = MetadataSyncJobParametersDeserializer.class )
 public class MetadataSyncJobParameters implements JobParameters
 {
-
     private static final long serialVersionUID = 332495511301532169L;
 
     private static final int DATA_VALUES_PAGE_SIZE_MIN = 50;
@@ -55,6 +55,10 @@ public class MetadataSyncJobParameters implements JobParameters
     private int trackerProgramPageSize = 20;
     private int eventProgramPageSize = 60;
     private int dataValuesPageSize = 10000;
+
+    public MetadataSyncJobParameters()
+    {
+    }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/PredictorJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/PredictorJobParameters.java
@@ -127,5 +127,4 @@ public class PredictorJobParameters
     {
         return Optional.empty();
     }
-
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/SmsJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/SmsJobParameters.java
@@ -111,5 +111,4 @@ public class SmsJobParameters
     {
         return Optional.empty();
     }
-
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TrackerProgramsDataSynchronizationJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TrackerProgramsDataSynchronizationJobParameters.java
@@ -55,7 +55,6 @@ public class TrackerProgramsDataSynchronizationJobParameters implements JobParam
 
     public TrackerProgramsDataSynchronizationJobParameters()
     {
-
     }
 
     public TrackerProgramsDataSynchronizationJobParameters( final int pageSize )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
@@ -37,14 +37,14 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
-@Service
+@Component( "dataIntegrityJob" )
 public class DataIntegrityJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderElectionJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderElectionJob.java
@@ -31,14 +31,14 @@ package org.hisp.dhis.leader.election;
 import org.hisp.dhis.scheduling.AbstractJob;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 /**
  * Job that attempts to elect the current instance as the leader of the cluster.
  *
  * @author Ameen Mohamed
  */
-@Service
+@Component
 public class LeaderElectionJob extends AbstractJob
 {
     private LeaderManager leaderManager;
@@ -61,6 +61,6 @@ public class LeaderElectionJob extends AbstractJob
     @Override
     public void execute( JobConfiguration jobConfiguration )
     {
-            leaderManager.electLeader();
+        leaderManager.electLeader();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
@@ -31,14 +31,14 @@ package org.hisp.dhis.leader.election;
 import org.hisp.dhis.scheduling.AbstractJob;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 /**
  * Job that attempts to elect the current instance as the leader of the cluster.
- * 
+ *
  * @author Ameen Mohamed
  */
-@Service
+@Component
 public class LeaderRenewalJob extends AbstractJob
 {
     private LeaderManager leaderManager;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
@@ -28,7 +28,9 @@ package org.hisp.dhis.sms.scheduling;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.commons.util.SystemUtils;
+import java.util.Date;
+import java.util.List;
+
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
@@ -41,27 +43,21 @@ import org.hisp.dhis.sms.outbound.OutboundSmsStatus;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-import java.util.Date;
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-/**
- * @author Chau Thu Tran
- */
-@Service( "sendScheduledMessageJob" )
+@Component( "sendScheduledMessageJob" )
 public class SendScheduledMessageJob
     extends AbstractJob
 {
     private final OutboundSmsService outboundSmsService;
-    
+
     private final MessageSender smsSender;
 
     private final Notifier notifier;
-    
+
     public SendScheduledMessageJob( OutboundSmsService outboundSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, Notifier notifier )
     {
@@ -87,10 +83,7 @@ public class SendScheduledMessageJob
     @Override
     public void execute( JobConfiguration jobConfiguration )
     {
-        final int cpuCores = SystemUtils.getCpuCores();
-
-        Clock clock = new Clock().startClock().logTime(
-            "Aggregate process started, number of CPU cores: " + cpuCores + ", " + SystemUtils.getMemoryString() );
+        Clock clock = new Clock().startClock();
 
         clock.logTime( "Starting to send messages in outbound" );
         notifier.notify( jobConfiguration, INFO, "Start to send messages in outbound", true );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/AnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/AnalyticsTableJob.java
@@ -44,7 +44,7 @@ import java.util.Date;
 /**
  * @author Lars Helge Overland
  */
-@Component
+@Component( "analyticsTableJob" )
 public class AnalyticsTableJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ResourceTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ResourceTableJob.java
@@ -32,7 +32,6 @@ import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.scheduling.AbstractJob;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -41,7 +40,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Lars Helge Overland
  */
 @Component( "resourceTableJob" )
-@Scope( value = "prototype" )
 public class ResourceTableJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -50,7 +50,7 @@ import org.springframework.stereotype.Component;
  *
  * @author Halvdan Hoem Grelland
  */
-@Component
+@Component( "fileResourceCleanUpJob" )
 public class FileResourceCleanUpJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
@@ -45,13 +45,11 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- *
  * Job will fetch all the image FileResources with flag hasMultiple set to false. It will process those image FileResources create three images files for each of them.
  * Once created, images will be stored at EWS and flag hasMultiple is set to true.
  *
  * @Author Zubair Asghar.
  */
-
 @Component( "imageResizingJob" )
 public class ImageResizingJob extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveExpiredReservedValuesJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveExpiredReservedValuesJob.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * @author Henning Håkonsen
  */
-@Component
+@Component( "removeExpiredReservedValuesJob" )
 public class RemoveExpiredReservedValuesJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/job/SendSmsJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/job/SendSmsJob.java
@@ -39,15 +39,13 @@ import org.hisp.dhis.sms.outbound.OutboundSmsService;
 import org.hisp.dhis.sms.outbound.OutboundSmsStatus;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.util.HashSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-@Component
-@Scope( value = "prototype" )
+@Component( "sendSmsJob" )
 public class SendSmsJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -64,7 +64,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author anilkumk
  */
-@Component
+@Component( "metadataSyncJob" )
 public class MetadataSyncJob
     extends AbstractJob
 {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( value = "dataSyncJob" )
+@Component( "dataSyncJob" )
 public class DataSynchronizationJob
     extends AbstractJob
 {


### PR DESCRIPTION
- Uses @Component annotation for all jobs.
- Using specific value for all component annotations.
- Removes prototype scope from ResourceTableJob.