### PR TITLE
feat: Add 'errorProperties' to ErrorReport

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorReport.java
@@ -28,13 +28,16 @@ package org.hisp.dhis.feedback;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.common.DxfNamespaces;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.base.MoreObjects;
+import org.hisp.dhis.common.DxfNamespaces;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -52,12 +55,15 @@ public class ErrorReport
 
     protected String errorProperty;
 
+    protected List<Object> errorProperties = new ArrayList<>();
+
     protected Object value;
 
     public ErrorReport( Class<?> mainKlass, ErrorCode errorCode, Object... args )
     {
         this.mainKlass = mainKlass;
         this.message = new ErrorMessage( errorCode, args );
+        this.errorProperties.addAll( Arrays.asList( args ) );
     }
 
     public ErrorReport( Class<?> mainKlass, ErrorMessage message )
@@ -65,9 +71,11 @@ public class ErrorReport
         this.mainKlass = mainKlass;
         this.message = message;
     }
-    
+
     @JsonCreator
-    public ErrorReport( @JsonProperty( "message" ) String message, @JsonProperty( "mainKlass" ) Class<?> mainKlass,
+    public ErrorReport(
+        @JsonProperty( "message" ) String message,
+        @JsonProperty( "mainKlass" ) Class<?> mainKlass,
         @JsonProperty( "errorCode" ) ErrorCode errorCode )
     {
         this.mainKlass = mainKlass;
@@ -132,6 +140,18 @@ public class ErrorReport
     {
         this.errorProperty = errorProperty;
         return this;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public List<Object> getErrorProperties()
+    {
+        return errorProperties;
+    }
+
+    public void setErrorProperties( List<Object> errorProperties )
+    {
+        this.errorProperties = errorProperties;
     }
 
     @JsonProperty


### PR DESCRIPTION
Adds `errorProperties` field to ErrorReport, contains all parameters to error message.