### PR TITLE
ci: Test multiple docker images

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -136,7 +136,6 @@ pipeline {
                     }
                 }
             }
-
         }
 
         stage('Publish image') {
@@ -164,6 +163,5 @@ pipeline {
                 channel: 'jenkins'
             )
         }
-
     }
 }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -125,6 +125,15 @@ pipeline {
                                     }
                                 }
                             }
+                            always {
+                                script {
+                                    dir("dhis-2/dhis-e2e-test") {
+                                        sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} down --rmi all -v --remove-orphans"
+                                        sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} down --rmi all -v --remove-orphans"
+                                     }
+                                }
+
+                            }
                         }
                     }
                 }
@@ -136,11 +145,6 @@ pipeline {
 
     post {
         always {
-            dir("dhis-2/dhis-e2e-test") {
-                sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} down --rmi all -v --remove-orphans"
-                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER} down --rmi all -v --remove-orphans"
-            }
-
             sh "docker image rm -f ${DOCKER_BASE_IMAGE_FULL_NAME}"
             sh "./docker/cleanup-images.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
 

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -112,6 +112,8 @@ pipeline {
                     }
                 }
             }
+            }
+
 
             post {
                 failure {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -103,13 +103,15 @@ pipeline {
                          }
                     }
                     stage('Run api tests') {
-                        script {
-                            echo 'Running tests for variant: ${DOCKER_VARIANT}'
-                            TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
+                        steps {
+                            script {
+                                echo 'Running tests for variant: ${DOCKER_VARIANT}'
+                                TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
 
-                            dir("dhis-2/dhis-e2e-test") {
-                                sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
-                                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                                dir("dhis-2/dhis-e2e-test") {
+                                    sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
+                                    sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                                }
                             }
                         }
 

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -88,7 +88,7 @@ pipeline {
                 axes {
                     axis {
                         name 'DOCKER_VARIANT'
-                        values '-8.5-jdk8-openjdk-slim', '-tomcat-9.0.27-jdk11-openjdk-slim'
+                        values '-tomcat-8.5-jdk8-openjdk-slim', '-tomcat-9.0.27-jdk11-openjdk-slim'
                     }
                 }
                 stages {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -88,7 +88,7 @@ pipeline {
                 axes {
                     axis {
                         name 'DOCKER_VARIANT'
-                        values '8.5-jdk8-openjdk-slim', '-tomcat-9.0.27-jdk11-openjdk-slim'
+                        values '-8.5-jdk8-openjdk-slim', '-tomcat-9.0.27-jdk11-openjdk-slim'
                     }
                 }
                 stages {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,7 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "pipeline-test"
+                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
                 }
             }
         }
@@ -139,6 +139,14 @@ pipeline {
 
         }
 
+        stage('Publish image') {
+            steps {
+                withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                    sh "docker push ${DOCKER_BASE_IMAGE_FULL_NAME}"
+                    sh "./docker/publish-containers.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
+                }
+            }
+        }
     }
 
     post {
@@ -147,6 +155,14 @@ pipeline {
             sh "./docker/cleanup-images.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
 
             sh "docker image prune --force --filter label=identifier=${DOCKER_IMAGE_TAG}"
+        }
+
+        failure {
+            slackSend(
+                color: '#ff0000',
+                message: 'Publishing of docker images for branch ' + env.BRANCH_NAME + ' failed. Visit ' + env.BUILD_URL + ' for more information',
+                channel: 'jenkins'
+            )
         }
 
     }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -91,43 +91,42 @@ pipeline {
                         values '', '-tomcat-9.0.27-jdk11-openjdk-slim'
                     }
                 }
-            }
-            stages {
-                stage('Start instance') {
-                     steps {
-                        dir("dhis-2/dhis-e2e-test") {
-                            sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p ${COMPOSE_PARAMETER} up -d"
-                        }
-                     }
-                }
-                stage('Run api tests') {
-                    script {
-                        echo 'Running tests for variant: ${DOCKER_VARIANT}'
-                        TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
+                stages {
+                    stage('Start instance') {
+                         steps {
+                            dir("dhis-2/dhis-e2e-test") {
+                                sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p "${COMPOSE_PARAMETER}${DOCKER_VARIANT}" up -d"
+                            }
+                         }
+                    }
+                    stage('Run api tests') {
+                        script {
+                            echo 'Running tests for variant: ${DOCKER_VARIANT}'
+                            TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
 
-                        dir("dhis-2/dhis-e2e-test") {
-                            sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
-                            sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                            dir("dhis-2/dhis-e2e-test") {
+                                sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
+                                sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                            }
+                        }
+
+
+                        post {
+                            failure {
+                                script {
+                                    dir("dhis-2/dhis-e2e-test") {
+                                        sh "docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} logs web > ${DOCKER_VARIANT}logs.txt"
+                                        archiveArtifacts artifacts: '${DOCKER_VARIANT}logs.txt'
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
-            }
 
-
-            post {
-                failure {
-                    script {
-                        dir("dhis-2/dhis-e2e-test") {
-                            sh "docker-compose -p ${COMPOSE_PARAMETER} logs web > logs.txt"
-                            archiveArtifacts artifacts: 'logs.txt'
-                        }
-                    }
-                }
-            }
         }
 
-     
     }
 
     post {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -97,7 +97,7 @@ pipeline {
                             script {
 
                                 dir("dhis-2/dhis-e2e-test") {
-                                    sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p "${COMPOSE_PARAMETER}${DOCKER_VARIANT}" up -d"
+                                    sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} up -d"
                                 }
                             }
                          }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -93,24 +93,24 @@ pipeline {
                 }
             }
             stages {
-        stage('Start instance') {
-            steps {
-                dir("dhis-2/dhis-e2e-test") {
+                stage('Start instance') {
+                     steps {
+                        dir("dhis-2/dhis-e2e-test") {
                             sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p ${COMPOSE_PARAMETER} up -d"
+                        }
+                     }
                 }
-            }
-        }
-        stage('Run api tests') {
-                script {
+                stage('Run api tests') {
+                    script {
                         echo 'Running tests for variant: ${DOCKER_VARIANT}'
                         TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
 
-                    dir("dhis-2/dhis-e2e-test") {
-                        sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
-                        sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                        dir("dhis-2/dhis-e2e-test") {
+                            sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
+                            sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                        }
                     }
                 }
-            }
             }
 
             post {
@@ -125,14 +125,7 @@ pipeline {
             }
         }
 
-        stage('Publish image') {
-            steps {
-                withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
-                    sh "docker push ${DOCKER_BASE_IMAGE_FULL_NAME}"
-                    sh "./docker/publish-containers.sh ${DOCKER_CORE_IMAGE_FULL_NAME}"
-                }
-            }
-        }
+     
     }
 
     post {
@@ -148,12 +141,5 @@ pipeline {
             sh "docker image prune --force --filter label=identifier=${DOCKER_IMAGE_TAG}"
         }
 
-        failure {
-            slackSend(
-                color: '#ff0000',
-                message: 'Publishing of docker images for branch ' + env.BRANCH_NAME + ' failed. Visit ' + env.BUILD_URL + ' for more information',
-                channel: 'jenkins'
-            )
-        }
     }
 }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,7 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
+                    DOCKER_IMAGE_TAG = "pipeline-test"
                 }
             }
         }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -83,24 +83,34 @@ pipeline {
             }
         }
 
+        stage('Run api tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'DOCKER_VARIANT'
+                        values '', '-tomcat-9.0.27-jdk11-openjdk-slim'
+                    }
+                }
+            }
+            stages {
         stage('Start instance') {
             steps {
                 dir("dhis-2/dhis-e2e-test") {
-                    sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} up -d"
+                            sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p ${COMPOSE_PARAMETER} up -d"
                 }
             }
         }
-
         stage('Run api tests') {
-            steps {
                 script {
-                    TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}"
+                        echo 'Running tests for variant: ${DOCKER_VARIANT}'
+                        TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
 
                     dir("dhis-2/dhis-e2e-test") {
                         sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
                         sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
                     }
                 }
+            }
             }
 
             post {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -88,7 +88,7 @@ pipeline {
                 axes {
                     axis {
                         name 'DOCKER_VARIANT'
-                        values '', '-tomcat-9.0.27-jdk11-openjdk-slim'
+                        values '8.5-jdk8-openjdk-slim', '-tomcat-9.0.27-jdk11-openjdk-slim'
                     }
                 }
                 stages {

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -95,7 +95,6 @@ pipeline {
                     stage('Start instance') {
                          steps {
                             script {
-
                                 dir("dhis-2/dhis-e2e-test") {
                                     sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} up -d"
                                 }
@@ -105,7 +104,6 @@ pipeline {
                     stage('Run api tests') {
                         steps {
                             script {
-                                echo 'Running tests for variant: ${DOCKER_VARIANT}'
                                 TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
 
                                 dir("dhis-2/dhis-e2e-test") {
@@ -121,7 +119,7 @@ pipeline {
                                 script {
                                     dir("dhis-2/dhis-e2e-test") {
                                         sh "docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} logs web > ${DOCKER_VARIANT}logs.txt"
-                                        archiveArtifacts artifacts: '${DOCKER_VARIANT}logs.txt'
+                                        archiveArtifacts artifacts: "${DOCKER_VARIANT}logs.txt"
                                     }
                                 }
                             }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -94,8 +94,11 @@ pipeline {
                 stages {
                     stage('Start instance') {
                          steps {
-                            dir("dhis-2/dhis-e2e-test") {
-                                sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p "${COMPOSE_PARAMETER}${DOCKER_VARIANT}" up -d"
+                            script {
+
+                                dir("dhis-2/dhis-e2e-test") {
+                                    sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME}${DOCKER_VARIANT} docker-compose -p "${COMPOSE_PARAMETER}${DOCKER_VARIANT}" up -d"
+                                }
                             }
                          }
                     }


### PR DESCRIPTION
PR introduces matrix within 'Run api tests' stage. Tests will be executed on multiple environments, in parallel: 
- TC8 + JDK 8 (docker image alliesed with default tag)
- TC9 + JDK 11


Note: I tested the pipeline and clean up on Jenkins, but I haven't tested that the logs will be published after both parallel stages finish. Please let me know if you see anything that might go wrong with that. 