### PR TITLE
fix: removed @Transactional annotation from listener

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -56,7 +55,6 @@ public class PostLoadAuditListener
     }
 
     @Override
-    @Transactional( readOnly = true )
     public void onPostLoad( PostLoadEvent postLoadEvent )
     {
         Object entity = postLoadEvent.getEntity();


### PR DESCRIPTION
- The annotation was causing hibernate to trigger "SET SESSION
CHARACTERISTICS" thousands of times for each api call