### PR TITLE
fix: Deletion of interpretation comments [DHIS2-8256]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/Interpretation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/Interpretation.java
@@ -92,7 +92,7 @@ public class Interpretation
 
     private String text;
 
-    private List<InterpretationComment> comments = new ArrayList<>();
+    private Set<InterpretationComment> comments = new HashSet<>();
 
     private int likes;
 
@@ -488,12 +488,12 @@ public class Interpretation
     @JsonProperty
     @JacksonXmlElementWrapper( localName = "comments", namespace = DXF_2_0 )
     @JacksonXmlProperty( localName = "comment", namespace = DXF_2_0 )
-    public List<InterpretationComment> getComments()
+    public Set<InterpretationComment> getComments()
     {
         return comments;
     }
 
-    public void setComments( List<InterpretationComment> comments )
+    public void setComments( Set<InterpretationComment> comments )
     {
         this.comments = comments;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/Interpretation.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/Interpretation.hbm.xml
@@ -41,13 +41,12 @@
 
     <property name="created" not-null="true" type="timestamp" />
 
-    <list name="comments" table="interpretation_comments" cascade="all,delete-orphan">
+    <set name="comments" table="interpretation_comments" cascade="all, delete-orphan" order-by="interpretationcommentid">
       <cache usage="read-write" />
       <key column="interpretationid" foreign-key="fk_interpretation_comments_interpretationid" />
-      <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.interpretation.InterpretationComment" column="interpretationcommentid"
         unique="true" foreign-key="fk_interpretation_comments_interpretationcommentid" />
-    </list>
+    </set>
 
     <property name="likes" />
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_1__Update_Interpretation_Comment_PKEY.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_1__Update_Interpretation_Comment_PKEY.sql
@@ -1,0 +1,13 @@
+-- Dropping PKEY constraint
+ALTER TABLE interpretation_comments DROP CONSTRAINT interpretation_comments_pkey;
+
+-- Adding new PKEY constraint
+ALTER TABLE interpretation_comments ADD PRIMARY KEY (interpretationid, interpretationcommentid);
+
+-- Removing unused column: sort_order
+ALTER TABLE interpretation_comments DROP COLUMN IF EXISTS sort_order;
+
+-- Removing duplicated comments
+DELETE FROM interpretation_comments ic1 USING interpretation_comments ic2
+WHERE ic1.interpretationcommentid < ic2.interpretationcommentid
+AND ic1.interpretationcommentid = ic2.interpretationcommentid;


### PR DESCRIPTION
Changing the collection type and sorting by comment id, so the many-to-many deletion works correctly.

Related DB migration PR: https://github.com/dhis2/wow-backend/pull/35