### PR TITLE
fix: NPE in TrackedEntityAttribute validator

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
@@ -178,7 +178,7 @@ public class TrackedEntityAttribute
 
         for ( Option option : getOptionSet().getOptions() )
         {
-            if ( value.equals( option.getCode() ) )
+            if ( option != null && value.equals( option.getCode() ) )
             {
                 return true;
             }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7417

the code throws NullPointerException as below 

`java.lang.NullPointerException
	at org.hisp.dhis.trackedentity.TrackedEntityAttribute.isValidOptionValue(TrackedEntityAttribute.java:181)
	at org.hisp.dhis.trackedentity.DefaultTrackedEntityAttributeService.validateValueType(DefaultTrackedEntityAttributeService.java:256)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:344)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:198)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:366)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:99)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212)
	at com.sun.proxy.$Proxy226.validateValueType(Unknown Source)
	at org.hisp.dhis.dxf2.events.trackedentity.AbstractTrackedEntityInstanceService.validateAttributeType(AbstractTrackedEntityInstanceService.java:1160)`