### PR TITLE
[2.32] fix: incorrect calculation of firstResult in pagination (#5165)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/PaginationUtils.java
@@ -42,7 +42,7 @@ public class PaginationUtils
      * Calculates the paging first result based on pagination data from
      * {@see WebOptions} if the WebOptions have pagination information
      * 
-     * The first result is simply calculated by multiplying page * page size
+     * The first result is simply calculated by multiplying page -1 * page size
      * 
      * @param options a {@see WebOptions} object
      * @return a {@see PaginationData} object either empty or containing pagination
@@ -50,9 +50,13 @@ public class PaginationUtils
      */
     public static Pagination getPaginationData( WebOptions options )
     {
-        return options.hasPaging()
-            ? new Pagination( options.getPage() == 1 ? 1 : (options.getPage() * options.getPageSize()),
-                options.getPageSize() )
-            : NO_PAGINATION;
+        if ( options.hasPaging() )
+        {
+            // ignore if page < 0
+            int page = Math.max( options.getPage(), 1 );
+            return new Pagination( (page - 1) * options.getPageSize(), options.getPageSize() );
+        }
+
+        return NO_PAGINATION;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebOptions.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebOptions.java
@@ -40,6 +40,13 @@ import java.util.Map;
 public class WebOptions
     extends Options
 {
+    public final static String PAGING = "paging";
+    public final static String PAGE = "page";
+    public final static String PAGE_SIZE = "pageSize";
+    public final static String ROOT_JUNCTION = "rootJunction";
+    public final static String VIEW_CLASS = "viewClass";
+    public final static String MANAGE = "manage";
+
     public WebOptions( Map<String, String> options )
     {
         super( options );
@@ -51,37 +58,37 @@ public class WebOptions
 
     public boolean hasPaging()
     {
-        return stringAsBoolean( options.get( "paging" ), true );
+        return stringAsBoolean( options.get( PAGING ), true );
     }
 
     public int getPage()
     {
-        return stringAsInt( options.get( "page" ), 1 );
+        return stringAsInt( options.get( PAGE ), 1 );
     }
 
     public String getViewClass()
     {
-        return stringAsString( options.get( "viewClass" ), null );
+        return stringAsString( options.get( VIEW_CLASS ), null );
     }
 
     public String getViewClass( String defaultValue )
     {
-        return stringAsString( options.get( "viewClass" ), defaultValue );
+        return stringAsString( options.get( VIEW_CLASS ), defaultValue );
     }
 
     public int getPageSize()
     {
-        return stringAsInt( options.get( "pageSize" ), Pager.DEFAULT_PAGE_SIZE );
+        return stringAsInt( options.get( PAGE_SIZE ), Pager.DEFAULT_PAGE_SIZE );
     }
 
     public boolean isManage()
     {
-        return stringAsBoolean( options.get( "manage" ), false );
+        return stringAsBoolean( options.get( MANAGE ), false );
     }
 
     public Junction.Type getRootJunction()
     {
-        String rootJunction = options.get( "rootJunction" );
+        String rootJunction = options.get( ROOT_JUNCTION );
         return "OR".equals( rootJunction ) ? Junction.Type.OR : Junction.Type.AND;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/utils/PaginationUtilsTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/utils/PaginationUtilsTest.java
@@ -1,0 +1,106 @@
+package org.hisp.dhis.webapi.utils;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hisp.dhis.query.Pagination;
+import org.hisp.dhis.webapi.webdomain.WebOptions;
+import org.junit.Test;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class PaginationUtilsTest
+{
+    @Test
+    public void verifyPaginationStartsAtZero()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put( WebOptions.PAGING, "true" );
+        options.put( WebOptions.PAGE, "1" );
+        options.put( WebOptions.PAGE_SIZE, "20" );
+        WebOptions webOptions = new WebOptions( options );
+
+        Pagination paginationData = PaginationUtils.getPaginationData( webOptions );
+
+        assertThat( paginationData.getFirstResult(), is( 0 ) );
+        assertThat( paginationData.getSize(), is( 20 ) );
+
+    }
+
+    @Test
+    public void verifyPaginationCalculation()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put( WebOptions.PAGING, "true" );
+        options.put( WebOptions.PAGE, "14" );
+        options.put( WebOptions.PAGE_SIZE, "200" );
+        WebOptions webOptions = new WebOptions( options );
+
+        Pagination paginationData = PaginationUtils.getPaginationData( webOptions );
+
+        assertThat( paginationData.getFirstResult(), is( 2600 ) );
+        assertThat( paginationData.getSize(), is( 200 ) );
+    }
+
+    @Test
+    public void verifyPaginationIsDisabled()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put( WebOptions.PAGING, "false" );
+        WebOptions webOptions = new WebOptions( options );
+
+        Pagination paginationData = PaginationUtils.getPaginationData( webOptions );
+
+        assertThat( paginationData.getFirstResult(), is( 0 ) );
+        assertThat( paginationData.getSize(), is( 0 ) );
+        assertThat( paginationData.hasPagination(), is( false ) );
+    }
+
+    @Test
+    public void verifyIgnoreNegativePage()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put( WebOptions.PAGING, "true" );
+        options.put( WebOptions.PAGE, "-2" );
+        options.put( WebOptions.PAGE_SIZE, "200" );
+        WebOptions webOptions = new WebOptions( options );
+
+        Pagination paginationData = PaginationUtils.getPaginationData( webOptions );
+
+        assertThat( paginationData.getFirstResult(), is( 0 ) );
+        assertThat( paginationData.getSize(), is( 200 ) );
+    }
+
+}


### PR DESCRIPTION
* fix: incorrect calculation of firstResult in pagination


(cherry picked from commit 7acf9882fdc5cb77fc5dfc0ea6af18e778328e6f)