### PR TITLE
[2.33] fix: use db-pagination when fetching metadata

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -35,11 +37,7 @@ import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.query.planner.QueryPlan;
 import org.hisp.dhis.query.planner.QueryPlanner;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -61,7 +59,8 @@ public class DefaultQueryService
 
     private final InMemoryQueryEngine<? extends IdentifiableObject> inMemoryQueryEngine;
 
-    @Autowired
+    private final Junction.Type DEFAULT_JUNCTION_TYPE = Junction.Type.AND;
+
     public DefaultQueryService( QueryParser queryParser, QueryPlanner queryPlanner,
         CriteriaQueryEngine<? extends IdentifiableObject> criteriaQueryEngine,
         InMemoryQueryEngine<? extends IdentifiableObject> inMemoryQueryEngine )
@@ -107,18 +106,29 @@ public class DefaultQueryService
     }
 
     @Override
-    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException
+    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination) throws QueryParserException
     {
-        return getQueryFromUrl( klass, filters, orders, Junction.Type.AND );
+        return getQueryFromUrl( klass, filters, orders, pagination, DEFAULT_JUNCTION_TYPE );
     }
 
     @Override
-    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Junction.Type rootJunction ) throws QueryParserException
+    public Query getQueryFromUrl(Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination, Junction.Type rootJunction ) throws QueryParserException
     {
         Query query = queryParser.parse( klass, filters, rootJunction );
         query.addOrders( orders );
-
+        if ( pagination.hasPagination() )
+        {
+            query.setFirstResult( pagination.getFirstResult() );
+            query.setMaxResults( pagination.getSize() );
+        }
+        
         return query;
+    }
+
+    @Override
+    public Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException
+    {
+        return getQueryFromUrl( klass, filters, orders, new Pagination(), DEFAULT_JUNCTION_TYPE );
     }
 
     //---------------------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Pagination.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Pagination.java
@@ -1,7 +1,5 @@
-package org.hisp.dhis.query;
-
 /*
- * Copyright (c) 2004-2019, University of Oslo
+ * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,68 +26,49 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.hisp.dhis.schema.Schema;
+package org.hisp.dhis.query;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Simple POJO containing the pagination directive from the HTTP Request
+ * 
+ * @author Luciano Fiandesio
  */
-public abstract class Criteria
+public class Pagination
 {
-    protected List<Criterion> criterions = new ArrayList<>();
+    private int firstResult;
 
-    protected Set<String> aliases = new HashSet<>();
+    private int size;
 
-    protected final Schema schema;
+    private boolean hasPagination = false;
 
-    public Criteria( Schema schema )
+    public Pagination(int firstResult, int size )
     {
-        this.schema = schema;
+        assert (size > 0);
+        this.firstResult = firstResult;
+        this.size = size;
+        this.hasPagination = true;
     }
 
-    public List<Criterion> getCriterions()
+    /**
+     * This constructor can be used to signal that there is no pagination data
+     */
+    public Pagination()
     {
-        return criterions;
+        // empty constructor
     }
 
-    public Set<String> getAliases()
+    public int getFirstResult()
     {
-        return aliases;
+        return firstResult;
     }
 
-    public Criteria add( Criterion criterion )
+    public int getSize()
     {
-        if ( !(criterion instanceof Restriction) )
-        {
-            this.criterions.add( criterion ); // if conjunction/disjunction just add it and move forward
-            return this;
-        }
-
-        Restriction restriction = (Restriction) criterion;
-
-        this.criterions.add( restriction );
-
-        return this;
+        return size;
     }
 
-    public Criteria add( Criterion... criterions )
+    public boolean hasPagination()
     {
-        for ( Criterion criterion : criterions )
-        {
-            add( criterion );
-        }
-
-        return this;
-    }
-
-    public Criteria add( Collection<Criterion> criterions )
-    {
-        criterions.forEach( this::add );
-        return this;
+        return hasPagination;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryService.java
@@ -75,7 +75,9 @@ public interface QueryService
      * @param rootJunction Root junction (defaults to AND)
      * @return New query instance using provided filters/orders
      */
-    Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Junction.Type rootJunction ) throws QueryParserException;
+    Query getQueryFromUrl(Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination, Junction.Type rootJunction ) throws QueryParserException;
+
+    Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders, Pagination pagination) throws QueryParserException;
 
     Query getQueryFromUrl( Class<?> klass, List<String> filters, List<Order> orders ) throws QueryParserException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -28,6 +28,15 @@ package org.hisp.dhis.query.planner;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
+
 import org.hisp.dhis.query.Conjunction;
 import org.hisp.dhis.query.Criterion;
 import org.hisp.dhis.query.Disjunction;
@@ -40,14 +49,8 @@ import org.hisp.dhis.schema.SchemaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Root;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -74,19 +77,21 @@ public class DefaultQueryPlanner implements QueryPlanner
     @Override
     public QueryPlan planQuery( Query query, boolean persistedOnly )
     {
-        if ( Junction.Type.OR == query.getRootJunctionType() && !persistedOnly )
+        // if only one filter, always set to Junction.Type AND
+        Junction.Type junctionType = query.getCriterions().size() <= 1 ? Junction.Type.AND : query.getRootJunctionType();
+        
+        if ( Junction.Type.OR == junctionType && !persistedOnly && !isFilterOnPersistedFieldOnly( query ))
         {
-            return new QueryPlan(
-                Query.from( query.getSchema() ).setPlannedQuery( true ),
-                Query.from( query ).setPlannedQuery( true )
-            );
+            return QueryPlan.QueryPlanBuilder
+                .newBuilder()
+                .persistedQuery( Query.from( query.getSchema() ).setPlannedQuery( true ) )
+                .nonPersistedQuery( Query.from( query ).setPlannedQuery( true ) )
+                .build();
         }
 
-        Query npQuery = Query.from( query )
-            .setUser( query.getUser() ).setPlannedQuery( true );
+        Query npQuery = Query.from( query ).setUser( query.getUser() ).setPlannedQuery( true );
 
-        Query pQuery = getQuery( npQuery, persistedOnly )
-            .setUser( query.getUser() ).setPlannedQuery( true );
+        Query pQuery = getQuery( npQuery, persistedOnly ).setUser( query.getUser() ).setPlannedQuery( true );
 
         // if there are any non persisted criterions left, we leave the paging to the in-memory engine
         if ( !npQuery.getCriterions().isEmpty() )
@@ -99,7 +104,11 @@ public class DefaultQueryPlanner implements QueryPlanner
             pQuery.setMaxResults( npQuery.getMaxResults() );
         }
 
-        return new QueryPlan( pQuery, npQuery );
+        return QueryPlan.QueryPlanBuilder
+            .newBuilder()
+            .persistedQuery( pQuery )
+            .nonPersistedQuery( npQuery )
+            .build();
     }
 
     @Override
@@ -158,7 +167,7 @@ public class DefaultQueryPlanner implements QueryPlanner
     public Path getQueryPath( Root root, Schema schema, String path )
     {
         Schema curSchema = schema;
-        Property curProperty = null;
+        Property curProperty;
         String[] pathComponents = path.split( "\\." );
 
         Path currentPath = root;
@@ -298,5 +307,28 @@ public class DefaultQueryPlanner implements QueryPlanner
         }
 
         return criteriaJunction;
+    }
+
+    /**
+     * Check if all the criteria for the given query are associated to "persisted" properties
+     *
+     * @param query a {@see Query} object
+     * @return true, if all criteria are on persisted properties
+     */
+    private boolean isFilterOnPersistedFieldOnly( Query query )
+    {
+        Set<String> persistedFields = query.getSchema().getPersistedProperties().keySet();
+        for ( Criterion criterion : query.getCriterions() )
+        {
+            if ( criterion instanceof Restriction )
+            {
+                Restriction restriction = (Restriction) criterion;
+                if ( !persistedFields.contains( restriction.getPath() ) )
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
@@ -41,7 +41,7 @@ public class QueryPlan
 
     private final Query nonPersistedQuery;
 
-    public QueryPlan( Query persistedQuery, Query nonPersistedQuery )
+    private QueryPlan( Query persistedQuery, Query nonPersistedQuery )
     {
         this.persistedQuery = persistedQuery;
         this.nonPersistedQuery = nonPersistedQuery;
@@ -95,6 +95,39 @@ public class QueryPlan
         if ( nonPersistedQuery != null )
         {
             nonPersistedQuery.setUser( user );
+        }
+    }
+
+    public static final class QueryPlanBuilder
+    {
+        private Query persistedQuery;
+
+        private Query nonPersistedQuery;
+
+        private QueryPlanBuilder()
+        {
+        }
+
+        public static QueryPlanBuilder newBuilder()
+        {
+            return new QueryPlanBuilder();
+        }
+
+        public QueryPlanBuilder persistedQuery( Query persistedQuery )
+        {
+            this.persistedQuery = persistedQuery;
+            return this;
+        }
+
+        public QueryPlanBuilder nonPersistedQuery( Query nonPersistedQuery )
+        {
+            this.nonPersistedQuery = nonPersistedQuery;
+            return this;
+        }
+
+        public QueryPlan build()
+        {
+            return new QueryPlan( persistedQuery, nonPersistedQuery );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.query;
+
+import static org.hamcrest.core.Is.is;
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.query.planner.DefaultQueryPlanner;
+import org.hisp.dhis.query.planner.QueryPlanner;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultQueryServiceTest
+{
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private DefaultQueryService subject;
+
+    @Mock
+    private QueryParser queryParser;
+
+    private QueryPlanner queryPlanner;
+
+    @Mock
+    private CriteriaQueryEngine<OrganisationUnit> criteriaQueryEngine;
+
+    @Mock
+    private InMemoryQueryEngine<OrganisationUnit> inMemoryQueryEngine;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Before
+    public void setUp()
+    {
+        queryPlanner = new DefaultQueryPlanner( schemaService );
+        subject = new DefaultQueryService( queryParser, queryPlanner, criteriaQueryEngine, inMemoryQueryEngine );
+    }
+
+    @Test
+    public void verifyQueryEngineUsesPaginationInformation()
+    {
+        Query query = Query.from( new OrganisationUnitSchemaDescriptor().getSchema() );
+        query.setFirstResult( 100 );
+        query.setMaxResults( 50 );
+
+        // Here we make sure that the pagination info are actually passed to the
+        // Hibernate query engine
+        when( criteriaQueryEngine.query( argThat( new QueryWithPagination( query ) ) ) )
+            .thenReturn( createOrgUnits( 20 ) );
+
+        List<? extends IdentifiableObject> orgUnits = subject.query( query );
+
+        assertThat( orgUnits.size(), is( 20 ) );
+    }
+
+    private List<OrganisationUnit> createOrgUnits( int size )
+    {
+
+        List<OrganisationUnit> result = new ArrayList<>();
+        for ( int i = 0; i < size; i++ )
+        {
+            result.add( createOrganisationUnit( RandomStringUtils.randomAlphabetic( 1 ) ) );
+        }
+        return result;
+    }
+
+    class QueryWithPagination
+        extends
+        ArgumentMatcher<Query>
+    {
+        int first;
+
+        int size;
+
+        QueryWithPagination( Query query )
+        {
+            this.first = query.getFirstResult();
+            this.size = query.getMaxResults();
+        }
+
+        @Override
+        public boolean matches( Object o )
+        {
+            Query q = (Query) o;
+            return q.getFirstResult() == first && q.getMaxResults() == size;
+        }
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -65,8 +65,6 @@ public class DefaultQueryServiceTest
     @Mock
     private QueryParser queryParser;
 
-    private QueryPlanner queryPlanner;
-
     @Mock
     private CriteriaQueryEngine<OrganisationUnit> criteriaQueryEngine;
 
@@ -79,7 +77,7 @@ public class DefaultQueryServiceTest
     @Before
     public void setUp()
     {
-        queryPlanner = new DefaultQueryPlanner( schemaService );
+        QueryPlanner queryPlanner = new DefaultQueryPlanner( schemaService );
         subject = new DefaultQueryService( queryParser, queryPlanner, criteriaQueryEngine, inMemoryQueryEngine );
     }
 
@@ -111,8 +109,8 @@ public class DefaultQueryServiceTest
         return result;
     }
 
-    class QueryWithPagination
-        extends
+    static class QueryWithPagination
+        implements
         ArgumentMatcher<Query>
     {
         int first;
@@ -126,10 +124,9 @@ public class DefaultQueryServiceTest
         }
 
         @Override
-        public boolean matches( Object o )
+        public boolean matches( Query query )
         {
-            Query q = (Query) o;
-            return q.getFirstResult() == first && q.getMaxResults() == size;
+            return query.getFirstResult() == first && query.getMaxResults() == size;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -28,7 +28,17 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -44,11 +54,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.*;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -118,10 +124,45 @@ public class QueryServiceTest
     }
 
     @Test
-    public void getAllQueryUrl() throws QueryParserException
+    public void getAllQueryUrl()
+        throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.<String>newArrayList(), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList(), Lists.newArrayList(),
+            new Pagination() );
         assertEquals( 6, queryService.query( query ).size() );
+    }
+
+    @Test
+    public void getAllQueryUrlWithPaginationReturnsPageSizeElements()
+        throws QueryParserException
+    {
+        List<? extends IdentifiableObject> resultPage1 = getResultWithPagination( 1, 3 );
+        List<? extends IdentifiableObject> resultPage2 = getResultWithPagination( 2, 3 );
+
+        String key1 = resultPage1.stream().map( IdentifiableObject::getUid ).collect( Collectors.joining( "," ) );
+        String key2 = resultPage2.stream().map( IdentifiableObject::getUid ).collect( Collectors.joining( "," ) );
+
+        assertEquals( 3, resultPage1.size() );
+        assertEquals( 3, resultPage2.size() );
+        // check that the actual results are different
+        assertThat( key1, not( key2 ) );
+    }
+
+    @Test
+    public void getAllQueryUrlWithPaginationReturnsNoDataWhenPageNumberHigherThanMaxNumberOfPages()
+            throws QueryParserException
+    {
+        List<? extends IdentifiableObject> resultPage = getResultWithPagination( 10, 3 );
+
+        assertEquals( 0, resultPage.size() );
+    }
+
+    private List<? extends IdentifiableObject> getResultWithPagination( int page, int pageSize )
+    {
+        Pagination pagination = new Pagination( page, pageSize );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList(), Lists.newArrayList(),
+                pagination);
+        return queryService.query( query );
     }
 
     @Test
@@ -154,7 +195,7 @@ public class QueryServiceTest
     @Test
     public void getEqQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:eq:deabcdefghA" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:eq:deabcdefghA" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 1, objects.size() );
@@ -181,7 +222,7 @@ public class QueryServiceTest
     @Test
     public void getNeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:ne:deabcdefghA" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "id:ne:deabcdefghA" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 5, objects.size() );
@@ -208,7 +249,7 @@ public class QueryServiceTest
     @Test
     public void getLikeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "name:like:F" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "name:like:F" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 1, objects.size() );
@@ -232,7 +273,7 @@ public class QueryServiceTest
     @Test
     public void getGtQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:gt:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:gt:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 3, objects.size() );
@@ -258,7 +299,7 @@ public class QueryServiceTest
     @Test
     public void getLtQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:lt:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:lt:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 2, objects.size() );
@@ -285,7 +326,7 @@ public class QueryServiceTest
     @Test
     public void getGeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:ge:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:ge:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 4, objects.size() );
@@ -313,7 +354,7 @@ public class QueryServiceTest
     @Test
     public void getLeQueryUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:le:2003" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "created:le:2003" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 3, objects.size() );
@@ -529,7 +570,7 @@ public class QueryServiceTest
     @Test
     public void testIsNotNullUrl() throws QueryParserException
     {
-        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "categoryCombo:!null" ), Lists.<Order>newArrayList() );
+        Query query = queryService.getQueryFromUrl( DataElement.class, Lists.newArrayList( "categoryCombo:!null" ), Lists.newArrayList(), new Pagination() );
         List<? extends IdentifiableObject> objects = queryService.query( query );
 
         assertEquals( 6, objects.size() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.query.planner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.beans.PropertyDescriptor;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.query.Junction;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.Restrictions;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultQueryPlannerTest
+{
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private DefaultQueryPlanner subject;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Before
+    public void setUp()
+    {
+        this.subject = new DefaultQueryPlanner( schemaService );
+    }
+
+    @Test
+    public void verifyPlanQueryReturnsPersistedAndNotPersistedQueries()
+        throws Exception
+    {
+        // Create schema with attributes
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "id", true );
+        addProperty( propertyMap, attribute, "uid", true );
+        Schema schema = new OrganisationUnitSchemaDescriptor().getSchema();
+        schema.setPropertyMap( propertyMap );
+
+        // Add restriction
+        Query query = Query.from( schema, Junction.Type.OR );
+        query.add( Restrictions.eq( "id", 100L ) );
+
+        // method under test
+        QueryPlan queryPlan = subject.planQuery( query, true );
+
+        Query persistedQuery = queryPlan.getPersistedQuery();
+
+        assertTrue( persistedQuery.isPlannedQuery() );
+        assertEquals( persistedQuery.getCriterions().size(), 1 );
+        assertEquals( persistedQuery.getFirstResult().intValue(), 0 );
+        assertEquals( persistedQuery.getMaxResults().intValue(), Integer.MAX_VALUE );
+        assertEquals( persistedQuery.getRootJunctionType(), Junction.Type.OR );
+
+        Query nonPersistedQuery = queryPlan.getNonPersistedQuery();
+        assertEquals( nonPersistedQuery.getCriterions().size(), 0 );
+        assertTrue( nonPersistedQuery.isPlannedQuery() );
+
+    }
+
+    /*
+     * Verifies that when adding criteria on non-persisted fields and using OR
+     * junction type the planner returns a "non Persisted Query" containing all the
+     * criteria - since it will execute filter on the entire dataset from the target
+     * table
+     */
+    @Test
+    public void verifyPlanQueryReturnsNonPersistedQueryWithCriterion()
+        throws Exception
+    {
+        // Create schema with attributes
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "id", true );
+        addProperty( propertyMap, attribute, "uid", true );
+        // note that this is a non-persisted attribute!
+        addProperty( propertyMap, attribute, "name", false );
+        Schema schema = new OrganisationUnitSchemaDescriptor().getSchema();
+        schema.setPropertyMap( propertyMap );
+
+        // Add restrictions on a non persisted field
+        Query query = Query.from( schema, Junction.Type.OR );
+        // adding a criterion on a non-persisted attribute
+        query.add( Restrictions.eq( "name", "test" ) );
+        query.add( Restrictions.eq( "id", 100 ) );
+
+        // method under test
+        QueryPlan queryPlan = subject.planQuery( query, false );
+
+        Query persistedQuery = queryPlan.getPersistedQuery();
+
+        assertTrue( persistedQuery.isPlannedQuery() );
+        assertEquals( persistedQuery.getCriterions().size(), 0 );
+        assertEquals( persistedQuery.getFirstResult().intValue(), 0 );
+        assertEquals( persistedQuery.getMaxResults().intValue(), Integer.MAX_VALUE );
+        assertEquals( persistedQuery.getRootJunctionType(), Junction.Type.AND );
+
+        Query nonPersistedQuery = queryPlan.getNonPersistedQuery();
+        assertEquals( nonPersistedQuery.getCriterions().size(), 2 );
+        assertTrue( nonPersistedQuery.isPlannedQuery() );
+        assertEquals( nonPersistedQuery.getRootJunctionType(), Junction.Type.OR );
+    }
+
+    @Test
+    public void verifyPlanQueryReturnsNonPersistedQueryWithCriterion2()
+        throws Exception
+    {
+        // Create schema with attributes
+        final Attribute attribute = new Attribute();
+        final Map<String, Property> propertyMap = new HashMap<>();
+        addProperty( propertyMap, attribute, "id", true );
+        addProperty( propertyMap, attribute, "uid", true );
+        addProperty( propertyMap, attribute, "name", true );
+        Schema schema = new OrganisationUnitSchemaDescriptor().getSchema();
+        schema.setPropertyMap( propertyMap );
+
+        // Add restrictions on a non persisted field
+        Query query = Query.from( schema, Junction.Type.AND );
+        query.setMaxResults( 10 );
+        query.setFirstResult( 500 );
+
+        query.add( Restrictions.eq( "name", "test" ) );
+        query.add( Restrictions.eq( "id", 100 ) );
+
+        // method under test
+        QueryPlan queryPlan = subject.planQuery( query, false );
+
+        Query persistedQuery = queryPlan.getPersistedQuery();
+
+        assertTrue( persistedQuery.isPlannedQuery() );
+        assertEquals( persistedQuery.getCriterions().size(), 2 );
+        assertEquals( persistedQuery.getFirstResult().intValue(), 500 );
+        assertEquals( persistedQuery.getMaxResults().intValue(), 10 );
+        assertEquals( persistedQuery.getRootJunctionType(), Junction.Type.AND );
+
+        Query nonPersistedQuery = queryPlan.getNonPersistedQuery();
+        assertEquals( nonPersistedQuery.getCriterions().size(), 0 );
+        assertTrue( nonPersistedQuery.isPlannedQuery() );
+        assertEquals( nonPersistedQuery.getRootJunctionType(), Junction.Type.AND );
+    }
+
+    private void addProperty( Map<String, Property> propertyMap, Object bean, String property, boolean persisted )
+        throws Exception
+    {
+        PropertyDescriptor pd = PropertyUtils.getPropertyDescriptor( bean, property );
+        Property p = new Property( pd.getPropertyType(), pd.getReadMethod(), pd.getWriteMethod() );
+        p.setName( pd.getName() );
+        p.setReadable( true );
+        p.setPersisted( persisted );
+
+        propertyMap.put( pd.getName(), p );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DimensionController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DimensionController.java
@@ -103,7 +103,7 @@ public class DimensionController
         throws QueryParserException
     {
         List<DimensionalObject> dimensionalObjects;
-        Query query = queryService.getQueryFromUrl( DimensionalObject.class, filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( DimensionalObject.class, filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         query.setObjects( dimensionService.getAllDimensions() );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -99,7 +99,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         // filters
         List<String> mentionsFromCustomFilters = MentionUtils.removeCustomFilters( filters );
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         // If custom filter (mentions:in:[username]) in filters -> Add as

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -81,6 +81,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -174,7 +175,7 @@ public class MessageConversationController
             messageConversations = new ArrayList<>( messageService.getMessageConversations( ) );
         }
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         query.setObjects( messageConversations );
@@ -193,7 +194,7 @@ public class MessageConversationController
                 "messages.text:" + queryOperator + ":" + options.get( "queryString" ),
                 "messages.sender.displayName:" + queryOperator + ":" + options.get( "queryString" ) );
             Query subQuery = queryService
-                .getQueryFromUrl( getEntityClass(), queryFilter, Arrays.asList(), Junction.Type.OR );
+                .getQueryFromUrl( getEntityClass(), queryFilter, Collections.emptyList(), getPaginationData(options), Junction.Type.OR );
             subQuery.setObjects( messageConversations );
             messageConversations = (List<org.hisp.dhis.message.MessageConversation>) queryService.query( subQuery );
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -28,14 +28,17 @@ package org.hisp.dhis.webapi.controller.dataelement;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
@@ -55,6 +58,7 @@ import org.hisp.dhis.schema.descriptors.DataElementOperandSchemaDescriptor;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.LinkService;
+import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.stereotype.Controller;
@@ -63,9 +67,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -146,7 +148,8 @@ public class DataElementOperandController
             }
         }
 
-        Query query = queryService.getQueryFromUrl( DataElementOperand.class, filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( DataElementOperand.class, filters, orders,
+            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setObjects( dataElementOperands );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -91,10 +91,10 @@ public class ProgramController
     protected List<Program> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
         throws QueryParserException
     {
-        Boolean userFilter = Boolean.parseBoolean( options.getOptions().get( "userFilter" ) );
+        boolean userFilter = Boolean.parseBoolean( options.getOptions().get( "userFilter" ) );
 
         List<Program> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramDataElementController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramDataElementController.java
@@ -28,7 +28,9 @@ package org.hisp.dhis.webapi.controller.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
@@ -49,6 +51,7 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.descriptors.ProgramDataElementDimensionItemSchemaDescriptor;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
+import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.stereotype.Controller;
@@ -57,8 +60,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Lists;
 
 /**
  * @author Lars Helge Overland
@@ -104,7 +106,8 @@ public class ProgramDataElementController
         WebMetadata metadata = new WebMetadata();
 
         List<ProgramDataElementDimensionItem> programDataElements;
-        Query query = queryService.getQueryFromUrl( ProgramDataElementDimensionItem.class, filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( ProgramDataElementDimensionItem.class, filters, orders,
+            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
 
         if ( options.contains( "program" ) )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -125,7 +125,7 @@ public class MapViewController
         throws QueryParserException
     {
         List<MapView> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -31,10 +31,19 @@ package org.hisp.dhis.webapi.controller.organisationunit;
 import static org.hisp.dhis.system.util.GeoUtils.getCoordinatesFromGeometry;
 
 import java.io.IOException;
-import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.common.TranslateParams;
@@ -55,11 +64,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -117,7 +121,7 @@ public class OrganisationUnitController
         else if ( options.isTrue( "levelSorted" ) )
         {
             objects = new ArrayList<>( manager.getAll( getEntityClass() ) );
-            Collections.sort( objects, OrganisationUnitByLevelComparator.INSTANCE );
+            objects.sort( OrganisationUnitByLevelComparator.INSTANCE );
         }
 
         // ---------------------------------------------------------------------
@@ -141,7 +145,7 @@ public class OrganisationUnitController
         // Standard Query handling
         // ---------------------------------------------------------------------
 
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ), options.getRootJunction() );
         query.setUser( currentUser );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -163,7 +163,7 @@ public class UserController
             ( orders == null ) ? null : orders.stream().map( Order::toOrderString ).collect( Collectors.toList() ) );
 
         // keep the memory query on the result
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData(options), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
         query.setObjects( users );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FormUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FormUtils.java
@@ -375,7 +375,6 @@ public class FormUtils
 
     private static Set<OrganisationUnit> getChildren( OrganisationUnit ou, Set<OrganisationUnit> children )
     {
-
         if ( ou != null && ou.getChildren() != null )
         {
             for ( OrganisationUnit organisationUnit : ou.getChildren() )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
@@ -1,7 +1,5 @@
-package org.hisp.dhis.query;
-
 /*
- * Copyright (c) 2004-2019, University of Oslo
+ * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,68 +26,33 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+package org.hisp.dhis.webapi.utils;
 
-import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.query.Pagination;
+import org.hisp.dhis.webapi.webdomain.WebOptions;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-public abstract class Criteria
+public class PaginationUtils
 {
-    protected List<Criterion> criterions = new ArrayList<>();
+    private final static Pagination NO_PAGINATION = new Pagination();
 
-    protected Set<String> aliases = new HashSet<>();
-
-    protected final Schema schema;
-
-    public Criteria( Schema schema )
+    /**
+     * Calculates the paging first result based on pagination data from
+     * {@see WebOptions} if the WebOptions have pagination information
+     * 
+     * The first result is simply calculated by multiplying page * page size
+     * 
+     * @param options a {@see WebOptions} object
+     * @return a {@see PaginationData} object either empty or containing pagination
+     *         data
+     */
+    public static Pagination getPaginationData( WebOptions options )
     {
-        this.schema = schema;
-    }
-
-    public List<Criterion> getCriterions()
-    {
-        return criterions;
-    }
-
-    public Set<String> getAliases()
-    {
-        return aliases;
-    }
-
-    public Criteria add( Criterion criterion )
-    {
-        if ( !(criterion instanceof Restriction) )
-        {
-            this.criterions.add( criterion ); // if conjunction/disjunction just add it and move forward
-            return this;
-        }
-
-        Restriction restriction = (Restriction) criterion;
-
-        this.criterions.add( restriction );
-
-        return this;
-    }
-
-    public Criteria add( Criterion... criterions )
-    {
-        for ( Criterion criterion : criterions )
-        {
-            add( criterion );
-        }
-
-        return this;
-    }
-
-    public Criteria add( Collection<Criterion> criterions )
-    {
-        criterions.forEach( this::add );
-        return this;
+        return options.hasPaging()
+            ? new Pagination( options.getPage() == 1 ? 1 : (options.getPage() * options.getPageSize()),
+                options.getPageSize() )
+            : NO_PAGINATION;
     }
 }


### PR DESCRIPTION
- propagates pagination information to the DefaultQueryService so that it can only fetch paginated data (from .. to)
- checks if all the filter attributes are "persisted" fields and skip the in-memory query
- make sure that if there is only one filter, the system default to Junction.Type AND
- unit tests

forward-port from: c1b7279c49889a82c61437f234e9737902d58bdc