### PR TITLE
[2.32] fix: Use Program Indicators to validate orgUnitField 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -28,7 +28,14 @@ package org.hisp.dhis.analytics.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.MoreObjects;
+import static org.hisp.dhis.common.DimensionalObject.*;
+import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
+import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.analytics.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -38,16 +45,12 @@ import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.common.DimensionalObject.*;
-import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
-import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
+import com.google.common.base.MoreObjects;
+import com.google.common.primitives.Booleans;
 
 /**
  * Class representing query parameters for retrieving event data from the
@@ -500,6 +503,24 @@ public class EventQueryParams
             return true;
         }
 
+        if ( program != null )
+        {
+            return validateProgramHasOrgUnitField( program );
+        }
+
+        if ( !itemProgramIndicators.isEmpty() )
+        {
+            // Fail validation if at least one program indicator is invalid
+            
+            return !itemProgramIndicators.stream().anyMatch( pi -> !validateProgramHasOrgUnitField( pi.getProgram() ) );
+        }
+
+        return false;
+    }
+
+    private boolean validateProgramHasOrgUnitField( Program program )
+    {
+
         if ( program.getTrackedEntityAttributes().stream()
             .anyMatch( at -> at.getValueType().isOrganisationUnit() && orgUnitField.equals( at.getUid() ) ) )
         {
@@ -514,7 +535,7 @@ public class EventQueryParams
 
         return false;
     }
-
+    
     /**
      * Gets program status
      */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
@@ -30,14 +30,23 @@ import com.google.common.collect.Lists;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
 import com.google.common.collect.Sets;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.TimeField;
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.legend.LegendSet;
@@ -47,17 +56,13 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.Set;
-
-import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
-import static org.junit.Assert.*;
 
 /**
  * @author Lars Helge Overland
@@ -78,7 +83,11 @@ public class EventQueryParamsTest
     private OrganisationUnit ouA;
     private OrganisationUnit ouB;
     private Program prA;
+    private Program prB;
+    private Program prC;
     private ProgramStage psA;
+    private ProgramStage psB;
+    private ProgramStage psC;
     private Period peA;
     private Period peB;
     private Period peC;
@@ -104,11 +113,29 @@ public class EventQueryParamsTest
         ouB = createOrganisationUnit( 'B' );
 
         psA = createProgramStage( 'A', prA );
+        psB = createProgramStage( 'B', prB );
+        psC = createProgramStage( 'B', prC );
+        
+        // Program Stage A
         psA.addDataElement( deA, 0 );
         psA.addDataElement( deB, 1 );
         psA.addDataElement( deC, 2 );
         psA.addDataElement( deD, 3 );
+        // Program Stage B
+        psB.addDataElement( deA, 0);
+        psB.addDataElement( deB, 1);
+        // Program Stage C
+        psC.addDataElement( deA, 0);
+
         prA = createProgram( 'A', Sets.newHashSet( psA ), ouA );
+        prB = createProgram( 'B', Sets.newHashSet( psB ), ouA );
+        prC = createProgram( 'C', Sets.newHashSet( psC ), ouA );
+
+        TrackedEntityAttribute teA = createTrackedEntityAttribute('A', ValueType.ORGANISATION_UNIT);
+        teA.setUid( deD.getUid() );
+        ProgramTrackedEntityAttribute pteA = createProgramTrackedEntityAttribute( prC, teA);
+
+        prC.setProgramAttributes( Collections.singletonList( pteA ) );
 
         peA = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() );
         peB = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
@@ -142,7 +169,7 @@ public class EventQueryParamsTest
         assertNotNull( paramsB.getKey() );
         assertEquals( 40, paramsB.getKey().length() );
 
-        assertFalse( paramsA.getKey().equals( paramsB.getKey() ) );
+        assertNotEquals( paramsA.getKey(), paramsB.getKey() );
     }
     @Test
     public void testReplacePeriodsWithStartEndDates()
@@ -260,5 +287,63 @@ public class EventQueryParamsTest
             .addItem( iA ).build();
 
         assertFalse( params.orgUnitFieldIsValid() );
+    }
+
+    @Test
+    public void testIsOrgUnitFieldValidWithOneProgramIndicator()
+    {
+        QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
+
+        ProgramIndicator programIndicatorA = createProgramIndicator('A', prA, "", "");
+
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( null )
+                .withOrgUnitField( deD.getUid() )
+                .addItem( iA )
+                .addItemProgramIndicator( programIndicatorA )
+                .build();
+
+        assertTrue( params.orgUnitFieldIsValid() );
+
+    }
+
+    @Test
+    public void testIsOrgUnitFieldValidWithMultipleProgramIndicator()
+    {
+        QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
+
+        ProgramIndicator programIndicatorA = createProgramIndicator('A', prA, "", "");
+        // this PI has 0 Data Element of type OrgUnit -> test should fail
+        ProgramIndicator programIndicatorB = createProgramIndicator('B', prB, "", "");
+
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( null )
+                .withOrgUnitField( deD.getUid() )
+                .addItem( iA )
+                .addItemProgramIndicator( programIndicatorA )
+                .addItemProgramIndicator( programIndicatorB )
+                .build();
+
+        assertFalse( params.orgUnitFieldIsValid() );
+
+    }
+
+    @Test
+    public void testIsOrgUnitFieldValidWithMultipleProgramIndicator2()
+    {
+        QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
+
+        // This PI has a Program that has a Tracked Entity Attribute of type Org Unit
+        ProgramIndicator programIndicatorA = createProgramIndicator('A', prC, "", "");
+
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( null )
+                .withOrgUnitField( deD.getUid() )
+                .addItem( iA )
+                .addItemProgramIndicator( programIndicatorA )
+                .build();
+
+        assertTrue( params.orgUnitFieldIsValid() );
+
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1683,6 +1683,17 @@ public abstract class DhisConvenienceTest
         return attribute;
     }
 
+    public static ProgramTrackedEntityAttribute createProgramTrackedEntityAttribute( Program program, TrackedEntityAttribute attribute )
+    {
+        ProgramTrackedEntityAttribute ptea = new ProgramTrackedEntityAttribute();
+        ptea.setAutoFields();
+
+        ptea.setProgram( program );
+        ptea.setAttribute( attribute );
+
+        return ptea;
+    }
+
     public static ProgramTrackedEntityAttribute createProgramTrackedEntityAttribute( char uniqueChar )
     {
         ProgramTrackedEntityAttribute attribute = new ProgramTrackedEntityAttribute();


### PR DESCRIPTION
* fix: use Prg. Indicators to validate orgUnitField

- DHIS2-7552
- When validating the orgUnitField value the system now takes in
consideration the event that a Program may be null and also checks for
Program Indicators. If the EventQueryParams contains Program Indicators,
the system runs the same validation against all the Programs associated
to the Program Indicators. If at least one fails, the entire validation
fails.

* chore: minor refactoring

* Update EventQueryParams.java

Co-authored-by: Lars Helge Øverland <lars@dhis2.org>