### PR TITLE
fix: DeletedObject constraint error when delete ProgramRule

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleAction.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleAction.java
@@ -453,7 +453,6 @@ public class ProgramRuleAction
     }
 
     @JsonProperty
-    @JsonSerialize( contentAs = BaseIdentifiableObject.class )
     @JacksonXmlElementWrapper( localName = "evaluationEnvironments", namespace = DxfNamespaces.DXF_2_0 )
     @JacksonXmlProperty( localName = "evaluationEnvironment", namespace = DxfNamespaces.DXF_2_0 )
     public Set<ProgramRuleActionEvaluationEnvironment> getProgramRuleActionEvaluationEnvironments()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -233,11 +233,6 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         AuditLogUtil.infoWrapper( log, username, object, AuditLogUtil.ACTION_CREATE );
 
         getSession().save( object );
-
-        if (object instanceof MetadataObject )
-        {
-            deletedObjectService.deleteDeletedObjects( new DeletedObjectQuery( object ) );
-        }
     }
 
     @Override
@@ -276,11 +271,6 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         if ( object != null )
         {
             getSession().update( object );
-        }
-
-        if ( object instanceof MetadataObject )
-        {
-            deletedObjectService.deleteDeletedObjects( new DeletedObjectQuery( object ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deletedobject/hibernate/DeletedObjectListenerConfigurer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deletedobject/hibernate/DeletedObjectListenerConfigurer.java
@@ -1,0 +1,40 @@
+package org.hisp.dhis.deletedobject.hibernate;
+
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+
+@Component
+public class DeletedObjectListenerConfigurer
+{
+    @PersistenceUnit
+    private EntityManagerFactory emf;
+
+    private final DeletedObjectPostInsertEventListener insertEventListener;
+
+    private final DeletedObjectPostDeleteEventListener deleteEventListener;
+
+    public DeletedObjectListenerConfigurer( DeletedObjectPostInsertEventListener insertEventListener,
+        DeletedObjectPostDeleteEventListener deleteEventListener )
+    {
+        this.deleteEventListener = deleteEventListener;
+        this.insertEventListener = insertEventListener;
+    }
+
+    @PostConstruct
+    protected void init()
+    {
+        SessionFactoryImpl sessionFactory = emf.unwrap( SessionFactoryImpl.class );
+
+        EventListenerRegistry registry = sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class );
+
+        registry.getEventListenerGroup( EventType.POST_COMMIT_INSERT ).appendListener( insertEventListener );
+
+        registry.getEventListenerGroup( EventType.POST_DELETE ).appendListener( deleteEventListener );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deletedobject/hibernate/DeletedObjectPostDeleteEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deletedobject/hibernate/DeletedObjectPostDeleteEventListener.java
@@ -36,21 +36,27 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.deletedobject.DeletedObject;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Component
 public class DeletedObjectPostDeleteEventListener implements PostDeleteEventListener
 {
     @Override
     public void onPostDelete( PostDeleteEvent event )
     {
+        if ( !IdentifiableObject.class.isAssignableFrom( event.getEntity().getClass() ) )
+        {
+            return;
+        }
+
         if ( MetadataObject.class.isInstance( event.getEntity() ) && !EmbeddedObject.class.isInstance( event.getEntity() ) )
         {
             IdentifiableObject identifiableObject = (IdentifiableObject) event.getEntity();
             DeletedObject deletedObject = new DeletedObject( identifiableObject );
             deletedObject.setDeletedBy( getUsername() );
-
             event.getSession().persist( deletedObject );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,1 +1,0 @@
-org.hisp.dhis.deletedobject.hibernate.DeletedObjectIntegrator

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -381,11 +381,6 @@ public class DefaultObjectBundleService implements ObjectBundleService
             objectBundleHooks.forEach( hook -> hook.preDelete( object, bundle ) );
             manager.delete( object, bundle.getUser() );
 
-            if (object instanceof MetadataObject)
-            {
-                deletedObjectService.deleteDeletedObjects( new DeletedObjectQuery( object ) );
-            }
-
             bundle.getPreheat().remove( bundle.getPreheatIdentifier(), object );
 
             if ( log.isDebugEnabled() )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
@@ -29,13 +29,18 @@ package org.hisp.dhis.programrule;
  */
 
 import com.google.common.collect.Sets;
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.IntegrationTestBase;
+import org.hisp.dhis.deletedobject.DeletedObjectQuery;
+import org.hisp.dhis.deletedobject.DeletedObjectService;
+import org.hisp.dhis.deletedobject.DeletedObjectStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.HashSet;
 import java.util.List;
@@ -72,6 +77,12 @@ public class ProgramRuleServiceTest
 
     @Autowired
     private ProgramRuleVariableService programRuleVariableService;
+
+    @Autowired
+    private DeletedObjectStore deletedObjectStore;
+
+    @Autowired
+    private SessionFactory sessionFactory;
 
     @Override
     public boolean emptyDatabaseAfterTest()
@@ -421,6 +432,41 @@ public class ProgramRuleServiceTest
 
         assertNull( programRuleService.getProgramRule( idI ) );
         assertNull( programRuleService.getProgramRule( idJ ) );
+    }
+
+    @Test
+    public void testDeleteDeletedObjectWithCascade()
+    {
+        ProgramRule programRule = createProgramRule( 'A', programA );
+
+        ProgramRuleAction programRuleAction = createProgramRuleAction( 'D' );
+        programRuleAction.setProgramRuleActionType( ProgramRuleActionType.SENDMESSAGE );
+        programRuleAction.setProgramRule( programRule );
+
+        programRule.setProgramRuleActions( Sets.newHashSet(programRuleAction) );
+
+        programRuleService.addProgramRule( programRule );
+
+        String programRuleUID = programRule.getUid();
+        String programRuleActionUID = programRuleAction.getUid();
+
+        programRuleService.deleteProgramRule( programRule );
+
+        ProgramRule programRule1 = createProgramRule( 'A', programA );
+        programRule1.setUid( programRuleUID );
+
+        ProgramRuleAction programRuleAction1 = createProgramRuleAction( 'D' );
+        programRuleAction1.setProgramRuleActionType( ProgramRuleActionType.SENDMESSAGE );
+        programRuleAction1.setProgramRule( programRule1 );
+        programRuleAction1.setUid( programRuleActionUID );
+
+        programRule1.setProgramRuleActions( Sets.newHashSet( programRuleAction1 ) );
+
+        programRuleService.addProgramRule( programRule1 );
+
+        programRuleService.deleteProgramRule( programRule1 );
+
+        assertNotNull( deletedObjectStore.query( new DeletedObjectQuery( programRule1 ) ) );
     }
 
     /*TODO: Fix the functionality for 2 level cascading deletes.


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-3454

- The issue is that for saving `DeletedObject` we use `DeletedObjectIntegrator` for triggering Hibernate POST_DELETE event, which is triggered for every objects including cascade objects
But for deleting the `DeletedObject` we explicit call `deleteDeletedObject` method in `HibernateIdentifiableObjectStore.save()` which does not touch the cascade objects.

- This fix remove `DeletedObjectIntegrator` and use Hibernate POST_COMMIT_INSERT event to call `deleteDeletedObject`, so the cascade objects will be taken care of. Also adding `DeletedObjectListenerConfigurer` to register those hibernate event listeners

- Also include a small fix for json serialization issue of `ProgramRuleAction.evaluationEnvironment` which is not an `IdentifiableObject` but was marked with `@JsonSerialize( contentAs = BaseIdentifiableObject.class )`