### PR TITLE
2.33 pepfar bug validation refactor

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/PreheatService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/PreheatService.java
@@ -63,13 +63,13 @@ public interface PreheatService
 
     Map<Class<?>, Map<String, Map<String, Object>>> collectObjectReferences( Object object );
 
-//    /**
-//     * Scan objects and collect unique values (used to verify object properties with unique=true)
-//     *
-//     * @param objects Objects to scan
-//     * @return Klass -> Property.name -> Value -> UID
-//     */
-//    Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects );
+    /**
+     * Scan objects and collect unique values (used to verify object properties with unique=true)
+     *
+     * @param objects Objects to scan
+     * @return Klass -> Property.name -> Value -> UID
+     */
+    Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects );
 
     /**
      * Connects id object references on a given object using a given identifier + a preheated Preheat cache.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/PreheatService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/PreheatService.java
@@ -63,13 +63,13 @@ public interface PreheatService
 
     Map<Class<?>, Map<String, Map<String, Object>>> collectObjectReferences( Object object );
 
-    /**
-     * Scan objects and collect unique values (used to verify object properties with unique=true)
-     *
-     * @param objects Objects to scan
-     * @return Klass -> Property.name -> Value -> UID
-     */
-    Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects );
+//    /**
+//     * Scan objects and collect unique values (used to verify object properties with unique=true)
+//     *
+//     * @param objects Objects to scan
+//     * @return Klass -> Property.name -> Value -> UID
+//     */
+//    Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects );
 
     /**
      * Connects id object references on a given object using a given identifier + a preheated Preheat cache.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -161,7 +162,7 @@ public class DefaultPreheatService implements PreheatService
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> uniqueCollectionMap = new HashMap<>();
         Set<Class<? extends IdentifiableObject>> klasses = new HashSet<>( params.getObjects().keySet() );
 
-        if ( PreheatMode.ALL == params.getPreheatMode() ) // TODO morten: this seems to be no longer used?
+        if ( PreheatMode.ALL == params.getPreheatMode() )
         {
             if ( params.getClasses().isEmpty() )
             {
@@ -171,7 +172,7 @@ public class DefaultPreheatService implements PreheatService
 
             for ( Class<? extends IdentifiableObject> klass : params.getClasses() )
             {
-                Query query = Query.from( schemaService.getDynamicSchema( klass ) ); // TODO morten: this will replicate the problem of fetching the entire table content
+                Query query = Query.from( schemaService.getDynamicSchema( klass ) );
                 query.setUser( preheat.getUser() );
                 List<? extends IdentifiableObject> objects = queryService.query( query );
 
@@ -238,37 +239,37 @@ public class DefaultPreheatService implements PreheatService
                 }
             }
 
-//            for ( Class<? extends IdentifiableObject> klass : klasses )
-//            {
-//                Query query = Query.from( schemaService.getDynamicSchema( klass ) );
-//                query.setUser( preheat.getUser() );
-//                List<? extends IdentifiableObject> objects = queryService.query( query );
-//
-//                if ( !objects.isEmpty() )
-//                {
-//                    uniqueCollectionMap.put( klass, new ArrayList<>( objects ) );
-//                }
-//            }
+            for ( Class<? extends IdentifiableObject> klass : klasses )
+            {
+                Query query = Query.from( schemaService.getDynamicSchema( klass ) );
+                query.setUser( preheat.getUser() );
+                List<? extends IdentifiableObject> objects = queryService.query( query );
+
+                if ( !objects.isEmpty() )
+                {
+                    uniqueCollectionMap.put( klass, new ArrayList<>( objects ) );
+                }
+            }
         }
 
-//        if ( uniqueCollectionMap.containsKey( User.class ) )
-//        {
-//            List<IdentifiableObject> userCredentials = new ArrayList<>();
-//
-//            for ( IdentifiableObject identifiableObject : uniqueCollectionMap.get( User.class ) )
-//            {
-//                User user = (User) identifiableObject;
-//
-//                if ( user.getUserCredentials() != null )
-//                {
-//                    userCredentials.add( user.getUserCredentials() );
-//                }
-//            }
-//
-//            uniqueCollectionMap.put( UserCredentials.class, userCredentials );
-//        }
-//
-//        preheat.setUniquenessMap( collectUniqueness( uniqueCollectionMap ) );
+        if ( uniqueCollectionMap.containsKey( User.class ) )
+        {
+            List<IdentifiableObject> userCredentials = new ArrayList<>();
+
+            for ( IdentifiableObject identifiableObject : uniqueCollectionMap.get( User.class ) )
+            {
+                User user = (User) identifiableObject;
+
+                if ( user.getUserCredentials() != null )
+                {
+                    userCredentials.add( user.getUserCredentials() );
+                }
+            }
+
+            uniqueCollectionMap.put( UserCredentials.class, userCredentials );
+        }
+
+        preheat.setUniquenessMap( collectUniqueness( uniqueCollectionMap ) );
 
         // add preheat placeholders for objects that will be created and set mandatory/unique attributes
         for ( Class<? extends IdentifiableObject> klass : params.getObjects().keySet() )
@@ -824,25 +825,25 @@ public class DefaultPreheatService implements PreheatService
         }
     }
 
-//    @Override
-//    public Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects )
-//    {
-//        Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> uniqueMap = new HashMap<>();
-//
-//        if ( objects.isEmpty() )
-//        {
-//            return uniqueMap;
-//        }
-//
-//        for ( Class<? extends IdentifiableObject> objectClass : objects.keySet() )
-//        {
-//            Schema schema = schemaService.getDynamicSchema( objectClass );
-//            List<IdentifiableObject> identifiableObjects = objects.get( objectClass );
-//            uniqueMap.put( objectClass, handleUniqueProperties( schema, identifiableObjects ) );
-//        }
-//
-//        return uniqueMap;
-//    }
+    @Override
+    public Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects )
+    {
+        Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> uniqueMap = new HashMap<>();
+
+        if ( objects.isEmpty() )
+        {
+            return uniqueMap;
+        }
+
+        for ( Class<? extends IdentifiableObject> objectClass : objects.keySet() )
+        {
+            Schema schema = schemaService.getDynamicSchema( objectClass );
+            List<IdentifiableObject> identifiableObjects = objects.get( objectClass );
+            uniqueMap.put( objectClass, handleUniqueProperties( schema, identifiableObjects ) );
+        }
+
+        return uniqueMap;
+    }
 
     @Override
     public void connectReferences( Object object, Preheat preheat, PreheatIdentifier identifier )
@@ -958,26 +959,26 @@ public class DefaultPreheatService implements PreheatService
         if ( !StringUtils.isEmpty( identifiableObject.getCode() ) ) codeMap.get( klass ).add( identifiableObject.getCode() );
     }
 
-//    private Map<String, Map<Object, String>> handleUniqueProperties( Schema schema, List<IdentifiableObject> objects )
-//    {
-//        List<Property> uniqueProperties = schema.getProperties().stream()
-//            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
-//            .collect( Collectors.toList() );
-//
-//        Map<String, Map<Object, String>> map = new HashMap<>();
-//
-//        for ( IdentifiableObject object : objects )
-//        {
-//            uniqueProperties.forEach( property ->
-//            {
-//                if ( !map.containsKey( property.getName() ) ) map.put( property.getName(), new HashMap<>() );
-//                Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
-//                if ( value != null ) map.get( property.getName() ).put( value, object.getUid() );
-//            } );
-//        }
-//
-//        return map;
-//    }
+    private Map<String, Map<Object, String>> handleUniqueProperties( Schema schema, List<IdentifiableObject> objects )
+    {
+        List<Property> uniqueProperties = schema.getProperties().stream()
+            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
+            .collect( Collectors.toList() );
+
+        Map<String, Map<Object, String>> map = new HashMap<>();
+
+        for ( IdentifiableObject object : objects )
+        {
+            uniqueProperties.forEach( property ->
+            {
+                if ( !map.containsKey( property.getName() ) ) map.put( property.getName(), new HashMap<>() );
+                Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
+                if ( value != null ) map.get( property.getName() ).put( value, object.getUid() );
+            } );
+        }
+
+        return map;
+    }
 
     private IdentifiableObject getPersistedObject( Preheat preheat, PreheatIdentifier identifier, IdentifiableObject ref )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -28,7 +28,17 @@ package org.hisp.dhis.preheat;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,7 +48,6 @@ import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -74,16 +83,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -152,6 +152,7 @@ public class DefaultPreheatService implements PreheatService
         preheat.put( PreheatIdentifier.UID, preheat.getUser() );
         preheat.put( PreheatIdentifier.CODE, preheat.getUser() );
 
+        // assign an uid to objects without an uid
         for ( Class<? extends IdentifiableObject> klass : params.getObjects().keySet() )
         {
             params.getObjects().get( klass ).stream()
@@ -458,11 +459,11 @@ public class DefaultPreheatService implements PreheatService
             return new HashMap<>();
         }
 
-        if ( Collection.class.isInstance( object ) )
+        if ( object instanceof Collection )
         {
             return collectReferences( (Collection<?>) object );
         }
-        else if ( Map.class.isInstance( object ) )
+        else if ( object instanceof Map )
         {
             return collectReferences( (Map<Class<?>, List<?>>) object );
         }
@@ -502,8 +503,7 @@ public class DefaultPreheatService implements PreheatService
             return map;
         }
 
-        Map<Class<?>, List<?>> targets = new HashMap<>();
-        targets.putAll( objects ); // Clone objects list, we don't want to modify it
+        Map<Class<?>, List<?>> targets = new HashMap<>( objects ); // Clone objects list, we don't want to modify it
         collectScanTargets( targets );
 
         for ( Class<?> klass : targets.keySet() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -162,7 +161,7 @@ public class DefaultPreheatService implements PreheatService
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> uniqueCollectionMap = new HashMap<>();
         Set<Class<? extends IdentifiableObject>> klasses = new HashSet<>( params.getObjects().keySet() );
 
-        if ( PreheatMode.ALL == params.getPreheatMode() )
+        if ( PreheatMode.ALL == params.getPreheatMode() ) // TODO morten: this seems to be no longer used?
         {
             if ( params.getClasses().isEmpty() )
             {
@@ -172,7 +171,7 @@ public class DefaultPreheatService implements PreheatService
 
             for ( Class<? extends IdentifiableObject> klass : params.getClasses() )
             {
-                Query query = Query.from( schemaService.getDynamicSchema( klass ) );
+                Query query = Query.from( schemaService.getDynamicSchema( klass ) ); // TODO morten: this will replicate the problem of fetching the entire table content
                 query.setUser( preheat.getUser() );
                 List<? extends IdentifiableObject> objects = queryService.query( query );
 
@@ -239,37 +238,37 @@ public class DefaultPreheatService implements PreheatService
                 }
             }
 
-            for ( Class<? extends IdentifiableObject> klass : klasses )
-            {
-                Query query = Query.from( schemaService.getDynamicSchema( klass ) );
-                query.setUser( preheat.getUser() );
-                List<? extends IdentifiableObject> objects = queryService.query( query );
-
-                if ( !objects.isEmpty() )
-                {
-                    uniqueCollectionMap.put( klass, new ArrayList<>( objects ) );
-                }
-            }
+//            for ( Class<? extends IdentifiableObject> klass : klasses )
+//            {
+//                Query query = Query.from( schemaService.getDynamicSchema( klass ) );
+//                query.setUser( preheat.getUser() );
+//                List<? extends IdentifiableObject> objects = queryService.query( query );
+//
+//                if ( !objects.isEmpty() )
+//                {
+//                    uniqueCollectionMap.put( klass, new ArrayList<>( objects ) );
+//                }
+//            }
         }
 
-        if ( uniqueCollectionMap.containsKey( User.class ) )
-        {
-            List<IdentifiableObject> userCredentials = new ArrayList<>();
-
-            for ( IdentifiableObject identifiableObject : uniqueCollectionMap.get( User.class ) )
-            {
-                User user = (User) identifiableObject;
-
-                if ( user.getUserCredentials() != null )
-                {
-                    userCredentials.add( user.getUserCredentials() );
-                }
-            }
-
-            uniqueCollectionMap.put( UserCredentials.class, userCredentials );
-        }
-
-        preheat.setUniquenessMap( collectUniqueness( uniqueCollectionMap ) );
+//        if ( uniqueCollectionMap.containsKey( User.class ) )
+//        {
+//            List<IdentifiableObject> userCredentials = new ArrayList<>();
+//
+//            for ( IdentifiableObject identifiableObject : uniqueCollectionMap.get( User.class ) )
+//            {
+//                User user = (User) identifiableObject;
+//
+//                if ( user.getUserCredentials() != null )
+//                {
+//                    userCredentials.add( user.getUserCredentials() );
+//                }
+//            }
+//
+//            uniqueCollectionMap.put( UserCredentials.class, userCredentials );
+//        }
+//
+//        preheat.setUniquenessMap( collectUniqueness( uniqueCollectionMap ) );
 
         // add preheat placeholders for objects that will be created and set mandatory/unique attributes
         for ( Class<? extends IdentifiableObject> klass : params.getObjects().keySet() )
@@ -825,25 +824,25 @@ public class DefaultPreheatService implements PreheatService
         }
     }
 
-    @Override
-    public Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects )
-    {
-        Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> uniqueMap = new HashMap<>();
-
-        if ( objects.isEmpty() )
-        {
-            return uniqueMap;
-        }
-
-        for ( Class<? extends IdentifiableObject> objectClass : objects.keySet() )
-        {
-            Schema schema = schemaService.getDynamicSchema( objectClass );
-            List<IdentifiableObject> identifiableObjects = objects.get( objectClass );
-            uniqueMap.put( objectClass, handleUniqueProperties( schema, identifiableObjects ) );
-        }
-
-        return uniqueMap;
-    }
+//    @Override
+//    public Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> collectUniqueness( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects )
+//    {
+//        Map<Class<? extends IdentifiableObject>, Map<String, Map<Object, String>>> uniqueMap = new HashMap<>();
+//
+//        if ( objects.isEmpty() )
+//        {
+//            return uniqueMap;
+//        }
+//
+//        for ( Class<? extends IdentifiableObject> objectClass : objects.keySet() )
+//        {
+//            Schema schema = schemaService.getDynamicSchema( objectClass );
+//            List<IdentifiableObject> identifiableObjects = objects.get( objectClass );
+//            uniqueMap.put( objectClass, handleUniqueProperties( schema, identifiableObjects ) );
+//        }
+//
+//        return uniqueMap;
+//    }
 
     @Override
     public void connectReferences( Object object, Preheat preheat, PreheatIdentifier identifier )
@@ -959,26 +958,26 @@ public class DefaultPreheatService implements PreheatService
         if ( !StringUtils.isEmpty( identifiableObject.getCode() ) ) codeMap.get( klass ).add( identifiableObject.getCode() );
     }
 
-    private Map<String, Map<Object, String>> handleUniqueProperties( Schema schema, List<IdentifiableObject> objects )
-    {
-        List<Property> uniqueProperties = schema.getProperties().stream()
-            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
-            .collect( Collectors.toList() );
-
-        Map<String, Map<Object, String>> map = new HashMap<>();
-
-        for ( IdentifiableObject object : objects )
-        {
-            uniqueProperties.forEach( property ->
-            {
-                if ( !map.containsKey( property.getName() ) ) map.put( property.getName(), new HashMap<>() );
-                Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
-                if ( value != null ) map.get( property.getName() ).put( value, object.getUid() );
-            } );
-        }
-
-        return map;
-    }
+//    private Map<String, Map<Object, String>> handleUniqueProperties( Schema schema, List<IdentifiableObject> objects )
+//    {
+//        List<Property> uniqueProperties = schema.getProperties().stream()
+//            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
+//            .collect( Collectors.toList() );
+//
+//        Map<String, Map<Object, String>> map = new HashMap<>();
+//
+//        for ( IdentifiableObject object : objects )
+//        {
+//            uniqueProperties.forEach( property ->
+//            {
+//                if ( !map.containsKey( property.getName() ) ) map.put( property.getName(), new HashMap<>() );
+//                Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
+//                if ( value != null ) map.get( property.getName() ).put( value, object.getUid() );
+//            } );
+//        }
+//
+//        return map;
+//    }
 
     private IdentifiableObject getPersistedObject( Preheat preheat, PreheatIdentifier identifier, IdentifiableObject ref )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -28,8 +28,23 @@ package org.hisp.dhis.dxf2.config;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.CreationCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DeletionCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DuplicateIdsCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.MandatoryAttributesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ReferencesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.SchemaCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.SecurityCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniqueAttributesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniquenessCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UpdateCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationHooksCheck;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
 import org.hisp.dhis.external.conf.ConfigurationPropertyFactoryBean;
+import org.hisp.dhis.importexport.ImportStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -39,12 +54,14 @@ import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * @author Luciano Fiandesio
  */
 @Configuration( "dxf2ServiceConfig" )
+@SuppressWarnings("unchecked")
 public class ServiceConfig
 {
 
@@ -73,5 +90,36 @@ public class ServiceConfig
         retryTemplate.setRetryPolicy( simpleRetryPolicy );
 
         return retryTemplate;
+    }
+
+    /*
+
+    Default validation chains for each Import Strategy
+
+     */
+
+    private final static List<Class<? extends ValidationCheck>> CREATE_UPDATE_CHECKS = Lists.newArrayList(
+            DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, SchemaCheck.class,
+            UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> CREATE_CHECKS = Lists.newArrayList(
+            DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, CreationCheck.class, SchemaCheck.class,
+            UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> UPDATE_CHECKS = Lists.newArrayList(
+            DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, UpdateCheck.class, SchemaCheck.class,
+            UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> DELETE_CHECKS = Lists.newArrayList( SecurityCheck.class,
+            DeletionCheck.class );
+
+    @Bean("validatorMap")
+    public Map<ImportStrategy, List<Class<? extends ValidationCheck>>> validatorMap() {
+
+        return ImmutableMap.of(
+            ImportStrategy.CREATE_AND_UPDATE, CREATE_UPDATE_CHECKS,
+            ImportStrategy.CREATE, CREATE_CHECKS,
+            ImportStrategy.UPDATE, UPDATE_CHECKS,
+            ImportStrategy.DELETE, DELETE_CHECKS);
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -90,6 +90,7 @@ public class DefaultObjectBundleValidationService
             cleanDefaults( bundle.getPreheat(), nonPersistedObjects );
             cleanDefaults( bundle.getPreheat(), persistedObjects );
 
+            // Validate the bundle by running the validation checks chain
             validation.addTypeReport( validationFactory.validateBundle( bundle, klass, persistedObjects,
                     nonPersistedObjects ) );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -115,6 +115,7 @@ public class DefaultObjectBundleValidationService
     {
         if ( AtomicMode.NONE == bundle.getAtomicMode() )
         {
+
             return;
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -28,82 +28,43 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.attribute.AttributeService;
-import org.hisp.dhis.attribute.AttributeValue;
-import org.hisp.dhis.common.EmbeddedObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.commons.timer.SystemTimer;
 import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
-import org.hisp.dhis.feedback.TypeReport;
-import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationFactory;
 import org.hisp.dhis.logging.LoggingManager;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.preheat.Preheat;
-import org.hisp.dhis.preheat.PreheatErrorReport;
-import org.hisp.dhis.preheat.PreheatIdentifier;
-import org.hisp.dhis.schema.Property;
-import org.hisp.dhis.schema.PropertyType;
-import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
-import org.hisp.dhis.schema.validation.SchemaValidator;
-import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.util.ReflectionUtils;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserCredentials;
-import org.hisp.dhis.user.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Service( "org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService" )
 @Transactional
-public class DefaultObjectBundleValidationService implements ObjectBundleValidationService
+public class DefaultObjectBundleValidationService
+    implements
+    ObjectBundleValidationService
 {
-    private static final LoggingManager.Logger log = LoggingManager.createLogger( DefaultObjectBundleValidationService.class );
+    private static final LoggingManager.Logger log = LoggingManager
+        .createLogger( DefaultObjectBundleValidationService.class );
 
-    @Autowired
-    private SchemaService schemaService;
+    private final SchemaService schemaService;
 
-    @Autowired
-    private SchemaValidator schemaValidator;
+    private final ValidationFactory validationFactory;
 
-    @Autowired
-    private AclService aclService;
-
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private IdentifiableObjectManager objectManager;
-
-    @Autowired
-    private AttributeService attributeService;
-
-    @Autowired( required = false )
-    private List<ObjectBundleHook> objectBundleHooks = new ArrayList<>();
+    public DefaultObjectBundleValidationService( ValidationFactory validationFactory, SchemaService schemaService )
+    {
+        this.schemaService = schemaService;
+        this.validationFactory = validationFactory;
+    }
 
     @Override
     public ObjectBundleValidationReport validate( ObjectBundle bundle )
@@ -114,7 +75,8 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
         if ( (bundle.getUser() == null || bundle.getUser().isSuper()) && bundle.isSkipValidation() )
         {
-            log.warn( "Skipping validation for metadata import by user '" + bundle.getUsername() + "'. Not recommended." );
+            log.warn(
+                "Skipping validation for metadata import by user '" + bundle.getUsername() + "'. Not recommended." );
             return validation;
         }
 
@@ -122,95 +84,14 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
         for ( Class<? extends IdentifiableObject> klass : klasses )
         {
-            TypeReport typeReport = new TypeReport( klass );
-
             List<IdentifiableObject> nonPersistedObjects = bundle.getObjects( klass, false );
             List<IdentifiableObject> persistedObjects = bundle.getObjects( klass, true );
-            List<IdentifiableObject> allObjects = bundle.getObjectMap().get( klass );
 
             cleanDefaults( bundle.getPreheat(), nonPersistedObjects );
             cleanDefaults( bundle.getPreheat(), persistedObjects );
 
-            typeReport.merge( checkDuplicateIds( bundle, klass, persistedObjects, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-            if ( bundle.getImportMode().isCreateAndUpdate() )
-            {
-                typeReport.merge( runValidationHooks( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( runValidationHooks( klass, persistedObjects, bundle ) );
-                typeReport.merge( validateSecurity( klass, nonPersistedObjects, bundle, ImportStrategy.CREATE ) );
-                typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.UPDATE ) );
-                typeReport.merge( validateBySchemas( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( validateBySchemas( klass, persistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueness( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
-
-                if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
-                {
-                    typeReport.getStats().incIgnored();
-                }
-
-                typeReport.getStats().incCreated( nonPersistedObjects.size() );
-                typeReport.getStats().incUpdated( persistedObjects.size() );
-
-                typeReport.merge( checkReferences );
-            }
-            else if ( bundle.getImportMode().isCreate() )
-            {
-                typeReport.merge( runValidationHooks( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( validateSecurity( klass, nonPersistedObjects, bundle, ImportStrategy.CREATE ) );
-                typeReport.merge( validateForCreate( klass, persistedObjects, bundle ) );
-                typeReport.merge( validateBySchemas( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
-
-                if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
-                {
-                    typeReport.getStats().incIgnored();
-                }
-
-                typeReport.getStats().incCreated( nonPersistedObjects.size() );
-
-                typeReport.merge( checkReferences );
-            }
-            else if ( bundle.getImportMode().isUpdate() )
-            {
-                typeReport.merge( runValidationHooks( klass, persistedObjects, bundle ) );
-                typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.UPDATE ) );
-                typeReport.merge( validateForUpdate( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( validateBySchemas( klass, persistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
-
-                if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
-                {
-                    typeReport.getStats().incIgnored();
-                }
-
-                typeReport.getStats().incUpdated( persistedObjects.size() );
-
-                typeReport.merge( checkReferences );
-            }
-            else if ( bundle.getImportMode().isDelete() )
-            {
-                typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.DELETE ) );
-                typeReport.merge( validateForDelete( klass, nonPersistedObjects, bundle ) );
-
-                typeReport.getStats().incDeleted( persistedObjects.size() );
-            }
-
-            validation.addTypeReport( typeReport );
+            validation.addTypeReport( validationFactory.validateBundle( bundle, klass, persistedObjects,
+                    nonPersistedObjects ) );
         }
 
         validateAtomicity( bundle, validation );
@@ -226,43 +107,9 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         objects.removeIf( preheat::isDefault );
     }
 
-    //----------------------------------------------------------------------------------------------------
+    // ----------------------------------------------------------------------------------------------------
     // Helpers
-    //----------------------------------------------------------------------------------------------------
-
-    private TypeReport runValidationHooks( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = new ArrayList<>();
-            objectBundleHooks.forEach( hook -> errorReports.addAll( hook.validate( object, bundle ) ) );
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-                continue;
-            }
-        }
-
-        return typeReport;
-    }
+    // ----------------------------------------------------------------------------------------------------
 
     private void validateAtomicity( ObjectBundle bundle, ObjectBundleValidationReport validation )
     {
@@ -271,7 +118,8 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
             return;
         }
 
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> nonPersistedObjects = bundle.getObjects( false );
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> nonPersistedObjects = bundle
+            .getObjects( false );
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> persistedObjects = bundle.getObjects( true );
 
         if ( AtomicMode.ALL == bundle.getAtomicMode() )
@@ -284,247 +132,6 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         }
     }
 
-    private TypeReport validateSecurity( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle, ImportStrategy importMode )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-        PreheatIdentifier identifier = bundle.getPreheatIdentifier();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( importMode.isCreate() )
-            {
-                if ( !aclService.canCreate( bundle.getUser(), klass ) )
-                {
-                    ObjectReport objectReport = new ObjectReport( object, bundle );
-                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                    objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3000, identifier.getIdentifiersWithName( bundle.getUser() ),
-                        identifier.getIdentifiersWithName( object ) ) );
-
-                    typeReport.addObjectReport( objectReport );
-                    typeReport.getStats().incIgnored();
-
-                    iterator.remove();
-                    continue;
-                }
-            }
-            else
-            {
-                IdentifiableObject persistedObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), object );
-
-                if ( importMode.isUpdate() )
-                {
-                    if ( !aclService.canUpdate( bundle.getUser(), persistedObject ) )
-                    {
-                        ObjectReport objectReport = new ObjectReport( object, bundle );
-                        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                        objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3001, identifier.getIdentifiersWithName( bundle.getUser() ),
-                            identifier.getIdentifiersWithName( object ) ) );
-
-                        typeReport.addObjectReport( objectReport );
-                        typeReport.getStats().incIgnored();
-
-                        iterator.remove();
-                        continue;
-                    }
-                }
-                else if ( importMode.isDelete() )
-                {
-                    if ( !aclService.canDelete( bundle.getUser(), persistedObject ) )
-                    {
-                        ObjectReport objectReport = new ObjectReport( object, bundle );
-                        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                        objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3002, identifier.getIdentifiersWithName( bundle.getUser() ),
-                            identifier.getIdentifiersWithName( object ) ) );
-
-                        typeReport.addObjectReport( objectReport );
-                        typeReport.getStats().incIgnored();
-
-                        iterator.remove();
-                        continue;
-                    }
-                }
-            }
-
-            if ( User.class.isInstance( object ) )
-            {
-                User user = (User) object;
-                List<ErrorReport> errorReports = userService.validateUser( user, bundle.getUser() );
-
-                if ( !errorReports.isEmpty() )
-                {
-                    ObjectReport objectReport = new ObjectReport( object, bundle );
-                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                    objectReport.addErrorReports( errorReports );
-
-                    typeReport.addObjectReport( objectReport );
-                    typeReport.getStats().incIgnored();
-
-                    iterator.remove();
-                    continue;
-                }
-            }
-
-            List<ErrorReport> sharingErrorReports = aclService.verifySharing( object, bundle.getUser() );
-
-            if ( !sharingErrorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( sharingErrorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-                continue;
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateForCreate( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject identifiableObject = iterator.next();
-            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
-
-            if ( object != null && object.getId() > 0 )
-            {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) ).setMainId( identifiableObject.getUid() ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateForUpdate( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject identifiableObject = iterator.next();
-            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
-
-            if ( object == null || object.getId() == 0 )
-            {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                    .setErrorProperty( "id" )
-                    .setMainId( identifiableObject.getUid() ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateForDelete( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject identifiableObject = iterator.next();
-            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
-
-            if ( object == null || object.getId() == 0 )
-            {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) ).setMainId( object != null ? object.getUid() : null ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateBySchemas( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> validationErrorReports = schemaValidator.validate( object );
-
-            if ( !validationErrorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( validationErrorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
     @SuppressWarnings( "unchecked" )
     private List<Class<? extends IdentifiableObject>> getSortedClasses( ObjectBundle bundle )
     {
@@ -532,8 +139,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = bundle.getObjectMap();
 
-        schemaService.getMetadataSchemas().forEach( schema ->
-        {
+        schemaService.getMetadataSchemas().forEach( schema -> {
             Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) schema.getKlass();
 
             if ( objectMap.containsKey( klass ) )
@@ -543,423 +149,5 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         } );
 
         return klasses;
-    }
-
-    private TypeReport checkReferences( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier, boolean skipSharing )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        for ( int idx = 0; idx < objects.size(); idx++ )
-        {
-            IdentifiableObject object = objects.get( idx );
-            List<PreheatErrorReport> errorReports = checkReferences( object, preheat, identifier, skipSharing );
-
-            if ( errorReports.isEmpty() ) continue;
-
-            ObjectReport objectReport = new ObjectReport( object, bundle );
-            objectReport.addErrorReports( errorReports );
-            typeReport.addObjectReport( objectReport );
-        }
-
-        return typeReport;
-    }
-
-    private List<PreheatErrorReport> checkReferences( IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier, boolean skipSharing )
-    {
-        List<PreheatErrorReport> preheatErrorReports = new ArrayList<>();
-
-        if ( object == null )
-        {
-            return preheatErrorReports;
-        }
-
-        Schema schema = schemaService.getDynamicSchema( object.getClass() );
-        schema.getProperties().stream()
-            .filter( p -> p.isPersisted() && p.isOwner() && (PropertyType.REFERENCE == p.getPropertyType() || PropertyType.REFERENCE == p.getItemPropertyType()) )
-            .forEach( p ->
-            {
-                if ( skipCheck( p.getKlass() ) || skipCheck( p.getItemKlass() ) )
-                {
-                    return;
-                }
-
-                if ( !p.isCollection() )
-                {
-                    IdentifiableObject refObject = ReflectionUtils.invokeMethod( object, p.getGetterMethod() );
-                    IdentifiableObject ref = preheat.get( identifier, refObject );
-
-                    if ( ref == null && refObject != null && !preheat.isDefault( refObject ) )
-                    {
-                        if ( !("user".equals( p.getName() ) && User.class.isAssignableFrom( p.getKlass() ) && skipSharing) )
-                        {
-                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                                identifier.getIdentifiersWithName( refObject ), identifier.getIdentifiersWithName( object ), p.getName() ) );
-                        }
-                    }
-                }
-                else
-                {
-                    Collection<IdentifiableObject> objects = ReflectionUtils.newCollectionInstance( p.getKlass() );
-                    Collection<IdentifiableObject> refObjects = ReflectionUtils.invokeMethod( object, p.getGetterMethod() );
-
-                    for ( IdentifiableObject refObject : refObjects )
-                    {
-                        if ( preheat.isDefault( refObject ) ) continue;
-
-                        IdentifiableObject ref = preheat.get( identifier, refObject );
-
-                        if ( ref == null && refObject != null )
-                        {
-                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                                identifier.getIdentifiersWithName( refObject ), identifier.getIdentifiersWithName( object ), p.getCollectionName() ) );
-                        }
-                        else
-                        {
-                            objects.add( refObject );
-                        }
-                    }
-
-                    ReflectionUtils.invokeMethod( object, p.getSetterMethod(), objects );
-                }
-            } );
-
-        if ( schema.havePersistedProperty( "attributeValues" ) )
-        {
-            object.getAttributeValues().stream()
-                .filter( attributeValue -> attributeValue.getAttribute() != null && preheat.get( identifier, attributeValue.getAttribute() ) == null )
-                .forEach( attributeValue -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                    identifier.getIdentifiersWithName( attributeValue.getAttribute() ), identifier.getIdentifiersWithName( object ), "attributeValues" ) ) );
-        }
-
-        if ( schema.havePersistedProperty( "userGroupAccesses" ) )
-        {
-            object.getUserGroupAccesses().stream()
-                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUserGroup() != null && preheat.get( identifier, userGroupAccess.getUserGroup() ) == null )
-                .forEach( userGroupAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                    identifier.getIdentifiersWithName( userGroupAccesses.getUserGroup() ), identifier.getIdentifiersWithName( object ), "userGroupAccesses" ) ) );
-        }
-
-        if ( schema.havePersistedProperty( "userAccesses" ) )
-        {
-            object.getUserAccesses().stream()
-                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUser() != null && preheat.get( identifier, userGroupAccess.getUser() ) == null )
-                .forEach( userAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                    identifier.getIdentifiersWithName( userAccesses.getUser() ), identifier.getIdentifiersWithName( object ), "userAccesses" ) ) );
-        }
-
-        return preheatErrorReports;
-    }
-
-    private TypeReport checkDuplicateIds( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
-        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( persistedObjects.isEmpty() && nonPersistedObjects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Map<Class<?>, String> idMap = new HashMap<>();
-
-        Iterator<IdentifiableObject> iterator = persistedObjects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
-            {
-                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(), object.getClass() )
-                    .setMainId( object.getUid() ).setErrorProperty( "id" );
-
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( errorReport );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-            else
-            {
-                idMap.put( object.getClass(), object.getUid() );
-            }
-        }
-
-        iterator = nonPersistedObjects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
-            {
-                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(), object.getClass() )
-                    .setMainId( object.getUid() ).setErrorProperty( "id" );
-
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( errorReport );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-            else
-            {
-                idMap.put( object.getClass(), object.getUid() );
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport checkUniqueness( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = new ArrayList<>();
-
-            if ( User.class.isInstance( object ) )
-            {
-                User user = (User) object;
-                errorReports.addAll( checkUniqueness( User.class, user, preheat, identifier ) );
-                errorReports.addAll( checkUniqueness( UserCredentials.class, user.getUserCredentials(), preheat, identifier ) );
-            }
-            else
-            {
-                errorReports = checkUniqueness( klass, object, preheat, identifier );
-            }
-
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private List<ErrorReport> checkUniqueness( Class<? extends IdentifiableObject> klass, IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
-    {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( object == null || preheat.isDefault( object ) ) return errorReports;
-
-        if ( !preheat.getUniquenessMap().containsKey( object.getClass() ) )
-        {
-            preheat.getUniquenessMap().put( object.getClass(), new HashMap<>() );
-        }
-
-        Map<String, Map<Object, String>> uniquenessMap = preheat.getUniquenessMap().get( object.getClass() );
-
-        Schema schema = schemaService.getDynamicSchema( object.getClass() );
-        List<Property> uniqueProperties = schema.getProperties().stream()
-            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
-            .collect( Collectors.toList() );
-
-        uniqueProperties.forEach( property ->
-        {
-            if ( !uniquenessMap.containsKey( property.getName() ) )
-            {
-                uniquenessMap.put( property.getName(), new HashMap<>() );
-            }
-
-            Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
-
-            if ( value != null )
-            {
-                String persistedUid = uniquenessMap.get( property.getName() ).get( value );
-
-                if ( persistedUid != null )
-                {
-                    if ( !object.getUid().equals( persistedUid ) )
-                    {
-                        errorReports.add( new ErrorReport( object.getClass(), ErrorCode.E5003, property.getName(), value,
-                            identifier.getIdentifiersWithName( object ), persistedUid ).setMainId( persistedUid ).setErrorProperty( property.getName() ) );
-                    }
-                }
-                else
-                {
-                    uniquenessMap.get( property.getName() ).put( value, object.getUid() );
-                }
-            }
-        } );
-
-        return errorReports;
-    }
-
-    private TypeReport checkMandatoryAttributes( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-        Schema schema = schemaService.getDynamicSchema( klass );
-
-        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = checkMandatoryAttributes( klass, object, preheat, identifier );
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private List<ErrorReport> checkMandatoryAttributes( Class<? extends IdentifiableObject> klass, IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
-    {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( object == null || preheat.isDefault( object ) || !preheat.getMandatoryAttributes().containsKey( klass ) )
-        {
-            return errorReports;
-        }
-
-        Set<AttributeValue> attributeValues = object.getAttributeValues();
-        Set<String> mandatoryAttributes = new HashSet<>( preheat.getMandatoryAttributes().get( klass ) ); // make copy for modification
-
-        if ( mandatoryAttributes.isEmpty() )
-        {
-            return errorReports;
-        }
-
-        attributeValues.forEach( attributeValue -> mandatoryAttributes.remove( attributeValue.getAttribute().getUid() ) );
-        mandatoryAttributes.forEach( att -> errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4011, att )
-            .setMainId( att ).setErrorProperty( "value" ) ) );
-
-        return errorReports;
-    }
-
-    private TypeReport checkUniqueAttributes( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-        Schema schema = schemaService.getDynamicSchema( klass );
-
-        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = checkUniqueAttributes( klass, object, preheat, identifier );
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private List<ErrorReport> checkUniqueAttributes( Class<? extends IdentifiableObject> klass, IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
-    {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( object == null || preheat.isDefault( object ) || !preheat.getUniqueAttributes().containsKey( klass ) )
-        {
-            return errorReports;
-        }
-
-        Set<AttributeValue> attributeValues = object.getAttributeValues();
-        List<String> uniqueAttributes = new ArrayList<>( preheat.getUniqueAttributes().get( klass ) ); // make copy for modification
-
-        if ( !preheat.getUniqueAttributeValues().containsKey( klass ) )
-        {
-            preheat.getUniqueAttributeValues().put( klass, new HashMap<>() );
-        }
-
-        Map<String, Map<String, String>> uniqueAttributeValues = preheat.getUniqueAttributeValues().get( klass );
-
-        if ( uniqueAttributes.isEmpty() )
-        {
-            return errorReports;
-        }
-
-        attributeValues.forEach( attributeValue ->
-        {
-            Attribute attribute = preheat.get( identifier, attributeValue.getAttribute() );
-
-            if ( attribute == null || !attribute.isUnique() || StringUtils.isEmpty( attributeValue.getValue() ) )
-            {
-                return;
-            }
-
-            if ( uniqueAttributeValues.containsKey( attribute.getUid() ) )
-            {
-                Map<String, String> values = uniqueAttributeValues.get( attribute.getUid() );
-
-                if ( values.containsKey( attributeValue.getValue() ) && !values.get( attributeValue.getValue() ).equals( object.getUid() ) )
-                {
-                    errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4009, IdentifiableObjectUtils.getDisplayName( attribute ),
-                        attributeValue.getValue() ).setMainId( attribute.getUid() ).setErrorProperty( "value" ) );
-                }
-                else
-                {
-                    uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
-                }
-            }
-            else
-            {
-                uniqueAttributeValues.put( attribute.getUid(), new HashMap<>() );
-                uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
-            }
-        } );
-
-        return errorReports;
-    }
-
-    private boolean skipCheck( Class<?> klass )
-    {
-        return klass != null && (UserCredentials.class.isAssignableFrom( klass ) || EmbeddedObject.class.isAssignableFrom( klass ) ||
-            Period.class.isAssignableFrom( klass ) || PeriodType.class.isAssignableFrom( klass ));
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class CreationCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( persistedObjects == null || persistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = persistedObjects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject identifiableObject = iterator.next();
+            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+
+            if ( object != null && object.getId() > 0 )
+            {
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object.getUid() );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setMainId( identifiableObject.getUid() ) );
+
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObject;
@@ -50,7 +49,7 @@ public class CreationCheck
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext ctx )
     {
         TypeReport typeReport = new TypeReport( klass );
 
@@ -59,25 +58,19 @@ public class CreationCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = persistedObjects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject identifiableObject : persistedObjects )
         {
-            IdentifiableObject identifiableObject = iterator.next();
             IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
 
             if ( object != null && object.getId() > 0 )
             {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
+                ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setMainId( identifiableObject.getUid() ) );
+                        .setMainId( identifiableObject.getUid() );
 
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
+                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
 
-                iterator.remove();
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObject;
@@ -50,7 +49,7 @@ public class DeletionCheck
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext ctx )
     {
         TypeReport typeReport = new TypeReport( klass );
 
@@ -59,26 +58,17 @@ public class DeletionCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = nonPersistedObjects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject identifiableObject : nonPersistedObjects )
         {
-            IdentifiableObject identifiableObject = iterator.next();
             IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
 
             if ( object == null || object.getId() == 0 )
             {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle,
-                    object == null ? null : object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setMainId( object != null ? object.getUid() : null ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
+                ErrorReport errorReport = new ErrorReport(klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
+                        bundle.getPreheatIdentifier().getIdentifiersWithName(identifiableObject))
+                        .setMainId(object != null ? object.getUid() : null);
+                ValidationUtils.addObjectReport(errorReport, typeReport, object, bundle);
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
@@ -1,0 +1,87 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DeletionCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( nonPersistedObjects == null || nonPersistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = nonPersistedObjects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject identifiableObject = iterator.next();
+            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+
+            if ( object == null || object.getId() == 0 )
+            {
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle,
+                    object == null ? null : object.getUid() );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setMainId( object != null ? object.getUid() : null ) );
+
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DuplicateIdsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DuplicateIdsCheck.java
@@ -1,0 +1,120 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DuplicateIdsCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( persistedObjects.isEmpty() && nonPersistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Map<Class<?>, String> idMap = new HashMap<>();
+
+        Iterator<IdentifiableObject> iterator = persistedObjects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+
+            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
+            {
+                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(),
+                    object.getClass() ).setMainId( object.getUid() ).setErrorProperty( "id" );
+
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReport( errorReport );
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+            else
+            {
+                idMap.put( object.getClass(), object.getUid() );
+            }
+        }
+
+        iterator = nonPersistedObjects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+
+            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
+            {
+                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(),
+                    object.getClass() ).setMainId( object.getUid() ).setErrorProperty( "id" );
+
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReport( errorReport );
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+            else
+            {
+                idMap.put( object.getClass(), object.getUid() );
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DuplicateIdsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DuplicateIdsCheck.java
@@ -55,7 +55,6 @@ public class DuplicateIdsCheck
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
         ImportStrategy importStrategy, ValidationContext context )
     {
-
         TypeReport typeReport = new TypeReport( klass );
 
         if ( persistedObjects.isEmpty() && nonPersistedObjects.isEmpty() )
@@ -65,33 +64,15 @@ public class DuplicateIdsCheck
 
         Map<Class<?>, String> idMap = new HashMap<>();
 
-        Iterator<IdentifiableObject> iterator = persistedObjects.iterator();
+        typeReport.merge( run( typeReport, bundle, persistedObjects.iterator(), idMap ));
+        typeReport.merge( run( typeReport, bundle, nonPersistedObjects.iterator(), idMap ));
 
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
-            {
-                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(),
-                    object.getClass() ).setMainId( object.getUid() ).setErrorProperty( "id" );
-
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( errorReport );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-            else
-            {
-                idMap.put( object.getClass(), object.getUid() );
-            }
-        }
-
-        iterator = nonPersistedObjects.iterator();
-
+        return typeReport;
+    }
+    
+    private TypeReport run( TypeReport typeReport, ObjectBundle bundle, Iterator<IdentifiableObject> iterator,
+        Map<Class<?>, String> idMap )
+    {
         while ( iterator.hasNext() )
         {
             IdentifiableObject object = iterator.next();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
@@ -47,6 +47,8 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.schema.Schema;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+
 /**
  * @author Luciano Fiandesio
  */
@@ -78,11 +80,7 @@ public class MandatoryAttributesCheck
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
+                addObjectReport( errorReports, typeReport, object, bundle );
 
                 iterator.remove();
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
@@ -1,0 +1,120 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.schema.Schema;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class MandatoryAttributesCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+        Schema schema = ctx.getSchemaService().getDynamicSchema( klass );
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+            List<ErrorReport> errorReports = checkMandatoryAttributes( klass, object, bundle.getPreheat() );
+
+            if ( !errorReports.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReports( errorReports );
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+    }
+
+    private List<ErrorReport> checkMandatoryAttributes( Class<? extends IdentifiableObject> klass,
+        IdentifiableObject object, Preheat preheat )
+    {
+        List<ErrorReport> errorReports = new ArrayList<>();
+
+        if ( object == null || preheat.isDefault( object ) || !preheat.getMandatoryAttributes().containsKey( klass ) )
+        {
+            return errorReports;
+        }
+
+        Set<AttributeValue> attributeValues = object.getAttributeValues();
+        Set<String> mandatoryAttributes = new HashSet<>( preheat.getMandatoryAttributes().get( klass ) ); // make copy
+                                                                                                          // for
+                                                                                                          // modification
+        if ( mandatoryAttributes.isEmpty() )
+        {
+            return errorReports;
+        }
+
+        attributeValues
+            .forEach( attributeValue -> mandatoryAttributes.remove( attributeValue.getAttribute().getUid() ) );
+        mandatoryAttributes.forEach( att -> errorReports.add(
+            new ErrorReport( Attribute.class, ErrorCode.E4011, att ).setMainId( att ).setErrorProperty( "value" ) ) );
+
+        return errorReports;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
@@ -28,26 +28,23 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.schema.Schema;
-
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
 
 /**
  * @author Luciano Fiandesio
@@ -71,18 +68,15 @@ public class MandatoryAttributesCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject object : objects )
         {
-            IdentifiableObject object = iterator.next();
             List<ErrorReport> errorReports = checkMandatoryAttributes( klass, object, bundle.getPreheat() );
 
             if ( !errorReports.isEmpty() )
             {
-                addObjectReport( errorReports, typeReport, object, bundle );
+                addObjectReports( errorReports, typeReport, object, bundle );
 
-                iterator.remove();
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
@@ -1,0 +1,204 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.hisp.dhis.common.EmbeddedObject;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.AtomicMode;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatErrorReport;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserCredentials;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ReferencesCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = ValidationUtils.joinObjects( persistedObjects, nonPersistedObjects );
+
+        if ( objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<PreheatErrorReport> errorReports = checkReferences( object, bundle.getPreheat(),
+                bundle.getPreheatIdentifier(), bundle.isSkipSharing(), ctx );
+
+            if ( errorReports.isEmpty() )
+                continue;
+
+            ObjectReport objectReport = new ObjectReport( object, bundle );
+            objectReport.addErrorReports( errorReports );
+            typeReport.addObjectReport( objectReport );
+        }
+
+        if ( !typeReport.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
+        {
+            typeReport.getStats().incIgnored();
+        }
+
+        return typeReport;
+    }
+
+    private List<PreheatErrorReport> checkReferences( IdentifiableObject object, Preheat preheat,
+        PreheatIdentifier identifier, boolean skipSharing, ValidationContext ctx )
+    {
+        List<PreheatErrorReport> preheatErrorReports = new ArrayList<>();
+
+        if ( object == null )
+        {
+            return preheatErrorReports;
+        }
+
+        Schema schema = ctx.getSchemaService().getDynamicSchema( object.getClass() );
+        schema.getProperties().stream().filter( p -> p.isPersisted() && p.isOwner()
+            && (PropertyType.REFERENCE == p.getPropertyType() || PropertyType.REFERENCE == p.getItemPropertyType()) )
+            .forEach( p -> {
+                if ( skipCheck( p.getKlass() ) || skipCheck( p.getItemKlass() ) )
+                {
+                    return;
+                }
+
+                if ( !p.isCollection() )
+                {
+                    IdentifiableObject refObject = ReflectionUtils.invokeMethod( object, p.getGetterMethod() );
+                    IdentifiableObject ref = preheat.get( identifier, refObject );
+
+                    if ( ref == null && refObject != null && !preheat.isDefault( refObject ) )
+                    {
+                        if ( !("user".equals( p.getName() ) && User.class.isAssignableFrom( p.getKlass() )
+                            && skipSharing) )
+                        {
+                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                                ErrorCode.E5002, identifier.getIdentifiersWithName( refObject ),
+                                identifier.getIdentifiersWithName( object ), p.getName() ) );
+                        }
+                    }
+                }
+                else
+                {
+                    Collection<IdentifiableObject> objects = ReflectionUtils.newCollectionInstance( p.getKlass() );
+                    Collection<IdentifiableObject> refObjects = ReflectionUtils.invokeMethod( object,
+                        p.getGetterMethod() );
+
+                    for ( IdentifiableObject refObject : refObjects )
+                    {
+                        if ( preheat.isDefault( refObject ) )
+                            continue;
+
+                        IdentifiableObject ref = preheat.get( identifier, refObject );
+
+                        if ( ref == null && refObject != null )
+                        {
+                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                                ErrorCode.E5002, identifier.getIdentifiersWithName( refObject ),
+                                identifier.getIdentifiersWithName( object ), p.getCollectionName() ) );
+                        }
+                        else
+                        {
+                            objects.add( refObject );
+                        }
+                    }
+
+                    ReflectionUtils.invokeMethod( object, p.getSetterMethod(), objects );
+                }
+            } );
+
+        if ( schema.havePersistedProperty( "attributeValues" ) )
+        {
+            object.getAttributeValues().stream()
+                .filter( attributeValue -> attributeValue.getAttribute() != null
+                    && preheat.get( identifier, attributeValue.getAttribute() ) == null )
+                .forEach(
+                    attributeValue -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                        ErrorCode.E5002, identifier.getIdentifiersWithName( attributeValue.getAttribute() ),
+                        identifier.getIdentifiersWithName( object ), "attributeValues" ) ) );
+        }
+
+        if ( schema.havePersistedProperty( "userGroupAccesses" ) )
+        {
+            object.getUserGroupAccesses().stream()
+                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUserGroup() != null
+                    && preheat.get( identifier, userGroupAccess.getUserGroup() ) == null )
+                .forEach(
+                    userGroupAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                        ErrorCode.E5002, identifier.getIdentifiersWithName( userGroupAccesses.getUserGroup() ),
+                        identifier.getIdentifiersWithName( object ), "userGroupAccesses" ) ) );
+        }
+
+        if ( schema.havePersistedProperty( "userAccesses" ) )
+        {
+            object.getUserAccesses().stream()
+                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUser() != null
+                    && preheat.get( identifier, userGroupAccess.getUser() ) == null )
+                .forEach( userAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier,
+                    object.getClass(), ErrorCode.E5002, identifier.getIdentifiersWithName( userAccesses.getUser() ),
+                    identifier.getIdentifiersWithName( object ), "userAccesses" ) ) );
+        }
+
+
+        return preheatErrorReports;
+    }
+
+    private boolean skipCheck( Class<?> klass )
+    {
+        return klass != null
+            && (UserCredentials.class.isAssignableFrom( klass ) || EmbeddedObject.class.isAssignableFrom( klass )
+                || Period.class.isAssignableFrom( klass ) || PeriodType.class.isAssignableFrom( klass ));
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
@@ -39,6 +39,8 @@ import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+
 /**
  * @author Luciano Fiandesio
  */
@@ -69,13 +71,8 @@ public class SchemaCheck
 
             if ( !validationErrorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( validationErrorReports );
 
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
+                addObjectReport( validationErrorReports, typeReport, object, bundle );
                 iterator.remove();
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class SchemaCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects == null || objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+            List<ErrorReport> validationErrorReports = context.getSchemaValidator().validate( object );
+
+            if ( !validationErrorReports.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReports( validationErrorReports );
+
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
@@ -28,18 +28,15 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Iterator;
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
-
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
 
 /**
  * @author Luciano Fiandesio
@@ -62,18 +59,14 @@ public class SchemaCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject object : objects )
         {
-            IdentifiableObject object = iterator.next();
             List<ErrorReport> validationErrorReports = context.getSchemaValidator().validate( object );
 
             if ( !validationErrorReports.isEmpty() )
             {
-
-                addObjectReport( validationErrorReports, typeReport, object, bundle );
-                iterator.remove();
+                addObjectReports( validationErrorReports, typeReport, object, bundle );
+                context.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
@@ -1,0 +1,191 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.user.User;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class SecurityCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+                             ImportStrategy importStrategy, ValidationContext context )
+    {
+
+        if ( importStrategy.isCreateAndUpdate() )
+        {
+            TypeReport report = runValidationCheck( bundle, klass, persistedObjects, ImportStrategy.UPDATE, context );
+            report.merge( runValidationCheck( bundle, klass, nonPersistedObjects, ImportStrategy.CREATE, context ) );
+            return report;
+        }
+        else if ( importStrategy.isCreate() )
+        {
+            return runValidationCheck( bundle, klass, nonPersistedObjects, ImportStrategy.CREATE, context );
+        }
+        else if ( importStrategy.isUpdate() )
+        {
+            return runValidationCheck( bundle, klass, persistedObjects, ImportStrategy.UPDATE, context );
+        }
+        else
+        {
+            return new TypeReport( klass );
+        }
+
+    }
+
+    private TypeReport runValidationCheck( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> objects, ImportStrategy importMode, ValidationContext ctx )
+    {
+
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( objects == null || objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+        PreheatIdentifier identifier = bundle.getPreheatIdentifier();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+
+            if ( importMode.isCreate() )
+            {
+                if ( !ctx.getAclService().canCreate( bundle.getUser(), klass ) )
+                {
+                    ObjectReport objectReport = new ObjectReport( object, bundle );
+                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                    objectReport.addErrorReport(
+                        new ErrorReport( klass, ErrorCode.E3000, identifier.getIdentifiersWithName( bundle.getUser() ),
+                            identifier.getIdentifiersWithName( object ) ) );
+
+                    typeReport.addObjectReport( objectReport );
+                    typeReport.getStats().incIgnored();
+
+                    iterator.remove();
+                    continue;
+                }
+            }
+            else
+            {
+                IdentifiableObject persistedObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), object );
+
+                if ( importMode.isUpdate() )
+                {
+                    if ( !ctx.getAclService().canUpdate( bundle.getUser(), persistedObject ) )
+                    {
+                        ObjectReport objectReport = new ObjectReport( object, bundle );
+                        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                        objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3001,
+                            identifier.getIdentifiersWithName( bundle.getUser() ),
+                            identifier.getIdentifiersWithName( object ) ) );
+
+                        typeReport.addObjectReport( objectReport );
+                        typeReport.getStats().incIgnored();
+
+                        iterator.remove();
+                        continue;
+                    }
+                }
+                else if ( importMode.isDelete() )
+                {
+                    if ( !ctx.getAclService().canDelete( bundle.getUser(), persistedObject ) )
+                    {
+                        ObjectReport objectReport = new ObjectReport( object, bundle );
+                        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                        objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3002,
+                            identifier.getIdentifiersWithName( bundle.getUser() ),
+                            identifier.getIdentifiersWithName( object ) ) );
+
+                        typeReport.addObjectReport( objectReport );
+                        typeReport.getStats().incIgnored();
+
+                        iterator.remove();
+                        continue;
+                    }
+                }
+            }
+
+            if ( object instanceof User )
+            {
+                User user = (User) object;
+                List<ErrorReport> errorReports = ctx.getUserService().validateUser( user, bundle.getUser() );
+
+                if ( !errorReports.isEmpty() )
+                {
+                    ObjectReport objectReport = new ObjectReport( object, bundle );
+                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                    objectReport.addErrorReports( errorReports );
+
+                    typeReport.addObjectReport( objectReport );
+                    typeReport.getStats().incIgnored();
+
+                    iterator.remove();
+                    continue;
+                }
+            }
+
+            List<ErrorReport> sharingErrorReports = ctx.getAclService().verifySharing( object, bundle.getUser() );
+
+            if ( !sharingErrorReports.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReports( sharingErrorReports );
+
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+                continue;
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
@@ -42,6 +42,8 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.user.User;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+
 /**
  * @author Luciano Fiandesio
  */
@@ -52,7 +54,7 @@ public class SecurityCheck
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-                             ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext context )
     {
 
         if ( importStrategy.isCreateAndUpdate() )
@@ -156,36 +158,24 @@ public class SecurityCheck
                 User user = (User) object;
                 List<ErrorReport> errorReports = ctx.getUserService().validateUser( user, bundle.getUser() );
 
-                if ( !errorReports.isEmpty() )
-                {
-                    ObjectReport objectReport = new ObjectReport( object, bundle );
-                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                    objectReport.addErrorReports( errorReports );
+                if ( !errorReports.isEmpty() ) {
 
-                    typeReport.addObjectReport( objectReport );
-                    typeReport.getStats().incIgnored();
-
+                    addObjectReport( errorReports, typeReport, object, bundle );
                     iterator.remove();
-                    continue;
                 }
             }
 
             List<ErrorReport> sharingErrorReports = ctx.getAclService().verifySharing( object, bundle.getUser() );
-
             if ( !sharingErrorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( sharingErrorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
+                addObjectReport( sharingErrorReports, typeReport, object, bundle );
                 iterator.remove();
-                continue;
+
             }
         }
 
         return typeReport;
     }
+
+
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
@@ -98,8 +98,9 @@ public class SecurityCheck
             {
                 if ( !ctx.getAclService().canCreate( bundle.getUser(), klass ) )
                 {
-                    ErrorReport errorReport =  new ErrorReport( klass, ErrorCode.E3000, identifier.getIdentifiersWithName( bundle.getUser() ),
-                            identifier.getIdentifiersWithName( object ) );
+                    ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E3000,
+                        identifier.getIdentifiersWithName( bundle.getUser() ),
+                        identifier.getIdentifiersWithName( object ) );
 
                     ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
                     ctx.markForRemoval( object );
@@ -127,9 +128,9 @@ public class SecurityCheck
                 {
                     if ( !ctx.getAclService().canDelete( bundle.getUser(), persistedObject ) )
                     {
-                        ErrorReport errorReport = new ErrorReport(klass, ErrorCode.E3002,
-                                identifier.getIdentifiersWithName(bundle.getUser()),
-                                identifier.getIdentifiersWithName(object));
+                        ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E3002,
+                            identifier.getIdentifiersWithName( bundle.getUser() ),
+                            identifier.getIdentifiersWithName( object ) );
 
                         ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -43,7 +45,6 @@ import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.Preheat;
@@ -82,12 +83,8 @@ public class UniqueAttributesCheck
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
 
+                addObjectReport( errorReports, typeReport, object, bundle );
                 iterator.remove();
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
@@ -28,11 +28,10 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -74,18 +73,16 @@ public class UniqueAttributesCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject object : objects )
         {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = checkUniqueAttributes( klass, object, bundle.getPreheat(), bundle.getPreheatIdentifier() );
+            List<ErrorReport> errorReports = checkUniqueAttributes( klass, object, bundle.getPreheat(),
+                bundle.getPreheatIdentifier() );
 
             if ( !errorReports.isEmpty() )
             {
 
-                addObjectReport( errorReports, typeReport, object, bundle );
-                iterator.remove();
+                addObjectReports( errorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
@@ -1,0 +1,157 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.Schema;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UniqueAttributesCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+        Schema schema = ctx.getSchemaService().getDynamicSchema( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+            List<ErrorReport> errorReports = checkUniqueAttributes( klass, object, bundle.getPreheat(), bundle.getPreheatIdentifier() );
+
+            if ( !errorReports.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReports( errorReports );
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+    }
+
+    private List<ErrorReport> checkUniqueAttributes( Class<? extends IdentifiableObject> klass,
+        IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
+    {
+        List<ErrorReport> errorReports = new ArrayList<>();
+
+        if ( object == null || preheat.isDefault( object ) || !preheat.getUniqueAttributes().containsKey( klass ) )
+        {
+            return errorReports;
+        }
+
+        Set<AttributeValue> attributeValues = object.getAttributeValues();
+        List<String> uniqueAttributes = new ArrayList<>( preheat.getUniqueAttributes().get( klass ) ); // make copy for
+                                                                                                       // modification
+
+        if ( !preheat.getUniqueAttributeValues().containsKey( klass ) )
+        {
+            preheat.getUniqueAttributeValues().put( klass, new HashMap<>() );
+        }
+
+        Map<String, Map<String, String>> uniqueAttributeValues = preheat.getUniqueAttributeValues().get( klass );
+
+        if ( uniqueAttributes.isEmpty() )
+        {
+            return errorReports;
+        }
+
+        attributeValues.forEach( attributeValue -> {
+            Attribute attribute = preheat.get( identifier, attributeValue.getAttribute() );
+
+            if ( attribute == null || !attribute.isUnique() || StringUtils.isEmpty( attributeValue.getValue() ) )
+            {
+                return;
+            }
+
+            if ( uniqueAttributeValues.containsKey( attribute.getUid() ) )
+            {
+                Map<String, String> values = uniqueAttributeValues.get( attribute.getUid() );
+
+                if ( values.containsKey( attributeValue.getValue() )
+                    && !values.get( attributeValue.getValue() ).equals( object.getUid() ) )
+                {
+                    errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4009,
+                        IdentifiableObjectUtils.getDisplayName( attribute ), attributeValue.getValue() )
+                            .setMainId( attribute.getUid() ).setErrorProperty( "value" ) );
+                }
+                else
+                {
+                    uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
+                }
+            }
+            else
+            {
+                uniqueAttributeValues.put( attribute.getUid(), new HashMap<>() );
+                uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
+            }
+        } );
+
+        return errorReports;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,11 +38,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.Preheat;
@@ -85,7 +85,7 @@ public class UniquenessCheck
             IdentifiableObject object = iterator.next();
             List<ErrorReport> errorReports = new ArrayList<>();
 
-            if ( User.class.isInstance( object ) )
+            if ( object instanceof User )
             {
                 User user = (User) object;
                 errorReports.addAll( checkUniqueness( user, bundle.getPreheat(), bundle.getPreheatIdentifier(), ctx ) );
@@ -99,12 +99,7 @@ public class UniquenessCheck
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
+                addObjectReport( errorReports, typeReport, object, bundle );
                 iterator.remove();
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
@@ -28,11 +28,10 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -63,7 +62,6 @@ public class UniquenessCheck
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
         ImportStrategy importStrategy, ValidationContext ctx )
     {
-
         TypeReport typeReport = new TypeReport( klass );
 
         List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
@@ -73,11 +71,8 @@ public class UniquenessCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject object : objects )
         {
-            IdentifiableObject object = iterator.next();
             List<ErrorReport> errorReports = new ArrayList<>();
 
             if ( object instanceof User )
@@ -94,8 +89,8 @@ public class UniquenessCheck
 
             if ( !errorReports.isEmpty() )
             {
-                addObjectReport( errorReports, typeReport, object, bundle );
-                iterator.remove();
+                addObjectReports( errorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
@@ -58,11 +58,6 @@ public class UniquenessCheck
     ValidationCheck
 {
 
-    // private TypeReport checkUniqueness( ObjectBundle bundle, Class<? extends
-    // IdentifiableObject> klass, List<IdentifiableObject> objects,
-    // Preheat preheat, PreheatIdentifier identifier )
-    //
-
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
@@ -1,0 +1,167 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.user.User;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UniquenessCheck
+    implements
+    ValidationCheck
+{
+
+    // private TypeReport checkUniqueness( ObjectBundle bundle, Class<? extends
+    // IdentifiableObject> klass, List<IdentifiableObject> objects,
+    // Preheat preheat, PreheatIdentifier identifier )
+    //
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+            List<ErrorReport> errorReports = new ArrayList<>();
+
+            if ( User.class.isInstance( object ) )
+            {
+                User user = (User) object;
+                errorReports.addAll( checkUniqueness( user, bundle.getPreheat(), bundle.getPreheatIdentifier(), ctx ) );
+                errorReports.addAll( checkUniqueness( user.getUserCredentials(), bundle.getPreheat(),
+                    bundle.getPreheatIdentifier(), ctx ) );
+            }
+            else
+            {
+                errorReports = checkUniqueness( object, bundle.getPreheat(), bundle.getPreheatIdentifier(), ctx );
+            }
+
+            if ( !errorReports.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReports( errorReports );
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+
+    }
+
+    private List<ErrorReport> checkUniqueness( IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier,
+        ValidationContext ctx )
+    {
+        List<ErrorReport> errorReports = new ArrayList<>();
+
+        if ( object == null || preheat.isDefault( object ) )
+            return errorReports;
+
+        if ( !preheat.getUniquenessMap().containsKey( object.getClass() ) )
+        {
+            preheat.getUniquenessMap().put( object.getClass(), new HashMap<>() );
+        }
+
+        Map<String, Map<Object, String>> uniquenessMap = preheat.getUniquenessMap().get( object.getClass() );
+
+        Schema schema = ctx.getSchemaService().getDynamicSchema( object.getClass() );
+        List<Property> uniqueProperties = schema.getProperties().stream()
+            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
+            .collect( Collectors.toList() );
+
+        uniqueProperties.forEach( property -> {
+            if ( !uniquenessMap.containsKey( property.getName() ) )
+            {
+                uniquenessMap.put( property.getName(), new HashMap<>() );
+            }
+
+            Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
+
+            if ( value != null )
+            {
+                String persistedUid = uniquenessMap.get( property.getName() ).get( value );
+
+                if ( persistedUid != null )
+                {
+                    if ( !object.getUid().equals( persistedUid ) )
+                    {
+                        errorReports.add( new ErrorReport( object.getClass(), ErrorCode.E5003, property.getName(),
+                            value, identifier.getIdentifiersWithName( object ), persistedUid ).setMainId( persistedUid )
+                                .setErrorProperty( property.getName() ) );
+                    }
+                }
+                else
+                {
+                    uniquenessMap.get( property.getName() ).put( value, object.getUid() );
+                }
+            }
+        } );
+
+        return errorReports;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObject;
@@ -50,7 +49,7 @@ public class UpdateCheck
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext ctx )
     {
         TypeReport typeReport = new TypeReport( klass );
 
@@ -59,26 +58,18 @@ public class UpdateCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = nonPersistedObjects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject identifiableObject : nonPersistedObjects )
         {
-            IdentifiableObject identifiableObject = iterator.next();
             IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
 
             if ( object == null || object.getId() == 0 )
             {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle,
-                    object == null ? null : object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
+                ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() ) );
+                        .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() );
 
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
+                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
 
 /**
  * @author Luciano Fiandesio
@@ -49,7 +50,7 @@ public class UpdateCheck
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext context )
     {
         TypeReport typeReport = new TypeReport( klass );
 
@@ -67,12 +68,12 @@ public class UpdateCheck
 
             if ( object == null || object.getId() == 0 )
             {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle,
+                    object == null ? null : object.getUid() );
                 objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
                 objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
-                        bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setErrorProperty( "id" )
-                        .setMainId( identifiableObject.getUid() ) );
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() ) );
 
                 typeReport.addObjectReport( objectReport );
                 typeReport.getStats().incIgnored();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UpdateCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ValidationContext context )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( nonPersistedObjects == null || nonPersistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = nonPersistedObjects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject identifiableObject = iterator.next();
+            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+
+            if ( object == null || object.getId() == 0 )
+            {
+                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
+                        bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setErrorProperty( "id" )
+                        .setMainId( identifiableObject.getUid() ) );
+
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationCheck.java
@@ -1,0 +1,83 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public interface ValidationCheck
+{
+
+    /**
+     *
+     * @param bundle
+     * @param klass
+     * @param persistedObjects
+     * @param nonPersistedObjects
+     * @param importStrategy
+     * @param context
+     * @return
+     */
+    TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context );
+
+
+    default List<IdentifiableObject> selectObjects( List<IdentifiableObject> persistedObjects,
+        List<IdentifiableObject> nonPersistedObjects, ImportStrategy importStrategy )
+    {
+
+        if ( importStrategy.isCreateAndUpdate() )
+        {
+            return ValidationUtils.joinObjects( persistedObjects, nonPersistedObjects );
+        }
+        else if ( importStrategy.isCreate() )
+        {
+            return nonPersistedObjects;
+        }
+        else if ( importStrategy.isUpdate() )
+        {
+            return persistedObjects;
+        }
+        else
+        {
+            return Collections.emptyList();
+        }
+
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationContext.java
@@ -28,8 +28,10 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleHook;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.validation.SchemaValidator;
@@ -51,6 +53,8 @@ public class ValidationContext
     private UserService userService;
 
     private SchemaService schemaService;
+
+    private List<IdentifiableObject> markedForRemoval = new ArrayList<>();
 
     public ValidationContext( List<ObjectBundleHook> objectBundleHooks, SchemaValidator schemaValidator,
         AclService aclService, UserService userService, SchemaService schemaService )
@@ -85,5 +89,15 @@ public class ValidationContext
     public SchemaService getSchemaService()
     {
         return schemaService;
+    }
+
+    public void markForRemoval( IdentifiableObject object )
+    {
+        this.markedForRemoval.add( object );
+    }
+
+    public List<IdentifiableObject> getMarkedForRemoval()
+    {
+        return markedForRemoval;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationContext.java
@@ -1,0 +1,89 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleHook;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.UserService;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationContext
+{
+
+    private List<ObjectBundleHook> objectBundleHooks;
+
+    private SchemaValidator schemaValidator;
+
+    private AclService aclService;
+
+    private UserService userService;
+
+    private SchemaService schemaService;
+
+    public ValidationContext( List<ObjectBundleHook> objectBundleHooks, SchemaValidator schemaValidator,
+        AclService aclService, UserService userService, SchemaService schemaService )
+    {
+        this.objectBundleHooks = objectBundleHooks;
+        this.schemaValidator = schemaValidator;
+        this.aclService = aclService;
+        this.userService = userService;
+        this.schemaService = schemaService;
+    }
+
+    public List<ObjectBundleHook> getObjectBundleHooks()
+    {
+        return objectBundleHooks;
+    }
+
+    public SchemaValidator getSchemaValidator()
+    {
+        return schemaValidator;
+    }
+
+    public AclService getAclService()
+    {
+        return aclService;
+    }
+
+    public UserService getUserService()
+    {
+        return userService;
+    }
+
+    public SchemaService getSchemaService()
+    {
+        return schemaService;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
@@ -78,9 +80,11 @@ public class ValidationFactory
         DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, SchemaCheck.class,
         UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
 
-    private final static List<Class<? extends ValidationCheck>> CREATE = CREATE_UPDATE; // + CreationCheck
+    private final static List<Class<? extends ValidationCheck>> CREATE = Stream
+        .concat( CREATE_UPDATE.stream(), Stream.of( CreationCheck.class ) ).collect( Collectors.toList() );
 
-    private final static List<Class<? extends ValidationCheck>> UPDATE = CREATE_UPDATE; // + UpdateCheck
+    private final static List<Class<? extends ValidationCheck>> UPDATE = Stream
+        .concat( CREATE_UPDATE.stream(), Stream.of( UpdateCheck.class ) ).collect( Collectors.toList() );
 
     private final static List<Class<? extends ValidationCheck>> DELETE = Lists.newArrayList( SecurityCheck.class,
         DeletionCheck.class );
@@ -96,15 +100,8 @@ public class ValidationFactory
     {
         return new ValidationRunner( validatorMap.get( bundle.getImportMode() ) ).executeValidationChain( bundle, klass,
             persistedObjects, nonPersistedObjects, getContext() );
-
-
-
-        
     }
 
-    
-    
-    
     private ValidationContext getContext()
     {
         return new ValidationContext( this.objectBundleHooks, this.schemaValidator, this.aclService, this.userService,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
@@ -1,0 +1,173 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleHook;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.UserService;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Component
+@SuppressWarnings( "unchecked" )
+public class ValidationFactory
+{
+
+    private final SchemaValidator schemaValidator;
+
+    private final SchemaService schemaService;
+    
+    private final AclService aclService;
+
+    private final UserService userService;
+
+    private List<ObjectBundleHook> objectBundleHooks;
+
+    public ValidationFactory(SchemaValidator schemaValidator, SchemaService schemaService, AclService aclService, UserService userService,
+                             List<ObjectBundleHook> objectBundleHooks )
+    {
+        this.schemaValidator = schemaValidator;
+        this.schemaService = schemaService;
+        this.aclService = aclService;
+        this.userService = userService;
+        this.objectBundleHooks = objectBundleHooks == null ? Collections.emptyList() : objectBundleHooks;
+    }
+
+    private final static List<Class<? extends ValidationCheck>> CREATE_UPDATE = Lists.newArrayList(
+        DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, SchemaCheck.class,
+        UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> CREATE = CREATE_UPDATE; // + CreationCheck
+
+    private final static List<Class<? extends ValidationCheck>> UPDATE = CREATE_UPDATE; // + UpdateCheck
+
+    private final static List<Class<? extends ValidationCheck>> DELETE = Lists.newArrayList( SecurityCheck.class,
+        DeletionCheck.class );
+
+    private final static Map<ImportStrategy, List<Class<? extends ValidationCheck>>> validatorMap = ImmutableMap.of(
+        ImportStrategy.CREATE_AND_UPDATE, CREATE_UPDATE, 
+        ImportStrategy.CREATE, CREATE, 
+        ImportStrategy.UPDATE, UPDATE,
+        ImportStrategy.DELETE, DELETE );
+
+    public TypeReport validateBundle( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects)
+    {
+        return new ValidationRunner( validatorMap.get( bundle.getImportMode() ) ).executeValidationChain( bundle, klass,
+            persistedObjects, nonPersistedObjects, getContext() );
+
+
+
+        
+    }
+
+    
+    
+    
+    private ValidationContext getContext()
+    {
+        return new ValidationContext( this.objectBundleHooks, this.schemaValidator, this.aclService, this.userService,
+            this.schemaService );
+    }
+    
+    static class ValidationRunner
+    {
+
+        private List<Class<? extends ValidationCheck>> validators;
+
+        public ValidationRunner( List<Class<? extends ValidationCheck>> validators )
+        {
+            this.validators = validators;
+        }
+
+        public TypeReport executeValidationChain( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+            List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+            ValidationContext ctx )
+        {
+
+            TypeReport typeReport = new TypeReport( klass );
+            for ( Class<? extends ValidationCheck> validator : validators )
+            {
+                try
+                {
+                    ValidationCheck validationCheck = validator.newInstance();
+                    typeReport.merge( validationCheck.check( bundle, klass, persistedObjects, nonPersistedObjects,
+                        bundle.getImportMode(), ctx ) );
+                }
+                catch ( InstantiationException | IllegalAccessException e )
+                {
+                    e.printStackTrace(); // TODO
+                }
+            }
+            return addStatistics( typeReport, bundle, persistedObjects, nonPersistedObjects );
+        }
+
+        private TypeReport addStatistics( TypeReport typeReport, ObjectBundle bundle,
+                                          List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects )
+        {
+            if ( bundle.getImportMode().isCreateAndUpdate() )
+            {
+                typeReport.getStats().incCreated( nonPersistedObjects.size() );
+                typeReport.getStats().incUpdated( persistedObjects.size() );
+
+            }
+            else if ( bundle.getImportMode().isCreate() )
+            {
+                typeReport.getStats().incCreated( nonPersistedObjects.size() );
+
+            }
+            else if ( bundle.getImportMode().isUpdate() )
+            {
+                typeReport.getStats().incUpdated( persistedObjects.size() );
+
+            }
+            else if ( bundle.getImportMode().isDelete() )
+            {
+                typeReport.getStats().incDeleted( persistedObjects.size() );
+            }
+            return typeReport;
+        }
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
@@ -1,0 +1,90 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationHooksCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects == null || objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+            List<ErrorReport> errorReports = new ArrayList<>();
+            ctx.getObjectBundleHooks().forEach( hook -> errorReports.addAll( hook.validate( object, bundle ) ) );
+
+            if ( !errorReports.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+                objectReport.addErrorReports( errorReports );
+
+                typeReport.addObjectReport( objectReport );
+                typeReport.getStats().incIgnored();
+
+                iterator.remove();
+                continue;
+            }
+        }
+
+        return typeReport;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
@@ -40,6 +40,8 @@ import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
+
 /**
  * @author Luciano Fiandesio
  */
@@ -72,15 +74,8 @@ public class ValidationHooksCheck
 
             if ( !errorReports.isEmpty() )
             {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
+                addObjectReport( errorReports, typeReport, object, bundle );
                 iterator.remove();
-                continue;
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
@@ -28,19 +28,16 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
-
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReport;
 
 /**
  * @author Luciano Fiandesio
@@ -64,18 +61,15 @@ public class ValidationHooksCheck
             return typeReport;
         }
 
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
+        for ( IdentifiableObject object : objects )
         {
-            IdentifiableObject object = iterator.next();
             List<ErrorReport> errorReports = new ArrayList<>();
             ctx.getObjectBundleHooks().forEach( hook -> errorReports.addAll( hook.validate( object, bundle ) ) );
 
             if ( !errorReports.isEmpty() )
             {
-                addObjectReport( errorReports, typeReport, object, bundle );
-                iterator.remove();
+                addObjectReports( errorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
@@ -33,6 +33,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
 
 /**
  * @author Luciano Fiandesio
@@ -44,5 +49,15 @@ public class ValidationUtils
         List<IdentifiableObject> nonPersistedObjects )
     {
         return Stream.concat( persistedObjects.stream(), nonPersistedObjects.stream() ).collect( Collectors.toList() );
+    }
+
+    public static void addObjectReport(List<ErrorReport> reports, TypeReport typeReport, IdentifiableObject object, ObjectBundle bundle )
+    {
+        ObjectReport objectReport = new ObjectReport( object, bundle );
+        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+        objectReport.addErrorReports( reports );
+
+        typeReport.addObjectReport( objectReport );
+        typeReport.getStats().incIgnored();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
@@ -51,11 +51,21 @@ public class ValidationUtils
         return Stream.concat( persistedObjects.stream(), nonPersistedObjects.stream() ).collect( Collectors.toList() );
     }
 
-    public static void addObjectReport(List<ErrorReport> reports, TypeReport typeReport, IdentifiableObject object, ObjectBundle bundle )
+    public static void addObjectReports(List<ErrorReport> reports, TypeReport typeReport, IdentifiableObject object, ObjectBundle bundle )
     {
         ObjectReport objectReport = new ObjectReport( object, bundle );
         objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
         objectReport.addErrorReports( reports );
+
+        typeReport.addObjectReport( objectReport );
+        typeReport.getStats().incIgnored();
+    }
+
+    public static void addObjectReport(ErrorReport report, TypeReport typeReport, IdentifiableObject object, ObjectBundle bundle )
+    {
+        ObjectReport objectReport = new ObjectReport( object, bundle );
+        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+        objectReport.addErrorReport( report );
 
         typeReport.addObjectReport( objectReport );
         typeReport.getStats().incIgnored();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
@@ -1,0 +1,48 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.common.IdentifiableObject;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationUtils
+{
+
+    public static List<IdentifiableObject> joinObjects( List<IdentifiableObject> persistedObjects,
+        List<IdentifiableObject> nonPersistedObjects )
+    {
+        return Stream.concat( persistedObjects.stream(), nonPersistedObjects.stream() ).collect( Collectors.toList() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
@@ -28,12 +28,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Sets;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
@@ -76,7 +71,11 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
-import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
@@ -28,7 +28,12 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Sets;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
@@ -71,11 +76,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.*;
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -180,19 +181,19 @@ public class ObjectBundleServiceTest
 
                 for ( ErrorReport errorReport : errorReports )
                 {
-                    assertTrue( PreheatErrorReport.class.isInstance( errorReport ) );
+                    assertTrue( errorReport instanceof PreheatErrorReport );
                     PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
                     assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
 
-                    if ( CategoryCombo.class.isInstance( preheatErrorReport.getValue() ) )
+                    if ( preheatErrorReport.getValue() instanceof CategoryCombo )
                     {
                         assertEquals( "p0KPaWEg3cf", preheatErrorReport.getObjectReference().getUid() );
                     }
-                    else if ( User.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof User )
                     {
                         assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
                     }
-                    else if ( OptionSet.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof OptionSet )
                     {
                         assertEquals( "pQYCiuosBnZ", preheatErrorReport.getObjectReference().getUid() );
                     }
@@ -238,21 +239,21 @@ public class ObjectBundleServiceTest
 
                 for ( ErrorReport errorReport : errorReports )
                 {
-                    assertTrue( PreheatErrorReport.class.isInstance( errorReport ) );
+                    assertTrue( errorReport instanceof PreheatErrorReport );
                     PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
                     assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
 
-                    if ( CategoryCombo.class.isInstance( preheatErrorReport.getValue() ) )
+                    if ( preheatErrorReport.getValue() instanceof CategoryCombo )
                     {
-                        assertFalse( true );
+                        fail();
                     }
-                    else if ( User.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof User )
                     {
                         assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
                     }
-                    else if ( OptionSet.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof OptionSet )
                     {
-                        assertFalse( true );
+                        fail();
                     }
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
@@ -28,6 +28,13 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -44,18 +51,9 @@ import org.hisp.dhis.user.UserAuthorityGroup;
 import org.hisp.dhis.user.UserService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactoryTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactoryTest.java
@@ -1,0 +1,131 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.importexport.ImportStrategy.CREATE_AND_UPDATE;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.UserService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationFactoryTest
+{
+
+    @Mock
+    private SchemaValidator schemaValidator;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private UserService userService;
+
+    @Rule
+    public MockitoRule mockitoRule = rule();
+
+    private ValidationFactory validationFactory;
+
+    @Before
+    public void setUp()
+    {
+        // Create a validation factory with a dummy check
+        validationFactory = new ValidationFactory( schemaValidator, schemaService, aclService, userService,
+            Collections.emptyList(), ImmutableMap.of( CREATE_AND_UPDATE, Lists.newArrayList( DummyCheck.class ) ) );
+    }
+
+    @Test
+    public void verifyValidationFactoryProcessValidationCheck()
+    {
+        ObjectBundle bundle = createObjectBundle();
+
+        TypeReport typeReport = validationFactory.validateBundle( bundle, Attribute.class,
+            bundle.getObjects( Attribute.class, true ), bundle.getObjects( Attribute.class, false ) );
+
+        // verify that object has been removed from bundle
+        assertThat( bundle.getObjects( Attribute.class, false ), hasSize( 0 ) );
+        assertThat( bundle.getObjects( Attribute.class, true ), hasSize( 0 ) );
+        assertThat( typeReport.getStats().getCreated(), is( 0 ) );
+        assertThat( typeReport.getStats().getUpdated(), is( 0 ) );
+        assertThat( typeReport.getStats().getDeleted(), is( 0 ) );
+        assertThat( typeReport.getStats().getIgnored(), is( 1 ) );
+        assertThat( typeReport.getObjectReports(), hasSize( 1 ) );
+    }
+
+    private ObjectBundle createObjectBundle()
+    {
+
+        Attribute attribute1 = new Attribute();
+        attribute1.setUid( "u1" );
+
+        ObjectBundleParams objectBundleParams = new ObjectBundleParams();
+        Preheat preheat = new Preheat();
+
+        final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = new HashMap<>();
+        objectMap.put( Attribute.class, new ArrayList<>() );
+
+        objectMap.get( Attribute.class ).add( attribute1 );
+
+        preheat.put( PreheatIdentifier.UID, attribute1 );
+
+        return new ObjectBundle( objectBundleParams, preheat, objectMap );
+    }
+
+}


### PR DESCRIPTION
This refactor is "born" out of an issue discovered with Pepfar db.
The `PreheatService` has a bug which causes an entire table to be loaded in memory (via Hibernate) in order to check for uniqueness.
This is the code that generates the query:

`DefaultPreheatService:242` (2.33)
```
for ( Class<? extends IdentifiableObject> klass : klasses )
{
    Query query = Query.from( schemaService.getDynamicSchema( klass ) );
    query.setUser( preheat.getUser() );
    List<? extends IdentifiableObject> objects = queryService.query( query ); // monster query!
    if ( !objects.isEmpty() )
    {
        uniqueCollectionMap.put( klass, new ArrayList<>( objects ) );
    }
}
```

This code preloads in memory all the values of a given class/table and pass it to the validation service.

--

In this PR, I have refactored the Validation Service, with the following goals in mind:

- Make the validation rules more isolated and testable
- Reduce the complexity of Validation Service
- Reduce the amount of duplicated code

The initial problem is not yet solved, because I'm struggling to understand the requirements for uniqueness check (see class `UniquenessCheck`). It would be great if someone could explain how uniqueness check is supposed to work during Tracker Import.

This is my understanding so far:

Each `IdentifiableObject` class is bound to a schema, which has unique attributes set. 
During import, the system must check if the objects being imported (either for insert or update) are already existing in the database - based on these unique attributes. If the object is in the database, we should skip the import and generate an error report.
