### PR TITLE
style: automatic code formatting on commit

### DIFF
--- a/dhis-2/license-header.txt
+++ b/dhis-2/license-header.txt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -387,10 +387,43 @@
             </execution>
           </executions>
         </plugin>
+
         <plugin>
           <groupId>org.projectlombok</groupId>
           <artifactId>lombok-maven-plugin</artifactId>
           <version>1.18.10.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>io.committed</groupId>
+          <artifactId>speedy-spotless-maven-plugin</artifactId>
+          <version>0.1.0</version>
+          <executions>
+            <execution>
+              <id>install-formatter-hook</id>
+              <goals>
+                <goal>install-hooks</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <java>
+              <licenseHeader>
+                <file>${rootDir}/license-header.txt</file>
+              </licenseHeader>
+              <eclipse>
+                <file>${rootDir}/DHISFormatter.xml</file>
+                <version>4.9.0</version>
+              </eclipse>
+              <trimTrailingWhitespace />
+              <removeUnusedImports />
+              <importOrder>
+                <order>
+                  java,javax,org,com
+                </order>
+              </importOrder>
+            </java>
+          </configuration>
         </plugin>
       </plugins>
 


### PR DESCRIPTION
- TECH-305
- Introducing "speedy-spotless" to automatically format Java code upon
  commit (see doc:
https://docs.google.com/document/d/1kOKCSmm3vXyHKkO6mllvvdYlBK793WHG6OGWEASfHe8/edit)

## How to use

- from the root dhis2 directory, execute

`mvn speedy-spotless:install-hooks`

This will install the pre-commit hook that invoke Spotless only on
modified Java files