### PR TITLE
fix: DHIS2-8223 predictor run fail

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -825,7 +825,7 @@ public class DefaultPredictionService
             String dx = (String) row.get( dxInx );
             String ou = (String) row.get( ouInx );
             String ao = hasAttributeOptions ? (String) row.get( aoInx ) : NON_AOC;
-            Double vl = (Double) row.get( vlInx );
+            Double vl = ( (Number)row.get( vlInx ) ).doubleValue();
 
             Period period = periodLookup.get( pe );
             DimensionalItemObject dimensionItem = dimensionItemLookup.get( dx );


### PR DESCRIPTION
FYI, this bug was caused by the fix to "DHIS2-8033 Round to Long when decimals is set to zero", because a Number is now being returned to Predictors instead of Double. I intend to fix validation rules as well.

Cheers,
Jim