### PR TITLE
fix: Option validation fail on update

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -59,20 +60,7 @@ public class OptionObjectBundleHook
         {
             OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class, option.getOptionSet() );
 
-            List<Option> persistedOptions = optionSet.getOptions();
-
-            for ( Option persistedOption : persistedOptions )
-            {
-                if ( persistedOption == null || persistedOption.getName() == null || persistedOption.getCode() == null )
-                {
-                    break;
-                }
-
-                if ( persistedOption.getName().equals( option.getName() ) && persistedOption.getCode().equals( option.getCode() ) )
-                {
-                    errors.add( new ErrorReport( OptionSet.class, ErrorCode.E4028, optionSet.getUid(), option.getUid() ) );
-                }
-            }
+            errors.addAll( checkDuplicateOption( optionSet, option ) );
         }
 
         return errors;
@@ -99,5 +87,42 @@ public class OptionObjectBundleHook
                 optionSet.addOption( option );
             }
         }
+    }
+
+    /**
+     * Check for duplication of Option's name OR code within given OptionSet
+     *
+     * @param listOptions
+     * @param checkOption
+     * @return
+     */
+    private List<ErrorReport> checkDuplicateOption( OptionSet optionSet, Option checkOption )
+    {
+        List<ErrorReport> errors = new ArrayList<>();
+
+        if ( optionSet == null || optionSet.getOptions().isEmpty() || checkOption == null )
+        {
+            return errors;
+        }
+
+        for ( Option option : optionSet.getOptions() )
+        {
+            if ( option == null || option.getName() == null || option.getCode() == null )
+            {
+                continue;
+            }
+
+            if ( ObjectUtils.allNotNull( option.getUid(), checkOption.getUid() ) && option.getUid().equals( checkOption.getUid() ) )
+            {
+                continue;
+            }
+
+            if ( option.getName().equals( checkOption.getName() ) || option.getCode().equals( checkOption.getCode() ) )
+            {
+                errors.add( new ErrorReport( OptionSet.class, ErrorCode.E4028, optionSet.getUid(), option.getUid() ) );
+            }
+        }
+
+        return errors;
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-8205

Issue: current validation of Option's name and code also check on updating same entity
Fix: skip the duplication check if the importing Option uid = checking option uid