### PR TITLE
fix: Fix broken security.xml config

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/security.xml
@@ -101,6 +101,7 @@
     <constructor-arg name="loginFormUrl" value="/dhis-web-commons/security/login.action" />
   </bean>
 
+  <bean id="httpBasicWebAuthenticationDetailsSource" class="org.hisp.dhis.security.basic.HttpBasicWebAuthenticationDetailsSource"/>
   <bean id="basicAuthenticationEntryPoint" class="org.hisp.dhis.security.BasicAuthenticationEntryPoint"/>
 
   <sec:http access-decision-manager-ref="accessDecisionManager" realm="DHIS2" disable-url-rewriting="true" use-expressions="true"


### PR DESCRIPTION
Fixes broken security.xml configuration, ie. referencing a non defined bean.
Missing bean config for "HttpBasicWebAuthenticationDetailsSource" is now defined in security.xml

Issue: [DHIS2-7602]