### PR TITLE
feat: Audit Matrix to control auditing

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/audit/Audit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/audit/Audit.java
@@ -95,7 +95,8 @@ public class Audit implements Serializable
      * Additional attributes attached to Audit. Stored as JSONB in the database.
      */
     @JsonProperty
-    private final AuditAttributes attributes;
+    @Builder.Default
+    private AuditAttributes attributes = new AuditAttributes();
 
     /**
      * GZipped payload. Exposed as raw json, make sure that the payload is decompressed first.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -63,8 +62,7 @@ import java.util.Set;
  */
 @JacksonXmlRootElement( localName = "identifiableObject", namespace = DxfNamespaces.DXF_2_0 )
 public class BaseIdentifiableObject
-    extends BaseLinkableObject
-    implements IdentifiableObject
+    extends BaseLinkableObject implements IdentifiableObject
 {
     /**
      * The database internal identifier for this Object.
@@ -304,12 +302,11 @@ public class BaseIdentifiableObject
 
     @Override
     @JsonProperty
+    @JsonSerialize( as = BaseIdentifiableObject.class )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @JsonSerialize( using = CustomLastUpdatedUserSerializer.class )
-    @JsonDeserialize
     public User getLastUpdatedBy()
     {
-        return  lastUpdatedBy;
+        return lastUpdatedBy;
     }
 
     public void setLastUpdatedBy( User lastUpdatedBy )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -28,8 +28,11 @@ package org.hisp.dhis.user;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.*;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
@@ -43,11 +46,11 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.security.Authorities;
 import org.springframework.util.StringUtils;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Nguyen Hong Duc
@@ -690,7 +693,6 @@ public class User
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-
     public String getWhatsApp()
     {
         return whatsApp;
@@ -713,7 +715,6 @@ public class User
         this.facebookMessenger = facebookMessenger;
     }
 
-
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getSkype()
@@ -726,7 +727,6 @@ public class User
         this.skype = skype;
     }
 
-
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getTelegram()
@@ -738,7 +738,6 @@ public class User
     {
         this.telegram = telegram;
     }
-
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )

--- a/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/legacy/MetadataAuditConsumer.java
+++ b/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/legacy/MetadataAuditConsumer.java
@@ -67,7 +67,6 @@ public class MetadataAuditConsumer implements AuditConsumer
         this.auditService = auditService;
         this.objectMapper = objectMapper;
 
-        // TODO remove and replace with Audit Configuration Grid (ACG)
         this.metadataAuditPersist = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_PERSIST ), "on" );
         this.metadataAuditLog = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_LOG ), "on" );
     }

--- a/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/legacy/MetadataAuditConsumer.java
+++ b/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/legacy/MetadataAuditConsumer.java
@@ -57,7 +57,6 @@ public class MetadataAuditConsumer implements AuditConsumer
     private final AuditService auditService;
     private final ObjectMapper objectMapper;
     private final boolean metadataAuditLog;
-    private final boolean metadataAuditPersist;
 
     public MetadataAuditConsumer(
         AuditService auditService,
@@ -67,7 +66,6 @@ public class MetadataAuditConsumer implements AuditConsumer
         this.auditService = auditService;
         this.objectMapper = objectMapper;
 
-        this.metadataAuditPersist = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_PERSIST ), "on" );
         this.metadataAuditLog = Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_LOG ), "on" );
     }
 
@@ -92,10 +90,7 @@ public class MetadataAuditConsumer implements AuditConsumer
                 log.info( objectMapper.writeValueAsString( audit ) );
             }
 
-            if ( metadataAuditPersist )
-            {
-                auditService.addAudit( audit );
-            }
+            auditService.addAudit( audit );
         }
         catch ( IOException e )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
@@ -226,7 +226,7 @@ public class DefaultSystemService
         info.setSystemMonitoringUrl( dhisConfig.getProperty( ConfigurationKey.SYSTEM_MONITORING_URL ) );
         info.setSystemId( config.getSystemId() );
         info.setClusterHostname( dhisConfig.getProperty( ConfigurationKey.CLUSTER_HOSTNAME ) );
-        info.setRedisEnabled( Boolean.valueOf( dhisConfig.getProperty( ConfigurationKey.REDIS_ENABLED ) ) );
+        info.setRedisEnabled( Boolean.parseBoolean( dhisConfig.getProperty( ConfigurationKey.REDIS_ENABLED ) ) );
 
         if ( info.isRedisEnabled() )
         {
@@ -245,7 +245,6 @@ public class DefaultSystemService
         // ---------------------------------------------------------------------
 
         info.setMetadataAudit( new MetadataAudit(
-            Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_PERSIST ), "on" ),
             Objects.equals( dhisConfig.getProperty( ConfigurationKey.METADATA_AUDIT_LOG ), "on" )
         ) );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/MetadataAudit.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/MetadataAudit.java
@@ -39,30 +39,15 @@ import org.hisp.dhis.common.DxfNamespaces;
 @JacksonXmlRootElement( localName = "metadataAudit", namespace = DxfNamespaces.DXF_2_0 )
 public class MetadataAudit
 {
-    private boolean persist;
-
     private boolean log;
 
     public MetadataAudit()
     {
     }
 
-    public MetadataAudit( boolean persist, boolean log )
+    public MetadataAudit( boolean log )
     {
-        this.persist = persist;
         this.log = log;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isPersist()
-    {
-        return persist;
-    }
-
-    public void setPersist( boolean persist )
-    {
-        this.persist = persist;
     }
 
     @JsonProperty
@@ -77,8 +62,4 @@ public class MetadataAudit
         this.log = log;
     }
 
-    public boolean isAudit()
-    {
-        return log || persist;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -28,10 +28,18 @@ package org.hisp.dhis.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.*;
+import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.*;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
+import org.hisp.dhis.artemis.audit.AuditableEntity;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.payloads.TrackedEntityAuditPayload;
 import org.hisp.dhis.common.AccessLevel;
@@ -66,7 +74,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -75,11 +82,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.*;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.*;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -804,7 +806,7 @@ public class DefaultTrackedEntityInstanceService
     {
         String[] split = item.split( DimensionalObject.DIMENSION_NAME_SEP );
 
-        if ( split == null || (split.length % 2 != 1) )
+        if ( split.length % 2 != 1 )
         {
             throw new IllegalQueryException( "Query item or filter is invalid: " + item );
         }
@@ -855,7 +857,7 @@ public class DefaultTrackedEntityInstanceService
         {
             String[] split = query.split( DimensionalObject.DIMENSION_NAME_SEP );
 
-            if ( split == null || split.length != 2 )
+            if ( split.length != 2 )
             {
                 throw new IllegalQueryException( "Query has invalid format: " + query );
             }
@@ -1021,7 +1023,7 @@ public class DefaultTrackedEntityInstanceService
             .createdBy( auditPayload.getAccessedBy() )
             .klass( TrackedEntityInstance.class.getName() )
             .uid( auditPayload.getTrackedEntityInstance() )
-            .data( auditPayload )
+            .auditableEntity( new AuditableEntity( auditPayload ) )
             .build() );
     }
 

--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -61,7 +61,21 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
@@ -79,7 +79,7 @@ public class Audit implements Message
     @JsonProperty
     private AuditAttributes attributes;
 
-    @JsonProperty // TODO remove this from builder
+    @JsonProperty
     private Object data;
 
     @JsonIgnore
@@ -187,13 +187,13 @@ public class Audit implements Message
 
     String toLog() {
         return "Audit{" +
-                "auditType=" + auditType +
-                ", auditScope=" + auditScope +
-                ", createdAt=" + createdAt +
-                ", createdBy='" + createdBy + '\'' +
-                ", klass='" + klass + '\'' +
-                ", uid='" + uid + '\'' +
-                ", code='" + code + '\'' +
-                '}';
+            "auditType=" + auditType +
+            ", auditScope=" + auditScope +
+            ", createdAt=" + createdAt +
+            ", createdBy='" + createdBy + '\'' +
+            ", klass='" + klass + '\'' +
+            ", uid='" + uid + '\'' +
+            ", code='" + code + '\'' +
+            '}';
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
@@ -85,46 +85,6 @@ public class Audit implements Message
     @JsonIgnore
     private AuditableEntity auditableEntity;
 
-    /**
-     * This constructor is used to create an instance of Audit using the 'Builder'
-     * pattern This should be used by a service that needs to create a new Audit
-     * entry
-     */
-    @Builder( builderClassName = "AuditBuilder" )
-    public Audit( AuditType auditType, AuditScope auditScope, LocalDateTime createdAt, String createdBy, String klass,
-        String uid, String code, AuditAttributes attributes, AuditableEntity auditableEntity )
-    {
-        this.auditType = auditType;
-        this.auditScope = auditScope;
-        this.createdAt = createdAt;
-        this.createdBy = createdBy;
-        this.klass = klass;
-        this.uid = uid;
-        this.code = code;
-        this.attributes = attributes;
-        this.auditableEntity = auditableEntity;
-    }
-
-    /**
-     * This constructor should only be used by Jackson to deserialize an Audit instance from a Json String
-     */
-    @JsonCreator
-    public Audit( @JsonProperty( "auditType" ) AuditType auditType, @JsonProperty( "auditScope" ) AuditScope auditScope,
-        @JsonProperty( "createdAt" ) LocalDateTime createdAt, @JsonProperty( "createdBy" ) String createdBy,
-        @JsonProperty( "klass" ) String klass, @JsonProperty( "uid" ) String uid, @JsonProperty( "code" ) String code,
-        @JsonProperty( "attributes" ) AuditAttributes attributes, @JsonProperty( "data" ) Object data )
-    {
-        this.auditType = auditType;
-        this.auditScope = auditScope;
-        this.createdAt = createdAt;
-        this.createdBy = createdBy;
-        this.klass = klass;
-        this.uid = uid;
-        this.code = code;
-        this.attributes = attributes;
-        this.data = data;
-    }
-
     @Override
     public MessageType getMessageType()
     {

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.artemis.audit;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -77,7 +76,8 @@ public class Audit implements Message
     private String code;
 
     @JsonProperty
-    private AuditAttributes attributes;
+    @Builder.Default
+    private AuditAttributes attributes = new AuditAttributes();
 
     /**
      * This property holds the serialized Audited entity: it should not be used during the construction
@@ -153,7 +153,8 @@ public class Audit implements Message
         }
     }
 
-    String toLog() {
+    String toLog()
+    {
         return "Audit{" +
             "auditType=" + auditType +
             ", auditScope=" + auditScope +

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.artemis.audit;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -54,7 +56,7 @@ import java.time.LocalDateTime;
 public class Audit implements Message
 {
     @JsonProperty
-    private AuditType auditType;
+    private final AuditType auditType;
 
     @JsonProperty
     private AuditScope auditScope;
@@ -77,8 +79,51 @@ public class Audit implements Message
     @JsonProperty
     private AuditAttributes attributes;
 
-    @JsonProperty
+    @JsonProperty // TODO remove this from builder
     private Object data;
+
+    @JsonIgnore
+    private AuditableEntity auditableEntity;
+
+    /**
+     * This constructor is used to create an instance of Audit using the 'Builder'
+     * pattern This should be used by a service that needs to create a new Audit
+     * entry
+     */
+    @Builder( builderClassName = "AuditBuilder" )
+    public Audit( AuditType auditType, AuditScope auditScope, LocalDateTime createdAt, String createdBy, String klass,
+        String uid, String code, AuditAttributes attributes, AuditableEntity auditableEntity )
+    {
+        this.auditType = auditType;
+        this.auditScope = auditScope;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.klass = klass;
+        this.uid = uid;
+        this.code = code;
+        this.attributes = attributes;
+        this.auditableEntity = auditableEntity;
+    }
+
+    /**
+     * This constructor should only be used by Jackson to deserialize an Audit instance from a Json String
+     */
+    @JsonCreator
+    public Audit( @JsonProperty( "auditType" ) AuditType auditType, @JsonProperty( "auditScope" ) AuditScope auditScope,
+        @JsonProperty( "createdAt" ) LocalDateTime createdAt, @JsonProperty( "createdBy" ) String createdBy,
+        @JsonProperty( "klass" ) String klass, @JsonProperty( "uid" ) String uid, @JsonProperty( "code" ) String code,
+        @JsonProperty( "attributes" ) AuditAttributes attributes, @JsonProperty( "data" ) Object data )
+    {
+        this.auditType = auditType;
+        this.auditScope = auditScope;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.klass = klass;
+        this.uid = uid;
+        this.code = code;
+        this.attributes = attributes;
+        this.data = data;
+    }
 
     @Override
     public MessageType getMessageType()
@@ -138,5 +183,17 @@ public class Audit implements Message
 
             return this;
         }
+    }
+
+    String toLog() {
+        return "Audit{" +
+                "auditType=" + auditType +
+                ", auditScope=" + auditScope +
+                ", createdAt=" + createdAt +
+                ", createdBy='" + createdBy + '\'' +
+                ", klass='" + klass + '\'' +
+                ", uid='" + uid + '\'' +
+                ", code='" + code + '\'' +
+                '}';
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/Audit.java
@@ -79,9 +79,17 @@ public class Audit implements Message
     @JsonProperty
     private AuditAttributes attributes;
 
+    /**
+     * This property holds the serialized Audited entity: it should not be used during the construction
+     * of an instance of this object
+     */
     @JsonProperty
     private Object data;
 
+    /**
+     * This property should be used when constructing an Audit instance to send to the Audit sub-system
+     * The AuditableEntity object allows the AuditManager to serialize the audited entity only if needed
+     */
     @JsonIgnore
     private AuditableEntity auditableEntity;
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
@@ -70,24 +70,23 @@ public class AuditManager
 
     public void send( Audit audit )
     {
-        if ( auditMatrix.isEnabled( audit ) )
+        if ( !auditMatrix.isEnabled( audit ) )
         {
-            audit.setData( ( audit.getAuditableEntity().getEntity() instanceof String ? audit.getAuditableEntity()
-                : this.objectFactory.create( audit.getAuditScope(), audit.getAuditType(), audit.getAuditableEntity().getEntity(),
-                    audit.getCreatedBy() )) );
+            log.debug( "Audit message ignored:\n" + audit.toLog() );
+            return;
+        }
+        
+        audit.setData( ( audit.getAuditableEntity().getEntity() instanceof String ? audit.getAuditableEntity()
+            : this.objectFactory.create( audit.getAuditScope(), audit.getAuditType(), audit.getAuditableEntity().getEntity(),
+                audit.getCreatedBy() )) );
 
-            if ( config.isUseQueue() )
-            {
-                auditScheduler.addAuditItem( audit );
-            }
-            else
-            {
-                auditProducerSupplier.publish( audit );
-            }
+        if ( config.isUseQueue() )
+        {
+            auditScheduler.addAuditItem( audit );
         }
         else
         {
-            log.debug( "Audit message ignored:\n" + audit.toLog() );
+            auditProducerSupplier.publish( audit );
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
@@ -28,14 +28,14 @@ package org.hisp.dhis.artemis.audit;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.artemis.AuditProducerConfiguration;
 import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.springframework.stereotype.Component;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -56,7 +56,8 @@ public class AuditManager
         AuditProducerSupplier auditProducerSupplier,
         AuditScheduler auditScheduler,
         AuditProducerConfiguration config,
-        AuditMatrix auditMatrix, AuditObjectFactory auditObjectFactory )
+        AuditMatrix auditMatrix,
+        AuditObjectFactory auditObjectFactory )
     {
         checkNotNull( auditProducerSupplier );
         checkNotNull( config );
@@ -77,10 +78,10 @@ public class AuditManager
             log.debug( "Audit message ignored:\n" + audit.toLog() );
             return;
         }
-        
-        audit.setData( ( audit.getAuditableEntity().getEntity() instanceof String ? audit.getAuditableEntity()
+
+        audit.setData( (audit.getAuditableEntity().getEntity() instanceof String ? audit.getAuditableEntity()
             : this.objectFactory.create( audit.getAuditScope(), audit.getAuditType(), audit.getAuditableEntity().getEntity(),
-                audit.getCreatedBy() )) );
+            audit.getCreatedBy() )) );
 
         if ( config.isUseQueue() )
         {

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
@@ -28,19 +28,19 @@ package org.hisp.dhis.artemis.audit;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import lombok.extern.slf4j.Slf4j;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.artemis.AuditProducerConfiguration;
 import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.springframework.stereotype.Component;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Component
-@Slf4j
 public class AuditManager
 {
     private final AuditProducerSupplier auditProducerSupplier;
@@ -49,6 +49,8 @@ public class AuditManager
     private final AuditMatrix auditMatrix;
 
     private final AuditObjectFactory objectFactory;
+
+    private static final Log log = LogFactory.getLog( AuditManager.class );
 
     public AuditManager(
         AuditProducerSupplier auditProducerSupplier,

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditableEntity.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditableEntity.java
@@ -1,3 +1,5 @@
+package org.hisp.dhis.artemis.audit;
+
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -26,8 +28,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.artemis.audit;
-
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -36,7 +36,7 @@ import lombok.Value;
  */
 @Value
 @AllArgsConstructor
-public class AuditableEntity {
-
+public class AuditableEntity
+{
     private Object entity;
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditableEntity.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditableEntity.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.artemis.audit.legacy;
-
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -28,15 +26,17 @@ package org.hisp.dhis.artemis.audit.legacy;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.audit.AuditScope;
-import org.hisp.dhis.audit.AuditType;
+package org.hisp.dhis.artemis.audit;
 
-import java.util.function.Supplier;
+import lombok.AllArgsConstructor;
+import lombok.Value;
 
 /**
  * @author Luciano Fiandesio
  */
-public interface AuditObjectFactory
-{
-    Object create( AuditScope auditScope, AuditType auditType, Object object, String user );
+@Value
+@AllArgsConstructor
+public class AuditableEntity {
+
+    private Object entity;
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.artemis.audit.listener;
-
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -28,58 +26,46 @@ package org.hisp.dhis.artemis.audit.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hibernate.event.spi.PostInsertEvent;
-import org.hibernate.event.spi.PostInsertEventListener;
-import org.hibernate.persister.entity.EntityPersister;
+package org.hisp.dhis.artemis.audit.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hisp.dhis.artemis.audit.Audit;
-import org.hisp.dhis.artemis.audit.AuditManager;
-import org.hisp.dhis.artemis.audit.AuditableEntity;
-import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
-import org.hisp.dhis.artemis.config.UsernameSupplier;
+import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Luciano Fiandesio
  */
 @Component
-public class PostInsertAuditListener
-    extends AbstractHibernateListener implements PostInsertEventListener
+public class AuditMatrix
 {
+    private static final Map<AuditType, Boolean> ALL_ENABLED = ImmutableMap.<AuditType, Boolean> builder()
+        .put( AuditType.CREATE, true ).put( AuditType.UPDATE, true ).put( AuditType.READ, true )
+        .put( AuditType.SEARCH, true ).build();
 
-    public PostInsertAuditListener( AuditManager auditManager, AuditObjectFactory auditObjectFactory,
-        UsernameSupplier userNameSupplier )
+    private Map<AuditScope, Map<AuditType, Boolean>> matrix;
+
+    public AuditMatrix()
     {
-        super( auditManager, auditObjectFactory, userNameSupplier );
+        // TODO initialize this matrix with real configuration data
+        matrix = new HashMap<>();
+
+        matrix.put( AuditScope.METADATA, ALL_ENABLED );
     }
 
-    @Override
-    AuditType getAuditType()
+    public boolean isEnabled( Audit audit )
     {
-        return AuditType.CREATE;
+        return matrix.get( audit.getAuditScope() ).getOrDefault( audit.getAuditType(), true );
     }
 
-    @Override
-    public void onPostInsert( PostInsertEvent postInsertEvent )
+    public boolean isEnabled( AuditScope auditScope, AuditType auditType )
     {
-        Object entity = postInsertEvent.getEntity();
-
-        getAuditable( entity, "create" ).ifPresent( auditable ->
-            auditManager.send(Audit.builder()
-                .auditType( getAuditType() )
-                .auditScope( auditable.scope() )
-                .createdAt( LocalDateTime.now() )
-                .createdBy( getCreatedBy() )
-                .object( entity )
-                .auditableEntity( new AuditableEntity( entity ) )
-                .build() ) );
+        return matrix.get( auditScope ).getOrDefault( auditType, true );
     }
 
-    @Override
-    public boolean requiresPostCommitHanding( EntityPersister entityPersister )
-    {
-        return false;
-    }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
@@ -1,3 +1,5 @@
+package org.hisp.dhis.artemis.audit.configuration;
+
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -26,17 +28,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.artemis.audit.configuration;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Map;
-
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
@@ -28,44 +28,39 @@
 
 package org.hisp.dhis.artemis.audit.configuration;
 
-import java.util.HashMap;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Map;
 
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Luciano Fiandesio
  */
 @Component
+@DependsOn( "dhisConfigurationProvider" )
 public class AuditMatrix
 {
-    private static final Map<AuditType, Boolean> ALL_ENABLED = ImmutableMap.<AuditType, Boolean> builder()
-        .put( AuditType.CREATE, true ).put( AuditType.UPDATE, true ).put( AuditType.READ, true )
-        .put( AuditType.SEARCH, true ).build();
-
     private Map<AuditScope, Map<AuditType, Boolean>> matrix;
 
-    public AuditMatrix()
+    public AuditMatrix( AuditMatrixConfigurer auditMatrixConfigurer )
     {
-        // TODO initialize this matrix with real configuration data
-        matrix = new HashMap<>();
+        checkNotNull( auditMatrixConfigurer );
 
-        matrix.put( AuditScope.METADATA, ALL_ENABLED );
+        matrix = auditMatrixConfigurer.configure();
     }
 
     public boolean isEnabled( Audit audit )
     {
-        return matrix.get( audit.getAuditScope() ).getOrDefault( audit.getAuditType(), true );
+        return matrix.get( audit.getAuditScope() ).getOrDefault( audit.getAuditType(), false );
     }
 
     public boolean isEnabled( AuditScope auditScope, AuditType auditType )
     {
-        return matrix.get( auditScope ).getOrDefault( auditType, true );
+        return matrix.get( auditScope ).getOrDefault( auditType, false );
     }
-
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
@@ -90,15 +90,18 @@ public class AuditMatrixConfigurer
         for ( AuditScope value : AuditScope.values() )
         {
             Optional<ConfigurationKey> confKey = ConfigurationKey.getByKey( PROPERTY_PREFIX + value.name().toLowerCase() );
+
             if ( confKey.isPresent() && !StringUtils.isEmpty( config.getProperty( confKey.get() ) ) )
             {
                 String[] configuredTypes = config.getProperty( confKey.get() ).split( AUDIT_TYPE_STRING_SEPAR );
 
                 Map<AuditType, Boolean> matrixAuditTypes = new HashMap<>();
+
                 for ( AuditType auditType : AuditType.values() )
                 {
                     matrixAuditTypes.put( auditType, ArrayUtils.contains( configuredTypes, auditType.name() ) );
                 }
+
                 matrix.put( value, matrixAuditTypes );
 
             }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.artemis.audit.configuration;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.audit.AuditScope;
+import org.hisp.dhis.audit.AuditType;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Configures the Audit Matrix based on configuration properties from dhis.conf
+ *
+ * This configurator uses properties with prefix "audit.". Each property prefixed with "audit."
+ * must match the (lowercase) name of an {@see AuditScope} and must contain a semi-colon list of valid
+ * {@see AuditType} names: (READ;UPDATE;...).
+ *
+ * Example:
+ *
+ * audit.tracker=CREATE;READ;UPDATE;DELETE
+ *
+ * Misspelled entries are ignored, and the specific type is set to false.
+ * Missing {@see AuditScope} are replaced with all-false types.
+ * To disable Auditing completely, simply do not declare any audit.* property in dhis.conf
+ *
+ * @author Luciano Fiandesio
+ */
+@Component
+@DependsOn( "dhisConfigurationProvider" )
+public class AuditMatrixConfigurer
+{
+    private final DhisConfigurationProvider config;
+    private final static String PROPERTY_PREFIX = "audit.";
+    private final static String AUDIT_TYPE_STRING_SEPAR = ";";
+    private static final Map<AuditType, Boolean> ALL_DISABLED = ImmutableMap.<AuditType, Boolean> builder()
+        .put( AuditType.CREATE, false )
+        .put( AuditType.UPDATE, false )
+        .put( AuditType.READ, false )
+        .put( AuditType.SEARCH, false )
+        .put( AuditType.SECURITY, false )
+        .build();
+
+    public AuditMatrixConfigurer( DhisConfigurationProvider dhisConfigurationProvider )
+    {
+        checkNotNull( dhisConfigurationProvider );
+
+        this.config = dhisConfigurationProvider;
+    }
+
+    public Map<AuditScope, Map<AuditType, Boolean>> configure()
+    {
+        Map<AuditScope, Map<AuditType, Boolean>> matrix = new HashMap<>();
+
+        for ( AuditScope value : AuditScope.values() )
+        {
+            Optional<ConfigurationKey> confKey = ConfigurationKey.getByKey( PROPERTY_PREFIX + value.name().toLowerCase() );
+            if ( confKey.isPresent() && !StringUtils.isEmpty( config.getProperty( confKey.get() ) ) )
+            {
+                String[] configuredTypes = config.getProperty( confKey.get() ).split( AUDIT_TYPE_STRING_SEPAR );
+
+                Map<AuditType, Boolean> matrixAuditTypes = new HashMap<>();
+                for ( AuditType auditType : AuditType.values() )
+                {
+                    matrixAuditTypes.put( auditType, ArrayUtils.contains( configuredTypes, auditType.name() ) );
+                }
+                matrix.put( value, matrixAuditTypes );
+
+            }
+            else
+            {
+                matrix.put( value, ALL_DISABLED );
+            }
+        }
+
+        return matrix;
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
@@ -38,23 +38,23 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Configures the Audit Matrix based on configuration properties from dhis.conf
- *
+ * <p>
  * This configurator uses properties with prefix "audit.". Each property prefixed with "audit."
  * must match the (lowercase) name of an {@see AuditScope} and must contain a semi-colon list of valid
  * {@see AuditType} names: (READ;UPDATE;...).
- *
+ * <p>
  * Example:
- *
+ * <p>
  * audit.tracker=CREATE;READ;UPDATE;DELETE
- *
+ * <p>
  * Misspelled entries are ignored, and the specific type is set to false.
  * Missing {@see AuditScope} are replaced with all-false types.
  * To disable Auditing completely, simply do not declare any audit.* property in dhis.conf
@@ -68,7 +68,7 @@ public class AuditMatrixConfigurer
     private final DhisConfigurationProvider config;
     private final static String PROPERTY_PREFIX = "audit.";
     private final static String AUDIT_TYPE_STRING_SEPAR = ";";
-    private static final Map<AuditType, Boolean> ALL_DISABLED = ImmutableMap.<AuditType, Boolean> builder()
+    private static final Map<AuditType, Boolean> ALL_DISABLED = ImmutableMap.<AuditType, Boolean>builder()
         .put( AuditType.CREATE, false )
         .put( AuditType.UPDATE, false )
         .put( AuditType.READ, false )

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/AuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/AuditObjectFactory.java
@@ -31,8 +31,6 @@ package org.hisp.dhis.artemis.audit.legacy;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 
-import java.util.function.Supplier;
-
 /**
  * @author Luciano Fiandesio
  */

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
@@ -31,10 +31,8 @@ package org.hisp.dhis.artemis.audit.listener;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
-import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.audit.Auditable;
-import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.system.util.AnnotationUtils;
 
 import java.util.Arrays;

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
@@ -31,11 +31,16 @@ package org.hisp.dhis.artemis.audit.listener;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
+import org.hisp.dhis.audit.AuditScope;
+import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.audit.Auditable;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.system.util.AnnotationUtils;
 
 import java.util.Arrays;
 import java.util.Optional;
+
+import static com.cronutils.utils.Preconditions.checkNotNull;
 
 /**
  * @author Luciano Fiandesio
@@ -51,6 +56,10 @@ public abstract class AbstractHibernateListener
         AuditObjectFactory objectFactory,
         UsernameSupplier usernameSupplier )
     {
+        checkNotNull( auditManager );
+        checkNotNull( objectFactory );
+        checkNotNull( usernameSupplier );
+
         this.auditManager = auditManager;
         this.objectFactory = objectFactory;
         this.usernameSupplier = usernameSupplier;
@@ -78,4 +87,6 @@ public abstract class AbstractHibernateListener
     {
         return usernameSupplier.get();
     }
+
+    abstract AuditType getAuditType();
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostDeleteAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostDeleteAuditListener.java
@@ -28,17 +28,18 @@ package org.hisp.dhis.artemis.audit.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.time.LocalDateTime;
+
 import org.hibernate.event.spi.PostDeleteEvent;
 import org.hibernate.event.spi.PostDeleteEventListener;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
+import org.hisp.dhis.artemis.audit.AuditableEntity;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
 
 /**
  * @author Luciano Fiandesio
@@ -47,9 +48,7 @@ import java.time.LocalDateTime;
 public class PostDeleteAuditListener
     extends AbstractHibernateListener implements PostDeleteEventListener
 {
-    public PostDeleteAuditListener(
-        AuditManager auditManager,
-        AuditObjectFactory auditObjectFactory,
+    public PostDeleteAuditListener( AuditManager auditManager, AuditObjectFactory auditObjectFactory,
         UsernameSupplier userNameSupplier )
     {
         super( auditManager, auditObjectFactory, userNameSupplier );
@@ -65,16 +64,20 @@ public class PostDeleteAuditListener
     public void onPostDelete( PostDeleteEvent postDeleteEvent )
     {
         Object entity = postDeleteEvent.getEntity();
-
-        getAuditable( entity, "delete" ).ifPresent( auditable -> {
+        getAuditable( entity, "delete" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
-                .auditType( AuditType.DELETE )
+                .auditType( getAuditType() )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( entity )
-                .data( this.objectFactory.create( auditable.scope(), AuditType.DELETE, entity, getCreatedBy() ) )
-                .build() );
-        } );
+                .auditableEntity( new AuditableEntity( entity ) )
+                .build() ) );
+    }
+
+    @Override
+    AuditType getAuditType()
+    {
+        return AuditType.DELETE;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostDeleteAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostDeleteAuditListener.java
@@ -28,8 +28,6 @@ package org.hisp.dhis.artemis.audit.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.time.LocalDateTime;
-
 import org.hibernate.event.spi.PostDeleteEvent;
 import org.hibernate.event.spi.PostDeleteEventListener;
 import org.hibernate.persister.entity.EntityPersister;
@@ -40,6 +38,8 @@ import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
@@ -67,7 +67,7 @@ public class PostInsertAuditListener
         Object entity = postInsertEvent.getEntity();
 
         getAuditable( entity, "create" ).ifPresent( auditable ->
-            auditManager.send(Audit.builder()
+            auditManager.send( Audit.builder()
                 .auditType( getAuditType() )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
@@ -32,6 +32,7 @@ import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
+import org.hisp.dhis.artemis.audit.AuditableEntity;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -54,20 +55,24 @@ public class PostLoadAuditListener
         super( auditManager, auditObjectFactory, userNameSupplier );
     }
 
+    AuditType getAuditType()
+    {
+        return AuditType.READ;
+    }
+
     @Override
     public void onPostLoad( PostLoadEvent postLoadEvent )
     {
         Object entity = postLoadEvent.getEntity();
 
-        getAuditable( entity, "read" ).ifPresent( auditable -> {
+        getAuditable( entity, "read" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
                 .auditType( AuditType.READ )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( entity )
-                .data( this.objectFactory.create( auditable.scope(), AuditType.READ, entity, getCreatedBy() ) )
-                .build() );
-        } );
+                .auditableEntity( new AuditableEntity( entity ) )
+                .build() ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
@@ -67,7 +67,7 @@ public class PostLoadAuditListener
 
         getAuditable( entity, "read" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
-                .auditType( AuditType.READ )
+                .auditType( getAuditType() )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
@@ -69,7 +69,7 @@ public class PostUpdateAuditListener
 
         getAuditable( entity, "update" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
-                .auditType( AuditType.UPDATE )
+                .auditType( getAuditType() )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
@@ -33,6 +33,7 @@ import org.hibernate.event.spi.PostUpdateEventListener;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
+import org.hisp.dhis.artemis.audit.AuditableEntity;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -56,20 +57,25 @@ public class PostUpdateAuditListener
     }
 
     @Override
+    AuditType getAuditType()
+    {
+        return AuditType.UPDATE;
+    }
+
+    @Override
     public void onPostUpdate( PostUpdateEvent postUpdateEvent )
     {
         Object entity = postUpdateEvent.getEntity();
 
-        getAuditable( entity, "update" ).ifPresent( auditable -> {
+        getAuditable( entity, "update" ).ifPresent( auditable ->
             auditManager.send( Audit.builder()
                 .auditType( AuditType.UPDATE )
                 .auditScope( auditable.scope() )
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( entity )
-                .data( this.objectFactory.create( auditable.scope(), AuditType.UPDATE, entity, getCreatedBy() ) )
-                .build() );
-        } );
+                .auditableEntity( new AuditableEntity( entity ) )
+                .build() ) );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/test/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/test/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.artemis.audit.configuration;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.audit.AuditScope.TRACKER;
+import static org.hisp.dhis.audit.AuditType.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.hisp.dhis.audit.AuditScope;
+import org.hisp.dhis.audit.AuditType;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class AuditMatrixConfigurerTest
+{
+    @Mock
+    private DhisConfigurationProvider config;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private AuditMatrixConfigurer subject;
+
+    private Map<AuditScope, Map<AuditType, Boolean>> matrix;
+
+    @Before
+    public void setUp()
+    {
+        this.subject = new AuditMatrixConfigurer( config );
+    }
+
+    @Test
+    public void verifyConfigurationForMatrixIsIngested()
+    {
+        when( config.getProperty( ConfigurationKey.AUDIT_METADATA_MATRIX ) ).thenReturn( "READ;" );
+        when( config.getProperty( ConfigurationKey.AUDIT_TRACKER_MATRIX ) ).thenReturn( "CREATE;READ;UPDATE;DELETE" );
+        when( config.getProperty( ConfigurationKey.AUDIT_AGGREGATE_MATRIX ) ).thenReturn( "CREATE;UPDATE;DELETE" );
+
+        matrix = this.subject.configure();
+
+        assertThat( matrix.get( AuditScope.METADATA ).keySet(), hasSize( 6 ) );
+        assertMatrixEnabled( AuditScope.METADATA, READ );
+        assertMatrixDisabled( AuditScope.METADATA, CREATE, UPDATE, DELETE );
+
+        assertThat( matrix.get( TRACKER ).keySet(), hasSize( 6 ) );
+        assertMatrixDisabled( TRACKER, SEARCH, SECURITY );
+        assertMatrixEnabled( TRACKER, CREATE, UPDATE, DELETE, READ );
+
+        assertThat( matrix.get( AuditScope.AGGREGATE ).keySet(), hasSize( 6 ) );
+        assertMatrixDisabled( AuditScope.AGGREGATE, READ, SECURITY, SEARCH );
+        assertMatrixEnabled( AuditScope.AGGREGATE, CREATE, UPDATE, DELETE );
+    }
+
+    @Test
+    public void verifyInvalidConfigurationIsIgnored()
+    {
+        when( config.getProperty( ConfigurationKey.AUDIT_METADATA_MATRIX ) ).thenReturn( "READX;UPDATE" );
+
+        matrix = this.subject.configure();
+        assertThat( matrix.get( AuditScope.METADATA ).keySet(), hasSize( 6 ) );
+        assertAllFalseBut( matrix.get( AuditScope.METADATA ), UPDATE );
+
+    }
+
+    private void assertAllFalseBut( Map<AuditType, Boolean> auditTypeBooleanMap, AuditType trueAuditType )
+    {
+        for ( AuditType auditType : auditTypeBooleanMap.keySet() )
+        {
+            if ( !auditType.name().equals( trueAuditType.name() ) )
+            {
+                assertFalse( auditTypeBooleanMap.get( auditType ) );
+            }
+            else
+            {
+                assertTrue( auditTypeBooleanMap.get( auditType ) );
+            }
+        }
+    }
+
+    private void assertMatrixEnabled( AuditScope auditScope, AuditType... auditTypes )
+    {
+        for ( AuditType auditType : auditTypes )
+        {
+            assertThat( "Expecting true for audit type: " + auditType.name(), matrix.get( auditScope ).get( auditType ),
+                is( true ) );
+        }
+    }
+
+    private void assertMatrixDisabled( AuditScope auditScope, AuditType... auditTypes )
+    {
+        for ( AuditType auditType : auditTypes )
+        {
+            assertThat( "Expecting false for audit type: " + auditType.name(),
+                matrix.get( auditScope ).get( auditType ), is( false ) );
+        }
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-audit/src/main/java/org/hisp/dhis/audit/JdbcAuditRepository.java
+++ b/dhis-2/dhis-support/dhis-support-audit/src/main/java/org/hisp/dhis/audit/JdbcAuditRepository.java
@@ -37,6 +37,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -240,6 +241,11 @@ public class JdbcAuditRepository implements AuditRepository
 
     private static byte[] compress( String data )
     {
+        if ( StringUtils.isEmpty( data ) )
+        {
+            return new byte[]{};
+        }
+
         byte[] result = data.getBytes( StandardCharsets.UTF_8 );
 
         try ( ByteArrayOutputStream bos = new ByteArrayOutputStream( data.length() ) )
@@ -259,6 +265,11 @@ public class JdbcAuditRepository implements AuditRepository
 
     private static String decompress( byte[] data )
     {
+        if ( data == null || data.length == 0 )
+        {
+            return "{}";
+        }
+
         String result = null;
 
         try ( ByteArrayInputStream bin = new ByteArrayInputStream( data ) )

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -66,7 +66,6 @@ public enum ConfigurationKey
     CLUSTER_MEMBERS( "cluster.members", "", false ),
     CLUSTER_CACHE_PORT( "cluster.cache.port", "4001", false ),
     CLUSTER_CACHE_REMOTE_OBJECT_PORT( "cluster.cache.remote.object.port", "0", false ),
-    METADATA_AUDIT_PERSIST( "metadata.audit.persist", "off", false ),
     METADATA_AUDIT_LOG( "metadata.audit.log", "off", false ),
     REDIS_HOST( "redis.host", "localhost", false ),
     REDIS_PORT( "redis.port", "6379", false ),

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -28,6 +28,11 @@ package org.hisp.dhis.external.conf;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.option.Option;
+
+import java.util.Arrays;
+import java.util.Optional;
+
 /**
  * @author Lars Helge Overland
  */
@@ -99,7 +104,10 @@ public enum ConfigurationKey
     MONITORING_LOG_REQUESTID_MAXSIZE( "monitoring.requestidlog.maxsize", "-1", false ),
     APP_STORE_URL( "appstore.base.url", "https://play.dhis2.org/appstore", false ),
     APP_STORE_API_URL( "appstore.api.url", "https://play.dhis2.org/appstore/api", false ),
-    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "on" );
+    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "on" ),
+    AUDIT_METADATA_MATRIX( "audit.metadata", "", false ),
+    AUDIT_TRACKER_MATRIX( "audit.tracker", "", false ),
+    AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false );
 
     private final String key;
 
@@ -141,5 +149,10 @@ public enum ConfigurationKey
     public boolean isConfidential()
     {
         return confidential;
+    }
+    
+    public static Optional<ConfigurationKey> getByKey( String key )
+    {
+        return Arrays.stream( ConfigurationKey.values() ).filter( k -> k.key.equals( key ) ).findFirst();
     }
 }


### PR DESCRIPTION
- DHIS2-8122
- Created `AuditMatrix` class to control Auditing message publishing based on simple rules (Audit category and Audit action - READ, WRITE, etc)
- `AuditMatrix` is configured by setting specific properties on `dhis.conf`
- Serialization of Auditable entities now takes place in the `AuditManager`, to prevent costly early serialization
