### PR TITLE
fix: Allow "unresolved" Indicators to survive validation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -498,12 +498,8 @@ public class DefaultAnalyticsService
                 {
                     String permKey = DimensionItem.asItemKey( dimensionItems );
 
-                    Map<DimensionalItemObject, Double> valueMap = permutationDimensionItemValueMap.get( permKey );
-
-                    if ( valueMap == null )
-                    {
-                        continue;
-                    }
+                    Map<DimensionalItemObject, Double> valueMap = permutationDimensionItemValueMap
+                        .getOrDefault( permKey, new HashMap<>() );
 
                     List<Period> periods = !filterPeriods.isEmpty() ? filterPeriods
                         : Collections.singletonList( (Period) DimensionItem.getPeriodItem( dimensionItems ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceIndicatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceIndicatorTest.java
@@ -92,6 +92,18 @@ public class AnalyticsServiceIndicatorTest
         dataElementService.addDataElement( dataElementA );
     }
 
+    @Test
+    public void verifyIndicatorWithStaticValuesIsComputedAndValueReturned()
+    {
+        IndicatorType indicatorTypeB = createIndicatorType( 'B' );
+        indicatorService.addIndicatorType( indicatorTypeB );
+        Indicator indicatorF = createIndicator( 'F', indicatorTypeB, "1", "5" );
+        Grid grid = this.analyticsService.getAggregatedDataValues( createParamsWithRootIndicator( indicatorF ) );
+
+        assertThat( grid.getRow( 0 ).get( 0 ), is( "mindicatorF" ) );
+        assertThat( grid.getRow( 0 ).get( 2 ), is( 20.0 ) );
+    }
+
     /**
      * IndicatorF -> IndicatorG -> IndicatorH -> IndicatorI
      *


### PR DESCRIPTION
@larshelge @jimgrace 
This [issue](https://jira.dhis2.org/browse/DHIS2-7862) is about allowing Indicators with static or constant values to "survive" the step in which we resolve the `DimensionalItemObject` from the query - when the "static values" indicators **are the only data dimension in the query**. 

Since an Indicator with static/constant values does not resolve to any `DimensionalItemObject`, the system exits without returning any data.
I have applied a **VERY SIMPLE** fix, which assumes that, if we have one or more Indicators in the query, the Indicators must be "correct" when it comes to numerator/denumerator. I'm not 100% sure about this solution, so please take a look.

