### PR TITLE
fix: Use correct minValue for PropertyIntrospectorService

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/AbstractPropertyIntrospectorService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/AbstractPropertyIntrospectorService.java
@@ -280,19 +280,19 @@ public abstract class AbstractPropertyIntrospectorService
                 }
                 else if (type instanceof IntegerType)
                 {
-                    property.setMin( 0d );
+                    property.setMin( (double) Integer.MIN_VALUE );
                     property.setMax( (double) Integer.MAX_VALUE );
                     property.setLength( Integer.MAX_VALUE );
                 }
                 else if (type instanceof LongType)
                 {
-                    property.setMin( 0d );
+                    property.setMin( (double) Long.MIN_VALUE );
                     property.setMax( (double) Long.MAX_VALUE );
                     property.setLength( Integer.MAX_VALUE );
                 }
                 else if (type instanceof DoubleType)
                 {
-                    property.setMin( 0d );
+                    property.setMin( Double.MIN_VALUE );
                     property.setMax( Double.MAX_VALUE );
                     property.setLength( Integer.MAX_VALUE );
                 }


### PR DESCRIPTION
This was discovered when I tried to fix the issue https://jira.dhis2.org/browse/DHIS2-8308
