### PR TITLE
fix: Hibernate cache issue of OptionSet.options

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleHook.java
@@ -111,4 +111,11 @@ public interface ObjectBundleHook
      * @param bundle Current commit phase bundle
      */
     <T extends IdentifiableObject> void preDelete( T persistedObject, ObjectBundle bundle );
+
+    /**
+     * Run in MetadataAsyncImporter, after transaction is committed and session is flushed
+     * This is to handle special case where object's reference is not updated after import job is done.
+     * @param klass
+     */
+    void clearCache( Class klass );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/AbstractObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/AbstractObjectBundleHook.java
@@ -112,4 +112,10 @@ public class AbstractObjectBundleHook implements ObjectBundleHook
     public <T extends IdentifiableObject> void preDelete( T persistedObject, ObjectBundle bundle )
     {
     }
+
+    @Override
+    public void clearCache( Class klass )
+    {
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
@@ -1,0 +1,40 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OptionSetObjectBundleHook
+    extends AbstractObjectBundleHook
+{
+    private SessionFactory sessionFactory;
+
+    public OptionSetObjectBundleHook( SessionFactory sessionFactory )
+    {
+        this.sessionFactory = sessionFactory;
+    }
+
+    /**
+     * Need to clear cache for OptionSets and Options because
+     * Option is saved before OptionSet,
+     * therefore after transaction committed, the cached Option objects have OptionSet reference = null
+     * although the database foreign keys are updated correctly.
+     * @param klass
+     */
+    @Override
+    public void clearCache( Class klass )
+    {
+        if ( !klass.isAssignableFrom( OptionSet.class ) )
+        {
+            return;
+        }
+
+        sessionFactory.getCache().evictEntityRegion( OptionSet.class );
+        sessionFactory.getCache().evictEntityRegion( Option.class );
+        sessionFactory.getCache().evictCollectionRegion( OptionSet.class.getName() + ".options" );
+        sessionFactory.getCache().evictQueryRegion( Option.class.getName() );
+        sessionFactory.getCache().evictQueryRegion( OptionSet.class.getName() );
+    }
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-2731

Isssue:
- After importing OptionSet and Option at the same time, Options are not shown on UI in Maintenance app.
- If we use the ClearCache app to clear hibernate cache, Options will be shown.

Cause: 
- Option is saved before OptionSet
- After transaction committed, session flushed, and cache cleared in `DefaultObjectBundleService` 

```
 dbmsManager.clearSession();
 cacheManager.clearCache();
```


the cached Option list still have OptionSet reference = null, not sure why, maybe because it's executed asynchronously

Solution: Add clearCache() to ObjectBundleHoook, and call it in method `after()` in `MetadataAsyncImporter` before unbind session from the thread.



