### PR TITLE
fix: Fix analytics table creation crash on geo columns

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -81,6 +81,7 @@ public abstract class AbstractEventJdbcTableManager
 
     protected final String numericClause = " and value " + statementBuilder.getRegexpMatch() + " '" + NUMERIC_LENIENT_REGEXP + "'";
     protected final String dateClause = " and value " + statementBuilder.getRegexpMatch() + " '" + DATE_REGEXP + "'";
+    protected static final String GEOMETRY_INDEX_TYPE = "gist";
 
     @Override
     @Async

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -115,7 +115,7 @@ public class JdbcEventAnalyticsTableManager
         new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP, "psi.lastupdated" ),
         new AnalyticsTableColumn( quote( "pistatus" ), CHARACTER_50, "pi.status" ),
         new AnalyticsTableColumn( quote( "psistatus" ), CHARACTER_50, "psi.status" ),
-        new AnalyticsTableColumn( quote( "psigeometry" ), GEOMETRY, "psi.geometry" ).withIndexType( "gist" ),
+        new AnalyticsTableColumn( quote( "psigeometry" ), GEOMETRY, "psi.geometry" ).withIndexType( GEOMETRY_INDEX_TYPE ),
         // TODO latitude and longitude deprecated in 2.30, should be removed after 2.33
         new AnalyticsTableColumn( quote( "longitude" ), DOUBLE, "CASE WHEN 'POINT' = GeometryType(psi.geometry) THEN ST_X(psi.geometry) ELSE null END" ),
         new AnalyticsTableColumn( quote( "latitude" ), DOUBLE, "CASE WHEN 'POINT' = GeometryType(psi.geometry) THEN ST_Y(psi.geometry) ELSE null END" ),
@@ -384,7 +384,7 @@ public class JdbcEventAnalyticsTableManager
             String geoSql = selectForInsert( attribute, "ou.geometry from organisationunit ou where ou.uid = (select value", dataClause );
 
             columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_GEOMETRY_COL_SUFFIX ), ColumnDataType.GEOMETRY, geoSql )
-                .withSkipIndex( skipIndex ) );
+                .withSkipIndex( skipIndex ).withIndexType( GEOMETRY_INDEX_TYPE ) );
         }
 
         columns.add( new AnalyticsTableColumn( quote( attribute.getUid() ), dataType,
@@ -430,8 +430,8 @@ public class JdbcEventAnalyticsTableManager
         {
             String geoSql = selectForInsert( dataElement, "ou.geometry from organisationunit ou where ou.uid = (select " + columnName, dataClause );
 
-            columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_GEOMETRY_COL_SUFFIX ), ColumnDataType.GEOMETRY, geoSql )
-                .withSkipIndex( true ) );
+            columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_GEOMETRY_COL_SUFFIX ),
+                    ColumnDataType.GEOMETRY, geoSql ).withSkipIndex( true ).withIndexType( GEOMETRY_INDEX_TYPE ) );
         }
 
         columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -284,7 +284,7 @@ public class JdbcEventAnalyticsTableManagerTest
             .addColumn( d5.getUid(), TEXT, toAlias( aliasD5, d5.getUid() ) ) // ValueType.ORGANISATION_UNIT
             .addColumn( d6.getUid(), BIGINT, toAlias( aliasD6, d6.getUid() ) ) // ValueType.INTEGER
             .addColumn( d7.getUid(), GEOMETRY_POINT, toAlias( aliasD7, d7.getUid() ) ) // ValueType.COORDINATES
-            .addColumn( d5.getUid() + "_geom" , GEOMETRY, toAlias( aliasD5_geo, d5.getUid() ) ) // element d5 also creates a Geo column
+            .addColumn( d5.getUid() + "_geom" , GEOMETRY, toAlias( aliasD5_geo, d5.getUid() ), "gist" ) // element d5 also creates a Geo column
             .withDefaultColumns( subject.getFixedColumns() )
             .build().verify();
     }
@@ -331,7 +331,7 @@ public class JdbcEventAnalyticsTableManagerTest
             .addColumn( d1.getUid(), TEXT, toAlias( aliasD1, d1.getUid() ) )  // ValueType.TEXT
             .addColumn( tea1.getUid(), TEXT, String.format( aliasTea1, "ou.name", tea1.getId(), tea1.getUid() ) )  // ValueType.ORGANISATION_UNIT
             // Second Geometry column created from the OU column above
-            .addColumn( tea1.getUid() + "_geom", GEOMETRY, String.format( aliasTea1, "ou.geometry", tea1.getId(), tea1.getUid() ) )
+            .addColumn( tea1.getUid() + "_geom", GEOMETRY, String.format( aliasTea1, "ou.geometry", tea1.getId(), tea1.getUid() ), "gist" )
             .withDefaultColumns( subject.getFixedColumns() )
             .build().verify();
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsColumnAsserter.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsColumnAsserter.java
@@ -51,8 +51,8 @@ public class AnalyticsColumnAsserter
         assertThat( "Column alias does not match!", expected.getAlias(), is( actual.getAlias() ) );
         assertThat( "Column creation date does not match!", expected.getCreated(), is( actual.getCreated() ) );
         assertThat( expected.getDataType(), is( actual.getDataType() ) );
-        assertThat( expected.getIndexType(), is( actual.getIndexType() ) );
-        // assertThat(actual.getIndexColumns(), is(expected.getIndexColumns()));
+        assertThat( String.format( "Index type for column %s does not match!", expected.getName() ),
+            expected.getIndexType(), is( actual.getIndexType() ) );
     }
 
     public static class Builder

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsTableAsserter.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsTableAsserter.java
@@ -79,8 +79,8 @@ public class AnalyticsTableAsserter
         // verify default columns
 
         Map<String, AnalyticsTableColumn> tableColumnMap = Stream
-            .concat( table.getDimensionColumns().stream(), table.getValueColumns().stream() )
-            .collect( Collectors.toMap( AnalyticsTableColumn::getName, c -> c ) );
+                .concat( table.getDimensionColumns().stream(), table.getValueColumns().stream() )
+                .collect( Collectors.toMap( AnalyticsTableColumn::getName, c -> c ) );
 
         for ( AnalyticsTableColumn col : defaultColumns )
         {
@@ -177,12 +177,21 @@ public class AnalyticsTableAsserter
 
         public Builder addColumn( String name, ColumnDataType dataType, String alias )
         {
-            return addColumnUnquoted( quote( name ), dataType, alias );
+            return addColumnUnquoted( quote( name ), dataType, alias, null );
         }
 
-        public Builder addColumnUnquoted( String name, ColumnDataType dataType, String alias )
+        public Builder addColumn( String name, ColumnDataType dataType, String alias, String indexType )
+        {
+            return addColumnUnquoted( quote( name ), dataType, alias, indexType );
+        }
+
+        public Builder addColumnUnquoted( String name, ColumnDataType dataType, String alias, String indexType )
         {
             AnalyticsTableColumn col = new AnalyticsTableColumn( name, dataType, alias );
+            if ( indexType != null )
+            {
+                col.withIndexType( indexType );
+            }
             this._columns.add( col );
 
             return this;


### PR DESCRIPTION
Specify the "gist" column type when creating indexes for Geometry.