### PR TITLE
fix: Check if relationship exists on import

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Abyot Asalefew
@@ -72,6 +73,18 @@ public interface RelationshipService
      * @return the relationship with the given identifier.
      */
     Relationship getRelationship( long id );
+
+    /**
+     * Fetches a {@see Relationship} based on a relationship identifying attributes:
+     *
+     * - relationship type
+     * - from
+     * - to
+     *
+     * @param relationship A valid Relationship
+     * @return an Optional Relationship
+     */
+    Optional<Relationship> getRelationshipByRelationship( Relationship relationship );
 
     Relationship getRelationship( String uid );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -51,4 +51,16 @@ public interface RelationshipStore
     List<Relationship> getByProgramStageInstance( ProgramStageInstance psi );
 
     List<Relationship> getByRelationshipType( RelationshipType relationshipType );
+
+    /**
+     * Fetches a {@see Relationship} based on a relationship identifying attributes:
+     * - relationship type
+     * - from
+     * - to
+     *
+     * @param relationship A valid Relationship
+     *
+     * @return a {@see Relationship} or null if no Relationship is found matching the identifying criterias
+     */
+    Relationship getByRelationship( Relationship relationship );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -135,8 +136,20 @@ public class DefaultRelationshipService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<Relationship> getRelationshipsByRelationshipType( RelationshipType relationshipType )
     {
         return relationshipStore.getByRelationshipType( relationshipType );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public Optional<Relationship> getRelationshipByRelationship( Relationship relationship )
+    {
+        checkNotNull( relationship.getFrom() );
+        checkNotNull( relationship.getTo() );
+        checkNotNull( relationship.getRelationshipType() );
+
+        return Optional.ofNullable( relationshipStore.getByRelationship( relationship ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -28,12 +28,21 @@ package org.hisp.dhis.relationship.hibernate;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
+
+import javax.persistence.NoResultException;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.deletedobject.DeletedObjectService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipStore;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.acl.AclService;
@@ -42,9 +51,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-
-import javax.persistence.criteria.CriteriaBuilder;
-import java.util.List;
 
 /**
  * @author Abyot Asalefew
@@ -105,5 +111,59 @@ public class HibernateRelationshipStore
         return getList( builder, newJpaParameters()
             .addPredicate( root -> builder.equal( root.join( "relationshipType" ), relationshipType ) ) );
 
+    }
+
+    @Override
+    public Relationship getByRelationship( Relationship relationship )
+    {
+        CriteriaBuilder builder = getCriteriaBuilder();
+        CriteriaQuery<Relationship> criteriaQuery = builder.createQuery( Relationship.class );
+
+        Root<Relationship> root = criteriaQuery.from( Relationship.class );
+
+        criteriaQuery.where( builder.and(
+            getFromOrToPredicate("from", builder, root, relationship),
+            getFromOrToPredicate("to", builder, root, relationship),
+            builder.equal( root.join( "relationshipType" ), relationship.getRelationshipType() ) ) );
+
+        try
+        {
+            return getSession().createQuery( criteriaQuery ).setMaxResults( 1 ).getSingleResult();
+        }
+        catch ( NoResultException nre )
+        {
+            return null;
+        }
+
+    }
+
+    private Predicate getFromOrToPredicate(String direction, CriteriaBuilder builder, Root<Relationship> root, Relationship relationship) {
+
+        RelationshipItem relationshipItemDirection = getItem( direction, relationship );
+
+        if ( relationshipItemDirection.getTrackedEntityInstance() != null )
+        {
+            return builder.equal( root.join( direction ).get( "trackedEntityInstance" ),
+                getItem( direction, relationship ).getTrackedEntityInstance() );
+        }
+        else if ( relationshipItemDirection.getProgramInstance() != null )
+        {
+            return builder.equal( root.join( direction ).get( "programInstance" ),
+                getItem( direction, relationship ).getProgramInstance() );
+        }
+        else if ( relationshipItemDirection.getProgramStageInstance() != null )
+        {
+            return builder.equal( root.join( direction ).get( "programStageInstance" ),
+                getItem( direction, relationship ).getProgramStageInstance() );
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private RelationshipItem getItem( String direction, Relationship relationship )
+    {
+        return (direction.equalsIgnoreCase( "from" ) ? relationship.getFrom() : relationship.getTo());
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -28,27 +28,25 @@ package org.hisp.dhis.relationship.hibernate;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
 import org.hisp.dhis.IntegrationTest;
 import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.*;
-import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.relationship.RelationshipItem;
-import org.hisp.dhis.relationship.RelationshipService;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.relationship.RelationshipTypeService;
+import org.hisp.dhis.relationship.*;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 @Category( IntegrationTest.class )
 public class RelationshipStoreTest
@@ -169,6 +167,8 @@ public class RelationshipStoreTest
 
         assertEquals( 1, relationshipList.size() );
         assertTrue( relationshipList.contains( relationshipA ) );
+
+        assertTrue( relationshipService.getRelationshipByRelationship( relationshipA ).isPresent() );
     }
 
     @Test
@@ -179,6 +179,15 @@ public class RelationshipStoreTest
         assertEquals( 1, relationshipList.size() );
         assertTrue( relationshipList.contains( relationship ) );
     }
+
+    @Test
+    public void testGetByRelationship()
+    {
+        Optional<Relationship> existing = relationshipService.getRelationshipByRelationship( relationship );
+
+        assertTrue( existing.isPresent() );
+    }
+
 
     @Override
     public boolean emptyDatabaseAfterTest()

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -94,6 +94,11 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -32,13 +32,7 @@ import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_STAGE_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.TRACKED_ENTITY_INSTANCE;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -250,15 +244,6 @@ public abstract class AbstractRelationshipService
             prepareCaches( Lists.newArrayList( relationship ), importOptions.getUser() );
         }
 
-        if ( relationshipService.relationshipExists( relationship.getRelationship() ) )
-        {
-            String message = "Relationship " + relationship.getRelationship() +
-                " already exists";
-            return new ImportSummary( ImportStatus.ERROR, message )
-                .setReference( relationship.getRelationship() )
-                .incrementIgnored();
-        }
-
         Set<ImportConflict> importConflicts = new HashSet<>( checkRelationship( relationship ) );
 
         if ( !importConflicts.isEmpty() )
@@ -269,12 +254,16 @@ public abstract class AbstractRelationshipService
             return importSummary;
         }
 
-        org.hisp.dhis.relationship.Relationship daoRelationship = createDAORelationship(
-            relationship );
+        org.hisp.dhis.relationship.Relationship daoRelationship = createDAORelationship( relationship );
 
-        if ( daoRelationship == null )
+        Optional<org.hisp.dhis.relationship.Relationship> existing = relationshipService
+            .getRelationshipByRelationship( daoRelationship );
+
+        if ( existing.isPresent() )
         {
-            return importSummary;
+            String message = "Relationship " + existing.get().getUid() + " already exists";
+            return new ImportSummary( ImportStatus.ERROR, message ).setReference( existing.get().getUid() )
+                .incrementIgnored();
         }
 
         // Check access for both sides
@@ -282,8 +271,7 @@ public abstract class AbstractRelationshipService
 
         if ( !errors.isEmpty() )
         {
-            return new ImportSummary( ImportStatus.ERROR, errors.toString() )
-                .incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR, errors.toString() ).incrementIgnored();
         }
 
         relationshipService.addRelationship( daoRelationship );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/relationship/JacksonRelationshipServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/relationship/JacksonRelationshipServiceTest.java
@@ -1,0 +1,217 @@
+package org.hisp.dhis.dxf2.events.relationship;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.hisp.dhis.dbms.DbmsManager;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.events.TrackerAccessManager;
+import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
+import org.hisp.dhis.dxf2.events.event.EventService;
+import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
+import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.relationship.RelationshipConstraint;
+import org.hisp.dhis.relationship.RelationshipEntity;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.UserService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class JacksonRelationshipServiceTest
+{
+
+    @Mock
+    protected DbmsManager dbmsManager;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private QueryService queryService;
+
+    @Mock
+    private TrackerAccessManager trackerAccessManager;
+
+    @Mock
+    private org.hisp.dhis.relationship.RelationshipService relationshipService;
+
+    @Mock
+    private TrackedEntityInstanceService trackedEntityInstanceService;
+
+    @Mock
+    private EnrollmentService enrollmentService;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private org.hisp.dhis.trackedentity.TrackedEntityInstanceService teiDaoService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private JacksonRelationshipService subject;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private BeanRandomizer rnd = new BeanRandomizer();
+
+    private Relationship relationship;
+
+    @Before
+    public void setUp()
+        throws IllegalAccessException
+    {
+        RelationshipType relationshipType = createRelationshipTypeWithTeiConstraint();
+        relationship = createTei2TeiRelationship( relationshipType );
+
+        initFakeCaches( relationship, relationshipType );
+    }
+
+    @Test
+    public void verifyRelationshipIsImportedIfDoesNotExist()
+    {
+
+        when(
+            relationshipService.getRelationshipByRelationship( any( org.hisp.dhis.relationship.Relationship.class ) ) )
+                .thenReturn( Optional.empty() );
+
+        ImportSummary importSummary = subject.addRelationship( relationship, rnd.randomObject( ImportOptions.class ) );
+
+        assertThat( importSummary.getStatus(), is( ImportStatus.SUCCESS ) );
+        assertThat( importSummary.getImportCount().getImported(), is( 1 ) );
+    }
+
+    @Test
+    public void verifyRelationshipIsNotImportedWhenDoesExist()
+    {
+        org.hisp.dhis.relationship.Relationship daoRelationship = new org.hisp.dhis.relationship.Relationship();
+        daoRelationship.setUid("12345");
+
+        when(
+            relationshipService.getRelationshipByRelationship( any( org.hisp.dhis.relationship.Relationship.class ) ) )
+                .thenReturn( Optional.of( daoRelationship ) );
+
+        ImportSummary importSummary = subject.addRelationship( relationship, rnd.randomObject( ImportOptions.class ) );
+
+        assertThat( importSummary.getStatus(), is( ImportStatus.ERROR ) );
+        assertThat( importSummary.getImportCount().getImported(), is( 0 ) );
+        assertThat( importSummary.getReference(), is( daoRelationship.getUid() ) );
+        assertThat( importSummary.getDescription(), is( "Relationship " + daoRelationship.getUid() + " already exists" ) );
+    }
+
+    private void initFakeCaches( Relationship relationship, RelationshipType relationshipType )
+        throws IllegalAccessException
+    {
+
+        HashMap<String, RelationshipType> relationshipTypeCache = new HashMap<>();
+        relationshipTypeCache.put( relationship.getRelationshipType(), relationshipType );
+
+        HashMap<String, TrackedEntityInstance> trackedEntityInstanceCache = new HashMap<>();
+        trackedEntityInstanceCache.put( relationship.getFrom().getTrackedEntityInstance().getTrackedEntityInstance(),
+            new TrackedEntityInstance()
+            {
+                {
+                    setTrackedEntityType( relationshipType.getFromConstraint().getTrackedEntityType() );
+                }
+            } );
+        trackedEntityInstanceCache.put( relationship.getTo().getTrackedEntityInstance().getTrackedEntityInstance(),
+            new TrackedEntityInstance()
+            {
+                {
+                    setTrackedEntityType( relationshipType.getToConstraint().getTrackedEntityType() );
+                }
+            } );
+
+        FieldUtils.writeField( subject, "relationshipTypeCache", relationshipTypeCache, true );
+        FieldUtils.writeField( subject, "trackedEntityInstanceCache", trackedEntityInstanceCache, true );
+
+    }
+
+    private Relationship createTei2TeiRelationship( RelationshipType relationshipType )
+    {
+
+        Relationship relationship = rnd.randomObject( Relationship.class );
+
+        relationship.getFrom().setEvent( null );
+        relationship.getFrom().setEnrollment( null );
+        relationship.getTo().setEnrollment( null );
+        relationship.getTo().setEvent( null );
+        relationship.setRelationshipType( relationshipType.getUid() );
+        return relationship;
+    }
+
+    private RelationshipType createRelationshipTypeWithTeiConstraint()
+    {
+        RelationshipType relationshipType = rnd.randomObject( RelationshipType.class );
+
+        RelationshipConstraint from = rnd.randomObject( RelationshipConstraint.class );
+        from.setProgram( null );
+        from.setProgramStage( null );
+        from.setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+
+        RelationshipConstraint to = rnd.randomObject( RelationshipConstraint.class );
+        to.setProgram( null );
+        to.setProgramStage( null );
+        to.setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+
+        relationshipType.setFromConstraint( from );
+        relationshipType.setToConstraint( to );
+
+        return relationshipType;
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/BeanRandomizer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/BeanRandomizer.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.random;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.vividsolutions.jts.geom.Geometry;
 import io.github.benas.randombeans.api.EnhancedRandom;
 import org.hisp.dhis.period.PeriodType;
 
@@ -48,6 +49,7 @@ public class BeanRandomizer
     {
         rand = aNewEnhancedRandomBuilder()
             .randomize( PeriodType.class, new PeriodTypeRandomizer() )
+            .randomize( Geometry.class, new GeometryRandomizer() )
             .randomize( field().named( "uid" ).ofType( String.class ).get(), new UidRandomizer() )
             .randomize( field().named( "id" ).ofType( long.class ).get(), new IdRandomizer() )
             .build();

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/GeometryRandomizer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/random/GeometryRandomizer.java
@@ -1,0 +1,49 @@
+package org.hisp.dhis.random;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import com.vividsolutions.jts.shape.random.RandomPointsInGridBuilder;
+import io.github.benas.randombeans.api.Randomizer;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class GeometryRandomizer
+    implements
+    Randomizer<Geometry>
+{
+
+    @Override
+    public Geometry getRandomValue()
+    {
+        return new RandomPointsInGridBuilder().getGeometry();
+    }
+}


### PR DESCRIPTION
- DHIS2-8137
- Improves the validation check executed when adding a new relationship,
by checking the existence of a Relationship by from, to and type

This fixes the problem of checking for an existing relationship when adding a new Relationship.
Note that this fix applies to the UI (Tracker capture app) and the `POST api/relationships/` API.

When an existing relationship is detected in the Tracker Capture App, a pop-up with "unknown error" is displayed to the user. See screeshot:

![duplicate-relationship-error](https://user-images.githubusercontent.com/300784/72801497-e4f8a100-3c49-11ea-8d1d-162801427747.png)
