### PR TITLE
test: Remove restriction for complex objects

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/SchemasActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/SchemasActions.java
@@ -49,11 +49,29 @@ public class SchemasActions
 
     public List<SchemaProperty> getRequiredProperties( String resource )
     {
-        List<SchemaProperty> list = get( resource ).extractList( "properties", SchemaProperty.class );
+        List<SchemaProperty> list = getProperties( resource );
 
         return list.stream()
             .filter( (schemaProperty -> schemaProperty.isRequired()) )
             .collect( Collectors.toList() );
+    }
+
+    public List<SchemaProperty> getProperties( String resource) {
+        List<SchemaProperty> list = get( resource ).extractList( "properties", SchemaProperty.class );
+
+        return list;
+    }
+
+    public List<SchemaProperty> getRequiredPropertiesByKlassName(String klass) {
+        String schemasEndpoint = findSchemaPropertyByKlassName( klass, "singular" );
+
+        return getRequiredProperties(schemasEndpoint);
+    }
+
+    public List<SchemaProperty> getAllPropertiesByKlassName(String klass) {
+        String schemasEndpoint = findSchemaPropertyByKlassName( klass, "singular" );
+
+        return getProperties( schemasEndpoint );
     }
 
     public Schema getSchema( String resource )

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/schemas/SchemaProperty.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/schemas/SchemaProperty.java
@@ -54,6 +54,8 @@ public class SchemaProperty
 
     private PropertyType propertyType;
 
+    private String klass;
+
     public String getName()
     {
         return name;
@@ -132,5 +134,15 @@ public class SchemaProperty
     public void setLength( long length )
     {
         this.length = length;
+    }
+
+    public String getKlass()
+    {
+        return klass;
+    }
+
+    public void setKlass( String klass )
+    {
+        this.klass = klass;
     }
 }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -124,7 +124,6 @@ public class DataGenerator
 
             if ( prop.getPropertyType() == PropertyType.REFERENCE )
             {
-
                 List<SchemaProperty> referenceProperties = schemasActions.getRequiredPropertiesByKlassName( prop.getKlass() );
 
                 JsonObject referenceObject = generateObjectMatchingSchema( referenceProperties );
@@ -137,7 +136,6 @@ public class DataGenerator
             {
                 if ( !StringUtils.containsAny( prop.getName(), "id", "uid", "code" ) )
                 {
-
                     Schema schema = schemasActions.getSchema( prop.getName() );
                     JsonObject referenceObject = generateObjectMatchingSchema( schema.getRequiredProperties() );
                     String uid = new RestApiActions( schema.getPlural() ).post( referenceObject ).extractUid();
@@ -150,7 +148,8 @@ public class DataGenerator
                 }
             }
 
-            else if ( prop.getPropertyType() == PropertyType.COMPLEX) {
+            else if ( prop.getPropertyType() == PropertyType.COMPLEX )
+            {
                 List<SchemaProperty> properties = schemasActions.getAllPropertiesByKlassName( prop.getKlass() );
 
                 JsonObject object = generateObjectMatchingSchema( properties );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
@@ -107,9 +107,6 @@ public class MetadataImportBasedOnSchemasTest
         List<SchemaProperty> schemaProperties = schemasActions.getRequiredProperties( schema );
 
         Assumptions.assumeFalse( blacklistedEndpoints.contains( endpoint ), "N/A test case - blacklisted endpoint." );
-        Assumptions.assumeFalse(
-            schemaProperties.stream().anyMatch( schemaProperty -> schemaProperty.getPropertyType() == PropertyType.COMPLEX ),
-            "N/A test case - body would require COMPLEX objects." );
 
         // post
         JsonObject object = DataGenerator.generateObjectMatchingSchema( schemaProperties );


### PR DESCRIPTION
Adds support for generating complex objects. With this, at least two additional endpoints are getting tested: /validationRules and /predictors. 

Predictors endpoint is currently failing because of the bug: https://jira.dhis2.org/browse/DHIS2-8068. **Please wait for that to be fixed before merging this one.** 