### PR TITLE
fix: Remove read-only tx at setting store level

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStore.java
@@ -80,7 +80,7 @@ public class HibernateUserSettingStore
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public UserSetting getUserSettingTx( User user, String name )
     {
         return getUserSetting( user, name );

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/hibernate/HibernateSystemSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/hibernate/HibernateSystemSettingStore.java
@@ -52,7 +52,7 @@ public class HibernateSystemSettingStore
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public SystemSetting getByNameTx( String name )
     {
         return getByName( name );


### PR DESCRIPTION
Causes exceptions when methods are called as part of larger read-write transactions.

Causes `ERROR cannot execute UPDATE in a read-only transaction` exceptions.