### PR TITLE
fix: Hibernate Support fails to compile on Java 9+

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -128,6 +128,27 @@
       <properties>
         <maven.compiler.release>8</maven.compiler.release>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.21.0</version>
+            <configuration>
+              <trimStackTrace>false</trimStackTrace>
+              <argLine>-Xmx1024m</argLine>
+              <excludedGroups>org.hisp.dhis.IntegrationTest</excludedGroups>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>6.2</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -246,9 +267,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <release>${maven.compiler.release}</release>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
+            <source>1.8</source>
+            <target>1.8</target>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>
           <dependencies>
@@ -1591,8 +1611,6 @@
 
   <properties>
     <rootDir></rootDir>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.version>5.2.4.RELEASE</spring.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -236,11 +236,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <!--
-            <release>11</release>
-            -->
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>
           <dependencies>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -121,6 +121,16 @@
 
   <profiles>
     <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+    </profile>
+
+    <profile>
       <id>default</id>
       <activation>
         <activeByDefault>true</activeByDefault>
@@ -236,7 +246,9 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <release>8</release>
+            <release>${maven.compiler.release}</release>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>
           <dependencies>
@@ -1579,6 +1591,8 @@
 
   <properties>
     <rootDir></rootDir>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.version>5.2.4.RELEASE</spring.version>


### PR DESCRIPTION
Due to maven compiler config issues, all compilation on Java 9+ JDKs fails.
The fix is described here: https://bugs.openjdk.java.net/browse/JDK-8212636

Added a new profile with activation by having jdk9+ to support both Java 8 and Java 9


Issue: [DHIS2-8468]