### PR TITLE
chore: Bumps spring / spring-security to latest versions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -201,7 +201,7 @@ public class DefaultTrackerImportService
 
     private <T extends Enum<T>> T getEnumWithDefault( Class<T> enumKlass, Map<String, List<String>> parameters, String key, T defaultValue )
     {
-        if ( parameters == null || parametersw.get( key ) == null || parameters.get( key ).isEmpty() )
+        if ( parameters == null || parameters.get( key ) == null || parameters.get( key ).isEmpty() )
         {
             return defaultValue;
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -201,7 +201,7 @@ public class DefaultTrackerImportService
 
     private <T extends Enum<T>> T getEnumWithDefault( Class<T> enumKlass, Map<String, List<String>> parameters, String key, T defaultValue )
     {
-        if ( parameters == null || parameters.get( key ) == null || parameters.get( key ).isEmpty() )
+        if ( parameters == null || parametersw.get( key ) == null || parameters.get( key ).isEmpty() )
         {
             return defaultValue;
         }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1541,8 +1541,8 @@
     <rootDir></rootDir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.version>5.2.3.RELEASE</spring.version>
-    <spring-security.version>5.2.1.RELEASE</spring-security.version>
+    <spring.version>5.2.4.RELEASE</spring.version>
+    <spring-security.version>5.2.2.RELEASE</spring-security.version>
     <spring-security-oauth2.version>2.4.0.RELEASE</spring-security-oauth2.version>
     <spring-session-data-redis.version>2.2.0.RELEASE</spring-session-data-redis.version>
     <lettuce.version>5.2.0.RELEASE</lettuce.version>


### PR DESCRIPTION
Bump spring to 5.2.4.RELEASE, and spring-security to 5.2.2.RELEASE