### PR TITLE
refactor(core-resource): remove core resource app from bundle

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/README.md
+++ b/dhis-2/dhis-web/dhis-web-apps/README.md
@@ -2,9 +2,9 @@
 
 The following shows the mapping of app repos to the DHIS2 versions that use the `master` branch of the app (feature toggling)
 
-|app repository|2.29|2.30|2.31|2.32|2.33|
-|---|---|---|---|---|---|
-|git@github.com:dhis2/core-resource-app.git|master|master|2.31|2.32|master|
-|git@github.com:dhis2/messaging-app.git|master|master|master|master|master|
-|git@github.com:dhis2/reports-app.git|n/a|n/a|n/a|n/a|master|
-|git@github.com:dhis2/usage-analytics-app.git|2.29|2.30|2.31|master|2.33| 
+|app repository|2.29|2.30|2.31|2.32|2.33|2.34|
+|---|---|---|---|---|---|---|
+|git@github.com:dhis2/core-resource-app.git|master|master|2.31|2.32|master|DELETED|
+|git@github.com:dhis2/messaging-app.git|master|master|master|master|master|master|
+|git@github.com:dhis2/reports-app.git|n/a|n/a|n/a|n/a|master|master|
+|git@github.com:dhis2/usage-analytics-app.git|2.29|2.30|2.31|master|2.33|master|

--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -2,7 +2,6 @@
     "https://github.com/d2-ci/app-management-app",
     "https://github.com/d2-ci/cache-cleaner-app",
     "https://github.com/d2-ci/capture-app",
-    "https://github.com/d2-ci/core-resource-app",
     "https://github.com/d2-ci/dashboards-app",
     "https://github.com/d2-ci/data-administration-app",
     "https://github.com/d2-ci/data-visualizer-app",

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/write-struts-xml.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/write-struts-xml.js
@@ -10,7 +10,6 @@ const mkdir = promisify(require('fs').mkdir)
  * not have struts definitions generated.
  */
 const blacklist = [
-    'core-resource-app',
     'user-profile-app'
 ]
 

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/cacheManifest.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/cacheManifest.vm
@@ -110,9 +110,5 @@ fonts/LiberationSans-Bold-webfont.svg
 ../dhis-web-commons/javascripts/jQuery/calendars/jquery.calendars.picker.min.js?_rev=$!{buildRevision}
 
 # Header bar with dependencies
-../dhis-web-core-resource/react-15/react-15.min.js
-../dhis-web-core-resource/rxjs/4.1.0/rx.lite.min.js
-../dhis-web-core-resource/lodash/4.15.0/lodash.min.js
-../dhis-web-core-resource/lodash-functional/lodash-functional.js
 ../dhis-web-commons/javascripts/header-bar/babel-polyfill.js?_rev=$!{buildRevision}
 ../dhis-web-commons/javascripts/header-bar/header-bar.js?_rev=$!{buildRevision}

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/main.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/main.vm
@@ -56,11 +56,6 @@
       } );
     </script>
 
-    <!-- Menu dependencies -->
-    <script type="text/javascript" src="../dhis-web-core-resource/react-15/react-15.min.js"></script>
-    <script type="text/javascript" src="../dhis-web-core-resource/rxjs/4.1.0/rx.lite.min.js"></script>
-    <script type="text/javascript" src="../dhis-web-core-resource/lodash/4.15.0/lodash.min.js"></script>
-    <script type="text/javascript" src="../dhis-web-core-resource/lodash-functional/lodash-functional.js"></script>
     <!-- Menu script is up here due to perceived loading time increase -->
     <script type="text/javascript" src="../dhis-web-commons/javascripts/header-bar/babel-polyfill.js?_rev=$!{buildRevision}"></script>
     <script type="text/javascript" src="../dhis-web-commons/javascripts/header-bar/header-bar.js?_rev=$!{buildRevision}"></script>


### PR DESCRIPTION
Fixes TECH-267.

https://jira.dhis2.org/browse/TECH-267

Needs testing, might break some Struts apps that implicitly depend on this legacy injection mechanism.