### PR TITLE
fix: Remove non-authorized cat options from query [DHIS2-7712]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -521,9 +521,15 @@ public class JdbcEventAnalyticsManager
 
     /**
      * This method will generate a sql sentence responsible for filtering out all
-     * the category options (of this program) not authorized.
-     *
+     * the category options (of this program categories). The list of category
+     * options within this list of categories should contains only not authorized
+     * category options (it means the category options that cannot be read by the
+     * current user based on the sharing settings defined for the category options.
+     * See
+     * @see org.hisp.dhis.analytics.security.DefaultAnalyticsSecurityManager#excludeOnlyAuthorizedCategoryOptions
+     * and
      * @see org.hisp.dhis.analytics.AnalyticsSecurityManager#decideAccess(DataQueryParams)
+     * to check how the category options of these categories were set.
      *
      * @param programCategories the list of program categories containing the list
      *        of category options not authorized for the current user.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -403,7 +403,7 @@ public class JdbcEventAnalyticsManager
         }
         else if ( params.hasProgram() && params.getProgram().hasCategoryCombo() )
         {
-            sql += queryOnlyAllowedCategoryOptionEvents( params.getProgram().getCategoryCombo().getCategories() );
+            sql += filterOutNotAuthorizedCategoryOptionEvents( params.getProgram().getCategoryCombo().getCategories() );
         }
 
         // ---------------------------------------------------------------------
@@ -520,18 +520,17 @@ public class JdbcEventAnalyticsManager
     }
 
     /**
-     * This method will generate a sql sentence responsible for filtering only the
-     * allowed category options for this program, and expects to receive only the
-     * authorized category options.
+     * This method will generate a sql sentence responsible for filtering out all
+     * the category options (of this program) not authorized.
      *
      * @see org.hisp.dhis.analytics.AnalyticsSecurityManager#decideAccess(DataQueryParams)
      *
      * @param programCategories the list of program categories containing the list
-     *        of authorized category options for the current user.
-     * @return the sql statement in the format:
-     *          "and ax."mEXqxV2KIUl" in ('qNqYLugIySD') or ax."r7NDRdgj5zs" in ('qNqYLugIySD') "
+     *        of category options not authorized for the current user.
+     * @return the sql statement in the format: "and ax."mEXqxV2KIUl" not in
+     *         ('qNqYLugIySD') or ax."r7NDRdgj5zs" not in ('qNqYLugIySD') "
      */
-    String queryOnlyAllowedCategoryOptionEvents( final List<Category> programCategories )
+    String filterOutNotAuthorizedCategoryOptionEvents( final List<Category> programCategories )
     {
         final StringBuilder query = new StringBuilder();
         final SqlHelper sqlHelper = new SqlHelper(true);
@@ -563,7 +562,7 @@ public class JdbcEventAnalyticsManager
     String buildInFilterForCategory(final Category category, final List<CategoryOption> categoryOptions )
     {
         final String categoryColumn = quoteAlias( category.getUid() );
-        final String inFilter = categoryColumn + " in (" + getQuotedCommaDelimitedString( getUids( categoryOptions ) )
+        final String inFilter = categoryColumn + " not in (" + getQuotedCommaDelimitedString( getUids( categoryOptions ) )
             + ") ";
         return inFilter;
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -96,17 +96,25 @@ public class DefaultAnalyticsSecurityManager
 
     /**
      * Will remove/exclude, from DataQueryParams, any category option that the
-     * current user is not allowed to read.
+     * current user is authorized to read, so we can filter out the category options
+     * not authorized later on (if any).
      *
      * @param programCategories the categories related to this program.
      */
-    void excludeNonAuthorizedCategoryOptions( final List<Category> programCategories )
+    void excludeOnlyAuthorizedCategoryOptions( final List<Category> programCategories )
     {
         if ( isNotEmpty( programCategories ) )
         {
             for ( Category category : programCategories )
             {
-                category.getCategoryOptions().removeIf( categoryOption -> !hasDataReadPermissionFor( categoryOption ) );
+
+                final List<CategoryOption> categoryOptions = category.getCategoryOptions();
+
+                if ( isNotEmpty( categoryOptions ) )
+                {
+                    category.getCategoryOptions()
+                        .removeIf( categoryOption -> hasDataReadPermissionFor( categoryOption ) );
+                }
             }
         }
     }
@@ -177,7 +185,7 @@ public class DefaultAnalyticsSecurityManager
             if ( params.getProgram().hasCategoryCombo() )
             {
                 final List<Category> programCategories = params.getProgram().getCategoryCombo().getCategories();
-                excludeNonAuthorizedCategoryOptions( programCategories );
+                excludeOnlyAuthorizedCategoryOptions( programCategories );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
@@ -102,7 +102,7 @@ public class JdbcEventAnalyticsManagerTest
         final EventQueryParams theEventQueryParams = stubEventQueryParamsWithoutDimensions(
             newArrayList( aCategoryA ) );
 
-        final String theExpectedSql = " and ax.\"uid-cat-A\" in ('uid-opt-A', 'uid-opt-B') ";
+        final String theExpectedSql = " and ax.\"uid-cat-A\" not in ('uid-opt-A', 'uid-opt-B') ";
 
         // When
         final String actualSql = jdbcEventAnalyticsManager.getWhereClause( theEventQueryParams );
@@ -126,7 +126,7 @@ public class JdbcEventAnalyticsManagerTest
         final EventQueryParams theEventQueryParams = stubEventQueryParamsWithoutDimensions(
             newArrayList( aCategoryA, aCategoryB ) );
 
-        final String theExpectedSql = " and ax.\"uid-cat-A\" in ('uid-opt-A', 'uid-opt-B')  or ax.\"uid-cat-B\" in ('uid-opt-A', 'uid-opt-B') ";
+        final String theExpectedSql = " and ax.\"uid-cat-A\" not in ('uid-opt-A', 'uid-opt-B')  or ax.\"uid-cat-B\" not in ('uid-opt-A', 'uid-opt-B') ";
 
         // When
         final String actualSql = jdbcEventAnalyticsManager.getWhereClause( theEventQueryParams );
@@ -136,7 +136,7 @@ public class JdbcEventAnalyticsManagerTest
     }
 
     @Test
-    public void testQueryOnlyAllowedCategoryOptionEvents()
+    public void testFilterOutNotAuthorizedCategoryOptionEvents()
     {
         // Given
         final CategoryOption aCategoryOptionA = stubCategoryOption( "cat-option-A", "uid-opt-A" );
@@ -147,31 +147,31 @@ public class JdbcEventAnalyticsManagerTest
         final Category aCategoryB = stubCategory( "cat-B", "uid-cat-B",
             newArrayList( aCategoryOptionA, aCategoryOptionB ) );
 
-        final String theExpectedSql = " and ax.\"uid-cat-A\" in ('uid-opt-A', 'uid-opt-B')  or ax.\"uid-cat-B\" in ('uid-opt-A', 'uid-opt-B') ";
+        final String theExpectedSql = " and ax.\"uid-cat-A\" not in ('uid-opt-A', 'uid-opt-B')  or ax.\"uid-cat-B\" not in ('uid-opt-A', 'uid-opt-B') ";
 
         // When
         final String actualSql = jdbcEventAnalyticsManager
-            .queryOnlyAllowedCategoryOptionEvents( newArrayList( aCategoryA, aCategoryB ) );
+            .filterOutNotAuthorizedCategoryOptionEvents( newArrayList( aCategoryA, aCategoryB ) );
 
         // Then
         assertThat( actualSql, containsString( theExpectedSql ) );
     }
 
     @Test
-    public void testQueryOnlyAllowedCategoryOptionEventsWithNoCategories()
+    public void testFilterOutNotAuthorizedCategoryOptionEventsWithNoCategories()
     {
         // Given
         final List<Category> emptyCategoryList = newArrayList();
 
         // When
-        final String actualSql = jdbcEventAnalyticsManager.queryOnlyAllowedCategoryOptionEvents( emptyCategoryList );
+        final String actualSql = jdbcEventAnalyticsManager.filterOutNotAuthorizedCategoryOptionEvents( emptyCategoryList );
 
         // Then
         assertThat( actualSql, isEmptyString() );
     }
 
     @Test
-    public void testQueryOnlyAllowedCategoryOptionEventsWithNoCategoryOptions()
+    public void testFilterOutNotAuthorizedCategoryOptionEventsWithNoCategoryOptions()
     {
         // Given
         final Category aCategoryA = stubCategory( "cat-A", "uid-cat-A", newArrayList() );
@@ -179,7 +179,7 @@ public class JdbcEventAnalyticsManagerTest
 
         // When
         final String actualSql = jdbcEventAnalyticsManager
-            .queryOnlyAllowedCategoryOptionEvents( newArrayList( aCategoryA, aCategoryB ) );
+            .filterOutNotAuthorizedCategoryOptionEvents( newArrayList( aCategoryA, aCategoryB ) );
 
         // Then
         assertThat( actualSql, isEmptyString() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
@@ -98,7 +98,7 @@ public class DefaultAnalyticsSecurityManagerTest
     }
 
     @Test
-    public void testExcludeNonAuthorizedCategoryOptionsWhenOneCategoryOptionIsNotAllowed()
+    public void testRemoveOnlyAuthorizedCategoryOptionsWhenOneCategoryOptionIsNotAllowed()
     {
         // Given
         final CategoryOption aCategoryOptionNotAllowed = stubCategoryOption( "cat-option-A", "uid-opt-A" );
@@ -120,17 +120,17 @@ public class DefaultAnalyticsSecurityManagerTest
             .thenReturn( canDataReadFalse );
         when( aclService.canDataRead( currentUserService.getCurrentUser(), aCategoryOptionAllowed ) )
             .thenReturn( canDataReadTrue );
-        defaultAnalyticsSecurityManager.excludeNonAuthorizedCategoryOptions( categories );
+        defaultAnalyticsSecurityManager.excludeOnlyAuthorizedCategoryOptions( categories );
 
         // Then
-        assertThat( aCategoryA.getCategoryOptions(), hasItems( aCategoryOptionAllowed ) );
-        assertThat( aCategoryB.getCategoryOptions(), hasItems( aCategoryOptionAllowed ) );
-        assertThat( aCategoryA.getCategoryOptions(), not( hasItems( aCategoryOptionNotAllowed ) ) );
-        assertThat( aCategoryB.getCategoryOptions(), not( hasItems( aCategoryOptionNotAllowed ) ) );
+        assertThat( aCategoryA.getCategoryOptions(), not( hasItems( aCategoryOptionAllowed ) ) );
+        assertThat( aCategoryB.getCategoryOptions(), not( hasItems( aCategoryOptionAllowed ) ) );
+        assertThat( aCategoryA.getCategoryOptions(), hasItems( aCategoryOptionNotAllowed ) );
+        assertThat( aCategoryB.getCategoryOptions(), hasItems( aCategoryOptionNotAllowed ) );
     }
 
     @Test
-    public void testExcludeNonAuthorizedCategoryOptionsWhenAllCategoryOptionsAreAllowed()
+    public void testRemoveOnlyAuthorizedCategoryOptionsWhenAllCategoryOptionsAreAllowed()
     {
         // Given
         final CategoryOption aCategoryOptionAllowed = stubCategoryOption( "cat-option-A", "uid-opt-A" );
@@ -151,11 +151,11 @@ public class DefaultAnalyticsSecurityManagerTest
             .thenReturn( canDataReadTrue );
         when( aclService.canDataRead( currentUserService.getCurrentUser(), anotherCategoryOptionAllowed ) )
             .thenReturn( canDataReadTrue );
-        defaultAnalyticsSecurityManager.excludeNonAuthorizedCategoryOptions( categories );
+        defaultAnalyticsSecurityManager.excludeOnlyAuthorizedCategoryOptions( categories );
 
         // Then
-        assertThat( aCategoryA.getCategoryOptions(), hasItems( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) );
-        assertThat( aCategoryB.getCategoryOptions(), hasItems( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) );
+        assertThat( aCategoryA.getCategoryOptions(), not( hasItems( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) ) );
+        assertThat( aCategoryB.getCategoryOptions(), not( hasItems( aCategoryOptionAllowed, anotherCategoryOptionAllowed ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
@@ -98,7 +98,7 @@ public class DefaultAnalyticsSecurityManagerTest
     }
 
     @Test
-    public void testRemoveOnlyAuthorizedCategoryOptionsWhenOneCategoryOptionIsNotAllowed()
+    public void testExcludeOnlyAuthorizedCategoryOptionsWhenOneCategoryOptionIsNotAllowed()
     {
         // Given
         final CategoryOption aCategoryOptionNotAllowed = stubCategoryOption( "cat-option-A", "uid-opt-A" );
@@ -130,7 +130,7 @@ public class DefaultAnalyticsSecurityManagerTest
     }
 
     @Test
-    public void testRemoveOnlyAuthorizedCategoryOptionsWhenAllCategoryOptionsAreAllowed()
+    public void testExcludeOnlyAuthorizedCategoryOptionsWhenAllCategoryOptionsAreAllowed()
     {
         // Given
         final CategoryOption aCategoryOptionAllowed = stubCategoryOption( "cat-option-A", "uid-opt-A" );


### PR DESCRIPTION
Inverting the logic so left not authorized category options are filtered out during the SQL query.