### PR TITLE
fix: Removing deprecated Chart/RT schemas [DHIS2-8148]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ChartSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ChartSchemaDescriptor.java
@@ -46,6 +46,10 @@ public class ChartSchemaDescriptor implements SchemaDescriptor
 
     public static final String API_ENDPOINT = "/" + PLURAL;
 
+    public static final String F_CHART_PUBLIC_ADD = "F_CHART_PUBLIC_ADD";
+
+    public static final String F_CHART_EXTERNAL = "F_CHART_EXTERNAL";
+
     @Override
     public Schema getSchema()
     {
@@ -54,8 +58,10 @@ public class ChartSchemaDescriptor implements SchemaDescriptor
         schema.setImplicitPrivateAuthority( true );
         schema.setOrder( 2000 );
 
-        schema.getAuthorities().add( new Authority( AuthorityType.CREATE_PUBLIC, Lists.newArrayList( "F_CHART_PUBLIC_ADD" ) ) );
-        schema.getAuthorities().add( new Authority( AuthorityType.EXTERNALIZE, Lists.newArrayList( "F_CHART_EXTERNAL" ) ) );
+        schema.getAuthorities()
+            .add( new Authority( AuthorityType.CREATE_PUBLIC, Lists.newArrayList( F_CHART_PUBLIC_ADD ) ) );
+        schema.getAuthorities()
+            .add( new Authority( AuthorityType.EXTERNALIZE, Lists.newArrayList( F_CHART_EXTERNAL ) ) );
 
         return schema;
     }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ReportTableSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ReportTableSchemaDescriptor.java
@@ -46,6 +46,10 @@ public class ReportTableSchemaDescriptor implements SchemaDescriptor
 
     public static final String API_ENDPOINT = "/" + PLURAL;
 
+    public static final String F_REPORTTABLE_PUBLIC_ADD = "F_REPORTTABLE_PUBLIC_ADD";
+
+    public static final String F_REPORTTABLE_EXTERNAL = "F_REPORTTABLE_EXTERNAL";
+
     @Override
     public Schema getSchema()
     {
@@ -54,8 +58,10 @@ public class ReportTableSchemaDescriptor implements SchemaDescriptor
         schema.setOrder( 2000 );
         schema.setImplicitPrivateAuthority( true );
 
-        schema.getAuthorities().add( new Authority( AuthorityType.CREATE_PUBLIC, Lists.newArrayList( "F_REPORTTABLE_PUBLIC_ADD" ) ) );
-        schema.getAuthorities().add( new Authority( AuthorityType.EXTERNALIZE, Lists.newArrayList( "F_REPORTTABLE_EXTERNAL" ) ) );
+        schema.getAuthorities()
+            .add( new Authority( AuthorityType.CREATE_PUBLIC, Lists.newArrayList( F_REPORTTABLE_PUBLIC_ADD ) ) );
+        schema.getAuthorities()
+            .add( new Authority( AuthorityType.EXTERNALIZE, Lists.newArrayList( F_REPORTTABLE_EXTERNAL ) ) );
 
         return schema;
     }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/commons/action/GetSystemAuthoritiesAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/commons/action/GetSystemAuthoritiesAction.java
@@ -40,12 +40,23 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
+import static org.hisp.dhis.schema.descriptors.ChartSchemaDescriptor.F_CHART_EXTERNAL;
+import static org.hisp.dhis.schema.descriptors.ChartSchemaDescriptor.F_CHART_PUBLIC_ADD;
+import static org.hisp.dhis.schema.descriptors.ReportTableSchemaDescriptor.F_REPORTTABLE_EXTERNAL;
+import static org.hisp.dhis.schema.descriptors.ReportTableSchemaDescriptor.F_REPORTTABLE_PUBLIC_ADD;
+
 /**
  * @author mortenoh
  */
 public class GetSystemAuthoritiesAction
     extends ActionPagingSupport<String>
 {
+
+    @Deprecated
+    private static final List<String> DEPRECATED_SCHEMAS = asList( F_REPORTTABLE_EXTERNAL, F_REPORTTABLE_PUBLIC_ADD,
+        F_CHART_EXTERNAL, F_CHART_PUBLIC_ADD );
+
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -100,7 +111,10 @@ public class GetSystemAuthoritiesAction
         listAuthorities.forEach( auth -> {
             String name = getAuthName( auth );
 
-            authNodes.add( mapper.createObjectNode().put( "id", auth ).put( "name", name ) );
+            if ( isNotDeprecated( auth ) )
+            {
+                authNodes.add( mapper.createObjectNode().put( "id", auth ).put( "name", name ) );
+            }
         } );
 
         root.set( "systemAuthorities", authNodes );
@@ -121,5 +135,18 @@ public class GetSystemAuthoritiesAction
         }
 
         return auth;
+    }
+
+    /**
+     * This checking is required in order to "temporally" remove the deprecated schemas.
+     * Created and used during the transition from Chart/ReportTable to Visualization.
+     *
+     * @param authId to be filtered out if the same is deprecated.
+     * @return true if the authId is NOT deprecated, false otherwise.
+     */
+    @Deprecated
+    private boolean isNotDeprecated( final String authId )
+    {
+        return !DEPRECATED_SCHEMAS.contains( authId );
     }
 }


### PR DESCRIPTION
This is required in order to avoid returning deprecate Authorization keys to the client/UI.
As the schemas are tight to other features and we still want to support the Chart and ReportTable endpoints, I cannot exclude the related schemas.
As the Authorization keys are build dynamically based on existing schemas I had to add a workaround to skip them.
