### PR TITLE
feat: Analytics handles multiple filter Data Elems

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -499,8 +499,7 @@ public class DefaultQueryPlanner
      * and the same Value Type. If the DataQueryParams has the aggregationType set, then the DataQueryParams
      * aggregationType overrides all the Data Elements' aggregation types.
      *
-     * @param params DataQueryParams object
-     *
+     * @param params DataQueryParams object.
      */
     private boolean filterHasDataElementsOfSameAggregationTypeAndValueType( DataQueryParams params )
     {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -28,41 +28,31 @@ package org.hisp.dhis.analytics.data;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.hisp.dhis.analytics.AggregationType;
-import org.hisp.dhis.analytics.AnalyticsAggregationType;
-import org.hisp.dhis.analytics.AnalyticsTableType;
-import org.hisp.dhis.analytics.DataQueryGroups;
-import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.analytics.DataType;
-import org.hisp.dhis.analytics.Partitions;
-import org.hisp.dhis.analytics.QueryPlanner;
-import org.hisp.dhis.analytics.QueryPlannerParams;
-import org.hisp.dhis.analytics.QueryValidator;
-import org.hisp.dhis.analytics.partition.PartitionManager;
-import org.hisp.dhis.analytics.table.PartitionUtils;
-import org.hisp.dhis.common.*;
-import org.hisp.dhis.commons.collection.PaginatedList;
-import org.hisp.dhis.dataelement.DataElementGroup;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.system.util.MathUtils;
-import org.hisp.dhis.util.ObjectUtils;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import org.springframework.stereotype.Component;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.analytics.DataQueryParams.LEVEL_PREFIX;
+import static org.hisp.dhis.common.DimensionalObject.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.analytics.DataQueryParams.LEVEL_PREFIX;
-import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.analytics.*;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.PartitionUtils;
+import org.hisp.dhis.common.*;
+import org.hisp.dhis.commons.collection.PaginatedList;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementGroup;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.system.util.MathUtils;
+import org.hisp.dhis.util.ObjectUtils;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 /**
  * @author Lars Helge Overland
@@ -477,15 +467,7 @@ public class DefaultQueryPlanner
 
             queries.add( query );
         }
-        /*
-         * This is a special case: if a *single* Data Element is used as filter, then we
-         * want to be able to calculate the proper aggregation type based on the Date
-         * Element aggregation type or the aggregation type selected for the query. It's
-         * not possible to handle more than one Data Element in the filter, because each
-         * Data Element may have different data type (NUMERIC, etc.) and the data type
-         * is required to construct the select the proper SQL function (avg, sum, etc)
-         */
-        else if ( params.getFilterOptions( DATA_X_DIM_ID, DataDimensionItemType.DATA_ELEMENT ).size() == 1 )
+        else if ( filterHasDataElementsOfSameAggregationTypeAndValueType( params ) )
         {
             ListMap<AnalyticsAggregationType, DimensionalItemObject> aggregationTypeDataElementMap = QueryPlannerUtils
                 .getAggregationTypeDataElementMap( params.getFilterOptions( DATA_X_DIM_ID, DataDimensionItemType.DATA_ELEMENT ),
@@ -510,6 +492,33 @@ public class DefaultQueryPlanner
         logQuerySplit( queries, "aggregation type" );
 
         return queries;
+    }
+
+    /**
+     * Check if the filter of this DataQueryParams contains Data Elements having the same Aggregation Type
+     * and the same Value Type. If the DataQueryParams has the aggregationType set, then the DataQueryParams
+     * aggregationType overrides all the Data Elements' aggregation types.
+     *
+     * @param params DataQueryParams object
+     *
+     */
+    private boolean filterHasDataElementsOfSameAggregationTypeAndValueType( DataQueryParams params )
+    {
+        List<DimensionalItemObject> filterDataElements = params.getFilterOptions( DATA_X_DIM_ID,
+            DataDimensionItemType.DATA_ELEMENT );
+
+        if ( filterDataElements.size() >= 1 )
+        {
+            DataElement firstDataElement = (DataElement) filterDataElements.get( 0 );
+            return (params.getAggregationType() != null || filterDataElements.stream().allMatch(
+                de -> de.getAggregationType().name().equals( firstDataElement.getAggregationType().name() ) ))
+                && filterDataElements.stream().allMatch(
+                    de -> ((DataElement) de).getValueType().name().equals( firstDataElement.getValueType().name() ) );
+        }
+        else
+        {
+            return false;
+        }
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultQueryPlannerGroupByAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultQueryPlannerGroupByAggregationTypeTest.java
@@ -115,12 +115,10 @@ public class DefaultQueryPlannerGroupByAggregationTypeTest
                 .and( hasProperty( "aggregationType", hasProperty( "dataType", is( DataType.TEXT ) ) ) ) ) );
     }
 
+
     @Test
     public void verifySingleNonDataElementRetainAggregationTypeButNullDataType()
     {
-        //
-        // Only single Data Element in filter are retaining the Data Type
-        //
         List<DimensionalItemObject> periods = new ArrayList<>();
         periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
         // DataQueryParams with **one** Indicator
@@ -151,7 +149,7 @@ public class DefaultQueryPlannerGroupByAggregationTypeTest
         // DataQueryParams with **one** DataElement as filter
         DataQueryParams queryParams = createDataQueryParams(
             new BaseDimensionalObject( "dx", DimensionType.DATA_X, DISPLAY_NAME_DATA_X, "display name",
-                Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ) ) ) );
+                Lists.newArrayList( createDataElement( 'A', ValueType.INTEGER, AggregationType.MAX ) ) ) );
 
         DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
             QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
@@ -159,7 +157,7 @@ public class DefaultQueryPlannerGroupByAggregationTypeTest
         assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
         DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
 
-        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.AVERAGE ) );
+        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.MAX ) );
 
         // Expect the datatype = NUMERIC (which will allow the SQL generator to pick-up
         // the proper SQL function)
@@ -173,6 +171,7 @@ public class DefaultQueryPlannerGroupByAggregationTypeTest
     public void verifyMultipleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
     {
         // DataQueryParams with **two** DataElement as filter
+        // Both have DataType NUMERIC and AggregationType SUM
         DataQueryParams queryParams = createDataQueryParams( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
             DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
                 createDataElement( 'B', new CategoryCombo() ) ) ) );
@@ -183,7 +182,75 @@ public class DefaultQueryPlannerGroupByAggregationTypeTest
         assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
         DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
 
-        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.AVERAGE ) );
+        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.SUM ) );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( DataType.NUMERIC ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterHavingDifferentAggTypeDoNotRetainAggregationType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // Both have DataType NUMERIC but different AggregationType
+        DataQueryParams queryParams = createDataQueryParams( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', ValueType.INTEGER, AggregationType.COUNT ) ) ) );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+        // Aggregation type defaults to SUM
+        assertDefaultAggregationType( dataQueryParam );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( nullValue() ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterHavingDifferentAggTypeRetainAggregationType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // Both have DataType NUMERIC but different AggregationType
+        // Aggregation type is overridden (COUNT)
+        DataQueryParams queryParams = createDataQueryParamsWithAggregationType( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', ValueType.INTEGER, AggregationType.COUNT ) ) ), AnalyticsAggregationType.COUNT );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+        // Aggregation type defaults to SUM
+        assertDefaultAggregationType( dataQueryParam );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( nullValue() ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterHavingDifferentDataTypeDoNotRetainAggregationType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // One Data Element has Type Numeric
+        // Aggregation type is overridden (COUNT)
+        DataQueryParams queryParams = createDataQueryParamsWithAggregationType( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', ValueType.TEXT, AggregationType.COUNT ) ) ), AnalyticsAggregationType.COUNT );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+        // Aggregation type defaults to SUM
+        assertDefaultAggregationType( dataQueryParam );
         assertThat( dataQueryParam.getAggregationType().getDataType(), is( nullValue() ) );
         assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
         assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
@@ -204,6 +271,19 @@ public class DefaultQueryPlannerGroupByAggregationTypeTest
                     ImmutableList.of( new OrganisationUnit( "bbb", "bbb", "OU_2", null, null, "c2" ) ) ),
                 // DATA ELEMENT AS FILTER
                 filterDataElements ) )
-            .withAggregationType( AnalyticsAggregationType.AVERAGE ).build();
+            .build();
+    }
+
+    private DataQueryParams createDataQueryParamsWithAggregationType( BaseDimensionalObject filterDataElements,
+        AnalyticsAggregationType analyticsAggregationType )
+    {
+
+        return createDataQueryParams( filterDataElements )
+            .copyTo( DataQueryParams.newBuilder().withAggregationType( analyticsAggregationType ).build() );
+    }
+
+    private void assertDefaultAggregationType( DataQueryParams dataQueryParam )
+    {
+        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.SUM ) );
     }
 }


### PR DESCRIPTION
- DHIS2-7797
- This change allows an Analytics query to retain the aggregation type
when multiple Data Elements having the same data type and aggregation
type are used as **query filters**.
If the filter Data Elements have **different aggregation types** or **different data
values**, then the system will default to **SUM** aggregation type and **NULL** data
type