### PR TITLE
fix: stop debug of full entity in auditing

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstance.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstance.java
@@ -28,12 +28,12 @@ package org.hisp.dhis.program;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.vividsolutions.jts.geom.Geometry;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -46,11 +46,12 @@ import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * @author Abyot Asalefew
@@ -550,10 +551,10 @@ public class ProgramInstance
             ", created=" + created +
             ", lastUpdated=" + lastUpdated +
             ", status=" + status +
-            ", organisationUnit=" + organisationUnit.getUid() +
+            ", organisationUnit=" + ( organisationUnit != null ? organisationUnit.getUid() : "null" ) +
             ", incidentDate=" + incidentDate +
             ", enrollmentDate=" + enrollmentDate +
-            ", entityInstance=" + entityInstance.getUid() +
+            ", entityInstance=" + ( entityInstance != null ? entityInstance.getUid() : "null" ) +
             ", program=" + program +
             ", deleted=" + deleted +
             ", storedBy='" + storedBy + '\'' +

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditProducerSupplier.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditProducerSupplier.java
@@ -28,15 +28,15 @@ package org.hisp.dhis.artemis.audit;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.Strings;
+import java.util.Map;
 
-
-import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.artemis.MessageManager;
 import org.hisp.dhis.audit.AuditScope;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
+import com.google.common.base.Strings;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Luciano Fiandesio
@@ -62,15 +62,16 @@ public class AuditProducerSupplier
 
         if ( !Strings.isNullOrEmpty( topic ) )
         {
-            log.debug( "sending auditing message to topic: [" + topic + "] with content: "
-                + audit.toString() );
-
+            if ( log.isDebugEnabled() )
+            {
+                log.debug( "sending auditing message to topic: [" + topic + "] with content: " + audit.toLog() );
+            }
             this.messageManager.send( topic, audit );
         }
         else
         {
             log.error( String.format( "Unable to map AuditScope [%s] to a topic name. Sending aborted",
-                audit ) );
+                audit.getAuditScope() ) );
         }
     }
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditScheduler.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditScheduler.java
@@ -29,15 +29,15 @@ package org.hisp.dhis.artemis.audit;
  */
 
 
-
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.DelayQueue;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Luciano Fiandesio
@@ -59,8 +59,10 @@ public class AuditScheduler
 
     public void addAuditItem( final Audit auditItem )
     {
-        log.debug( String.format( "add Audit object with content %s to delayed queue", auditItem.toString() ) );
-
+        if ( log.isDebugEnabled() )
+        {
+            log.debug( String.format( "add Audit object with content %s to delayed queue", auditItem.toLog() ) );
+        }
         final QueuedAudit postponed = new QueuedAudit( auditItem, delay );
 
         if ( !delayed.contains( postponed ) )

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -104,7 +104,7 @@ public enum ConfigurationKey
     MONITORING_LOG_REQUESTID_MAXSIZE( "monitoring.requestidlog.maxsize", "-1", false ),
     APPHUB_BASE_URL( "apphub.base.url", "https://apps.dhis2.org", false ),
     APPHUB_API_URL( "apphub.api.url", "https://apps.dhis2.org/api", false ),
-    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "on" ),
+    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "off" ),
     AUDIT_METADATA_MATRIX( "audit.metadata", "", false ),
     AUDIT_TRACKER_MATRIX( "audit.tracker", "", false ),
     AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false );


### PR DESCRIPTION
- made sure we only log basic info about the audited entity (instead of the full payload)
- fix possible NPE in `ProgramStageInstance` `toString` method
- disabled in-memory queue for auditing as default, has to be explicitely enabled