### PR TITLE
feat: Audit Matrix to control auditing

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.common.IdentifiableObject;
 
 import java.time.LocalDateTime;
+import java.util.function.Supplier;
 
 /**
  * Class for Audit messages, mostly compatible with {@link org.hisp.dhis.audit.Audit}
@@ -75,7 +76,9 @@ public class Audit implements Message
     private AuditAttributes attributes;
 
     @JsonProperty
-    private Object data;
+    private Supplier<Object> data;
+
+    private Object serializedData;
 
     @Override
     public MessageType getMessageType()
@@ -103,9 +106,9 @@ public class Audit implements Message
             .code( code )
             .attributes( attributes );
 
-        if ( data instanceof String )
+        if ( serializedData instanceof String )
         {
-            auditBuilder.data( (String) data );
+            auditBuilder.data( (String) serializedData );
         }
 
         return auditBuilder.build();
@@ -134,5 +137,10 @@ public class Audit implements Message
 
             return this;
         }
+    }
+    
+    void serialize()
+    {
+        this.serializedData = data.get();
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/AuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/AuditObjectFactory.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.artemis.audit.legacy;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 
+import java.util.function.Supplier;
+
 /**
  * @author Luciano Fiandesio
  */

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.render.RenderService;
 import org.springframework.stereotype.Component;
 
+import java.util.function.Supplier;
+
 /**
  * A factory for constructing @{@link org.hisp.dhis.audit.Audit} data payloads. This can be the object itself
  * (as is the case for metadata), or it can be a wrapper object collecting the parts wanted.
@@ -67,7 +69,7 @@ public class DefaultAuditObjectFactory implements AuditObjectFactory
         return null;
     }
 
-    private Object handleTracker( AuditType auditType, Object object, String user )
+    private Object handleTracker(AuditType auditType, Object object, String user )
     {
         return null;
     }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
@@ -31,11 +31,16 @@ package org.hisp.dhis.artemis.audit.listener;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
+import org.hisp.dhis.audit.AuditScope;
+import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.audit.Auditable;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.system.util.AnnotationUtils;
 
 import java.util.Arrays;
 import java.util.Optional;
+
+import static com.cronutils.utils.Preconditions.checkNotNull;
 
 /**
  * @author Luciano Fiandesio
@@ -51,6 +56,10 @@ public abstract class AbstractHibernateListener
         AuditObjectFactory objectFactory,
         UsernameSupplier usernameSupplier )
     {
+        checkNotNull( auditManager );
+        checkNotNull( objectFactory );
+        checkNotNull( usernameSupplier );
+
         this.auditManager = auditManager;
         this.objectFactory = objectFactory;
         this.usernameSupplier = usernameSupplier;
@@ -78,4 +87,6 @@ public abstract class AbstractHibernateListener
     {
         return usernameSupplier.get();
     }
+
+    abstract AuditType getAuditType();
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
@@ -55,20 +55,25 @@ public class PostInsertAuditListener
     }
 
     @Override
+    AuditType getAuditType()
+    {
+        return AuditType.CREATE;
+    }
+
+    @Override
     public void onPostInsert( PostInsertEvent postInsertEvent )
     {
         Object entity = postInsertEvent.getEntity();
 
-        getAuditable( entity, "create" ).ifPresent( auditable -> {
-            auditManager.send( Audit.builder()
-                .auditType( AuditType.CREATE )
-                .auditScope( auditable.scope() )
-                .createdAt( LocalDateTime.now() )
-                .createdBy( getCreatedBy() )
-                .object( entity )
-                .data( this.objectFactory.create( auditable.scope(), AuditType.CREATE, entity, getCreatedBy() ) )
-                .build() );
-        } );
+        getAuditable( entity, "create" ).ifPresent( auditable ->
+            auditManager.send(Audit.builder()
+                .auditType(getAuditType())
+                .auditScope(auditable.scope())
+                .createdAt(LocalDateTime.now())
+                .createdBy(getCreatedBy())
+                .object(entity)
+                .data( () -> this.objectFactory.create(auditable.scope(), getAuditType(), entity, getCreatedBy()))
+                .build()));
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
@@ -56,20 +56,25 @@ public class PostLoadAuditListener
     }
 
     @Override
+    AuditType getAuditType()
+    {
+        return AuditType.READ;
+    }
+
+    @Override
     @Transactional( readOnly = true )
     public void onPostLoad( PostLoadEvent postLoadEvent )
     {
         Object entity = postLoadEvent.getEntity();
 
-        getAuditable( entity, "read" ).ifPresent( auditable -> {
+        getAuditable( entity, "read" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
                 .auditType( AuditType.READ )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( entity )
-                .data( this.objectFactory.create( auditable.scope(), AuditType.READ, entity, getCreatedBy() ) )
-                .build() );
-        } );
+                .data( () -> this.objectFactory.create( auditable.scope(), getAuditType(), entity, getCreatedBy() ) )
+                .build() ));
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
@@ -56,20 +56,25 @@ public class PostUpdateAuditListener
     }
 
     @Override
+    AuditType getAuditType()
+    {
+        return AuditType.UPDATE;
+    }
+
+    @Override
     public void onPostUpdate( PostUpdateEvent postUpdateEvent )
     {
         Object entity = postUpdateEvent.getEntity();
 
-        getAuditable( entity, "update" ).ifPresent( auditable -> {
+        getAuditable( entity, "update" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
                 .auditType( AuditType.UPDATE )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( entity )
-                .data( this.objectFactory.create( auditable.scope(), AuditType.UPDATE, entity, getCreatedBy() ) )
-                .build() );
-        } );
+                .data( () -> this.objectFactory.create( auditable.scope(), getAuditType(), entity, getCreatedBy() ) )
+                .build() ));
     }
 
     @Override


### PR DESCRIPTION
- DHIS2-8122

Introduced AuditMatrix to control which Entity gets Audited.
Some open points for @mortenoh 
1) The new class `AuditMatrix` probably sucks from a naming point of view. Any better idea?
2) The Audit Matrix is initialized to "all true": everything gets audited
3) I use lazy evaluation (via lambda) to keep all the matrix logic in the main `AuditService`: I think it works well, but take a look 