### PR TITLE
[2.34] fix: fetch unique values during metadata import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/SchemaToDataFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/SchemaToDataFetcher.java
@@ -1,0 +1,164 @@
+package org.hisp.dhis.preheat;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.springframework.stereotype.Component;
+
+/**
+ * This component is responsible for fetching all the unique attributes for a {@see IdentifiableObject} subclass
+ *
+ * @author Luciano Fiandesio
+ */
+@Component
+public class SchemaToDataFetcher
+{
+    protected static final Log log = LogFactory.getLog( SchemaToDataFetcher.class );
+
+    private final SessionFactory sessionFactory;
+
+    public SchemaToDataFetcher( SessionFactory sessionFactory )
+    {
+        checkNotNull( sessionFactory );
+
+        this.sessionFactory = sessionFactory;
+    }
+
+    /**
+     * Executes a read-only query for the given Schema class and fetches only the fields
+     * marked as "unique"
+     * 
+     * @param schema a {@see Schema}
+     * @return a List of objects corresponding to the "klass" of the given Schema
+     */
+    public List<? extends IdentifiableObject> fetch( Schema schema )
+    {
+        if ( schema == null )
+        {
+            return Collections.emptyList();
+        }
+
+        return mapUniqueFields(schema);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<? extends IdentifiableObject> mapUniqueFields( Schema schema )
+    {
+        List<Property> uniqueProperties = schema.getUniqueProperties();
+
+        List objects = new ArrayList();
+
+        if ( !uniqueProperties.isEmpty() )
+        {
+            final String fields = extractUniqueFields( uniqueProperties );
+
+            objects = sessionFactory.getCurrentSession()
+                .createQuery( "SELECT " + fields + " from " + schema.getKlass().getSimpleName() )
+                .setReadOnly( true )
+                .getResultList();
+        }
+
+        // Hibernate returns a List containing an array of Objects if multiple columns are used in the query
+        // or a "simple" List if only one columns is used in the query
+        return uniqueProperties.size() == 1 ? handleSingleColumn( objects, uniqueProperties, schema )
+            : handleMultipleColumn( objects, uniqueProperties, schema );
+
+    }
+
+    private List<IdentifiableObject> handleMultipleColumn( List<Object[]> objects, List<Property> uniqueProperties,
+        Schema schema )
+    {
+        List<IdentifiableObject> resultsObjects = new ArrayList( objects.size() );
+
+        for ( Object[] uniqueValuesArray : objects )
+        {
+            Map<String, Object> valuesMap = new HashMap<>();
+
+            for ( int i = 0; i < uniqueValuesArray.length; i++ )
+            {
+                valuesMap.put( uniqueProperties.get( i ).getFieldName(), uniqueValuesArray[i] );
+            }
+
+            addToResult( schema, valuesMap, resultsObjects );
+        }
+
+        return resultsObjects;
+    }
+    
+    private List<IdentifiableObject> handleSingleColumn( List<Object> objects, List<Property> uniqueProperties,
+        Schema schema )
+    {
+        List<IdentifiableObject> resultsObjects = new ArrayList( objects.size() );
+        for ( Object uniqueValue : objects )
+        {
+            Map<String, Object> valuesMap = new HashMap<>();
+            valuesMap.put( uniqueProperties.get( 0 ).getFieldName(), uniqueValue );
+
+            addToResult( schema, valuesMap, resultsObjects );
+        }
+
+        return resultsObjects;
+    }
+
+    private void addToResult( Schema schema, Map<String, Object> valuesMap, List<IdentifiableObject> resultsObjects )
+    {
+
+        try
+        {
+            IdentifiableObject identifiableObject = (IdentifiableObject) schema.getKlass().newInstance();
+            BeanUtils.populate( identifiableObject, valuesMap );
+            resultsObjects.add( identifiableObject );
+        }
+        catch ( Exception e )
+        {
+            log.error( "Error during dynamic population of object type: " + schema.getKlass().getSimpleName(), e );
+        }
+    }
+    
+    private String extractUniqueFields( List<Property> uniqueProperties )
+    {
+        return uniqueProperties.stream().map( Property::getFieldName ).collect( Collectors.joining( "," ) );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/DummyDataElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/DummyDataElement.java
@@ -1,0 +1,81 @@
+package org.hisp.dhis.preheat;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.option.OptionSet;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DummyDataElement
+    extends
+    BaseDimensionalItemObject
+    implements
+    MetadataObject,
+    ValueTypedDimensionalItemObject
+{
+
+    private String url;
+
+    @Override
+    public boolean hasOptionSet()
+    {
+        return false;
+    }
+
+    @Override
+    public OptionSet getOptionSet()
+    {
+        return null;
+    }
+
+    @Override
+    public ValueType getValueType()
+    {
+        return null;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+    public void setUrl( String url )
+    {
+        if ( url.endsWith( "-exception" ) )
+        {
+            throw new NullPointerException();
+        }
+        this.url = url;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
@@ -61,26 +61,26 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.google.common.collect.Lists;
+
 /**
  * @author Luciano Fiandesio
  */
-@SuppressWarnings("unchecked")
-public class SchemaToDataFetcherTest extends DhisConvenienceTest
+@SuppressWarnings( "unchecked" )
+public class SchemaToDataFetcherTest
+    extends
+    DhisConvenienceTest
 {
-    private SchemaToDataFetcher subject;
-
-    @Mock
-    private SessionFactory sessionFactory;
-
-    @Mock
-    private Session session;
-    
-    @Mock
-    private Query query;
-    
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
+    @Mock
+    private SessionFactory sessionFactory;
+    @Mock
+    private Session session;
+    @Mock
+    private Query query;
+
+    private SchemaToDataFetcher subject;
 
     @Before
     public void setUp()
@@ -88,25 +88,23 @@ public class SchemaToDataFetcherTest extends DhisConvenienceTest
         when( sessionFactory.getCurrentSession() ).thenReturn( session );
         subject = new SchemaToDataFetcher( sessionFactory );
     }
-    
+
     @Test
     public void verifyInput()
     {
-        assertThat(subject.fetch( null ), hasSize(0));
+        assertThat( subject.fetch( null ), hasSize( 0 ) );
     }
 
     @Test
     public void verifyUniqueFieldsAreMappedToHibernateObject()
     {
-       Schema schema = createSchema( DataElement.class, "dataElement",
-           Stream.of(
-            createUniqueProperty( Integer.class, "id", true, true ),
-            createProperty( String.class, "name", true, true ),
-            createUniqueProperty( String.class, "code", true, true ),
-            createProperty( Date.class, "created", true, true ),
-            createProperty( Date.class, "lastUpdated", true, true ),
-            createProperty( Integer.class, "int", true, true )).collect(toList())
-       );
+        Schema schema = createSchema( DataElement.class, "dataElement",
+            Stream.of( createUniqueProperty( Integer.class, "id", true, true ),
+                createProperty( String.class, "name", true, true ),
+                createUniqueProperty( String.class, "code", true, true ),
+                createProperty( Date.class, "created", true, true ),
+                createProperty( Date.class, "lastUpdated", true, true ),
+                createProperty( Integer.class, "int", true, true ) ).collect( toList() ) );
 
         mockSession( "SELECT code,id from " + schema.getKlass().getSimpleName() );
 
@@ -115,37 +113,26 @@ public class SchemaToDataFetcherTest extends DhisConvenienceTest
         l.add( new Object[] { "abc", 123456 } );
         l.add( new Object[] { "bce", 123888 } );
         l.add( new Object[] { "def", 123999 } );
-        
+
         when( query.getResultList() ).thenReturn( l );
 
         List<DataElement> result = (List<DataElement>) subject.fetch( schema );
 
         assertThat( result, hasSize( 3 ) );
 
-        assertThat( result, IsIterableContainingInAnyOrder.containsInAnyOrder(
-            allOf(
-                hasProperty( "code", is( "abc" ) ),
-                hasProperty( "id", is( 123456L ) )
-            ),
-            allOf(
-                hasProperty( "code", is( "bce" ) ),
-                hasProperty( "id", is( 123888L ) )
-            ),
-            allOf(
-                hasProperty( "code", is( "def" ) ),
-                hasProperty( "id", is( 123999L ) )
-            )
-        ) );
+        assertThat( result,
+            IsIterableContainingInAnyOrder.containsInAnyOrder(
+                allOf( hasProperty( "code", is( "abc" ) ), hasProperty( "id", is( 123456L ) ) ),
+                allOf( hasProperty( "code", is( "bce" ) ), hasProperty( "id", is( 123888L ) ) ),
+                allOf( hasProperty( "code", is( "def" ) ), hasProperty( "id", is( 123999L ) ) ) ) );
     }
 
     @Test
     public void verifyUniqueFieldsAreSkippedOnReflectionError()
     {
         Schema schema = createSchema( DummyDataElement.class, "dummyDataElement",
-            Stream.of(
-                createUniqueProperty( String.class, "url", true, true ),
-                createUniqueProperty( String.class, "code", true, true )).collect(toList())
-        );
+            Stream.of( createUniqueProperty( String.class, "url", true, true ),
+                createUniqueProperty( String.class, "code", true, true ) ).collect( toList() ) );
 
         mockSession( "SELECT code,url from " + schema.getKlass().getSimpleName() );
 
@@ -161,35 +148,27 @@ public class SchemaToDataFetcherTest extends DhisConvenienceTest
 
         assertThat( result, hasSize( 2 ) );
 
-        assertThat( result, IsIterableContainingInAnyOrder.containsInAnyOrder(
-            allOf(
-                    hasProperty( "code", is( "def" ) ),
-                    hasProperty( "url", is( "http://also-ok" ) )
-            ),
-            allOf(
-                    hasProperty( "code", is( "abc" ) ),
-                    hasProperty( "url", is( "http://ok" ) )
-            )
-        ) );
+        assertThat( result,
+            IsIterableContainingInAnyOrder.containsInAnyOrder(
+                allOf( hasProperty( "code", is( "def" ) ), hasProperty( "url", is( "http://also-ok" ) ) ),
+                allOf( hasProperty( "code", is( "abc" ) ), hasProperty( "url", is( "http://ok" ) ) ) ) );
     }
 
     @Test
     public void verifyUniqueFieldsAre()
     {
         Schema schema = createSchema( DummyDataElement.class, "dummyDataElement",
-            Stream.of(
-                createProperty( String.class, "name", true, true ),
+            Stream.of( createProperty( String.class, "name", true, true ),
                 createUniqueProperty( String.class, "url", true, true ),
-                createProperty( String.class, "code", true, true )).collect(toList())
-        );
+                createProperty( String.class, "code", true, true ) ).collect( toList() ) );
 
         mockSession( "SELECT url from " + schema.getKlass().getSimpleName() );
 
         List<Object> l = new ArrayList();
 
-        l.add(  "http://ok"  );
-        l.add(  "http://is-ok"  );
-        l.add(  "http://also-ok"  );
+        l.add( "http://ok" );
+        l.add( "http://is-ok" );
+        l.add( "http://also-ok" );
 
         when( query.getResultList() ).thenReturn( l );
 
@@ -197,18 +176,10 @@ public class SchemaToDataFetcherTest extends DhisConvenienceTest
 
         assertThat( result, hasSize( 3 ) );
 
-        assertThat( result, IsIterableContainingInAnyOrder.containsInAnyOrder(
-                allOf(
-                        hasProperty( "url", is( "http://also-ok" ) )
-                ),
-                allOf(
-                        hasProperty( "url", is( "http://ok" ) )
-                ),
-                allOf(
-                        hasProperty( "url", is( "http://is-ok" ) )
-                )
-        ) );
-
+        assertThat( result,
+            IsIterableContainingInAnyOrder.containsInAnyOrder( allOf( hasProperty( "url", is( "http://also-ok" ) ) ),
+                allOf( hasProperty( "url", is( "http://ok" ) ) ),
+                allOf( hasProperty( "url", is( "http://is-ok" ) ) ) ) );
 
     }
 
@@ -225,11 +196,9 @@ public class SchemaToDataFetcherTest extends DhisConvenienceTest
     @Test
     public void verifyNoSqlWhenNoUniquePropertyExist()
     {
-        Schema schema = createSchema( SMSCommand.class, "smsCommand",
-                Stream.of(
-                        createProperty( String.class, "name", true, true ),
-                        createProperty( String.class, "id", true, true ) ).collect( toList() )
-        );
+        Schema schema = createSchema( SMSCommand.class, "smsCommand", Stream
+            .of( createProperty( String.class, "name", true, true ), createProperty( String.class, "id", true, true ) )
+            .collect( toList() ) );
 
         subject.fetch( schema );
 
@@ -242,8 +211,8 @@ public class SchemaToDataFetcherTest extends DhisConvenienceTest
         when( query.setReadOnly( true ) ).thenReturn( query );
     }
 
-    private Schema createSchema(Class<? extends IdentifiableObject> klass, String singularName,
-                               List<Property> properties )
+    private Schema createSchema( Class<? extends IdentifiableObject> klass, String singularName,
+        List<Property> properties )
     {
         Schema schema = new Schema( klass, singularName, singularName + "s" );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
@@ -1,0 +1,277 @@
+package org.hisp.dhis.preheat;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.sms.command.SMSCommand;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.Lists;
+/**
+ * @author Luciano Fiandesio
+ */
+@SuppressWarnings("unchecked")
+public class SchemaToDataFetcherTest extends DhisConvenienceTest
+{
+    private SchemaToDataFetcher subject;
+
+    @Mock
+    private SessionFactory sessionFactory;
+
+    @Mock
+    private Session session;
+    
+    @Mock
+    private Query query;
+    
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+
+    @Before
+    public void setUp()
+    {
+        when( sessionFactory.getCurrentSession() ).thenReturn( session );
+        subject = new SchemaToDataFetcher( sessionFactory );
+    }
+    
+    @Test
+    public void verifyInput()
+    {
+        assertThat(subject.fetch( null ), hasSize(0));
+    }
+
+    @Test
+    public void verifyUniqueFieldsAreMappedToHibernateObject()
+    {
+       Schema schema = createSchema( DataElement.class, "dataElement",
+           Stream.of(
+            createUniqueProperty( Integer.class, "id", true, true ),
+            createProperty( String.class, "name", true, true ),
+            createUniqueProperty( String.class, "code", true, true ),
+            createProperty( Date.class, "created", true, true ),
+            createProperty( Date.class, "lastUpdated", true, true ),
+            createProperty( Integer.class, "int", true, true )).collect(toList())
+       );
+
+        mockSession( "SELECT code,id from " + schema.getKlass().getSimpleName() );
+
+        List<Object[]> l = new ArrayList();
+
+        l.add( new Object[] { "abc", 123456 } );
+        l.add( new Object[] { "bce", 123888 } );
+        l.add( new Object[] { "def", 123999 } );
+        
+        when( query.getResultList() ).thenReturn( l );
+
+        List<DataElement> result = (List<DataElement>) subject.fetch( schema );
+
+        assertThat( result, hasSize( 3 ) );
+
+        assertThat( result, IsIterableContainingInAnyOrder.containsInAnyOrder(
+            allOf(
+                hasProperty( "code", is( "abc" ) ),
+                hasProperty( "id", is( 123456L ) )
+            ),
+            allOf(
+                hasProperty( "code", is( "bce" ) ),
+                hasProperty( "id", is( 123888L ) )
+            ),
+            allOf(
+                hasProperty( "code", is( "def" ) ),
+                hasProperty( "id", is( 123999L ) )
+            )
+        ) );
+    }
+
+    @Test
+    public void verifyUniqueFieldsAreSkippedOnReflectionError()
+    {
+        Schema schema = createSchema( DummyDataElement.class, "dummyDataElement",
+            Stream.of(
+                createUniqueProperty( String.class, "url", true, true ),
+                createUniqueProperty( String.class, "code", true, true )).collect(toList())
+        );
+
+        mockSession( "SELECT code,url from " + schema.getKlass().getSimpleName() );
+
+        List<Object[]> l = new ArrayList();
+
+        l.add( new Object[] { "abc", "http://ok" } );
+        l.add( new Object[] { "bce", "http://-exception" } );
+        l.add( new Object[] { "def", "http://also-ok" } );
+
+        when( query.getResultList() ).thenReturn( l );
+
+        List<DataElement> result = (List<DataElement>) subject.fetch( schema );
+
+        assertThat( result, hasSize( 2 ) );
+
+        assertThat( result, IsIterableContainingInAnyOrder.containsInAnyOrder(
+            allOf(
+                    hasProperty( "code", is( "def" ) ),
+                    hasProperty( "url", is( "http://also-ok" ) )
+            ),
+            allOf(
+                    hasProperty( "code", is( "abc" ) ),
+                    hasProperty( "url", is( "http://ok" ) )
+            )
+        ) );
+    }
+
+    @Test
+    public void verifyUniqueFieldsAre()
+    {
+        Schema schema = createSchema( DummyDataElement.class, "dummyDataElement",
+            Stream.of(
+                createProperty( String.class, "name", true, true ),
+                createUniqueProperty( String.class, "url", true, true ),
+                createProperty( String.class, "code", true, true )).collect(toList())
+        );
+
+        mockSession( "SELECT url from " + schema.getKlass().getSimpleName() );
+
+        List<Object> l = new ArrayList();
+
+        l.add(  "http://ok"  );
+        l.add(  "http://is-ok"  );
+        l.add(  "http://also-ok"  );
+
+        when( query.getResultList() ).thenReturn( l );
+
+        List<DataElement> result = (List<DataElement>) subject.fetch( schema );
+
+        assertThat( result, hasSize( 3 ) );
+
+        assertThat( result, IsIterableContainingInAnyOrder.containsInAnyOrder(
+                allOf(
+                        hasProperty( "url", is( "http://also-ok" ) )
+                ),
+                allOf(
+                        hasProperty( "url", is( "http://ok" ) )
+                ),
+                allOf(
+                        hasProperty( "url", is( "http://is-ok" ) )
+                )
+        ) );
+
+
+    }
+
+    @Test
+    public void verifyNoSqlWhenUniquePropertiesListIsEmpty()
+    {
+        Schema schema = createSchema( SMSCommand.class, "smsCommand", Lists.newArrayList() );
+
+        subject.fetch( schema );
+
+        verify( sessionFactory, times( 0 ) ).getCurrentSession();
+    }
+
+    @Test
+    public void verifyNoSqlWhenNoUniquePropertyExist()
+    {
+        Schema schema = createSchema( SMSCommand.class, "smsCommand",
+                Stream.of(
+                        createProperty( String.class, "name", true, true ),
+                        createProperty( String.class, "id", true, true ) ).collect( toList() )
+        );
+
+        subject.fetch( schema );
+
+        verify( sessionFactory, times( 0 ) ).getCurrentSession();
+    }
+
+    private void mockSession( String hql )
+    {
+        when( session.createQuery( hql ) ).thenReturn( query );
+        when( query.setReadOnly( true ) ).thenReturn( query );
+    }
+
+    private Schema createSchema(Class<? extends IdentifiableObject> klass, String singularName,
+                               List<Property> properties )
+    {
+        Schema schema = new Schema( klass, singularName, singularName + "s" );
+
+        for ( Property property : properties )
+        {
+            schema.addProperty( property );
+        }
+
+        return schema;
+    }
+
+    private Property createProperty( Class<?> klazz, String name, boolean simple, boolean persisted )
+    {
+        Property property = new Property( klazz );
+        property.setName( name );
+        property.setFieldName( name );
+        property.setSimple( simple );
+        property.setOwner( true );
+        property.setPersisted( persisted );
+
+        return property;
+    }
+
+    public Property createUniqueProperty( Class<?> klazz, String name, boolean simple, boolean persisted )
+    {
+        Property property = createProperty( klazz, name, simple, persisted );
+        property.setUnique( true );
+        return property;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -28,8 +28,25 @@ package org.hisp.dhis.dxf2.config;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.CreationCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DeletionCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DuplicateIdsCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.MandatoryAttributesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ReferencesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.SchemaCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.SecurityCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniqueAttributesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniquenessCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UpdateCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationHooksCheck;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
 import org.hisp.dhis.external.conf.ConfigurationPropertyFactoryBean;
+import org.hisp.dhis.importexport.ImportStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -38,13 +55,14 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 
 /**
  * @author Luciano Fiandesio
  */
 @Configuration( "dxf2ServiceConfig" )
+@SuppressWarnings("unchecked")
 public class ServiceConfig
 {
 
@@ -73,5 +91,37 @@ public class ServiceConfig
         retryTemplate.setRetryPolicy( simpleRetryPolicy );
 
         return retryTemplate;
+    }
+
+    /*
+
+    Default validation chains for each Import Strategy
+
+     */
+
+    private final static List<Class<? extends ValidationCheck>> CREATE_UPDATE_CHECKS = Lists.newArrayList(
+        DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, SchemaCheck.class,
+        UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> CREATE_CHECKS = Lists.newArrayList(
+        DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, CreationCheck.class, SchemaCheck.class,
+        UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> UPDATE_CHECKS = Lists.newArrayList(
+        DuplicateIdsCheck.class, ValidationHooksCheck.class, SecurityCheck.class, UpdateCheck.class, SchemaCheck.class,
+        UniquenessCheck.class, MandatoryAttributesCheck.class, UniqueAttributesCheck.class, ReferencesCheck.class );
+
+    private final static List<Class<? extends ValidationCheck>> DELETE_CHECKS = Lists.newArrayList( SecurityCheck.class,
+        DeletionCheck.class );
+
+    @Bean( "validatorMap" )
+    public Map<ImportStrategy, List<Class<? extends ValidationCheck>>> validatorMap()
+    {
+        return ImmutableMap.of(
+            ImportStrategy.CREATE_AND_UPDATE, CREATE_UPDATE_CHECKS,
+            ImportStrategy.CREATE, CREATE_CHECKS,
+            ImportStrategy.UPDATE, UPDATE_CHECKS,
+            ImportStrategy.DELETE, DELETE_CHECKS
+        );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -28,40 +28,18 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.attribute.AttributeValue;
-import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.commons.timer.SystemTimer;
 import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
-import org.hisp.dhis.feedback.TypeReport;
-import org.hisp.dhis.importexport.ImportStrategy;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationFactory;
 import org.hisp.dhis.preheat.Preheat;
-import org.hisp.dhis.preheat.PreheatErrorReport;
-import org.hisp.dhis.preheat.PreheatIdentifier;
-import org.hisp.dhis.schema.Property;
-import org.hisp.dhis.schema.PropertyType;
-import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
-import org.hisp.dhis.schema.validation.SchemaValidator;
-import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.util.ReflectionUtils;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserCredentials;
-import org.hisp.dhis.user.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,22 +51,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service( "org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService" )
 @Transactional
-public class DefaultObjectBundleValidationService implements ObjectBundleValidationService
+public class DefaultObjectBundleValidationService
+    implements
+    ObjectBundleValidationService
 {
-    @Autowired
-    private SchemaService schemaService;
+    private final ValidationFactory validationFactory;
+    private final SchemaService schemaService;
 
-    @Autowired
-    private SchemaValidator schemaValidator;
-
-    @Autowired
-    private AclService aclService;
-
-    @Autowired
-    private UserService userService;
-
-    @Autowired( required = false )
-    private List<ObjectBundleHook> objectBundleHooks = new ArrayList<>();
+    public DefaultObjectBundleValidationService( ValidationFactory validationFactory, SchemaService schemaService )
+    {
+        this.schemaService = schemaService;
+        this.validationFactory = validationFactory;
+    }
 
     @Override
     public ObjectBundleValidationReport validate( ObjectBundle bundle )
@@ -99,7 +73,8 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
         if ( (bundle.getUser() == null || bundle.getUser().isSuper()) && bundle.isSkipValidation() )
         {
-            log.warn( "Skipping validation for metadata import by user '" + bundle.getUsername() + "'. Not recommended." );
+            log.warn(
+                "Skipping validation for metadata import by user '" + bundle.getUsername() + "'. Not recommended." );
             return validation;
         }
 
@@ -107,95 +82,15 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
         for ( Class<? extends IdentifiableObject> klass : klasses )
         {
-            TypeReport typeReport = new TypeReport( klass );
-
             List<IdentifiableObject> nonPersistedObjects = bundle.getObjects( klass, false );
             List<IdentifiableObject> persistedObjects = bundle.getObjects( klass, true );
-            List<IdentifiableObject> allObjects = bundle.getObjectMap().get( klass );
 
             cleanDefaults( bundle.getPreheat(), nonPersistedObjects );
             cleanDefaults( bundle.getPreheat(), persistedObjects );
 
-            typeReport.merge( checkDuplicateIds( bundle, klass, persistedObjects, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-            if ( bundle.getImportMode().isCreateAndUpdate() )
-            {
-                typeReport.merge( runValidationHooks( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( runValidationHooks( klass, persistedObjects, bundle ) );
-                typeReport.merge( validateSecurity( klass, nonPersistedObjects, bundle, ImportStrategy.CREATE ) );
-                typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.UPDATE ) );
-                typeReport.merge( validateBySchemas( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( validateBySchemas( klass, persistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueness( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
-
-                if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
-                {
-                    typeReport.getStats().incIgnored();
-                }
-
-                typeReport.getStats().incCreated( nonPersistedObjects.size() );
-                typeReport.getStats().incUpdated( persistedObjects.size() );
-
-                typeReport.merge( checkReferences );
-            }
-            else if ( bundle.getImportMode().isCreate() )
-            {
-                typeReport.merge( runValidationHooks( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( validateSecurity( klass, nonPersistedObjects, bundle, ImportStrategy.CREATE ) );
-                typeReport.merge( validateForCreate( klass, persistedObjects, bundle ) );
-                typeReport.merge( validateBySchemas( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, nonPersistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
-
-                if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
-                {
-                    typeReport.getStats().incIgnored();
-                }
-
-                typeReport.getStats().incCreated( nonPersistedObjects.size() );
-
-                typeReport.merge( checkReferences );
-            }
-            else if ( bundle.getImportMode().isUpdate() )
-            {
-                typeReport.merge( runValidationHooks( klass, persistedObjects, bundle ) );
-                typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.UPDATE ) );
-                typeReport.merge( validateForUpdate( klass, nonPersistedObjects, bundle ) );
-                typeReport.merge( validateBySchemas( klass, persistedObjects, bundle ) );
-                typeReport.merge( checkUniqueness( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkMandatoryAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-                typeReport.merge( checkUniqueAttributes( bundle, klass, persistedObjects, bundle.getPreheat(), bundle.getPreheatIdentifier() ) );
-
-                TypeReport checkReferences = checkReferences( bundle, klass, allObjects, bundle.getPreheat(), bundle.getPreheatIdentifier(), bundle.isSkipSharing() );
-
-                if ( !checkReferences.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
-                {
-                    typeReport.getStats().incIgnored();
-                }
-
-                typeReport.getStats().incUpdated( persistedObjects.size() );
-
-                typeReport.merge( checkReferences );
-            }
-            else if ( bundle.getImportMode().isDelete() )
-            {
-                typeReport.merge( validateSecurity( klass, persistedObjects, bundle, ImportStrategy.DELETE ) );
-                typeReport.merge( validateForDelete( klass, nonPersistedObjects, bundle ) );
-
-                typeReport.getStats().incDeleted( persistedObjects.size() );
-            }
-
-            validation.addTypeReport( typeReport );
+            // Validate the bundle by running the validation checks chain
+            validation.addTypeReport( validationFactory.validateBundle( bundle, klass, persistedObjects,
+                    nonPersistedObjects ) );
         }
 
         validateAtomicity( bundle, validation );
@@ -211,52 +106,20 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         objects.removeIf( preheat::isDefault );
     }
 
-    //----------------------------------------------------------------------------------------------------
+    // ----------------------------------------------------------------------------------------------------
     // Helpers
-    //----------------------------------------------------------------------------------------------------
-
-    private TypeReport runValidationHooks( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = new ArrayList<>();
-            objectBundleHooks.forEach( hook -> errorReports.addAll( hook.validate( object, bundle ) ) );
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-                continue;
-            }
-        }
-
-        return typeReport;
-    }
+    // ----------------------------------------------------------------------------------------------------
 
     private void validateAtomicity( ObjectBundle bundle, ObjectBundleValidationReport validation )
     {
         if ( AtomicMode.NONE == bundle.getAtomicMode() )
         {
+
             return;
         }
 
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> nonPersistedObjects = bundle.getObjects( false );
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> nonPersistedObjects = bundle
+            .getObjects( false );
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> persistedObjects = bundle.getObjects( true );
 
         if ( AtomicMode.ALL == bundle.getAtomicMode() )
@@ -269,247 +132,6 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         }
     }
 
-    private TypeReport validateSecurity( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle, ImportStrategy importMode )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-        PreheatIdentifier identifier = bundle.getPreheatIdentifier();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( importMode.isCreate() )
-            {
-                if ( !aclService.canCreate( bundle.getUser(), klass ) )
-                {
-                    ObjectReport objectReport = new ObjectReport( object, bundle );
-                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                    objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3000, identifier.getIdentifiersWithName( bundle.getUser() ),
-                        identifier.getIdentifiersWithName( object ) ) );
-
-                    typeReport.addObjectReport( objectReport );
-                    typeReport.getStats().incIgnored();
-
-                    iterator.remove();
-                    continue;
-                }
-            }
-            else
-            {
-                IdentifiableObject persistedObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), object );
-
-                if ( importMode.isUpdate() )
-                {
-                    if ( !aclService.canUpdate( bundle.getUser(), persistedObject ) )
-                    {
-                        ObjectReport objectReport = new ObjectReport( object, bundle );
-                        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                        objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3001, identifier.getIdentifiersWithName( bundle.getUser() ),
-                            identifier.getIdentifiersWithName( object ) ) );
-
-                        typeReport.addObjectReport( objectReport );
-                        typeReport.getStats().incIgnored();
-
-                        iterator.remove();
-                        continue;
-                    }
-                }
-                else if ( importMode.isDelete() )
-                {
-                    if ( !aclService.canDelete( bundle.getUser(), persistedObject ) )
-                    {
-                        ObjectReport objectReport = new ObjectReport( object, bundle );
-                        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                        objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E3002, identifier.getIdentifiersWithName( bundle.getUser() ),
-                            identifier.getIdentifiersWithName( object ) ) );
-
-                        typeReport.addObjectReport( objectReport );
-                        typeReport.getStats().incIgnored();
-
-                        iterator.remove();
-                        continue;
-                    }
-                }
-            }
-
-            if ( User.class.isInstance( object ) )
-            {
-                User user = (User) object;
-                List<ErrorReport> errorReports = userService.validateUser( user, bundle.getUser() );
-
-                if ( !errorReports.isEmpty() )
-                {
-                    ObjectReport objectReport = new ObjectReport( object, bundle );
-                    objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                    objectReport.addErrorReports( errorReports );
-
-                    typeReport.addObjectReport( objectReport );
-                    typeReport.getStats().incIgnored();
-
-                    iterator.remove();
-                    continue;
-                }
-            }
-
-            List<ErrorReport> sharingErrorReports = aclService.verifySharing( object, bundle.getUser() );
-
-            if ( !sharingErrorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( sharingErrorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-                continue;
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateForCreate( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject identifiableObject = iterator.next();
-            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
-
-            if ( object != null && object.getId() > 0 )
-            {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) ).setMainId( identifiableObject.getUid() ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateForUpdate( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject identifiableObject = iterator.next();
-            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
-
-            if ( object == null || object.getId() == 0 )
-            {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                    .setErrorProperty( "id" )
-                    .setMainId( identifiableObject.getUid() ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateForDelete( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject identifiableObject = iterator.next();
-            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
-
-            if ( object == null || object.getId() == 0 )
-            {
-                ObjectReport objectReport = new ObjectReport( identifiableObject, bundle, object == null ? null : object.getUid() );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
-                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) ).setMainId( object != null ? object.getUid() : null ) );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport validateBySchemas( Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, ObjectBundle bundle )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects == null || objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> validationErrorReports = schemaValidator.validate( object );
-
-            if ( !validationErrorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( validationErrorReports );
-
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
     @SuppressWarnings( "unchecked" )
     private List<Class<? extends IdentifiableObject>> getSortedClasses( ObjectBundle bundle )
     {
@@ -517,8 +139,7 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
 
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = bundle.getObjectMap();
 
-        schemaService.getMetadataSchemas().forEach( schema ->
-        {
+        schemaService.getMetadataSchemas().forEach( schema -> {
             Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) schema.getKlass();
 
             if ( objectMap.containsKey( klass ) )
@@ -528,428 +149,5 @@ public class DefaultObjectBundleValidationService implements ObjectBundleValidat
         } );
 
         return klasses;
-    }
-
-    private TypeReport checkReferences( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier, boolean skipSharing )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        for ( int idx = 0; idx < objects.size(); idx++ )
-        {
-            IdentifiableObject object = objects.get( idx );
-            List<PreheatErrorReport> errorReports = checkReferences( object, preheat, identifier, skipSharing );
-
-            if ( errorReports.isEmpty() ) continue;
-
-            ObjectReport objectReport = new ObjectReport( object, bundle );
-            objectReport.addErrorReports( errorReports );
-            typeReport.addObjectReport( objectReport );
-        }
-
-        return typeReport;
-    }
-
-    private List<PreheatErrorReport> checkReferences( IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier, boolean skipSharing )
-    {
-        List<PreheatErrorReport> preheatErrorReports = new ArrayList<>();
-
-        if ( object == null )
-        {
-            return preheatErrorReports;
-        }
-
-        Schema schema = schemaService.getDynamicSchema( object.getClass() );
-        schema.getProperties().stream()
-            .filter( p -> p.isPersisted() && p.isOwner() && (PropertyType.REFERENCE == p.getPropertyType() || PropertyType.REFERENCE == p.getItemPropertyType()) )
-            .forEach( p ->
-            {
-                if ( skipCheck( p.getKlass() ) || skipCheck( p.getItemKlass() ) )
-                {
-                    return;
-                }
-
-                if ( !p.isCollection() )
-                {
-                    IdentifiableObject refObject = ReflectionUtils.invokeMethod( object, p.getGetterMethod() );
-                    IdentifiableObject ref = preheat.get( identifier, refObject );
-
-                    if ( ref == null && refObject != null && !preheat.isDefault( refObject ) )
-                    {
-                        if ( !("user".equals( p.getName() ) && User.class.isAssignableFrom( p.getKlass() ) && skipSharing) )
-                        {
-                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                                identifier.getIdentifiersWithName( refObject ), identifier.getIdentifiersWithName( object ), p.getName() ) );
-                        }
-                    }
-                }
-                else
-                {
-                    Collection<IdentifiableObject> objects = ReflectionUtils.newCollectionInstance( p.getKlass() );
-                    Collection<IdentifiableObject> refObjects = ReflectionUtils.invokeMethod( object, p.getGetterMethod() );
-
-                    if ( refObjects != null )
-                    {
-                        for ( IdentifiableObject refObject : refObjects )
-                        {
-                            if ( preheat.isDefault( refObject ) )
-                                continue;
-
-                            IdentifiableObject ref = preheat.get( identifier, refObject );
-
-                            if ( ref == null && refObject != null )
-                            {
-                                preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
-                                    ErrorCode.E5002, identifier.getIdentifiersWithName( refObject ),
-                                    identifier.getIdentifiersWithName( object ), p.getCollectionName() ) );
-                            }
-                            else
-                            {
-                                objects.add( refObject );
-                            }
-                        }
-
-                        ReflectionUtils.invokeMethod( object, p.getSetterMethod(), objects );
-                    }
-                }
-            } );
-
-        if ( schema.havePersistedProperty( "attributeValues" ) )
-        {
-            object.getAttributeValues().stream()
-                .filter( attributeValue -> attributeValue.getAttribute() != null && preheat.get( identifier, attributeValue.getAttribute() ) == null )
-                .forEach( attributeValue -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                    identifier.getIdentifiersWithName( attributeValue.getAttribute() ), identifier.getIdentifiersWithName( object ), "attributeValues" ) ) );
-        }
-
-        if ( schema.havePersistedProperty( "userGroupAccesses" ) )
-        {
-            object.getUserGroupAccesses().stream()
-                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUserGroup() != null && preheat.get( identifier, userGroupAccess.getUserGroup() ) == null )
-                .forEach( userGroupAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                    identifier.getIdentifiersWithName( userGroupAccesses.getUserGroup() ), identifier.getIdentifiersWithName( object ), "userGroupAccesses" ) ) );
-        }
-
-        if ( schema.havePersistedProperty( "userAccesses" ) )
-        {
-            object.getUserAccesses().stream()
-                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUser() != null && preheat.get( identifier, userGroupAccess.getUser() ) == null )
-                .forEach( userAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(), ErrorCode.E5002,
-                    identifier.getIdentifiersWithName( userAccesses.getUser() ), identifier.getIdentifiersWithName( object ), "userAccesses" ) ) );
-        }
-
-        return preheatErrorReports;
-    }
-
-    private TypeReport checkDuplicateIds( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
-        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( persistedObjects.isEmpty() && nonPersistedObjects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Map<Class<?>, String> idMap = new HashMap<>();
-
-        Iterator<IdentifiableObject> iterator = persistedObjects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
-            {
-                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(), object.getClass() )
-                    .setMainId( object.getUid() ).setErrorProperty( "id" );
-
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( errorReport );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-            else
-            {
-                idMap.put( object.getClass(), object.getUid() );
-            }
-        }
-
-        iterator = nonPersistedObjects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-
-            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
-            {
-                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(), object.getClass() )
-                    .setMainId( object.getUid() ).setErrorProperty( "id" );
-
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReport( errorReport );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-            else
-            {
-                idMap.put( object.getClass(), object.getUid() );
-            }
-        }
-
-        return typeReport;
-    }
-
-    private TypeReport checkUniqueness( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-
-        if ( objects.isEmpty() )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = new ArrayList<>();
-
-            if ( User.class.isInstance( object ) )
-            {
-                User user = (User) object;
-                errorReports.addAll( checkUniqueness( User.class, user, preheat, identifier ) );
-                errorReports.addAll( checkUniqueness( UserCredentials.class, user.getUserCredentials(), preheat, identifier ) );
-            }
-            else
-            {
-                errorReports = checkUniqueness( klass, object, preheat, identifier );
-            }
-
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private List<ErrorReport> checkUniqueness( Class<? extends IdentifiableObject> klass, IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
-    {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( object == null || preheat.isDefault( object ) ) return errorReports;
-
-        if ( !preheat.getUniquenessMap().containsKey( object.getClass() ) )
-        {
-            preheat.getUniquenessMap().put( object.getClass(), new HashMap<>() );
-        }
-
-        Map<String, Map<Object, String>> uniquenessMap = preheat.getUniquenessMap().get( object.getClass() );
-
-        Schema schema = schemaService.getDynamicSchema( object.getClass() );
-        List<Property> uniqueProperties = schema.getProperties().stream()
-            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
-            .collect( Collectors.toList() );
-
-        uniqueProperties.forEach( property ->
-        {
-            if ( !uniquenessMap.containsKey( property.getName() ) )
-            {
-                uniquenessMap.put( property.getName(), new HashMap<>() );
-            }
-
-            Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
-
-            if ( value != null )
-            {
-                String persistedUid = uniquenessMap.get( property.getName() ).get( value );
-
-                if ( persistedUid != null )
-                {
-                    if ( !object.getUid().equals( persistedUid ) )
-                    {
-                        errorReports.add( new ErrorReport( object.getClass(), ErrorCode.E5003, property.getName(), value,
-                            identifier.getIdentifiersWithName( object ), persistedUid ).setMainId( persistedUid ).setErrorProperty( property.getName() ) );
-                    }
-                }
-                else
-                {
-                    uniquenessMap.get( property.getName() ).put( value, object.getUid() );
-                }
-            }
-        } );
-
-        return errorReports;
-    }
-
-    private TypeReport checkMandatoryAttributes( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-        Schema schema = schemaService.getDynamicSchema( klass );
-
-        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = checkMandatoryAttributes( klass, object, preheat, identifier );
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private List<ErrorReport> checkMandatoryAttributes( Class<? extends IdentifiableObject> klass, IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
-    {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( object == null || preheat.isDefault( object ) || !preheat.getMandatoryAttributes().containsKey( klass ) )
-        {
-            return errorReports;
-        }
-
-        Set<AttributeValue> attributeValues = object.getAttributeValues();
-        Set<String> mandatoryAttributes = new HashSet<>( preheat.getMandatoryAttributes().get( klass ) ); // make copy for modification
-
-        if ( mandatoryAttributes.isEmpty() )
-        {
-            return errorReports;
-        }
-
-        attributeValues.forEach( attributeValue -> mandatoryAttributes.remove( attributeValue.getAttribute().getUid() ) );
-        mandatoryAttributes.forEach( att -> errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4011, att )
-            .setMainId( att ).setErrorProperty( "value" ) ) );
-
-        return errorReports;
-    }
-
-    private TypeReport checkUniqueAttributes( ObjectBundle bundle, Class<? extends IdentifiableObject> klass, List<IdentifiableObject> objects, Preheat preheat, PreheatIdentifier identifier )
-    {
-        TypeReport typeReport = new TypeReport( klass );
-        Schema schema = schemaService.getDynamicSchema( klass );
-
-        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
-        {
-            return typeReport;
-        }
-
-        Iterator<IdentifiableObject> iterator = objects.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            IdentifiableObject object = iterator.next();
-            List<ErrorReport> errorReports = checkUniqueAttributes( klass, object, preheat, identifier );
-
-            if ( !errorReports.isEmpty() )
-            {
-                ObjectReport objectReport = new ObjectReport( object, bundle );
-                objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-                objectReport.addErrorReports( errorReports );
-                typeReport.addObjectReport( objectReport );
-                typeReport.getStats().incIgnored();
-
-                iterator.remove();
-            }
-        }
-
-        return typeReport;
-    }
-
-    private List<ErrorReport> checkUniqueAttributes( Class<? extends IdentifiableObject> klass, IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
-    {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( object == null || preheat.isDefault( object ) || !preheat.getUniqueAttributes().containsKey( klass ) )
-        {
-            return errorReports;
-        }
-
-        Set<AttributeValue> attributeValues = object.getAttributeValues();
-        List<String> uniqueAttributes = new ArrayList<>( preheat.getUniqueAttributes().get( klass ) ); // make copy for modification
-
-        if ( !preheat.getUniqueAttributeValues().containsKey( klass ) )
-        {
-            preheat.getUniqueAttributeValues().put( klass, new HashMap<>() );
-        }
-
-        Map<String, Map<String, String>> uniqueAttributeValues = preheat.getUniqueAttributeValues().get( klass );
-
-        if ( uniqueAttributes.isEmpty() )
-        {
-            return errorReports;
-        }
-
-        attributeValues.forEach( attributeValue ->
-        {
-            Attribute attribute = preheat.get( identifier, attributeValue.getAttribute() );
-
-            if ( attribute == null || !attribute.isUnique() || StringUtils.isEmpty( attributeValue.getValue() ) )
-            {
-                return;
-            }
-
-            if ( uniqueAttributeValues.containsKey( attribute.getUid() ) )
-            {
-                Map<String, String> values = uniqueAttributeValues.get( attribute.getUid() );
-
-                if ( values.containsKey( attributeValue.getValue() ) && !values.get( attributeValue.getValue() ).equals( object.getUid() ) )
-                {
-                    errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4009, IdentifiableObjectUtils.getDisplayName( attribute ),
-                        attributeValue.getValue() ).setMainId( attribute.getUid() ).setErrorProperty( "value" ) );
-                }
-                else
-                {
-                    uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
-                }
-            }
-            else
-            {
-                uniqueAttributeValues.put( attribute.getUid(), new HashMap<>() );
-                uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
-            }
-        } );
-
-        return errorReports;
-    }
-
-    private boolean skipCheck( Class<?> klass )
-    {
-        return klass != null && (UserCredentials.class.isAssignableFrom( klass ) || EmbeddedObject.class.isAssignableFrom( klass ) ||
-            Period.class.isAssignableFrom( klass ) || PeriodType.class.isAssignableFrom( klass ));
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
@@ -1,0 +1,77 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class CreationCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( persistedObjects == null || persistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject identifiableObject : persistedObjects )
+        {
+            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+
+            if ( object != null && object.getId() > 0 )
+            {
+                ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setMainId( identifiableObject.getUid() );
+
+                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
@@ -1,0 +1,75 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DeletionCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( nonPersistedObjects == null || nonPersistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject identifiableObject : nonPersistedObjects )
+        {
+            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+
+            if ( object == null || object.getId() == 0 )
+            {
+                ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setMainId( object != null ? object.getUid() : null );
+                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DuplicateIdsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DuplicateIdsCheck.java
@@ -1,0 +1,94 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DuplicateIdsCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( persistedObjects.isEmpty() && nonPersistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Map<Class<?>, String> idMap = new HashMap<>();
+
+        typeReport.merge( run( typeReport, bundle, persistedObjects.iterator(), idMap, ctx ) );
+        typeReport.merge( run( typeReport, bundle, nonPersistedObjects.iterator(), idMap, ctx ) );
+
+        return typeReport;
+    }
+
+    private TypeReport run( TypeReport typeReport, ObjectBundle bundle, Iterator<IdentifiableObject> iterator,
+        Map<Class<?>, String> idMap, ValidationContext context )
+    {
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+
+            if ( idMap.containsKey( object.getClass() ) && idMap.get( object.getClass() ).equals( object.getUid() ) )
+            {
+                ErrorReport errorReport = new ErrorReport( object.getClass(), ErrorCode.E5004, object.getUid(),
+                    object.getClass() ).setMainId( object.getUid() ).setErrorProperty( "id" );
+
+                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                context.markForRemoval( object );
+            }
+            else
+            {
+                idMap.put( object.getClass(), object.getUid() );
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MandatoryAttributesCheck.java
@@ -1,0 +1,110 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.schema.Schema;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class MandatoryAttributesCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+        Schema schema = ctx.getSchemaService().getDynamicSchema( klass );
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<ErrorReport> errorReports = checkMandatoryAttributes( klass, object, bundle.getPreheat() );
+
+            if ( !errorReports.isEmpty() )
+            {
+                addObjectReports( errorReports, typeReport, object, bundle );
+
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+
+    private List<ErrorReport> checkMandatoryAttributes( Class<? extends IdentifiableObject> klass,
+        IdentifiableObject object, Preheat preheat )
+    {
+        List<ErrorReport> errorReports = new ArrayList<>();
+
+        if ( object == null || preheat.isDefault( object ) || !preheat.getMandatoryAttributes().containsKey( klass ) )
+        {
+            return errorReports;
+        }
+
+        Set<AttributeValue> attributeValues = object.getAttributeValues();
+        Set<String> mandatoryAttributes = new HashSet<>( preheat.getMandatoryAttributes().get( klass ) ); // make copy
+                                                                                                          // for
+        if ( mandatoryAttributes.isEmpty() )
+        {
+            return errorReports;
+        }
+
+        attributeValues
+            .forEach( attributeValue -> mandatoryAttributes.remove( attributeValue.getAttribute().getUid() ) );
+        mandatoryAttributes.forEach( att -> errorReports.add(
+            new ErrorReport( Attribute.class, ErrorCode.E4011, att ).setMainId( att ).setErrorProperty( "value" ) ) );
+
+        return errorReports;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
@@ -1,0 +1,206 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.hisp.dhis.common.EmbeddedObject;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.AtomicMode;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatErrorReport;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserCredentials;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ReferencesCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = ValidationUtils.joinObjects( persistedObjects, nonPersistedObjects );
+
+        if ( objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<PreheatErrorReport> errorReports = checkReferences( object, bundle.getPreheat(),
+                bundle.getPreheatIdentifier(), bundle.isSkipSharing(), ctx );
+
+            if ( errorReports.isEmpty() )
+                continue;
+            
+            if ( object != null )
+            {
+                ObjectReport objectReport = new ObjectReport( object, bundle );
+                objectReport.addErrorReports( errorReports );
+                typeReport.addObjectReport( objectReport );
+            }
+        }
+
+        if ( !typeReport.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
+        {
+            typeReport.getStats().incIgnored();
+        }
+
+        return typeReport;
+    }
+
+    private List<PreheatErrorReport> checkReferences( IdentifiableObject object, Preheat preheat,
+        PreheatIdentifier identifier, boolean skipSharing, ValidationContext ctx )
+    {
+        List<PreheatErrorReport> preheatErrorReports = new ArrayList<>();
+
+        if ( object == null )
+        {
+            return preheatErrorReports;
+        }
+
+        Schema schema = ctx.getSchemaService().getDynamicSchema( object.getClass() );
+        schema.getProperties().stream().filter( p -> p.isPersisted() && p.isOwner()
+            && ( PropertyType.REFERENCE == p.getPropertyType() || PropertyType.REFERENCE == p.getItemPropertyType() ) )
+            .forEach( p -> {
+                if ( skipCheck( p.getKlass() ) || skipCheck( p.getItemKlass() ) )
+                {
+                    return;
+                }
+
+                if ( !p.isCollection() )
+                {
+                    IdentifiableObject refObject = ReflectionUtils.invokeMethod( object, p.getGetterMethod() );
+                    IdentifiableObject ref = preheat.get( identifier, refObject );
+
+                    if ( ref == null && refObject != null && !preheat.isDefault( refObject ) )
+                    {
+                        if ( !("user".equals( p.getName() ) && User.class.isAssignableFrom( p.getKlass() )
+                            && skipSharing) )
+                        {
+                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                                ErrorCode.E5002, identifier.getIdentifiersWithName( refObject ),
+                                identifier.getIdentifiersWithName( object ), p.getName() ) );
+                        }
+                    }
+                }
+                else
+                {
+                    Collection<IdentifiableObject> objects = ReflectionUtils.newCollectionInstance( p.getKlass() );
+                    Collection<IdentifiableObject> refObjects = ReflectionUtils.invokeMethod( object,
+                        p.getGetterMethod() );
+
+                    for ( IdentifiableObject refObject : refObjects )
+                    {
+                        if ( preheat.isDefault( refObject ) )
+                            continue;
+
+                        IdentifiableObject ref = preheat.get( identifier, refObject );
+
+                        if ( ref == null && refObject != null )
+                        {
+                            preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                                ErrorCode.E5002, identifier.getIdentifiersWithName( refObject ),
+                                identifier.getIdentifiersWithName( object ), p.getCollectionName() ) );
+                        }
+                        else
+                        {
+                            objects.add( refObject );
+                        }
+                    }
+
+                    ReflectionUtils.invokeMethod( object, p.getSetterMethod(), objects );
+                }
+            } );
+
+        if ( schema.havePersistedProperty( "attributeValues" ) )
+        {
+            object.getAttributeValues().stream()
+                .filter( attributeValue -> attributeValue.getAttribute() != null
+                    && preheat.get( identifier, attributeValue.getAttribute() ) == null )
+                .forEach(
+                    attributeValue -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                        ErrorCode.E5002, identifier.getIdentifiersWithName( attributeValue.getAttribute() ),
+                        identifier.getIdentifiersWithName( object ), "attributeValues" ) ) );
+        }
+
+        if ( schema.havePersistedProperty( "userGroupAccesses" ) )
+        {
+            object.getUserGroupAccesses().stream()
+                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUserGroup() != null
+                    && preheat.get( identifier, userGroupAccess.getUserGroup() ) == null )
+                .forEach(
+                    userGroupAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier, object.getClass(),
+                        ErrorCode.E5002, identifier.getIdentifiersWithName( userGroupAccesses.getUserGroup() ),
+                        identifier.getIdentifiersWithName( object ), "userGroupAccesses" ) ) );
+        }
+
+        if ( schema.havePersistedProperty( "userAccesses" ) )
+        {
+            object.getUserAccesses().stream()
+                .filter( userGroupAccess -> !skipSharing && userGroupAccess.getUser() != null
+                    && preheat.get( identifier, userGroupAccess.getUser() ) == null )
+                .forEach( userAccesses -> preheatErrorReports.add( new PreheatErrorReport( identifier,
+                    object.getClass(), ErrorCode.E5002, identifier.getIdentifiersWithName( userAccesses.getUser() ),
+                    identifier.getIdentifiersWithName( object ), "userAccesses" ) ) );
+        }
+
+
+        return preheatErrorReports;
+    }
+
+    private boolean skipCheck( Class<?> klass )
+    {
+        return klass != null
+            && (UserCredentials.class.isAssignableFrom( klass ) || EmbeddedObject.class.isAssignableFrom( klass )
+                || Period.class.isAssignableFrom( klass ) || PeriodType.class.isAssignableFrom( klass ));
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
@@ -1,0 +1,76 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class SchemaCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects == null || objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<ErrorReport> validationErrorReports = context.getSchemaValidator().validate( object );
+
+            if ( !validationErrorReports.isEmpty() )
+            {
+                addObjectReports( validationErrorReports, typeReport, object, bundle );
+                context.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
@@ -1,0 +1,168 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.user.User;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class SecurityCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+
+        if ( importStrategy.isCreateAndUpdate() )
+        {
+            TypeReport report = runValidationCheck( bundle, klass, persistedObjects, ImportStrategy.UPDATE, context );
+            report.merge( runValidationCheck( bundle, klass, nonPersistedObjects, ImportStrategy.CREATE, context ) );
+            return report;
+        }
+        else if ( importStrategy.isCreate() )
+        {
+            return runValidationCheck( bundle, klass, nonPersistedObjects, ImportStrategy.CREATE, context );
+        }
+        else if ( importStrategy.isUpdate() )
+        {
+            return runValidationCheck( bundle, klass, persistedObjects, ImportStrategy.UPDATE, context );
+        }
+        else
+        {
+            return new TypeReport( klass );
+        }
+
+    }
+
+    private TypeReport runValidationCheck( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> objects, ImportStrategy importMode, ValidationContext ctx )
+    {
+
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( objects == null || objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        Iterator<IdentifiableObject> iterator = objects.iterator();
+        PreheatIdentifier identifier = bundle.getPreheatIdentifier();
+
+        while ( iterator.hasNext() )
+        {
+            IdentifiableObject object = iterator.next();
+
+            if ( importMode.isCreate() )
+            {
+                if ( !ctx.getAclService().canCreate( bundle.getUser(), klass ) )
+                {
+                    ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E3000,
+                        identifier.getIdentifiersWithName( bundle.getUser() ),
+                        identifier.getIdentifiersWithName( object ) );
+
+                    ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
+                    ctx.markForRemoval( object );
+                    continue;
+                }
+            }
+            else
+            {
+                IdentifiableObject persistedObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), object );
+
+                if ( importMode.isUpdate() )
+                {
+                    if ( !ctx.getAclService().canUpdate( bundle.getUser(), persistedObject ) )
+                    {
+                        ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E3001,
+                            identifier.getIdentifiersWithName( bundle.getUser() ),
+                            identifier.getIdentifiersWithName( object ) );
+
+                        ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
+                        ctx.markForRemoval( object );
+                        continue;
+                    }
+                }
+                else if ( importMode.isDelete() )
+                {
+                    if ( !ctx.getAclService().canDelete( bundle.getUser(), persistedObject ) )
+                    {
+                        ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E3002,
+                            identifier.getIdentifiersWithName( bundle.getUser() ),
+                            identifier.getIdentifiersWithName( object ) );
+
+                        ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
+
+                        ctx.markForRemoval( object );
+                        continue;
+                    }
+                }
+            }
+
+            if ( object instanceof User )
+            {
+                User user = (User) object;
+                List<ErrorReport> errorReports = ctx.getUserService().validateUser( user, bundle.getUser() );
+
+                if ( !errorReports.isEmpty() ) {
+
+                    addObjectReports( errorReports, typeReport, object, bundle );
+                    ctx.markForRemoval( object );
+                }
+            }
+
+            List<ErrorReport> sharingErrorReports = ctx.getAclService().verifySharing( object, bundle.getUser() );
+            if ( !sharingErrorReports.isEmpty() )
+            {
+                addObjectReports( sharingErrorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
+
+            }
+        }
+
+        return typeReport;
+    }
+
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
@@ -102,7 +102,7 @@ public class SecurityCheck
                         identifier.getIdentifiersWithName( bundle.getUser() ),
                         identifier.getIdentifiersWithName( object ) );
 
-                    ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
+                    ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
                     ctx.markForRemoval( object );
                     continue;
                 }
@@ -119,7 +119,7 @@ public class SecurityCheck
                             identifier.getIdentifiersWithName( bundle.getUser() ),
                             identifier.getIdentifiersWithName( object ) );
 
-                        ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
+                        ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
                         ctx.markForRemoval( object );
                         continue;
                     }
@@ -132,7 +132,7 @@ public class SecurityCheck
                             identifier.getIdentifiersWithName( bundle.getUser() ),
                             identifier.getIdentifiersWithName( object ) );
 
-                        ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle);
+                        ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
 
                         ctx.markForRemoval( object );
                         continue;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
@@ -1,0 +1,150 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.Schema;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UniqueAttributesCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+        Schema schema = ctx.getSchemaService().getDynamicSchema( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<ErrorReport> errorReports = checkUniqueAttributes( klass, object, bundle.getPreheat(),
+                bundle.getPreheatIdentifier() );
+
+            if ( !errorReports.isEmpty() )
+            {
+
+                addObjectReports( errorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+
+    private List<ErrorReport> checkUniqueAttributes( Class<? extends IdentifiableObject> klass,
+        IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier )
+    {
+        List<ErrorReport> errorReports = new ArrayList<>();
+
+        if ( object == null || preheat.isDefault( object ) || !preheat.getUniqueAttributes().containsKey( klass ) )
+        {
+            return errorReports;
+        }
+
+        Set<AttributeValue> attributeValues = object.getAttributeValues();
+        List<String> uniqueAttributes = new ArrayList<>( preheat.getUniqueAttributes().get( klass ) ); // make copy for
+                                                                                                       // modification
+
+        if ( !preheat.getUniqueAttributeValues().containsKey( klass ) )
+        {
+            preheat.getUniqueAttributeValues().put( klass, new HashMap<>() );
+        }
+
+        Map<String, Map<String, String>> uniqueAttributeValues = preheat.getUniqueAttributeValues().get( klass );
+
+        if ( uniqueAttributes.isEmpty() )
+        {
+            return errorReports;
+        }
+
+        attributeValues.forEach( attributeValue -> {
+            Attribute attribute = preheat.get( identifier, attributeValue.getAttribute() );
+
+            if ( attribute == null || !attribute.isUnique() || StringUtils.isEmpty( attributeValue.getValue() ) )
+            {
+                return;
+            }
+
+            if ( uniqueAttributeValues.containsKey( attribute.getUid() ) )
+            {
+                Map<String, String> values = uniqueAttributeValues.get( attribute.getUid() );
+
+                if ( values.containsKey( attributeValue.getValue() )
+                    && !values.get( attributeValue.getValue() ).equals( object.getUid() ) )
+                {
+                    errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4009,
+                        IdentifiableObjectUtils.getDisplayName( attribute ), attributeValue.getValue() )
+                            .setMainId( attribute.getUid() ).setErrorProperty( "value" ) );
+                }
+                else
+                {
+                    uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
+                }
+            }
+            else
+            {
+                uniqueAttributeValues.put( attribute.getUid(), new HashMap<>() );
+                uniqueAttributeValues.get( attribute.getUid() ).put( attributeValue.getValue(), object.getUid() );
+            }
+        } );
+
+        return errorReports;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniquenessCheck.java
@@ -1,0 +1,152 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.user.User;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UniquenessCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<ErrorReport> errorReports = new ArrayList<>();
+
+            if ( object instanceof User )
+            {
+                User user = (User) object;
+                errorReports.addAll( checkUniqueness( user, bundle.getPreheat(), bundle.getPreheatIdentifier(), ctx ) );
+                errorReports.addAll( checkUniqueness( user.getUserCredentials(), bundle.getPreheat(),
+                    bundle.getPreheatIdentifier(), ctx ) );
+            }
+            else
+            {
+                errorReports = checkUniqueness( object, bundle.getPreheat(), bundle.getPreheatIdentifier(), ctx );
+            }
+
+            if ( !errorReports.isEmpty() )
+            {
+                addObjectReports( errorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+
+    }
+
+    private List<ErrorReport> checkUniqueness( IdentifiableObject object, Preheat preheat, PreheatIdentifier identifier,
+        ValidationContext ctx )
+    {
+        List<ErrorReport> errorReports = new ArrayList<>();
+
+        if ( object == null || preheat.isDefault( object ) )
+            return errorReports;
+
+        if ( !preheat.getUniquenessMap().containsKey( object.getClass() ) )
+        {
+            preheat.getUniquenessMap().put( object.getClass(), new HashMap<>() );
+        }
+
+        Map<String, Map<Object, String>> uniquenessMap = preheat.getUniquenessMap().get( object.getClass() );
+
+        Schema schema = ctx.getSchemaService().getDynamicSchema( object.getClass() );
+        List<Property> uniqueProperties = schema.getProperties().stream()
+            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
+            .collect( Collectors.toList() );
+
+        uniqueProperties.forEach( property -> {
+            if ( !uniquenessMap.containsKey( property.getName() ) )
+            {
+                uniquenessMap.put( property.getName(), new HashMap<>() );
+            }
+
+            Object value = ReflectionUtils.invokeMethod( object, property.getGetterMethod() );
+
+            if ( value != null )
+            {
+                String persistedUid = uniquenessMap.get( property.getName() ).get( value );
+
+                if ( persistedUid != null )
+                {
+                    if ( !object.getUid().equals( persistedUid ) )
+                    {
+                        errorReports.add( new ErrorReport( object.getClass(), ErrorCode.E5003, property.getName(),
+                            value, identifier.getIdentifiersWithName( object ), persistedUid ).setMainId( persistedUid )
+                                .setErrorProperty( property.getName() ) );
+                    }
+                }
+                else
+                {
+                    uniquenessMap.get( property.getName() ).put( value, object.getUid() );
+                }
+            }
+        } );
+
+        return errorReports;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
@@ -1,0 +1,76 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UpdateCheck
+    implements
+    ValidationCheck
+{
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        if ( nonPersistedObjects == null || nonPersistedObjects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject identifiableObject : nonPersistedObjects )
+        {
+            IdentifiableObject object = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
+
+            if ( object == null || object.getId() == 0 )
+            {
+                ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
+                        .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() );
+
+                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationCheck.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * This interface is implemented by classes that can validate an {@see ObjectBundle}
+ *
+ * @author Luciano Fiandesio
+ */
+public interface ValidationCheck
+{
+    /**
+     * Execute a validation check against the {@see ObjectBundle}
+     *
+     * @param bundle an {@see ObjectBundle} to validate
+     * @param klass the class of Object to validate, within the bundle
+     * @param persistedObjects a List of IdentifiableObject
+     * @param nonPersistedObjects a List of IdentifiableObject
+     * @param importStrategy the {@see ImportStrategy}
+     * @param context a {@see ValidationContext} containing the services required
+     *        for validation
+     *
+     * @return a {@see TypeReport}
+     */
+    TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context );
+
+    default List<IdentifiableObject> selectObjects( List<IdentifiableObject> persistedObjects,
+        List<IdentifiableObject> nonPersistedObjects, ImportStrategy importStrategy )
+    {
+
+        if ( importStrategy.isCreateAndUpdate() )
+        {
+            return ValidationUtils.joinObjects( persistedObjects, nonPersistedObjects );
+        }
+        else if ( importStrategy.isCreate() )
+        {
+            return nonPersistedObjects;
+        }
+        else if ( importStrategy.isUpdate() )
+        {
+            return persistedObjects;
+        }
+        else
+        {
+            return Collections.emptyList();
+        }
+
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationContext.java
@@ -1,0 +1,103 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleHook;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.UserService;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationContext
+{
+
+    private List<ObjectBundleHook> objectBundleHooks;
+
+    private SchemaValidator schemaValidator;
+
+    private AclService aclService;
+
+    private UserService userService;
+
+    private SchemaService schemaService;
+
+    private List<IdentifiableObject> markedForRemoval = new ArrayList<>();
+
+    public ValidationContext( List<ObjectBundleHook> objectBundleHooks, SchemaValidator schemaValidator,
+        AclService aclService, UserService userService, SchemaService schemaService )
+    {
+        this.objectBundleHooks = objectBundleHooks;
+        this.schemaValidator = schemaValidator;
+        this.aclService = aclService;
+        this.userService = userService;
+        this.schemaService = schemaService;
+    }
+
+    public List<ObjectBundleHook> getObjectBundleHooks()
+    {
+        return objectBundleHooks;
+    }
+
+    public SchemaValidator getSchemaValidator()
+    {
+        return schemaValidator;
+    }
+
+    public AclService getAclService()
+    {
+        return aclService;
+    }
+
+    public UserService getUserService()
+    {
+        return userService;
+    }
+
+    public SchemaService getSchemaService()
+    {
+        return schemaService;
+    }
+
+    public void markForRemoval( IdentifiableObject object )
+    {
+        this.markedForRemoval.add( object );
+    }
+
+    public List<IdentifiableObject> getMarkedForRemoval()
+    {
+        return markedForRemoval;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
@@ -1,0 +1,185 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleHook;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.UserService;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Component
+public class ValidationFactory
+{
+
+    private static final Log log = LogFactory.getLog( ValidationFactory.class );
+
+    private final SchemaValidator schemaValidator;
+
+    private final SchemaService schemaService;
+
+    private final AclService aclService;
+
+    private final UserService userService;
+
+    private final Map<ImportStrategy, List<Class<? extends ValidationCheck>>> validatorMap;
+
+    private List<ObjectBundleHook> objectBundleHooks;
+
+    public ValidationFactory( SchemaValidator schemaValidator, SchemaService schemaService, AclService aclService,
+        UserService userService, List<ObjectBundleHook> objectBundleHooks,
+        Map<ImportStrategy, List<Class<? extends ValidationCheck>>> validatorMap )
+    {
+        this.schemaValidator = schemaValidator;
+        this.schemaService = schemaService;
+        this.aclService = aclService;
+        this.userService = userService;
+        this.validatorMap = validatorMap;
+        this.objectBundleHooks = objectBundleHooks == null ? Collections.emptyList() : objectBundleHooks;
+    }
+
+    /**
+     * Run the validation checks against the bundle
+     *
+     * @param bundle an {@see ObjectBundle}
+     * @param klass the Class type that is getting validated
+     * @param persistedObjects a List of IdentifiableObject
+     * @param nonPersistedObjects a List of IdentifiableObject
+     *
+     * @return a {@see TypeReport} containing the outcome of the validation
+     */
+    public TypeReport validateBundle( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects )
+    {
+        ValidationContext ctx = getContext();
+        TypeReport typeReport = new ValidationRunner( validatorMap.get( bundle.getImportMode() ) )
+            .executeValidationChain( bundle, klass, persistedObjects, nonPersistedObjects, ctx );
+
+        // remove from the bundle the invalid objects
+        removeFromBundle( klass, ctx, bundle );
+
+        return addStatistics( typeReport, bundle, persistedObjects, nonPersistedObjects );
+    }
+
+    private TypeReport addStatistics( TypeReport typeReport, ObjectBundle bundle,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects )
+    {
+        if ( bundle.getImportMode().isCreateAndUpdate() )
+        {
+            typeReport.getStats().incCreated( nonPersistedObjects.size() );
+            typeReport.getStats().incUpdated( persistedObjects.size() );
+
+        }
+        else if ( bundle.getImportMode().isCreate() )
+        {
+            typeReport.getStats().incCreated( nonPersistedObjects.size() );
+
+        }
+        else if ( bundle.getImportMode().isUpdate() )
+        {
+            typeReport.getStats().incUpdated( persistedObjects.size() );
+
+        }
+        else if ( bundle.getImportMode().isDelete() )
+        {
+            typeReport.getStats().incDeleted( persistedObjects.size() );
+        }
+        return typeReport;
+    }
+
+    /**
+     *
+     * @param klass the class of the objects to remove from bundle
+     * @param ctx the {@see ValidationContext} containing the list of objects to
+     *        remove
+     * @param bundle the {@see ObjectBundle}
+     */
+    private void removeFromBundle( Class<? extends IdentifiableObject> klass, ValidationContext ctx,
+        ObjectBundle bundle )
+    {
+        List<IdentifiableObject> persisted = bundle.getObjects( klass, true );
+        persisted.removeAll( ctx.getMarkedForRemoval() );
+
+        List<IdentifiableObject> nonPersisted = bundle.getObjects( klass, false );
+        nonPersisted.removeAll( ctx.getMarkedForRemoval() );
+    }
+
+    private ValidationContext getContext()
+    {
+        return new ValidationContext( this.objectBundleHooks, this.schemaValidator, this.aclService, this.userService,
+            this.schemaService );
+    }
+
+    static class ValidationRunner
+    {
+
+        private List<Class<? extends ValidationCheck>> validators;
+
+        public ValidationRunner( List<Class<? extends ValidationCheck>> validators )
+        {
+            this.validators = validators;
+        }
+
+        public TypeReport executeValidationChain( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+            List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+            ValidationContext ctx )
+        {
+
+            TypeReport typeReport = new TypeReport( klass );
+            for ( Class<? extends ValidationCheck> validator : validators )
+            {
+                try
+                {
+                    ValidationCheck validationCheck = validator.newInstance();
+                    typeReport.merge( validationCheck.check( bundle, klass, persistedObjects, nonPersistedObjects,
+                        bundle.getImportMode(), ctx ) );
+                }
+                catch ( InstantiationException | IllegalAccessException e )
+                {
+                    log.error( "An error occurred during metadata import validation", e );
+                }
+            }
+            return typeReport;
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationHooksCheck.java
@@ -1,0 +1,79 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationHooksCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx )
+    {
+        TypeReport typeReport = new TypeReport( klass );
+
+        List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects == null || objects.isEmpty() )
+        {
+            return typeReport;
+        }
+
+        for ( IdentifiableObject object : objects )
+        {
+            List<ErrorReport> errorReports = new ArrayList<>();
+            ctx.getObjectBundleHooks().forEach( hook -> errorReports.addAll( hook.validate( object, bundle ) ) );
+
+            if ( !errorReports.isEmpty() )
+            {
+                addObjectReports( errorReports, typeReport, object, bundle );
+                ctx.markForRemoval( object );
+            }
+        }
+
+        return typeReport;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
@@ -1,0 +1,75 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationUtils
+{
+
+    public static List<IdentifiableObject> joinObjects( List<IdentifiableObject> persistedObjects,
+        List<IdentifiableObject> nonPersistedObjects )
+    {
+        return Stream.concat( persistedObjects.stream(), nonPersistedObjects.stream() ).collect( Collectors.toList() );
+    }
+
+    public static void addObjectReports( List<ErrorReport> reports, TypeReport typeReport, IdentifiableObject object,
+        ObjectBundle bundle )
+    {
+        ObjectReport objectReport = new ObjectReport( object, bundle );
+        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+        objectReport.addErrorReports( reports );
+
+        typeReport.addObjectReport( objectReport );
+        typeReport.getStats().incIgnored();
+    }
+
+    public static void addObjectReport( ErrorReport report, TypeReport typeReport, IdentifiableObject object,
+        ObjectBundle bundle )
+    {
+        ObjectReport objectReport = new ObjectReport( object, bundle );
+        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
+        objectReport.addErrorReport( report );
+
+        typeReport.addObjectReport( objectReport );
+        typeReport.getStats().incIgnored();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
@@ -180,19 +180,19 @@ public class ObjectBundleServiceTest
 
                 for ( ErrorReport errorReport : errorReports )
                 {
-                    assertTrue( PreheatErrorReport.class.isInstance( errorReport ) );
+                    assertTrue( errorReport instanceof PreheatErrorReport );
                     PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
                     assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
 
-                    if ( CategoryCombo.class.isInstance( preheatErrorReport.getValue() ) )
+                    if ( preheatErrorReport.getValue() instanceof CategoryCombo )
                     {
                         assertEquals( "p0KPaWEg3cf", preheatErrorReport.getObjectReference().getUid() );
                     }
-                    else if ( User.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof User )
                     {
                         assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
                     }
-                    else if ( OptionSet.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof OptionSet )
                     {
                         assertEquals( "pQYCiuosBnZ", preheatErrorReport.getObjectReference().getUid() );
                     }
@@ -238,21 +238,21 @@ public class ObjectBundleServiceTest
 
                 for ( ErrorReport errorReport : errorReports )
                 {
-                    assertTrue( PreheatErrorReport.class.isInstance( errorReport ) );
+                    assertTrue( errorReport instanceof PreheatErrorReport );
                     PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
                     assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
 
-                    if ( CategoryCombo.class.isInstance( preheatErrorReport.getValue() ) )
+                    if ( preheatErrorReport.getValue() instanceof CategoryCombo )
                     {
-                        assertFalse( true );
+                        fail();
                     }
-                    else if ( User.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof User )
                     {
                         assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
                     }
-                    else if ( OptionSet.class.isInstance( preheatErrorReport.getValue() ) )
+                    else if ( preheatErrorReport.getValue() instanceof OptionSet )
                     {
-                        assertFalse( true );
+                        fail();
                     }
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DummyCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DummyCheck.java
@@ -1,0 +1,72 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DummyCheck
+    implements
+    ValidationCheck
+{
+
+    @Override
+    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+
+        TypeReport typeReport = new TypeReport( klass );
+
+        for ( IdentifiableObject nonPersistedObject : nonPersistedObjects )
+        {
+            if ( nonPersistedObject.getUid().startsWith( "u" ) )
+            {
+
+                ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
+                    bundle.getPreheatIdentifier().getIdentifiersWithName( nonPersistedObject ) )
+                        .setMainId( nonPersistedObject.getUid() );
+                ValidationUtils.addObjectReport( errorReport, typeReport, nonPersistedObject, bundle );
+
+                context.markForRemoval( nonPersistedObject );
+            }
+        }
+
+        return typeReport;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactoryTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactoryTest.java
@@ -1,0 +1,130 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.importexport.ImportStrategy.CREATE_AND_UPDATE;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.UserService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ValidationFactoryTest
+{
+    @Mock
+    private SchemaValidator schemaValidator;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private UserService userService;
+
+    @Rule
+    public MockitoRule mockitoRule = rule();
+
+    private ValidationFactory validationFactory;
+
+    @Before
+    public void setUp()
+    {
+        // Create a validation factory with a dummy check
+        validationFactory = new ValidationFactory( schemaValidator, schemaService, aclService, userService,
+            Collections.emptyList(), ImmutableMap.of( CREATE_AND_UPDATE, Lists.newArrayList( DummyCheck.class ) ) );
+    }
+
+    @Test
+    public void verifyValidationFactoryProcessValidationCheck()
+    {
+        ObjectBundle bundle = createObjectBundle();
+
+        TypeReport typeReport = validationFactory.validateBundle( bundle, Attribute.class,
+            bundle.getObjects( Attribute.class, true ), bundle.getObjects( Attribute.class, false ) );
+
+        // verify that object has been removed from bundle
+        assertThat( bundle.getObjects( Attribute.class, false ), hasSize( 0 ) );
+        assertThat( bundle.getObjects( Attribute.class, true ), hasSize( 0 ) );
+        assertThat( typeReport.getStats().getCreated(), is( 0 ) );
+        assertThat( typeReport.getStats().getUpdated(), is( 0 ) );
+        assertThat( typeReport.getStats().getDeleted(), is( 0 ) );
+        assertThat( typeReport.getStats().getIgnored(), is( 1 ) );
+        assertThat( typeReport.getObjectReports(), hasSize( 1 ) );
+    }
+
+    private ObjectBundle createObjectBundle()
+    {
+
+        Attribute attribute1 = new Attribute();
+        attribute1.setUid( "u1" );
+
+        ObjectBundleParams objectBundleParams = new ObjectBundleParams();
+        Preheat preheat = new Preheat();
+
+        final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = new HashMap<>();
+        objectMap.put( Attribute.class, new ArrayList<>() );
+
+        objectMap.get( Attribute.class ).add( attribute1 );
+
+        preheat.put( PreheatIdentifier.UID, attribute1 );
+
+        return new ObjectBundle( objectBundleParams, preheat, objectMap );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/Schema.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/Schema.java
@@ -701,6 +701,17 @@ public class Schema implements Ordered, Klass
         this.order = order;
     }
 
+    /**
+     * Gets a list of properties marked as unique for this schema
+     *
+      * @return a List of {@see Property}
+     */
+    public List<Property> getUniqueProperties()
+    {
+        return this.getProperties().stream()
+            .filter( p -> p.isPersisted() && p.isOwner() && p.isUnique() && p.isSimple() )
+            .collect( Collectors.toList() );
+    }
 
     @Override
     public int hashCode()


### PR DESCRIPTION
- DHIS2-8267
- Introduce new component that fetches only unique attributes for a
  Metadata object during Metadata import pre-heat (instead of executing
something like "select * from table" now the system executes "select
column_a, column_c from table".
- Force the query to be read-only to prevent Hibernate to syncronize the
  data with the database
- Refactored Metadata import validation into Validation Rules, in order
to improve testability and "code-cleaness"
- "forward-port" from 2.33 c346476902b87567ae335875745c933c2ace61c7