### PR TITLE
[2.31] Avoid "SELECT * FROM TABLE" when fetching metadata

### DIFF
--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -697,7 +697,7 @@ public class DefaultAclService implements AclService
 
         for ( UserGroupAccess userGroupAccess : object.getUserGroupAccesses() )
         {
-            /**
+            /*
              * Is the user allowed to read this object through group access?
              *
              */
@@ -710,7 +710,7 @@ public class DefaultAclService implements AclService
 
         for ( UserAccess userAccess : object.getUserAccesses() )
         {
-            /**
+            /*
              * Is the user allowed to read to this object through user access?
              *
              */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Criteria.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Criteria.java
@@ -28,13 +28,13 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.schema.Schema;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.hisp.dhis.schema.Schema;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -64,7 +64,7 @@ public abstract class Criteria
 
     public Criteria add( Criterion criterion )
     {
-        if ( !Restriction.class.isInstance( criterion ) )
+        if ( !(criterion instanceof Restriction) )
         {
             this.criterions.add( criterion ); // if conjunction/disjunction just add it and move forward
             return this;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
@@ -98,20 +98,20 @@ public class DefaultQueryService
     }
 
     @Override
-    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, PaginationData paginationData ) throws QueryParserException
+    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination) throws QueryParserException
     {
-        return getQueryFromUrl( klass, filters, orders, paginationData, DEFAULT_JUNCTION_TYPE );
+        return getQueryFromUrl( klass, filters, orders, pagination, DEFAULT_JUNCTION_TYPE );
     }
 
     @Override
-    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, PaginationData paginationData, Junction.Type rootJunction ) throws QueryParserException
+    public Query getQueryFromUrl(Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination, Junction.Type rootJunction ) throws QueryParserException
     {
         Query query = queryParser.parse( klass, filters, rootJunction );
         query.addOrders( orders );
-        if ( paginationData.hasPagination() )
+        if ( pagination.hasPagination() )
         {
-            query.setFirstResult( paginationData.getFirstResult() );
-            query.setMaxResults( paginationData.getSize() );
+            query.setFirstResult( pagination.getFirstResult() );
+            query.setMaxResults( pagination.getSize() );
         }
         
         return query;
@@ -120,7 +120,7 @@ public class DefaultQueryService
     @Override
     public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException
     {
-        return getQueryFromUrl( klass, filters, orders, new PaginationData(), DEFAULT_JUNCTION_TYPE );
+        return getQueryFromUrl( klass, filters, orders, new Pagination(), DEFAULT_JUNCTION_TYPE );
     }
 
     //---------------------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -35,8 +37,6 @@ import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.query.planner.QueryPlan;
 import org.hisp.dhis.query.planner.QueryPlanner;
-
-import java.util.List;
 
 /**
  * Default implementation of QueryService which works with IdObjects.
@@ -108,7 +108,12 @@ public class DefaultQueryService
     {
         Query query = queryParser.parse( klass, filters, rootJunction );
         query.addOrders( orders );
-
+        if ( paginationData.hasPagination() )
+        {
+            query.setFirstResult( paginationData.getFirstResult() );
+            query.setMaxResults( paginationData.getSize() );
+        }
+        
         return query;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.query.planner.QueryPlan;
 import org.hisp.dhis.query.planner.QueryPlanner;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
@@ -57,7 +56,8 @@ public class DefaultQueryService
 
     private final InMemoryQueryEngine<? extends IdentifiableObject> inMemoryQueryEngine;
 
-    @Autowired
+    private final Junction.Type DEFAULT_JUNCTION_TYPE = Junction.Type.AND;
+
     public DefaultQueryService( QueryParser queryParser, QueryPlanner queryPlanner,
         CriteriaQueryEngine<? extends IdentifiableObject> criteriaQueryEngine,
         InMemoryQueryEngine<? extends IdentifiableObject> inMemoryQueryEngine )
@@ -98,18 +98,24 @@ public class DefaultQueryService
     }
 
     @Override
-    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException
+    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, PaginationData paginationData ) throws QueryParserException
     {
-        return getQueryFromUrl( klass, filters, orders, Junction.Type.AND );
+        return getQueryFromUrl( klass, filters, orders, paginationData, DEFAULT_JUNCTION_TYPE );
     }
 
     @Override
-    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Junction.Type rootJunction ) throws QueryParserException
+    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, PaginationData paginationData, Junction.Type rootJunction ) throws QueryParserException
     {
         Query query = queryParser.parse( klass, filters, rootJunction );
         query.addOrders( orders );
 
         return query;
+    }
+
+    @Override
+    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException
+    {
+        return getQueryFromUrl( klass, filters, orders, new PaginationData(), DEFAULT_JUNCTION_TYPE );
     }
 
     //---------------------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Pagination.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Pagination.java
@@ -33,7 +33,7 @@ package org.hisp.dhis.query;
  * 
  * @author Luciano Fiandesio
  */
-public class PaginationData
+public class Pagination
 {
     private int firstResult;
 
@@ -41,7 +41,7 @@ public class PaginationData
 
     private boolean hasPagination = false;
 
-    public PaginationData( int firstResult, int size )
+    public Pagination(int firstResult, int size )
     {
         assert (size > 0);
         this.firstResult = firstResult;
@@ -52,7 +52,7 @@ public class PaginationData
     /**
      * This constructor can be used to signal that there is no pagination data
      */
-    public PaginationData()
+    public Pagination()
     {
         // empty constructor
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/PaginationData.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/PaginationData.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.query;
+
+/**
+ * Simple POJO containing the pagination directive from the HTTP Request
+ * 
+ * @author Luciano Fiandesio
+ */
+public class PaginationData
+{
+    private int page;
+
+    private int pageSize;
+
+    private boolean hasPagination = false;
+
+    public PaginationData( int page, int pageSize )
+    {
+        assert (pageSize > 0);
+        this.page = page;
+        this.pageSize = pageSize;
+        this.hasPagination = true;
+    }
+
+    /**
+     * This constructor can be used to signal that there is no pagination data
+     */
+    public PaginationData()
+    {
+        // empty constructor
+    }
+
+    public int getPage()
+    {
+        return page;
+    }
+
+    public int getPageSize()
+    {
+        return pageSize;
+    }
+
+    public boolean hasPagination()
+    {
+        return hasPagination;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/PaginationData.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/PaginationData.java
@@ -35,17 +35,17 @@ package org.hisp.dhis.query;
  */
 public class PaginationData
 {
-    private int page;
+    private int firstResult;
 
-    private int pageSize;
+    private int size;
 
     private boolean hasPagination = false;
 
-    public PaginationData( int page, int pageSize )
+    public PaginationData( int firstResult, int size )
     {
-        assert (pageSize > 0);
-        this.page = page;
-        this.pageSize = pageSize;
+        assert (size > 0);
+        this.firstResult = firstResult;
+        this.size = size;
         this.hasPagination = true;
     }
 
@@ -57,14 +57,14 @@ public class PaginationData
         // empty constructor
     }
 
-    public int getPage()
+    public int getFirstResult()
     {
-        return page;
+        return firstResult;
     }
 
-    public int getPageSize()
+    public int getSize()
     {
-        return pageSize;
+        return size;
     }
 
     public boolean hasPagination()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryService.java
@@ -75,9 +75,9 @@ public interface QueryService
      * @param rootJunction Root junction (defaults to AND)
      * @return New query instance using provided filters/orders
      */
-    Query getQueryFromUrl( Class<?> klass,  List<String> filters, List<Order> orders, PaginationData paginationData, Junction.Type rootJunction ) throws QueryParserException;
+    Query getQueryFromUrl(Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination, Junction.Type rootJunction ) throws QueryParserException;
 
-    Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, PaginationData paginationData ) throws QueryParserException;
+    Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination) throws QueryParserException;
 
     Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryService.java
@@ -75,7 +75,9 @@ public interface QueryService
      * @param rootJunction Root junction (defaults to AND)
      * @return New query instance using provided filters/orders
      */
-    Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Junction.Type rootJunction ) throws QueryParserException;
+    Query getQueryFromUrl( Class<?> klass,  List<String> filters, List<Order> orders, PaginationData paginationData, Junction.Type rootJunction ) throws QueryParserException;
+
+    Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, PaginationData paginationData ) throws QueryParserException;
 
     Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -74,7 +74,7 @@ public class DefaultQueryPlanner implements QueryPlanner
         if ( Junction.Type.OR == junctionType && !persistedOnly && !isFilterOnPersistedFieldOnly( query ))
         {
             return QueryPlan.QueryPlanBuilder
-                .aQueryPlan()
+                .newBuilder()
                 .persistedQuery( Query.from( query.getSchema() ).setPlannedQuery( true ) )
                 .nonPersistedQuery( Query.from( query ).setPlannedQuery( true ) )
                 .build();
@@ -96,7 +96,7 @@ public class DefaultQueryPlanner implements QueryPlanner
         }
 
         return QueryPlan.QueryPlanBuilder
-            .aQueryPlan()
+            .newBuilder()
             .persistedQuery( pQuery )
             .nonPersistedQuery( npQuery )
             .build();
@@ -299,7 +299,13 @@ public class DefaultQueryPlanner implements QueryPlanner
 
         return criteriaJunction;
     }
-    
+
+    /**
+     * Check if all the criteria for the given query are associated to "persisted" properties
+     *
+     * @param query a {@see Query} object
+     * @return true, if all criteria are on persisted properties
+     */
     private boolean isFilterOnPersistedFieldOnly( Query query )
     {
         Set<String> persistedFields = query.getSchema().getPersistedProperties().keySet();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
@@ -41,7 +41,7 @@ public class QueryPlan
 
     private final Query nonPersistedQuery;
 
-    public QueryPlan( Query persistedQuery, Query nonPersistedQuery )
+    private QueryPlan( Query persistedQuery, Query nonPersistedQuery )
     {
         this.persistedQuery = persistedQuery;
         this.nonPersistedQuery = nonPersistedQuery;
@@ -95,6 +95,39 @@ public class QueryPlan
         if ( nonPersistedQuery != null )
         {
             nonPersistedQuery.setUser( user );
+        }
+    }
+
+    public static final class QueryPlanBuilder
+    {
+        private Query persistedQuery;
+
+        private Query nonPersistedQuery;
+
+        private QueryPlanBuilder()
+        {
+        }
+
+        public static QueryPlanBuilder aQueryPlan()
+        {
+            return new QueryPlanBuilder();
+        }
+
+        public QueryPlanBuilder persistedQuery( Query persistedQuery )
+        {
+            this.persistedQuery = persistedQuery;
+            return this;
+        }
+
+        public QueryPlanBuilder nonPersistedQuery( Query nonPersistedQuery )
+        {
+            this.nonPersistedQuery = nonPersistedQuery;
+            return this;
+        }
+
+        public QueryPlan build()
+        {
+            return new QueryPlan( persistedQuery, nonPersistedQuery );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
@@ -108,7 +108,7 @@ public class QueryPlan
         {
         }
 
-        public static QueryPlanBuilder aQueryPlan()
+        public static QueryPlanBuilder newBuilder()
         {
             return new QueryPlanBuilder();
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.query;
+
+import static org.hamcrest.core.Is.is;
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.query.planner.DefaultQueryPlanner;
+import org.hisp.dhis.query.planner.QueryPlanner;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultQueryServiceTest
+{
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private DefaultQueryService subject;
+
+    @Mock
+    private QueryParser queryParser;
+
+    private QueryPlanner queryPlanner;
+
+    @Mock
+    private CriteriaQueryEngine<OrganisationUnit> criteriaQueryEngine;
+
+    @Mock
+    private InMemoryQueryEngine<OrganisationUnit> inMemoryQueryEngine;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Before
+    public void setUp()
+    {
+        queryPlanner = new DefaultQueryPlanner( schemaService );
+        subject = new DefaultQueryService( queryParser, queryPlanner, criteriaQueryEngine, inMemoryQueryEngine );
+    }
+
+    @Test
+    public void verifyQueryEngineUsesPaginationInformation()
+    {
+        Query query = Query.from( new OrganisationUnitSchemaDescriptor().getSchema() );
+        query.setFirstResult( 100 );
+        query.setMaxResults( 50 );
+
+        // Here we make sure that the pagination info are actually passed to the
+        // Hibernate query engine
+        when( criteriaQueryEngine.query( argThat( new QueryWithPagination( query ) ) ) )
+            .thenReturn( createOrgUnits( 20 ) );
+
+        List<? extends IdentifiableObject> orgUnits = subject.query( query );
+
+        assertThat( orgUnits.size(), is( 20 ) );
+    }
+
+    private List<OrganisationUnit> createOrgUnits( int size )
+    {
+
+        List<OrganisationUnit> result = new ArrayList<>();
+        for ( int i = 0; i < size; i++ )
+        {
+            result.add( createOrganisationUnit( RandomStringUtils.randomAlphabetic( 1 ) ) );
+        }
+        return result;
+    }
+
+    class QueryWithPagination
+        extends
+        ArgumentMatcher<Query>
+    {
+        int first;
+
+        int size;
+
+        QueryWithPagination( Query query )
+        {
+            this.first = query.getFirstResult();
+            this.size = query.getMaxResults();
+        }
+
+        @Override
+        public boolean matches( Object o )
+        {
+            Query q = (Query) o;
+            return q.getFirstResult() == first && q.getMaxResults() == size;
+        }
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -120,7 +120,7 @@ public class QueryServiceTest
     @Test
     public void getAllQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.<String>newArrayList(), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList(), Lists.newArrayList(), new PaginationData() );
         assertEquals( 6, queryService.query( query ).size() );
     }
 
@@ -154,7 +154,7 @@ public class QueryServiceTest
     @Test
     public void getEqQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:eq:deabcdefghA" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:eq:deabcdefghA" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 1, objects.size() );
@@ -181,7 +181,7 @@ public class QueryServiceTest
     @Test
     public void getNeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:ne:deabcdefghA" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:ne:deabcdefghA" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 5, objects.size() );
@@ -208,7 +208,7 @@ public class QueryServiceTest
     @Test
     public void getLikeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "name:like:F" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "name:like:F" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 1, objects.size() );
@@ -232,7 +232,7 @@ public class QueryServiceTest
     @Test
     public void getGtQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:gt:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:gt:2003" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 3, objects.size() );
@@ -258,7 +258,7 @@ public class QueryServiceTest
     @Test
     public void getLtQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:lt:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:lt:2003" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 2, objects.size() );
@@ -285,7 +285,7 @@ public class QueryServiceTest
     @Test
     public void getGeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:ge:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:ge:2003" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 4, objects.size() );
@@ -313,7 +313,7 @@ public class QueryServiceTest
     @Test
     public void getLeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:le:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:le:2003" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 3, objects.size() );
@@ -529,7 +529,7 @@ public class QueryServiceTest
     @Test
     public void testIsNotNullUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "categoryCombo:!null" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "categoryCombo:!null" ), Lists.newArrayList(), new PaginationData() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 6, objects.size() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -28,7 +28,17 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -44,11 +54,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.*;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -118,10 +124,45 @@ public class QueryServiceTest
     }
 
     @Test
-    public void getAllQueryUrl() throws QueryParserException
+    public void getAllQueryUrl()
+        throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList(), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList(), Lists.newArrayList(),
+            new Pagination() );
         assertEquals( 6, queryService.query( query ).size() );
+    }
+
+    @Test
+    public void getAllQueryUrlWithPaginationReturnsPageSizeElements()
+        throws QueryParserException
+    {
+        List<? extends IdentifiableObject> resultPage1 = getResultWithPagination( 1, 3 );
+        List<? extends IdentifiableObject> resultPage2 = getResultWithPagination( 2, 3 );
+
+        String key1 = resultPage1.stream().map( IdentifiableObject::getUid ).collect( Collectors.joining( "," ) );
+        String key2 = resultPage2.stream().map( IdentifiableObject::getUid ).collect( Collectors.joining( "," ) );
+
+        assertEquals( 3, resultPage1.size() );
+        assertEquals( 3, resultPage2.size() );
+        // check that the actual results are different
+        assertThat( key1, not( key2 ) );
+    }
+
+    @Test
+    public void getAllQueryUrlWithPaginationReturnsNoDataWhenPageNumberHigherThanMaxNumberOfPages()
+            throws QueryParserException
+    {
+        List<? extends IdentifiableObject> resultPage = getResultWithPagination( 10, 3 );
+
+        assertEquals( 0, resultPage.size() );
+    }
+
+    private List<? extends IdentifiableObject> getResultWithPagination( int page, int pageSize )
+    {
+        Pagination pagination = new Pagination( page, pageSize );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList(), Lists.newArrayList(),
+                pagination);
+        return queryService.query( query );
     }
 
     @Test
@@ -154,7 +195,7 @@ public class QueryServiceTest
     @Test
     public void getEqQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:eq:deabcdefghA" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:eq:deabcdefghA" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 1, objects.size() );
@@ -181,7 +222,7 @@ public class QueryServiceTest
     @Test
     public void getNeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:ne:deabcdefghA" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:ne:deabcdefghA" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 5, objects.size() );
@@ -208,7 +249,7 @@ public class QueryServiceTest
     @Test
     public void getLikeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "name:like:F" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "name:like:F" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 1, objects.size() );
@@ -232,7 +273,7 @@ public class QueryServiceTest
     @Test
     public void getGtQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:gt:2003" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:gt:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 3, objects.size() );
@@ -258,7 +299,7 @@ public class QueryServiceTest
     @Test
     public void getLtQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:lt:2003" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:lt:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 2, objects.size() );
@@ -285,7 +326,7 @@ public class QueryServiceTest
     @Test
     public void getGeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:ge:2003" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:ge:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 4, objects.size() );
@@ -313,7 +354,7 @@ public class QueryServiceTest
     @Test
     public void getLeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:le:2003" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:le:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 3, objects.size() );
@@ -529,7 +570,7 @@ public class QueryServiceTest
     @Test
     public void testIsNotNullUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "categoryCombo:!null" ), Lists.newArrayList(), new PaginationData() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "categoryCombo:!null" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 6, objects.size() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.query.planner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.beans.PropertyDescriptor;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.query.Junction;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.Restrictions;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultQueryPlannerTest
+{
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private DefaultQueryPlanner subject;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Before
+    public void setUp()
+    {
+        this.subject = new DefaultQueryPlanner( schemaService );
+    }
+
+    @Test
+    public void verifyPlanQueryReturnsPersistedAndNotPersistedQueries()
+        throws Exception
+    {
+        // Create schema with attributes
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "id", true );
+        addProperty( propertyMap, attribute, "uid", true );
+        Schema schema = new OrganisationUnitSchemaDescriptor().getSchema();
+        schema.setPropertyMap( propertyMap );
+
+        // Add restriction
+        Query query = Query.from( schema, Junction.Type.OR );
+        query.add( Restrictions.eq( "id", 100L ) );
+
+        // method under test
+        QueryPlan queryPlan = subject.planQuery( query, true );
+
+        Query persistedQuery = queryPlan.getPersistedQuery();
+
+        assertTrue( persistedQuery.isPlannedQuery() );
+        assertEquals( persistedQuery.getCriterions().size(), 1 );
+        assertEquals( persistedQuery.getFirstResult().intValue(), 0 );
+        assertEquals( persistedQuery.getMaxResults().intValue(), Integer.MAX_VALUE );
+        assertEquals( persistedQuery.getRootJunctionType(), Junction.Type.OR );
+
+        Query nonPersistedQuery = queryPlan.getNonPersistedQuery();
+        assertEquals( nonPersistedQuery.getCriterions().size(), 0 );
+        assertTrue( nonPersistedQuery.isPlannedQuery() );
+
+    }
+
+    /*
+     * Verifies that when adding criteria on non-persisted fields and using OR
+     * junction type the planner returns a "non Persisted Query" containing all the
+     * criteria - since it will execute filter on the entire dataset from the target
+     * table
+     */
+    @Test
+    public void verifyPlanQueryReturnsNonPersistedQueryWithCriterion()
+        throws Exception
+    {
+        // Create schema with attributes
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "id", true );
+        addProperty( propertyMap, attribute, "uid", true );
+        // note that this is a non-persisted attribute!
+        addProperty( propertyMap, attribute, "name", false );
+        Schema schema = new OrganisationUnitSchemaDescriptor().getSchema();
+        schema.setPropertyMap( propertyMap );
+
+        // Add restrictions on a non persisted field
+        Query query = Query.from( schema, Junction.Type.OR );
+        // adding a criterion on a non-persisted attribute
+        query.add( Restrictions.eq( "name", "test" ) );
+        query.add( Restrictions.eq( "id", 100 ) );
+
+        // method under test
+        QueryPlan queryPlan = subject.planQuery( query, false );
+
+        Query persistedQuery = queryPlan.getPersistedQuery();
+
+        assertTrue( persistedQuery.isPlannedQuery() );
+        assertEquals( persistedQuery.getCriterions().size(), 0 );
+        assertEquals( persistedQuery.getFirstResult().intValue(), 0 );
+        assertEquals( persistedQuery.getMaxResults().intValue(), Integer.MAX_VALUE );
+        assertEquals( persistedQuery.getRootJunctionType(), Junction.Type.AND );
+
+        Query nonPersistedQuery = queryPlan.getNonPersistedQuery();
+        assertEquals( nonPersistedQuery.getCriterions().size(), 2 );
+        assertTrue( nonPersistedQuery.isPlannedQuery() );
+        assertEquals( nonPersistedQuery.getRootJunctionType(), Junction.Type.OR );
+    }
+
+    @Test
+    public void verifyPlanQueryReturnsNonPersistedQueryWithCriterion2()
+        throws Exception
+    {
+        // Create schema with attributes
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "id", true );
+        addProperty( propertyMap, attribute, "uid", true );
+        addProperty( propertyMap, attribute, "name", true );
+        Schema schema = new OrganisationUnitSchemaDescriptor().getSchema();
+        schema.setPropertyMap( propertyMap );
+
+        // Add restrictions on a non persisted field
+        Query query = Query.from( schema, Junction.Type.AND );
+        query.setMaxResults( 10 );
+        query.setFirstResult( 500 );
+
+        query.add( Restrictions.eq( "name", "test" ) );
+        query.add( Restrictions.eq( "id", 100 ) );
+
+        // method under test
+        QueryPlan queryPlan = subject.planQuery( query, false );
+
+        Query persistedQuery = queryPlan.getPersistedQuery();
+
+        assertTrue( persistedQuery.isPlannedQuery() );
+        assertEquals( persistedQuery.getCriterions().size(), 2 );
+        assertEquals( persistedQuery.getFirstResult().intValue(), 500 );
+        assertEquals( persistedQuery.getMaxResults().intValue(), 10 );
+        assertEquals( persistedQuery.getRootJunctionType(), Junction.Type.AND );
+
+        Query nonPersistedQuery = queryPlan.getNonPersistedQuery();
+        assertEquals( nonPersistedQuery.getCriterions().size(), 0 );
+        assertTrue( nonPersistedQuery.isPlannedQuery() );
+        assertEquals( nonPersistedQuery.getRootJunctionType(), Junction.Type.AND );
+    }
+
+    private void addProperty( Map<String, Property> propertyMap, Object bean, String property, boolean persisted )
+        throws Exception
+    {
+        PropertyDescriptor pd = PropertyUtils.getPropertyDescriptor( bean, property );
+        Property p = new Property( pd.getPropertyType(), pd.getReadMethod(), pd.getWriteMethod() );
+        p.setName( pd.getName() );
+        p.setReadable( true );
+        p.setPersisted( persisted );
+
+        propertyMap.put( pd.getName(), p );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -86,7 +86,7 @@ import org.hisp.dhis.patch.Patch;
 import org.hisp.dhis.patch.PatchParams;
 import org.hisp.dhis.patch.PatchService;
 import org.hisp.dhis.query.Order;
-import org.hisp.dhis.query.PaginationData;
+import org.hisp.dhis.query.Pagination;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryService;
@@ -1127,7 +1127,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             translateParams.getLocaleWithDefault( (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE ) ) : null;
     }
 
-    protected PaginationData getPaginationData( WebOptions options )
+    protected Pagination getPaginationData(WebOptions options )
     {
         return PaginationUtils.getPaginationData( options );
     } 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -28,10 +28,18 @@ package org.hisp.dhis.webapi.controller;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.Enums;
-import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -78,6 +86,7 @@ import org.hisp.dhis.patch.Patch;
 import org.hisp.dhis.patch.PatchParams;
 import org.hisp.dhis.patch.PatchService;
 import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.PaginationData;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryService;
@@ -98,6 +107,7 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.LinkService;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,16 +122,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -195,7 +199,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     @RequestMapping( method = RequestMethod.GET )
     public @ResponseBody RootNode getObjectList(
         @RequestParam Map<String, String> rpParameters, OrderParams orderParams,
-        HttpServletResponse response, HttpServletRequest request, User currentUser ) throws QueryParserException
+        HttpServletResponse response, User currentUser ) throws QueryParserException
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
@@ -226,7 +230,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         postProcessEntities( entities );
         postProcessEntities( entities, options, rpParameters );
 
-        handleLinksAndAccess( entities, fields, false, currentUser );
+        handleLinksAndAccess( entities, fields, false );
 
         linkService.generatePagerLinks( pager, getEntityClass() );
 
@@ -277,7 +281,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
         @RequestParam Map<String, String> rpParameters,
         TranslateParams translateParams,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletResponse response ) throws Exception
     {
         User user = currentUserService.getCurrentUser();
 
@@ -382,7 +386,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void partialUpdateObject(
         @PathVariable( "uid" ) String pvUid, @RequestParam Map<String, String> rpParameters,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         WebOptions options = new WebOptions( rpParameters );
         List<T> entities = getEntity( pvUid, options );
@@ -426,7 +430,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void updateObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty, @RequestParam Map<String, String> rpParameters,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         WebOptions options = new WebOptions( rpParameters );
 
@@ -482,14 +486,15 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), uid ) );
         }
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(), options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
+            getPaginationData( options ), options.getRootJunction() );
         query.setUser( user );
         query.setObjects( entities );
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 
         entities = (List<T>) queryService.query( query );
 
-        handleLinksAndAccess( entities, fields, true, user );
+        handleLinksAndAccess( entities, fields, true );
 
         for ( T entity : entities )
         {
@@ -586,7 +591,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new CreateAccessDeniedException( "You don't have the proper permissions to create this object." );
         }
 
-        T parsed = deserializeXmlEntity( request, response );
+        T parsed = deserializeXmlEntity( request );
         parsed.getTranslations().clear();
 
         preCreateEntity( parsed );
@@ -751,7 +756,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new UpdateAccessDeniedException( "You don't have the proper permissions to update this object." );
         }
 
-        T parsed = deserializeXmlEntity( request, response );
+        T parsed = deserializeXmlEntity( request );
         ((BaseIdentifiableObject) parsed).setUid( pvUid );
 
         preUpdateEntity( objects.get( 0 ), parsed );
@@ -879,7 +884,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         @PathVariable( "itemId" ) String pvItemId,
         @RequestParam Map<String, String> parameters,
         TranslateParams translateParams,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletResponse response ) throws Exception
     {
         User user = currentUserService.getCurrentUser();
         setUserContext( user, translateParams );
@@ -895,11 +900,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         if ( !rootNode.getChildren().isEmpty() && rootNode.getChildren().get( 0 ).isCollection() )
         {
             rootNode.getChildren().get( 0 ).getChildren().stream().filter( Node::isComplex ).forEach( node ->
-            {
                 node.getChildren().stream()
                     .filter( child -> child.isSimple() && child.getName().equals( "id" ) && !((SimpleNode) child).getValue().equals( pvItemId ) )
-                    .forEach( child -> rootNode.getChildren().get( 0 ).removeChild( node ) );
-            } );
+                    .forEach( child -> rootNode.getChildren().get( 0 ).removeChild( node ) ));
         }
 
         if ( rootNode.getChildren().isEmpty() || rootNode.getChildren().get( 0 ).getChildren().isEmpty() )
@@ -916,7 +919,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         IdentifiableObjects identifiableObjects = renderService.fromJson( request.getInputStream(), IdentifiableObjects.class );
@@ -929,7 +932,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         IdentifiableObjects identifiableObjects = renderService.fromXml( request.getInputStream(), IdentifiableObjects.class );
@@ -942,7 +945,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         IdentifiableObjects identifiableObjects = renderService.fromJson( request.getInputStream(), IdentifiableObjects.class );
@@ -955,7 +958,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void replaceCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         IdentifiableObjects identifiableObjects = renderService.fromXml( request.getInputStream(), IdentifiableObjects.class );
@@ -969,7 +972,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
         @PathVariable( "itemId" ) String pvItemId,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletResponse response ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         response.setStatus( HttpServletResponse.SC_NO_CONTENT );
@@ -986,7 +989,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void deleteCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         IdentifiableObjects identifiableObjects = renderService.fromJson( request.getInputStream(), IdentifiableObjects.class );
@@ -998,7 +1001,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void deleteCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletRequest request ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         IdentifiableObjects identifiableObjects = renderService.fromXml( request.getInputStream(), IdentifiableObjects.class );
@@ -1011,7 +1014,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
         @PathVariable( "itemId" ) String pvItemId,
-        HttpServletRequest request, HttpServletResponse response ) throws Exception
+        HttpServletResponse response ) throws Exception
     {
         List<T> objects = getEntity( pvUid );
         response.setStatus( HttpServletResponse.SC_NO_CONTENT );
@@ -1033,7 +1036,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return renderService.fromJson( request.getInputStream(), getEntityClass() );
     }
 
-    protected T deserializeXmlEntity( HttpServletRequest request, HttpServletResponse response ) throws IOException
+    protected T deserializeXmlEntity( HttpServletRequest request) throws IOException
     {
         return renderService.fromXml( request.getInputStream(), getEntityClass() );
     }
@@ -1124,12 +1127,17 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             translateParams.getLocaleWithDefault( (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE ) ) : null;
     }
 
+    protected PaginationData getPaginationData( WebOptions options )
+    {
+        return PaginationUtils.getPaginationData( options );
+    } 
+    
     @SuppressWarnings( "unchecked" )
     protected List<T> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
         throws QueryParserException
     {
         List<T> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 
@@ -1201,7 +1209,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return fieldsContains( "access", fields );
     }
 
-    protected void handleLinksAndAccess( List<T> entityList, List<String> fields, boolean deep, User user )
+    protected void handleLinksAndAccess( List<T> entityList, List<String> fields, boolean deep )
     {
         boolean generateLinks = hasHref( fields );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DimensionController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DimensionController.java
@@ -102,7 +102,7 @@ public class DimensionController
         throws QueryParserException
     {
         List<DimensionalObject> dimensionalObjects;
-        Query query = queryService.getQueryFromUrl( DimensionalObject.class, filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( DimensionalObject.class, filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         query.setObjects( dimensionService.getAllDimensions() );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -99,7 +99,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         // filters
         List<String> mentionsFromCustomFilters = MentionUtils.removeCustomFilters( filters );
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         // If custom filter (mentions:in:[username]) in filters -> Add as

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -81,6 +81,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -180,7 +181,7 @@ public class MessageConversationController
             messageConversations = new ArrayList<>( messageService.getMessageConversations( ) );
         }
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         query.setObjects( messageConversations );
@@ -199,7 +200,7 @@ public class MessageConversationController
                 "messages.text:" + queryOperator + ":" + options.get( "queryString" ),
                 "messages.sender.displayName:" + queryOperator + ":" + options.get( "queryString" ) );
             Query subQuery = queryService
-                .getQueryFromUrl( getEntityClass(), queryFilter, Arrays.asList(), Junction.Type.OR );
+                .getQueryFromUrl( getEntityClass(), queryFilter, Collections.emptyList(), getPaginationData(options), Junction.Type.OR );
             subQuery.setObjects( messageConversations );
             messageConversations = (List<org.hisp.dhis.message.MessageConversation>) queryService.query( subQuery );
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -28,14 +28,17 @@ package org.hisp.dhis.webapi.controller.dataelement;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
@@ -55,6 +58,7 @@ import org.hisp.dhis.schema.descriptors.DataElementOperandSchemaDescriptor;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.LinkService;
+import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.stereotype.Controller;
@@ -63,9 +67,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -146,7 +148,8 @@ public class DataElementOperandController
             }
         }
 
-        Query query = queryService.getQueryFromUrl( DataElementOperand.class, filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( DataElementOperand.class, filters, orders,
+            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setObjects( dataElementOperands );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -95,10 +95,10 @@ public class ProgramController
     protected List<Program> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
         throws QueryParserException
     {
-        Boolean userFilter = Boolean.parseBoolean( options.getOptions().get( "userFilter" ) );
+        boolean userFilter = Boolean.parseBoolean( options.getOptions().get( "userFilter" ) );
 
         List<Program> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramDataElementController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramDataElementController.java
@@ -28,7 +28,9 @@ package org.hisp.dhis.webapi.controller.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
@@ -49,6 +51,7 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.descriptors.ProgramDataElementDimensionItemSchemaDescriptor;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
+import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.stereotype.Controller;
@@ -57,8 +60,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Lists;
 
 /**
  * @author Lars Helge Overland
@@ -104,7 +106,8 @@ public class ProgramDataElementController
         WebMetadata metadata = new WebMetadata();
 
         List<ProgramDataElementDimensionItem> programDataElements;
-        Query query = queryService.getQueryFromUrl( ProgramDataElementDimensionItem.class, filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( ProgramDataElementDimensionItem.class, filters, orders,
+            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
 
         if ( options.contains( "program" ) )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.mapping.MappingService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.PaginationData;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.descriptors.MapViewSchemaDescriptor;
@@ -125,7 +126,7 @@ public class MapViewController
         throws QueryParserException
     {
         List<MapView> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.mapping.MappingService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.query.Order;
-import org.hisp.dhis.query.PaginationData;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.descriptors.MapViewSchemaDescriptor;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -28,10 +28,16 @@ package org.hisp.dhis.webapi.controller.organisationunit;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.fieldfilter.Defaults;
@@ -60,14 +66,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -125,7 +127,7 @@ public class OrganisationUnitController
         else if ( options.isTrue( "levelSorted" ) )
         {
             objects = new ArrayList<>( manager.getAll( getEntityClass() ) );
-            Collections.sort( objects, OrganisationUnitByLevelComparator.INSTANCE );
+            objects.sort( OrganisationUnitByLevelComparator.INSTANCE );
         }
 
         // ---------------------------------------------------------------------
@@ -147,7 +149,7 @@ public class OrganisationUnitController
         // Standard Query handling
         // ---------------------------------------------------------------------
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setUser( currentUser );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
@@ -163,7 +165,7 @@ public class OrganisationUnitController
         // Collection member count in hierarchy handling
         // ---------------------------------------------------------------------
 
-        IdentifiableObject member = null;
+        IdentifiableObject member;
 
         if ( memberObject != null && memberCollection != null && (member = manager.get( memberObject )) != null )
         {

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -166,7 +166,7 @@ public class UserController
             ( orders == null ) ? null : orders.stream().map( Order::toOrderString ).collect( Collectors.toList() ) );
 
         // keep the memory query on the result
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         query.setObjects( users );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FormUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FormUtils.java
@@ -375,7 +375,6 @@ public class FormUtils
 
     private static Set<OrganisationUnit> getChildren( OrganisationUnit ou, Set<OrganisationUnit> children )
     {
-
         if ( ou != null && ou.getChildren() != null )
         {
             for ( OrganisationUnit organisationUnit : ou.getChildren() )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
@@ -28,7 +28,7 @@
 
 package org.hisp.dhis.webapi.utils;
 
-import org.hisp.dhis.query.PaginationData;
+import org.hisp.dhis.query.Pagination;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 
 /**
@@ -36,7 +36,8 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
  */
 public class PaginationUtils
 {
-    private final static PaginationData NO_PAGINATION = new PaginationData();
+    private final static Pagination NO_PAGINATION = new Pagination();
+
     /**
      * Calculates the paging first result based on pagination data from
      * {@see WebOptions} if the WebOptions have pagination information
@@ -47,10 +48,10 @@ public class PaginationUtils
      * @return a {@see PaginationData} object either empty or containing pagination
      *         data
      */
-    public static PaginationData getPaginationData( WebOptions options )
+    public static Pagination getPaginationData( WebOptions options )
     {
         return options.hasPaging()
-            ? new PaginationData( options.getPage() == 1 ? 1 : ( options.getPage() * options.getPageSize() ),
+            ? new Pagination( options.getPage() == 1 ? 1 : (options.getPage() * options.getPageSize()),
                 options.getPageSize() )
             : NO_PAGINATION;
     }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
@@ -34,10 +34,24 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 /**
  * @author Luciano Fiandesio
  */
-public class PaginationUtils {
-
-    public static PaginationData getPaginationData(WebOptions options )
+public class PaginationUtils
+{
+    private final static PaginationData NO_PAGINATION = new PaginationData();
+    /**
+     * Calculates the paging first result based on pagination data from
+     * {@see WebOptions} if the WebOptions have pagination information
+     * 
+     * The first result is simply calculated by multiplying page * page size
+     * 
+     * @param options a {@see WebOptions} object
+     * @return a {@see PaginationData} object either empty or containing pagination
+     *         data
+     */
+    public static PaginationData getPaginationData( WebOptions options )
     {
-        return options.hasPaging() ? new PaginationData( options.getPage(), options.getPageSize() ) : new PaginationData( );
+        return options.hasPaging()
+            ? new PaginationData( options.getPage() == 1 ? 1 : ( options.getPage() * options.getPageSize() ),
+                options.getPageSize() )
+            : NO_PAGINATION;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.webapi.utils;
+
+import org.hisp.dhis.query.PaginationData;
+import org.hisp.dhis.webapi.webdomain.WebOptions;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class PaginationUtils {
+
+    public static PaginationData getPaginationData(WebOptions options )
+    {
+        return options.hasPaging() ? new PaginationData( options.getPage(), options.getPageSize() ) : new PaginationData( );
+    }
+}


### PR DESCRIPTION
This PR:
- propagates pagination information to the `DefaultQueryService` so that it can only fetch paginated data (from .. to)
- checks if all the `filter` attributes are "persisted" fields and skip the in-memory query
- make sure that if there is only one filter, the system default to Junction.Type AND
- unit tests

