### PR TITLE
fix: Servlet config change to allow API monitoring

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/config/WebConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/config/WebConfig.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.webapi.config;
+
+import static org.springframework.http.MediaType.parseMediaType;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
+import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.accept.ContentNegotiationManager;
+import org.springframework.web.accept.FixedContentNegotiationStrategy;
+import org.springframework.web.accept.HeaderContentNegotiationStrategy;
+import org.springframework.web.accept.ParameterContentNegotiationStrategy;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Configuration
+public class WebConfig
+{
+    private Map<String, MediaType> mediaTypeMap = new ImmutableMap.Builder<String, MediaType>()
+        .put( "json", MediaType.APPLICATION_JSON )
+        .put( "json.gz", parseMediaType( "application/json+gzip" ) )
+        .put( "json.zip", parseMediaType( "application/json+zip" ) )
+        .put( "jsonp", parseMediaType( "application/javascript" ) )
+        .put( "xml", MediaType.APPLICATION_XML ) 
+        .put( "xml.gz", parseMediaType( "application/xml+gzip" ) )
+        .put( "xml.zip", parseMediaType( "application/xml+zip" ) )
+        .put( "png", MediaType.IMAGE_PNG )
+        .put( "pdf", MediaType.APPLICATION_PDF )
+        .put( "xls", parseMediaType( "application/vnd.ms-excel" ) )
+        .put( "xlsx", parseMediaType( "application/vnd.ms-excel" ) )
+        .put( "csv", parseMediaType( "application/csv" ) )
+        .put( "csv.gz", parseMediaType( "application/csv+gzip" ) )
+        .put( "csv.zip", parseMediaType( "application/csv+zip" ) )
+        .put( "geojson", parseMediaType( "application/json+geojson" ) )
+        .build();
+
+    @Bean
+    public HandlerMappingIntrospector handlerMappingIntrospector()
+    {
+        return new HandlerMappingIntrospector();
+    }
+
+    @Bean
+    public CustomPathExtensionContentNegotiationStrategy customPathExtensionContentNegotiationStrategy()
+    {
+        CustomPathExtensionContentNegotiationStrategy customPathExtensionContentNegotiationStrategy = new CustomPathExtensionContentNegotiationStrategy(
+            mediaTypeMap );
+        customPathExtensionContentNegotiationStrategy.setUseJaf( false );
+        return customPathExtensionContentNegotiationStrategy;
+    }
+
+    @Bean
+    public ParameterContentNegotiationStrategy parameterContentNegotiationStrategy()
+    {
+        String[] mediaTypes = new String[] { "json", "jsonp", "xml", "png", "xls","pdf", "csv"};
+
+        return new ParameterContentNegotiationStrategy( mediaTypeMap.entrySet().stream()
+            .filter( x -> ArrayUtils.contains( mediaTypes, x.getKey() ) )
+            .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) ) );
+    }
+
+    @Bean
+    public HeaderContentNegotiationStrategy headerContentNegotiationStrategy()
+    {
+        return new HeaderContentNegotiationStrategy();
+    }
+
+    @Bean
+    public FixedContentNegotiationStrategy fixedContentNegotiationStrategy()
+    {
+        return new FixedContentNegotiationStrategy( MediaType.APPLICATION_JSON );
+    }
+
+    @Bean
+    public ContentNegotiationManager contentNegotiationManager(
+        CustomPathExtensionContentNegotiationStrategy customPathExtensionContentNegotiationStrategy,
+        ParameterContentNegotiationStrategy parameterContentNegotiationStrategy,
+        HeaderContentNegotiationStrategy headerContentNegotiationStrategy,
+        FixedContentNegotiationStrategy fixedContentNegotiationStrategy )
+    {
+        return new ContentNegotiationManager( Arrays.asList( customPathExtensionContentNegotiationStrategy,
+            parameterContentNegotiationStrategy, headerContentNegotiationStrategy, fixedContentNegotiationStrategy ) );
+    }
+
+    @Bean
+    public CustomRequestMappingHandlerMapping customRequestMappingHandlerMapping(
+        ContentNegotiationManager contentNegotiationManager )
+    {
+        CustomRequestMappingHandlerMapping customRequestMappingHandlerMapping = new CustomRequestMappingHandlerMapping();
+        customRequestMappingHandlerMapping.setContentNegotiationManager( contentNegotiationManager );
+
+        return customRequestMappingHandlerMapping;
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/config/WebMvcMetricsConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/config/WebMvcMetricsConfig.java
@@ -45,7 +45,6 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
@@ -68,11 +67,11 @@ public class WebMvcMetricsConfig
     }
 
     @Bean
-    @SuppressWarnings("deprecation")
     public WebMvcMetricsFilter webMetricsFilter( MeterRegistry registry, WebMvcTagsProvider tagsProvider,
-        WebApplicationContext ctx )
+        HandlerMappingIntrospector handlerMappingIntrospector )
     {
-        return new WebMvcMetricsFilter( registry, tagsProvider, "http_server_requests", true, new HandlerMappingIntrospector(ctx) );
+        return new WebMvcMetricsFilter( registry, tagsProvider, "http_server_requests", true,
+            handlerMappingIntrospector );
     }
 
     @Configuration

--- a/dhis-2/dhis-web/dhis-web-api/src/main/resources/META-INF/dhis/servlet.xml
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/resources/META-INF/dhis/servlet.xml
@@ -20,10 +20,6 @@
   <bean id="renderServiceMessageConverter"
     class="org.hisp.dhis.webapi.mvc.messageconverter.RenderServiceMessageConverter" />
 
-  <bean id="requestMappingHandlerMapping" class="org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping">
-    <property name="contentNegotiationManager" ref="contentNegotiationManager" />
-  </bean>
-
   <bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean" />
 
   <bean class="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" />
@@ -183,63 +179,9 @@
   </mvc:annotation-driven>
   -->
 
-  <bean id="contentNegotiationManager" class="org.springframework.web.accept.ContentNegotiationManager">
-    <constructor-arg>
-      <list>
-        <ref bean="customPathExtensionContentNegotiationStrategy" />
-        <ref bean="parameterContentNegotiationStrategy" />
-        <ref bean="headerContentNegotiationStrategy" />
-        <ref bean="fixedContentNegotiationStrategy" />
-      </list>
-    </constructor-arg>
-  </bean>
-
   <mvc:interceptors>
     <bean class="org.hisp.dhis.webapi.mvc.interceptor.TranslationInterceptor" />
   </mvc:interceptors>
-
-  <bean id="customPathExtensionContentNegotiationStrategy" class="org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy">
-    <constructor-arg name="mediaTypes">
-      <map>
-        <entry key="json" value="application/json" />
-        <entry key="json.gz" value="application/json+gzip" />
-        <entry key="json.zip" value="application/json+zip" />
-        <entry key="jsonp" value="application/javascript" />
-        <entry key="xml" value="application/xml" />
-        <entry key="xml.gz" value="application/xml+gzip" />
-        <entry key="xml.zip" value="application/xml+zip" />
-        <entry key="png" value="image/png" />
-        <entry key="pdf" value="application/pdf" />
-        <entry key="xls" value="application/vnd.ms-excel" />
-        <entry key="xlsx" value="application/vnd.ms-excel" />
-        <entry key="csv" value="application/csv" />
-        <entry key="csv.gz" value="application/csv+gzip" />
-        <entry key="csv.zip" value="application/csv+zip" />
-        <entry key="geojson" value="application/json+geojson" />
-      </map>
-    </constructor-arg>
-    <property name="useJaf" value="false" />
-  </bean>
-
-  <bean id="parameterContentNegotiationStrategy" class="org.springframework.web.accept.ParameterContentNegotiationStrategy">
-    <constructor-arg name="mediaTypes">
-      <map>
-        <entry key="json" value="application/json" />
-        <entry key="jsonp" value="application/javascript" />
-        <entry key="xml" value="application/xml" />
-        <entry key="png" value="image/png" />
-        <entry key="pdf" value="application/pdf" />
-        <entry key="xls" value="application/vnd.ms-excel" />
-        <entry key="csv" value="application/csv" />
-      </map>
-    </constructor-arg>
-  </bean>
-
-  <bean id="headerContentNegotiationStrategy" class="org.springframework.web.accept.HeaderContentNegotiationStrategy" />
-
-  <bean id="fixedContentNegotiationStrategy" class="org.springframework.web.accept.FixedContentNegotiationStrategy">
-    <constructor-arg type="org.springframework.http.MediaType" value="application/json" />
-  </bean>
 
   <bean class="org.springframework.web.servlet.view.ContentNegotiatingViewResolver">
     <property name="order" value="1" />

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1522,12 +1522,12 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-spring-legacy</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.5</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- DHIS2-8321
- Move the custom negotiation strategies from servlet.xml to Java Web
  configuration so that `HandlerMappingIntrospector` can access DHIS2
`CustomRequestMappingHandlerMapping` and allows WebMetricsFilter to work with the custom mapping handler
- Bumped micrometer lib version to latest