### PR TITLE
fix: Program indicator to use variables in d2:hasValue function

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -132,6 +132,7 @@ public class  DefaultProgramIndicatorService
 
         .put( V_ANALYTICS_PERIOD_END, new vAnalyticsPeriodEnd() )
         .put( V_ANALYTICS_PERIOD_START, new vAnalyticsPeriodStart() )
+        .put( V_COMPLETED_DATE, new vCompletedDate() )
         .put( V_CREATION_DATE, new vCreationDate() )
         .put( V_CURRENT_DATE, new vCurrentDate() )
         .put( V_DUE_DATE, new vDueDate() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
@@ -40,7 +40,7 @@ public class vCompletedDate extends ProgramDateVariable
     public Object getSql( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-            null, "completed", visitor.getReportingStartDate(),
+            null, "completeddate", visitor.getReportingStartDate(),
             visitor.getReportingStartDate(), visitor.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
@@ -1,7 +1,7 @@
-package org.hisp.dhis.program.function;
+package org.hisp.dhis.program.variable;
 
 /*
- * Copyright (c) 2004-2020, University of Oslo
+ * Copyright (c) 2004-2018, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,29 +29,18 @@ package org.hisp.dhis.program.function;
  */
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-import org.hisp.dhis.parser.expression.function.SimpleScalarFunction;
-
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
 
 /**
- * Program indicator function: d2 has value
- *
- * @author Jim Grace
+ * @author Zubair Asghar
  */
-public class D2HasValue
-    extends SimpleScalarFunction
+public class vCompletedDate extends ProgramDateVariable
 {
     @Override
-    public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
+    public Object getSql( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.visit( ctx.expr( 0 ) );
-
-        return true;
-    }
-
-    @Override
-    public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        return "(" + visitor.visitAllowingNulls( ctx.expr( 0 ) ) + " is not null)";
+        return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
+            null, "completed", visitor.getReportingStartDate(),
+            visitor.getReportingStartDate(), visitor.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.program.variable;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
+import org.hisp.dhis.program.AnalyticsType;
 
 /**
  * @author Zubair Asghar
@@ -39,6 +40,11 @@ public class vCompletedDate extends ProgramDateVariable
     @Override
     public Object getSql( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
+        if ( AnalyticsType.EVENT == visitor.getProgramIndicator().getAnalyticsType() )
+        {
+            return "completeddate";
+        }
+
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
             null, "completeddate", visitor.getReportingStartDate(),
             visitor.getReportingStartDate(), visitor.getProgramIndicator() );

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -55,6 +55,7 @@ expr
 
     |   'V{' fun='analytics_period_end' '}'
     |   'V{' fun='analytics_period_start' '}'
+    |   'V{' fun='completed_date' '}'
     |   'V{' fun='creation_date' '}'
     |   'V{' fun='current_date' '}'
     |   'V{' fun='due_date' '}'
@@ -80,7 +81,7 @@ expr
     |   fun='d2:countIfCondition(' WS* stageDataElement ',' WS* stringLiteral WS* ')'
     |   fun='d2:countIfValue(' WS* stageDataElement WS* ',' WS* numStringLiteral WS*  ')'
     |   fun='d2:daysBetween(' compareDate ',' compareDate ')'
-    |   fun='d2:hasValue(' item ')'
+    |   fun='d2:hasValue(' expr ')'
     |   fun='d2:maxValue(' ( item | compareDate ) ')'
     |   fun='d2:minutesBetween(' compareDate ',' compareDate ')'
     |   fun='d2:minValue(' ( item | compareDate ) ')'
@@ -206,6 +207,7 @@ VARIANCE        : 'variance(';
 
 V_ANALYTICS_PERIOD_END  : 'analytics_period_end';
 V_ANALYTICS_PERIOD_START: 'analytics_period_start';
+V_COMPLETED_DATE        : 'completed_date';
 V_CREATION_DATE         : 'creation_date';
 V_CURRENT_DATE          : 'current_date';
 V_DUE_DATE              : 'due_date';


### PR DESCRIPTION
Program indicator throws an error when program variables are used in d2:hasValue function. Fixed it by adding it to variable support in ANTLR grammar.