### PR TITLE
fix: Use read-write JDBC template for SQL views

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.sqlview.SqlView;
 import org.hisp.dhis.sqlview.SqlViewStore;
 import org.hisp.dhis.sqlview.SqlViewType;
 import org.hisp.dhis.user.CurrentUserService;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.UncategorizedSQLException;
@@ -74,23 +73,19 @@ public class HibernateSqlViewStore
 
     private final StatementBuilder statementBuilder;
 
-    private final JdbcTemplate readOnlyJdbcTemplate;
-
     private final SystemSettingManager systemSettingManager;
 
     public HibernateSqlViewStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
         ApplicationEventPublisher publisher, CurrentUserService currentUserService, DeletedObjectService deletedObjectService,
         AclService aclService, StatementBuilder statementBuilder,
-        @Qualifier( "readOnlyJdbcTemplate" ) JdbcTemplate readOnlyJdbcTemplate, SystemSettingManager systemSettingManager )
+        SystemSettingManager systemSettingManager )
     {
         super( sessionFactory, jdbcTemplate, publisher, SqlView.class, currentUserService, deletedObjectService, aclService, false );
 
         checkNotNull( statementBuilder );
-        checkNotNull( readOnlyJdbcTemplate );
         checkNotNull( systemSettingManager );
 
         this.statementBuilder = statementBuilder;
-        this.readOnlyJdbcTemplate = readOnlyJdbcTemplate;
         this.systemSettingManager = systemSettingManager;
     }
 
@@ -137,7 +132,7 @@ public class HibernateSqlViewStore
     @Override
     public void populateSqlViewGrid( Grid grid, String sql )
     {
-        SqlRowSet rs = readOnlyJdbcTemplate.queryForRowSet( sql );
+        SqlRowSet rs = jdbcTemplate.queryForRowSet( sql );
 
         int maxLimit = (Integer) systemSettingManager.getSystemSetting( SettingKey.SQL_VIEW_MAX_LIMIT );
 


### PR DESCRIPTION
Changes SQL view querying to read from master database instead of potentially from read replicas.