### PR TITLE
[2.33] fix: Use Program Indicators to validate orgUnitField (#4673)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -28,7 +28,14 @@ package org.hisp.dhis.analytics.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.MoreObjects;
+import static org.hisp.dhis.common.DimensionalObject.*;
+import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
+import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.analytics.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -38,16 +45,12 @@ import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.common.DimensionalObject.*;
-import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
-import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
+import com.google.common.base.MoreObjects;
+import com.google.common.primitives.Booleans;
 
 /**
  * Class representing query parameters for retrieving event data from the
@@ -500,6 +503,24 @@ public class EventQueryParams
             return true;
         }
 
+        if ( program != null )
+        {
+            return validateProgramHasOrgUnitField( program );
+        }
+
+        if ( !itemProgramIndicators.isEmpty() )
+        {
+            // Fail validation if at least one program indicator is invalid
+            
+            return !itemProgramIndicators.stream().anyMatch( pi -> !validateProgramHasOrgUnitField( pi.getProgram() ) );
+        }
+
+        return false;
+    }
+
+    private boolean validateProgramHasOrgUnitField( Program program )
+    {
+
         if ( program.getTrackedEntityAttributes().stream()
             .anyMatch( at -> at.getValueType().isOrganisationUnit() && orgUnitField.equals( at.getUid() ) ) )
         {
@@ -514,7 +535,7 @@ public class EventQueryParams
 
         return false;
     }
-
+    
     /**
      * Gets program status
      */


### PR DESCRIPTION
* fix: use Prg. Indicators to validate orgUnitField

- DHIS2-7552
- When validating the orgUnitField value the system now takes in
consideration the event that a Program may be null and also checks for
Program Indicators. If the EventQueryParams contains Program Indicators,
the system runs the same validation against all the Programs associated
to the Program Indicators. If at least one fails, the entire validation
fails.

* chore: minor refactoring

* Update EventQueryParams.java

Co-authored-by: Lars Helge Øverland <lars@dhis2.org>