### PR TITLE
fix: (2.33) Add custom authentication logger without sensitive info

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
@@ -1,0 +1,88 @@
+package org.hisp.dhis.security;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.base.Charsets;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class AuthenticationLoggerListener
+    implements ApplicationListener<AbstractAuthenticationEvent>
+{
+    private static final Log log = LogFactory.getLog( AuthenticationLoggerListener.class );
+
+    public void onApplicationEvent( AbstractAuthenticationEvent event )
+    {
+        if ( log.isWarnEnabled() )
+        {
+            final StringBuilder builder = new StringBuilder();
+            builder.append( "Authentication event " );
+            builder.append( ClassUtils.getShortName( event.getClass() ) );
+            builder.append( ": " );
+            builder.append( event.getAuthentication().getName() );
+
+            Object details = event.getAuthentication().getDetails();
+
+            if ( ForwardedIpAwareWebAuthenticationDetails.class.isAssignableFrom( details.getClass() ) )
+            {
+                ForwardedIpAwareWebAuthenticationDetails authDetails = (ForwardedIpAwareWebAuthenticationDetails) details;
+                String ip = authDetails.getIp();
+
+                builder.append( "; ip: " );
+                builder.append( ip );
+
+                String sessionId = authDetails.getSessionId();
+                if ( sessionId != null )
+                {
+                    HashCode hash = Hashing.sha256().newHasher().putString( sessionId, Charsets.UTF_8 ).hash();
+                    builder.append( " sessionId: " );
+                    builder.append( hash.toString() );
+                }
+
+            }
+
+            if ( event instanceof AbstractAuthenticationFailureEvent )
+            {
+                builder.append( "; exception: " );
+                builder.append( ((AbstractAuthenticationFailureEvent) event).getException().getMessage() );
+            }
+
+            log.warn( builder.toString() );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ForwardedIpAwareWebAuthenticationDetails.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ForwardedIpAwareWebAuthenticationDetails.java
@@ -1,0 +1,60 @@
+package org.hisp.dhis.security;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import javax.servlet.http.HttpServletRequest;
+import org.hisp.dhis.util.ObjectUtils;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class ForwardedIpAwareWebAuthenticationDetails
+    extends WebAuthenticationDetails
+{
+    private static final String HEADER_FORWARDED_FOR = "X-Forwarded-For";
+
+    private String ip;
+
+    public ForwardedIpAwareWebAuthenticationDetails( HttpServletRequest request )
+    {
+        super( request );
+        this.ip = ObjectUtils.firstNonNull( request.getHeader( HEADER_FORWARDED_FOR ), request.getRemoteAddr() );
+    }
+
+    public String getIp()
+    {
+        return ip;
+    }
+
+    public void setIp( String ip )
+    {
+        this.ip = ip;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/basic/HttpBasicWebAuthenticationDetails.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/basic/HttpBasicWebAuthenticationDetails.java
@@ -1,0 +1,47 @@
+package org.hisp.dhis.security.basic;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import javax.servlet.http.HttpServletRequest;
+import org.hisp.dhis.security.ForwardedIpAwareWebAuthenticationDetails;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class HttpBasicWebAuthenticationDetails
+    extends ForwardedIpAwareWebAuthenticationDetails
+{
+
+    public HttpBasicWebAuthenticationDetails( HttpServletRequest request )
+    {
+        super( request );
+    }
+
+}
+

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/basic/HttpBasicWebAuthenticationDetailsSource.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/basic/HttpBasicWebAuthenticationDetailsSource.java
@@ -1,0 +1,49 @@
+package org.hisp.dhis.security.basic;
+
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Component
+public class HttpBasicWebAuthenticationDetailsSource
+    implements AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails>
+{
+    @Override
+    public WebAuthenticationDetails buildDetails( HttpServletRequest request )
+    {
+        return new HttpBasicWebAuthenticationDetails( request );
+    }
+}
+

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorWebAuthenticationDetails.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorWebAuthenticationDetails.java
@@ -28,31 +28,25 @@ package org.hisp.dhis.security.spring2fa;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.util.ObjectUtils;
-import org.springframework.security.web.authentication.WebAuthenticationDetails;
-
 import javax.servlet.http.HttpServletRequest;
+import org.hisp.dhis.security.ForwardedIpAwareWebAuthenticationDetails;
 
 /**
  * @author Henning Håkonsen
  * @author Lars Helge Øverland
  */
 public class TwoFactorWebAuthenticationDetails
-    extends WebAuthenticationDetails
+    extends ForwardedIpAwareWebAuthenticationDetails
 {
-    private static final String HEADER_FORWARDED_FOR = "X-Forwarded-For";
 
     private static final String TWO_FACTOR_AUTHENTICATION_GETTER = "2fa_code";
 
     private String code;
 
-    private String ip;
-
     public TwoFactorWebAuthenticationDetails( HttpServletRequest request )
     {
         super( request );
         code = request.getParameter( TWO_FACTOR_AUTHENTICATION_GETTER );
-        ip = ObjectUtils.firstNonNull( request.getHeader( HEADER_FORWARDED_FOR ), request.getRemoteAddr() );
     }
 
     public String getCode()
@@ -60,9 +54,9 @@ public class TwoFactorWebAuthenticationDetails
         return code;
     }
 
-    public String getIp()
+    public void setCode( String code )
     {
-        return ip;
+        this.code = code;
     }
 }
 

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/AuthenticationListener.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/AuthenticationListener.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
-import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
 import org.springframework.security.core.Authentication;
@@ -63,7 +63,7 @@ public class AuthenticationListener
     private DhisConfigurationProvider config;
 
     @EventListener
-    public void handleAuthenticationFailure( AuthenticationFailureBadCredentialsEvent event )
+    public void handleAuthenticationFailure( AbstractAuthenticationFailureEvent event )
     {
         Authentication auth = event.getAuthentication();
 

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -127,7 +127,8 @@
 
     <sec:csrf disabled="true" />
 
-    <sec:http-basic entry-point-ref="basicAuthenticationEntryPoint" />
+    <sec:http-basic entry-point-ref="basicAuthenticationEntryPoint"
+      authentication-details-source-ref="httpBasicWebAuthenticationDetailsSource"/>
     <sec:logout logout-url="/dhis-web-commons-security/logout.action" logout-success-url="/" delete-cookies="JSESSIONID"/>
     <sec:intercept-url pattern="/dhis-web-commons/i18nJavaScript.action" access="permitAll()" />
     <sec:intercept-url pattern="/dhis-web-commons/security/**" access="permitAll()" />
@@ -200,6 +201,10 @@
     <property name="defaultFailureUrl" value="/dhis-web-commons/security/login.action?failed=true" />
   </bean>
 
+  <!-- Security : Listener -->
+
+  <bean id="loggerListener" class="org.hisp.dhis.security.AuthenticationLoggerListener" />
+
   <!-- Security : Action -->
 
   <bean id="restrictOrganisationUnitsAction" class="org.hisp.dhis.security.action.RestrictOrganisationUnitsAction"
@@ -217,10 +222,6 @@
       </map>
     </property>
   </bean>
-
-  <!-- Security : Listener -->
-
-  <bean id="loggerListener" class="org.springframework.security.authentication.event.LoggerListener" />
 
   <!-- Security : AccessProvider -->
 


### PR DESCRIPTION
The org.springframework.security.authentication.event.LoggerListener should not be used in production since it leaks raw session ids in the logger.

The spring LoggerListener is replaced by a new custom listener, this new listener hashes the session id to prevent it from leaking into the logs.
To also be able to log auth events from http basic, the http-basic config in security.xml is extended with a new AuthenticationDetails object that capture the x-forwarded-for header if present.

Issue: [DHIS2-7602]
(cherry picked from commit 00b7ce04d19bf8adbed780aad5dd851f520fd510)