### PR TITLE
fix: ensure datasets are uncompleted in aggregate sms

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -144,14 +144,14 @@ public class AggregateDataSetSMSListener
 
         List<Object> errorElems = submitDataValues( subm.getValues(), period, orgUnit, aoc, user );
 
+        CompleteDataSetRegistration existingReg = registrationService.getCompleteDataSetRegistration( dataSet, period,
+            orgUnit, aoc );
+        if ( existingReg != null )
+        {
+            registrationService.deleteCompleteDataSetRegistration( existingReg );
+        }
         if ( subm.isComplete() )
         {
-            CompleteDataSetRegistration existingReg = registrationService.getCompleteDataSetRegistration( dataSet,
-                period, orgUnit, aoc );
-            if ( existingReg != null )
-            {
-                registrationService.deleteCompleteDataSetRegistration( existingReg );
-            }
             Date now = new Date();
             String username = user.getUsername();
             CompleteDataSetRegistration newReg = new CompleteDataSetRegistration( dataSet, period, orgUnit, aoc, now,


### PR DESCRIPTION
This PR is to ensure that when the server processes aggregate dataset submissions, if the completion status is set to not complete, it should unset any existing completion.

Fixes: https://jira.dhis2.org/browse/DHIS2-8224