### PR TITLE
[2.32] feat: Single data element as filter retains aggregation type

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -925,6 +925,19 @@ public class DataQueryParams
     }
 
     /**
+     * Retrieves the options for the given dimension and dimension type.
+     * Returns an empty list if the filtering options do not match any dimension.
+     */
+    public List<DimensionalItemObject> getFilterOptions( String filter, DataDimensionItemType dataDimensionItemType )
+    {
+        int index = filters.indexOf( new BaseDimensionalObject( filter ) );
+
+        return index != -1
+                ? AnalyticsUtils.getByDataDimensionItemType( dataDimensionItemType, filters.get( index ).getItems() )
+                : new ArrayList<>();
+    }
+
+    /**
      * Retrieves the filter with the given filter identifier.
      */
     public DimensionalObject getFilter( String filter )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -41,13 +41,9 @@ import org.hisp.dhis.analytics.QueryPlannerParams;
 import org.hisp.dhis.analytics.QueryValidator;
 import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.analytics.table.PartitionUtils;
-import org.hisp.dhis.common.BaseDimensionalObject;
-import org.hisp.dhis.common.DimensionType;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.ListMap;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.PaginatedList;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
@@ -197,7 +193,7 @@ public class DefaultQueryPlanner
         {
             DimensionalObject dim = query.getDimension( dimension );
 
-            List<DimensionalItemObject> values = null;
+            List<DimensionalItemObject> values;
 
             if ( dim == null || (values = dim.getItems()) == null || values.isEmpty() )
             {
@@ -442,8 +438,9 @@ public class DefaultQueryPlanner
 
         if ( !params.getDataElements().isEmpty() )
         {
-            ListMap<AnalyticsAggregationType, DimensionalItemObject> aggregationTypeDataElementMap =
-                QueryPlannerUtils.getAggregationTypeDataElementMap( params );
+            ListMap<AnalyticsAggregationType, DimensionalItemObject> aggregationTypeDataElementMap = QueryPlannerUtils
+                .getAggregationTypeDataElementMap( params.getDataElements(), params.getAggregationType(),
+                    params.getPeriodType() );
 
             for ( AnalyticsAggregationType aggregationType : aggregationTypeDataElementMap.keySet() )
             {
@@ -475,6 +472,20 @@ public class DefaultQueryPlanner
 
             queries.add( query );
         }
+        else if ( filterHasDataElementsOfSameAggregationTypeAndValueType( params ) )
+        {
+            ListMap<AnalyticsAggregationType, DimensionalItemObject> aggregationTypeDataElementMap = QueryPlannerUtils
+                    .getAggregationTypeDataElementMap( params.getFilterOptions( DATA_X_DIM_ID, DataDimensionItemType.DATA_ELEMENT ),
+                            params.getAggregationType(), params.getPeriodType() );
+
+            for ( AnalyticsAggregationType aggregationType : aggregationTypeDataElementMap.keySet() )
+            {
+                DataQueryParams query = DataQueryParams.newBuilder( params ).withAggregationType( aggregationType )
+                        .build();
+
+                queries.add( query );
+            }
+        }
         else
         {
             DataQueryParams query = DataQueryParams.newBuilder( params )
@@ -486,6 +497,32 @@ public class DefaultQueryPlanner
         logQuerySplit( queries, "aggregation type" );
 
         return queries;
+    }
+
+    /**
+     * Check if the filter of this DataQueryParams contains Data Elements having the same Aggregation Type
+     * and the same Value Type. If the DataQueryParams has the aggregationType set, then the DataQueryParams
+     * aggregationType overrides all the Data Elements' aggregation types.
+     *
+     * @param params DataQueryParams object.
+     */
+    private boolean filterHasDataElementsOfSameAggregationTypeAndValueType( DataQueryParams params )
+    {
+        List<DimensionalItemObject> filterDataElements = params.getFilterOptions( DATA_X_DIM_ID,
+                DataDimensionItemType.DATA_ELEMENT );
+
+        if ( filterDataElements.size() >= 1 )
+        {
+            DataElement firstDataElement = (DataElement) filterDataElements.get( 0 );
+            return (params.getAggregationType() != null || filterDataElements.stream().allMatch(
+                    de -> de.getAggregationType().name().equals( firstDataElement.getAggregationType().name() ) ))
+                    && filterDataElements.stream().allMatch(
+                    de -> ((DataElement) de).getValueType().name().equals( firstDataElement.getValueType().name() ) );
+        }
+        else
+        {
+            return false;
+        }
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/QueryPlannerUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/QueryPlannerUtils.java
@@ -117,24 +117,25 @@ public class QueryPlannerUtils
      * Creates a mapping between the aggregation type and data elements for the
      * given data elements and period type.
      *
-     * @param params the data query parameters.
+     * @param dataElements a List of {@see DimensionalItemObject}
+     * @param aggregationType an {@see AnalyticsAggregationType}
+     * @param periodType a String representing a Period Type (e.g. 201901)
      */
-    public static ListMap<AnalyticsAggregationType, DimensionalItemObject> getAggregationTypeDataElementMap( DataQueryParams params )
+    public static ListMap<AnalyticsAggregationType, DimensionalItemObject> getAggregationTypeDataElementMap(
+            List<DimensionalItemObject> dataElements, AnalyticsAggregationType aggregationType, String periodType )
     {
-        List<DimensionalItemObject> dataElements = params.getDataElements();
-        PeriodType aggregationPeriodType = PeriodType.getPeriodTypeByName( params.getPeriodType() );
-
+        PeriodType aggregationPeriodType = PeriodType.getPeriodTypeByName( periodType );
         ListMap<AnalyticsAggregationType, DimensionalItemObject> map = new ListMap<>();
 
         for ( DimensionalItemObject element : dataElements )
         {
             DataElement de = (DataElement) element;
 
-            AnalyticsAggregationType aggregationType = ObjectUtils.firstNonNull( params.getAggregationType(),
-                AnalyticsAggregationType.fromAggregationType( de.getAggregationType() ) );
+            AnalyticsAggregationType aggType = ObjectUtils.firstNonNull( aggregationType,
+                    AnalyticsAggregationType.fromAggregationType( de.getAggregationType() ) );
 
-            AnalyticsAggregationType analyticsAggregationType = getAggregationType( aggregationType, de.getValueType(),
-                aggregationPeriodType, de.getPeriodType() );
+            AnalyticsAggregationType analyticsAggregationType = getAggregationType( aggType, de.getValueType(),
+                    aggregationPeriodType, de.getPeriodType() );
 
             map.putValue( analyticsAggregationType, de );
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultQueryPlannerGroupByAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultQueryPlannerGroupByAggregationTypeTest.java
@@ -1,0 +1,285 @@
+package org.hisp.dhis.analytics.data;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_DATA_X;
+import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_ORGUNIT;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hisp.dhis.analytics.*;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElementDomain;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.MonthlyPeriodType;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultQueryPlannerGroupByAggregationTypeTest
+{
+    @InjectMocks
+    private DefaultQueryPlanner subject;
+
+    @Mock
+    private QueryValidator queryValidator;
+
+    @Mock
+    private PartitionManager partitionManager;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void verifyMultipleDataElementIsAggregatedWithTwoQueryGroupWhenDataTypeIsDifferent()
+    {
+        List<DimensionalItemObject> periods = new ArrayList<>();
+        periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
+        // DataQueryParams with **two** DataElement with different data type as
+        // dimension
+        DataQueryParams queryParams = DataQueryParams.newBuilder().withDimensions(
+                // PERIOD DIMENSION
+                Lists.newArrayList( new BaseDimensionalObject( "pe", DimensionType.PERIOD, periods ),
+                        new BaseDimensionalObject( "dx", DimensionType.DATA_X, DISPLAY_NAME_DATA_X, "display name",
+                                Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                                        createDataElement( 'B', ValueType.TEXT, AggregationType.COUNT,
+                                                DataElementDomain.AGGREGATE ) ) ) ) )
+                .withFilters( Lists.newArrayList(
+                        // OU FILTER
+                        new BaseDimensionalObject( "ou", DimensionType.ORGANISATION_UNIT, null, DISPLAY_NAME_ORGUNIT,
+                                ImmutableList.of( new OrganisationUnit( "bbb", "bbb", "OU_2", null, null, "c2" ) ) ) ) )
+                .withAggregationType( AnalyticsAggregationType.AVERAGE ).build();
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 2 ) );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasItem(
+                both( hasProperty( "aggregationType", hasProperty( "aggregationType", is( AggregationType.AVERAGE ) ) ) )
+                        .and( hasProperty( "aggregationType", hasProperty( "dataType", is( DataType.NUMERIC ) ) ) ) ) );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasItem(
+                both( hasProperty( "aggregationType", hasProperty( "aggregationType", is( AggregationType.AVERAGE ) ) ) )
+                        .and( hasProperty( "aggregationType", hasProperty( "dataType", is( DataType.TEXT ) ) ) ) ) );
+    }
+
+
+    @Test
+    public void verifySingleNonDataElementRetainAggregationTypeButNullDataType()
+    {
+        List<DimensionalItemObject> periods = new ArrayList<>();
+        periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
+        // DataQueryParams with **one** Indicator
+        DataQueryParams queryParams = DataQueryParams.newBuilder().withDimensions(
+                // PERIOD DIMENSION
+                Lists.newArrayList( new BaseDimensionalObject( "pe", DimensionType.PERIOD, periods ),
+                        new BaseDimensionalObject( "dx", DimensionType.DATA_X, DISPLAY_NAME_DATA_X, "display name",
+                                Lists.newArrayList( createIndicator('A', createIndicatorType( 'A' ) ) ) ) ) )
+                .withFilters( Lists.newArrayList(
+                        // OU FILTER
+                        new BaseDimensionalObject( "ou", DimensionType.ORGANISATION_UNIT, null, DISPLAY_NAME_ORGUNIT,
+                                ImmutableList.of( new OrganisationUnit( "bbb", "bbb", "OU_2", null, null, "c2" ) ) ) ) )
+                .withAggregationType( AnalyticsAggregationType.AVERAGE ).build();
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasItem(
+                both( hasProperty( "aggregationType", hasProperty( "aggregationType", is( AggregationType.AVERAGE ) ) ) )
+                        .and( hasProperty( "aggregationType", hasProperty( "dataType", is( nullValue() ) ) ) ) ) );
+    }
+
+    @Test
+    public void verifyASingleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
+    {
+        // DataQueryParams with **one** DataElement as filter
+        DataQueryParams queryParams = createDataQueryParams(
+                new BaseDimensionalObject( "dx", DimensionType.DATA_X, DISPLAY_NAME_DATA_X, "display name",
+                        Lists.newArrayList( createDataElement( 'A', ValueType.INTEGER, AggregationType.MAX ) ) ) );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+
+        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.MAX ) );
+
+        // Expect the datatype = NUMERIC (which will allow the SQL generator to pick-up
+        // the proper SQL function)
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( DataType.NUMERIC ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // Both have DataType NUMERIC and AggregationType SUM
+        DataQueryParams queryParams = createDataQueryParams( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', new CategoryCombo() ) ) ) );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+
+        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.SUM ) );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( DataType.NUMERIC ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterHavingDifferentAggTypeDoNotRetainAggregationType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // Both have DataType NUMERIC but different AggregationType
+        DataQueryParams queryParams = createDataQueryParams( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', ValueType.INTEGER, AggregationType.COUNT ) ) ) );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+        // Aggregation type defaults to SUM
+        assertDefaultAggregationType( dataQueryParam );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( nullValue() ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterHavingDifferentAggTypeRetainAggregationType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // Both have DataType NUMERIC but different AggregationType
+        // Aggregation type is overridden (COUNT)
+        DataQueryParams queryParams = createDataQueryParamsWithAggregationType( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', ValueType.INTEGER, AggregationType.COUNT ) ) ), AnalyticsAggregationType.COUNT );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+        // Aggregation type defaults to SUM
+        assertDefaultAggregationType( dataQueryParam );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( nullValue() ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMultipleDataElementAsFilterHavingDifferentDataTypeDoNotRetainAggregationType()
+    {
+        // DataQueryParams with **two** DataElement as filter
+        // One Data Element has Type Numeric
+        // Aggregation type is overridden (COUNT)
+        DataQueryParams queryParams = createDataQueryParamsWithAggregationType( new BaseDimensionalObject( "dx", DimensionType.DATA_X,
+                DISPLAY_NAME_DATA_X, "display name", Lists.newArrayList( createDataElement( 'A', new CategoryCombo() ),
+                createDataElement( 'B', ValueType.TEXT, AggregationType.COUNT ) ) ), AnalyticsAggregationType.COUNT );
+
+        DataQueryGroups dataQueryGroups = subject.planQuery( queryParams,
+                QueryPlannerParams.newBuilder().withTableType( AnalyticsTableType.DATA_VALUE ).build() );
+
+        assertThat( dataQueryGroups.getAllQueries(), hasSize( 1 ) );
+        DataQueryParams dataQueryParam = dataQueryGroups.getAllQueries().get( 0 );
+        // Aggregation type defaults to SUM
+        assertDefaultAggregationType( dataQueryParam );
+        assertThat( dataQueryParam.getAggregationType().getDataType(), is( nullValue() ) );
+        assertThat( dataQueryParam.getPeriods(), hasSize( 1 ) );
+        assertThat( dataQueryParam.getFilterDataElements(), hasSize( 2 ) );
+        assertThat( dataQueryParam.getFilterOrganisationUnits(), hasSize( 1 ) );
+    }
+
+    private DataQueryParams createDataQueryParams( BaseDimensionalObject filterDataElements )
+    {
+        List<DimensionalItemObject> periods = new ArrayList<>();
+        periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
+
+        return DataQueryParams.newBuilder().withDimensions(
+                // PERIOD DIMENSION
+                Lists.newArrayList( new BaseDimensionalObject( "pe", DimensionType.PERIOD, periods ) ) )
+                .withFilters( Lists.newArrayList(
+                        // OU FILTER
+                        new BaseDimensionalObject( "ou", DimensionType.ORGANISATION_UNIT, null, DISPLAY_NAME_ORGUNIT,
+                                ImmutableList.of( new OrganisationUnit( "bbb", "bbb", "OU_2", null, null, "c2" ) ) ),
+                        // DATA ELEMENT AS FILTER
+                        filterDataElements ) )
+                .build();
+    }
+
+    private DataQueryParams createDataQueryParamsWithAggregationType( BaseDimensionalObject filterDataElements,
+                                                                      AnalyticsAggregationType analyticsAggregationType )
+    {
+
+        return createDataQueryParams( filterDataElements )
+                .copyTo( DataQueryParams.newBuilder().withAggregationType( analyticsAggregationType ).build() );
+    }
+
+    private void assertDefaultAggregationType( DataQueryParams dataQueryParam )
+    {
+        assertTrue( dataQueryParam.getAggregationType().isAggregationType( AggregationType.SUM ) );
+    }
+}


### PR DESCRIPTION
- DHIS2-7797
- This change allows an Analytics query to retain the aggregation type
when multiple Data Elements having the same data type and aggregation
type are used as query filters.
If the filter Data Elements have different aggregation types or different data
values, then the system will default to SUM aggregation type and NULL data
type