### PR TITLE
fix: Use Program Indicators to validate orgUnitField

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -510,7 +510,8 @@ public class EventQueryParams
 
         if ( !itemProgramIndicators.isEmpty() )
         {
-            // if at least one Program Indicator doesn't validate, fail the validation
+            // Fail validation if at least one program indicator is invalid
+            
             return !itemProgramIndicators.stream().anyMatch( pi -> !validateProgramHasOrgUnitField( pi.getProgram() ) );
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -510,18 +510,8 @@ public class EventQueryParams
 
         if ( !itemProgramIndicators.isEmpty() )
         {
-            boolean[] isValidated = new boolean[itemProgramIndicators.size()];
-
-            for ( int i = 0; i < itemProgramIndicators.size(); i++ )
-            {
-                ProgramIndicator itemProgramIndicator = itemProgramIndicators.get( i );
-                Program program = itemProgramIndicator.getProgram();
-
-                isValidated[i] = validateProgramHasOrgUnitField( program );
-
-            }
             // if at least one Program Indicator doesn't validate, fail the validation
-            return !Booleans.contains( isValidated, false );
+            return !itemProgramIndicators.stream().anyMatch( pi -> !validateProgramHasOrgUnitField( pi.getProgram() ) );
         }
 
         return false;


### PR DESCRIPTION
- DHIS2-7552
- When validating the `orgUnitField` value the system now takes in
consideration the event that a Program may be `null` and therefore checks for
Program Indicators. If the `EventQueryParams` object contains Program Indicators,
the system runs the same validation against all the Programs associated
to the Program Indicators. If at least one fails, the entire validation
fails.