### PR TITLE
chore: Use generics in query declarations

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -231,6 +231,13 @@ public class JobConfiguration
         return jobType.isConfigurable();
     }
 
+    @JacksonXmlProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
+    public SchedulingType getSchedulingType()
+    {
+        return jobType.getSchedulingType();
+    }
+
     public boolean hasCronExpression()
     {
         return cronExpression != null && !cronExpression.isEmpty();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
@@ -78,7 +78,7 @@ public class HibernateCategoryOptionComboStore
             hql += " and :option" + option.getId() + " in elements (co.categoryOptions)";
         }
 
-        Query query = getQuery( hql );
+        Query<CategoryOptionCombo> query = getQuery( hql );
 
         query.setParameter( "categoryCombo", categoryCombo );
 
@@ -87,7 +87,7 @@ public class HibernateCategoryOptionComboStore
             query.setParameter( "option" + option.getId(), option );
         }
 
-        return (CategoryOptionCombo) query.uniqueResult();
+        return query.uniqueResult();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -316,7 +316,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
             hql += " and dv.attributeOptionCombo =:attributeOptionCombo ";
         }
 
-        Query query = getQuery( hql )
+        Query<DataValue> query = getQuery( hql )
             .setParameter( "dataElements", dataElements )
             .setParameter( "period", storedPeriod );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/hibernate/HibernateInterpretationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/hibernate/HibernateInterpretationStore.java
@@ -62,26 +62,24 @@ public class HibernateInterpretationStore
         super( sessionFactory, jdbcTemplate, publisher, Interpretation.class, currentUserService, deletedObjectService, aclService, false );
     }
 
-    @SuppressWarnings("unchecked")
     public List<Interpretation> getInterpretations( User user )
     {
         String hql = "select distinct i from Interpretation i left join i.comments c " +
             "where i.user = :user or c.user = :user order by i.lastUpdated desc";
 
-        Query query = getQuery( hql )
+        Query<Interpretation> query = getQuery( hql )
             .setParameter( "user", user )
             .setCacheable( cacheable );
 
         return query.list();
     }
 
-    @SuppressWarnings("unchecked")
     public List<Interpretation> getInterpretations( User user, int first, int max )
     {
         String hql = "select distinct i from Interpretation i left join i.comments c " +
             "where i.user = :user or c.user = :user order by i.lastUpdated desc";
 
-        Query query = getQuery( hql )
+        Query<Interpretation> query = getQuery( hql )
             .setParameter( "user", user )
             .setMaxResults( first )
             .setMaxResults( max )
@@ -125,10 +123,9 @@ public class HibernateInterpretationStore
     {
         String hql = "from Interpretation i where i.chart.id = " + id;
 
-        Query query = getSession().createQuery( hql )
-            .setCacheable( cacheable );
+        Query<Interpretation> query = getQuery( hql );
 
-        return (Interpretation) query.uniqueResult();
+        return query.uniqueResult();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
@@ -128,7 +128,6 @@ public class HibernateOrganisationUnitStore
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public List<OrganisationUnit> getOrganisationUnits( OrganisationUnitQueryParams params )
     {
         SqlHelper hlp = new SqlHelper();
@@ -179,7 +178,7 @@ public class HibernateOrganisationUnitStore
 
         hql += "order by o." +  params.getOrderBy().getName();
 
-        Query query = getQuery( hql );
+        Query<OrganisationUnit> query = getQuery( hql );
 
         if ( params.hasQuery() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -296,12 +296,11 @@ public class HibernateProgramInstanceStore
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public List<ProgramInstance> getByType( ProgramType type )
     {
         String hql = "from ProgramInstance pi where pi.program.programType = :type";
 
-        Query query = getQuery( hql );
+        Query<ProgramInstance> query = getQuery( hql );
         query.setParameter( "type", type );
 
         return query.list();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -120,7 +120,6 @@ public class HibernateTrackedEntityInstanceStore
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params )
     {
         String hql = buildTrackedEntityInstanceHql( params );
@@ -131,7 +130,7 @@ public class HibernateTrackedEntityInstanceStore
             hql = hql.replaceFirst( "select tei from", "select distinct tei from" );
         }
 
-        Query query = getQuery( hql );
+        Query<TrackedEntityInstance> query = getQuery( hql );
 
         if ( params.isPaging() )
         {
@@ -868,6 +867,7 @@ public class HibernateTrackedEntityInstanceStore
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public List<TrackedEntityInstance> getTrackedEntityInstancesByUid( List<String> uids, User user )
     {
         return getSharingCriteria( user )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -269,7 +269,7 @@ public class HibernateUserStore
             hql += "order by " + StringUtils.defaultString( orderExpression, "u.surname, u.firstName" );
         }
 
-        Query query = sessionFactory.getCurrentSession().createQuery( hql );
+        Query query = getQuery( hql );
 
         if ( params.getQuery() != null )
         {

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
@@ -141,7 +141,8 @@ public class HibernateGenericStore<T>
     @SuppressWarnings( "unchecked" )
     protected final Query<T> getQuery( String hql )
     {
-        return getSession().createQuery( hql )
+        return getSession()
+            .createQuery( hql )
             .setCacheable( cacheable ).setHint( QueryHints.CACHEABLE, cacheable );
     }
 


### PR DESCRIPTION
Use generics in Query declarations, which essentially centralizes the casting to `getQuery` method.