### PR TITLE
fix: ContextUtilTest to use dynamic date assignment

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -125,8 +125,7 @@ public class ContextUtilsTest
         Calendar thisYear = Calendar.getInstance();
         Calendar fiveYearBack = Calendar.getInstance();
 
-        thisYear.set( 2017, 01, 01 );
-        fiveYearBack.set( 2012, 01, 01 );
+        fiveYearBack.add( Calendar.YEAR, -5 );
 
         DataQueryParams withinThreshold = DataQueryParams.newBuilder().withEndDate( thisYear.getTime() ).build();
         DataQueryParams outsideThreshold = DataQueryParams.newBuilder().withEndDate( fiveYearBack.getTime() ).build();


### PR DESCRIPTION
Tests started failing today because of a static date assignment. 