### PR TITLE
[2.34] fix: enable default auditing scopes

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -84,6 +84,7 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <properties>

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
@@ -113,7 +113,7 @@ public class AuditMatrixConfigurer
             }
             else
             {
-                matrix.put( value, DEFAULT_AUDIT_CONFIGURATION);
+                matrix.put( value, DEFAULT_AUDIT_CONFIGURATION );
             }
         }
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
@@ -68,9 +68,15 @@ public class AuditMatrixConfigurer
     private final DhisConfigurationProvider config;
     private final static String PROPERTY_PREFIX = "audit.";
     private final static String AUDIT_TYPE_STRING_SEPAR = ";";
-    private static final Map<AuditType, Boolean> ALL_DISABLED = ImmutableMap.<AuditType, Boolean>builder()
-        .put( AuditType.CREATE, false )
-        .put( AuditType.UPDATE, false )
+
+    /**
+     * Default Audit configuration: CREATE, UPDATE and DELETE operations are audited by default.
+     * Other Audit types have to be explicitly enabled by the user
+     */
+    private static final Map<AuditType, Boolean> DEFAULT_AUDIT_CONFIGURATION = ImmutableMap.<AuditType, Boolean>builder()
+        .put( AuditType.CREATE, true )
+        .put( AuditType.UPDATE, true )
+        .put( AuditType.DELETE, true )
         .put( AuditType.READ, false )
         .put( AuditType.SEARCH, false )
         .put( AuditType.SECURITY, false )
@@ -107,7 +113,7 @@ public class AuditMatrixConfigurer
             }
             else
             {
-                matrix.put( value, ALL_DISABLED );
+                matrix.put( value, DEFAULT_AUDIT_CONFIGURATION);
             }
         }
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
@@ -30,9 +30,18 @@ package org.hisp.dhis.artemis.audit.configuration;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.audit.AuditScope.AGGREGATE;
+import static org.hisp.dhis.audit.AuditScope.METADATA;
 import static org.hisp.dhis.audit.AuditScope.TRACKER;
-import static org.hisp.dhis.audit.AuditType.*;
-import static org.junit.Assert.*;
+import static org.hisp.dhis.audit.AuditType.CREATE;
+import static org.hisp.dhis.audit.AuditType.DELETE;
+import static org.hisp.dhis.audit.AuditType.READ;
+import static org.hisp.dhis.audit.AuditType.SEARCH;
+import static org.hisp.dhis.audit.AuditType.SECURITY;
+import static org.hisp.dhis.audit.AuditType.UPDATE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -78,17 +87,17 @@ public class AuditMatrixConfigurerTest
 
         matrix = this.subject.configure();
 
-        assertThat( matrix.get( AuditScope.METADATA ).keySet(), hasSize( 6 ) );
-        assertMatrixEnabled( AuditScope.METADATA, READ );
-        assertMatrixDisabled( AuditScope.METADATA, CREATE, UPDATE, DELETE );
+        assertThat( matrix.get( METADATA ).keySet(), hasSize( 6 ) );
+        assertMatrixEnabled( METADATA, READ );
+        assertMatrixDisabled( METADATA, CREATE, UPDATE, DELETE );
 
         assertThat( matrix.get( TRACKER ).keySet(), hasSize( 6 ) );
         assertMatrixDisabled( TRACKER, SEARCH, SECURITY );
         assertMatrixEnabled( TRACKER, CREATE, UPDATE, DELETE, READ );
 
-        assertThat( matrix.get( AuditScope.AGGREGATE ).keySet(), hasSize( 6 ) );
-        assertMatrixDisabled( AuditScope.AGGREGATE, READ, SECURITY, SEARCH );
-        assertMatrixEnabled( AuditScope.AGGREGATE, CREATE, UPDATE, DELETE );
+        assertThat( matrix.get( AGGREGATE ).keySet(), hasSize( 6 ) );
+        assertMatrixDisabled( AGGREGATE, READ, SECURITY, SEARCH );
+        assertMatrixEnabled( AGGREGATE, CREATE, UPDATE, DELETE );
     }
 
     @Test
@@ -97,9 +106,28 @@ public class AuditMatrixConfigurerTest
         when( config.getProperty( ConfigurationKey.AUDIT_METADATA_MATRIX ) ).thenReturn( "READX;UPDATE" );
 
         matrix = this.subject.configure();
-        assertThat( matrix.get( AuditScope.METADATA ).keySet(), hasSize( 6 ) );
-        assertAllFalseBut( matrix.get( AuditScope.METADATA ), UPDATE );
+        assertThat( matrix.get( METADATA ).keySet(), hasSize( 6 ) );
+        assertAllFalseBut( matrix.get( METADATA ), UPDATE );
+    }
 
+    @Test
+    public void verifyDefaultAuditingConfiguration()
+    {
+        matrix = this.subject.configure();
+        assertMatrixDisabled( METADATA, READ );
+        assertMatrixEnabled( METADATA, CREATE );
+        assertMatrixEnabled( METADATA, UPDATE );
+        assertMatrixEnabled( METADATA, DELETE );
+
+        assertMatrixDisabled( TRACKER, READ );
+        assertMatrixEnabled( TRACKER, CREATE );
+        assertMatrixEnabled( TRACKER, UPDATE );
+        assertMatrixEnabled( TRACKER, DELETE );
+
+        assertMatrixDisabled( AGGREGATE, READ );
+        assertMatrixEnabled( AGGREGATE, CREATE );
+        assertMatrixEnabled( AGGREGATE, UPDATE );
+        assertMatrixEnabled( AGGREGATE, DELETE );
     }
 
     private void assertAllFalseBut( Map<AuditType, Boolean> auditTypeBooleanMap, AuditType trueAuditType )

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/AnnotationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/AnnotationUtilsTest.java
@@ -28,13 +28,13 @@ package org.hisp.dhis.artemis.audit.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.Auditable;
 import org.hisp.dhis.system.util.AnnotationUtils;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 
 /**

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/NestedTestImplementation.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/NestedTestImplementation.java
@@ -36,7 +36,7 @@ import org.hisp.dhis.audit.AuditAttribute;
 
 public class NestedTestImplementation
     extends
-    TestImplementation
+        org.hisp.dhis.artemis.audit.listener.TestImplementation
 {
     private String testAttribute3;
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/TestImplementation.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/TestImplementation.java
@@ -34,7 +34,7 @@ import org.hisp.dhis.audit.AuditAttribute;
  * @author Luciano Fiandesio
  */
 public class TestImplementation
-    implements TestInterface
+    implements org.hisp.dhis.artemis.audit.listener.TestInterface
 {
     @AuditAttribute
     private String testAttribute1;


### PR DESCRIPTION
- DHIS2-8416
- Auto-configure the Auditing sub-system to audit Tracker, Metadata and
Aggregate for CREATE, UPDATE and DELETE actions.
Configuration can be over-ridden by user.