### PR TITLE
[WIP] fix: Api filter x.y with alias doesn't work 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -236,12 +236,13 @@ public class DefaultQueryPlanner implements QueryPlanner
                 Restriction restriction = (Restriction) criterion;
                 restriction.setQueryPath( getQueryPath( query.getSchema(), restriction.getPath() ) );
 
-                if ( restriction.getQueryPath().isPersisted() && !restriction.getQueryPath().haveAlias() )
+                if ( restriction.getQueryPath().isPersisted() && restriction.getQueryPath().haveAlias() )
                 {
                     pQuery.getAliases().addAll( Arrays.asList( ((Restriction) criterion).getQueryPath().getAlias() ) );
                     pQuery.getCriterions().add( criterion );
                     iterator.remove();
                 }
+
             }
         }
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-2731

If an api filter x.y where x is a complicated object which need a hibernate alias then the filter will not work. For example  /api/options?filter=optionSet.id:eq:JhwT1ulnSym

