### PR TITLE
fix: Remove costly call to I18nManager in event import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.dxf2.events.event;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.io.IOException;
 import java.util.*;
@@ -67,8 +68,6 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResourceService;
-import org.hisp.dhis.i18n.I18nFormat;
-import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -152,8 +151,6 @@ public abstract class AbstractEventService
 
     private final EventStore eventStore;
 
-    protected final I18nManager i18nManager;
-
     protected final Notifier notifier;
 
     protected final SessionFactory sessionFactory;
@@ -193,7 +190,7 @@ public abstract class AbstractEventService
         OrganisationUnitService organisationUnitService, DataElementService dataElementService,
         CurrentUserService currentUserService, EventDataValueService eventDataValueService,
         TrackedEntityInstanceService entityInstanceService, TrackedEntityCommentService commentService,
-        EventStore eventStore, I18nManager i18nManager, Notifier notifier, SessionFactory sessionFactory,
+        EventStore eventStore, Notifier notifier, SessionFactory sessionFactory,
         DbmsManager dbmsManager, IdentifiableObjectManager manager, CategoryService categoryService,
         FileResourceService fileResourceService, SchemaService schemaService, QueryService queryService,
         TrackerAccessManager trackerAccessManager, TrackerOwnershipManager trackerOwnershipAccessManager,
@@ -212,7 +209,6 @@ public abstract class AbstractEventService
         checkNotNull( entityInstanceService );
         checkNotNull( commentService );
         checkNotNull( eventStore );
-        checkNotNull( i18nManager );
         checkNotNull( notifier );
         checkNotNull( sessionFactory );
         checkNotNull( dbmsManager );
@@ -240,7 +236,6 @@ public abstract class AbstractEventService
         this.entityInstanceService = entityInstanceService;
         this.commentService = commentService;
         this.eventStore = eventStore;
-        this.i18nManager = i18nManager;
         this.notifier = notifier;
         this.sessionFactory = sessionFactory;
         this.dbmsManager = dbmsManager;
@@ -2226,8 +2221,6 @@ public abstract class AbstractEventService
 
     private void validateAttributeOptionComboDate( CategoryOptionCombo attributeOptionCombo, Date date )
     {
-        I18nFormat i18nFormat = i18nManager.getI18nFormat();
-
         if ( date == null )
         {
             throw new IllegalQueryException( "Event date can not be empty" );
@@ -2237,15 +2230,15 @@ public abstract class AbstractEventService
         {
             if ( option.getStartDate() != null && date.compareTo( option.getStartDate() ) < 0 )
             {
-                throw new IllegalQueryException( "Event date " + i18nFormat.formatDate( date )
-                    + " is before start date " + i18nFormat.formatDate( option.getStartDate() )
+                throw new IllegalQueryException( "Event date " + getMediumDateString( date )
+                    + " is before start date " + getMediumDateString( option.getStartDate() )
                     + " for attributeOption '" + option.getName() + "'" );
             }
 
             if ( option.getEndDate() != null && date.compareTo( option.getEndDate() ) > 0 )
             {
-                throw new IllegalQueryException( "Event date " + i18nFormat.formatDate( date )
-                    + " is after end date " + i18nFormat.formatDate( option.getEndDate() )
+                throw new IllegalQueryException( "Event date " + getMediumDateString( date )
+                    + " is after end date " + getMediumDateString( option.getEndDate() )
                     + " for attributeOption '" + option.getName() + "'" );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.commons.config.jackson.EmptyStringToNullStdDeserializer;
 import org.hisp.dhis.commons.config.jackson.ParseDateStdDeserializer;
 import org.hisp.dhis.commons.config.jackson.WriteDateStdSerializer;
-import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.node.geometry.JtsXmlModule;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.*;
@@ -103,7 +102,7 @@ public class JacksonEventService extends AbstractEventService
         OrganisationUnitService organisationUnitService, DataElementService dataElementService,
         CurrentUserService currentUserService, EventDataValueService eventDataValueService,
         TrackedEntityInstanceService entityInstanceService, TrackedEntityCommentService commentService,
-        EventStore eventStore, I18nManager i18nManager, Notifier notifier, SessionFactory sessionFactory,
+        EventStore eventStore, Notifier notifier, SessionFactory sessionFactory,
         DbmsManager dbmsManager, IdentifiableObjectManager manager, CategoryService categoryService,
         FileResourceService fileResourceService, SchemaService schemaService, QueryService queryService,
         TrackerAccessManager trackerAccessManager, TrackerOwnershipManager trackerOwnershipAccessManager,
@@ -112,7 +111,7 @@ public class JacksonEventService extends AbstractEventService
     {
         super( programService, programStageService, programInstanceService, programStageInstanceService,
             organisationUnitService, dataElementService, currentUserService, eventDataValueService,
-            entityInstanceService, commentService, eventStore, i18nManager, notifier, sessionFactory, dbmsManager,
+            entityInstanceService, commentService, eventStore, notifier, sessionFactory, dbmsManager,
             manager, categoryService, fileResourceService, schemaService, queryService, trackerAccessManager,
             trackerOwnershipAccessManager, aclService, eventPublisher, relationshipService, userService,
             eventSyncService, ruleVariableService );


### PR DESCRIPTION
Removes costly and unnecessary call to `I18nManager` in event import. Triggered once per event and only used to i18n two dates in the response message.