### PR TITLE
fix: Prevent invalid query when using PI as sort item

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDataDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDataDimensionalItemObject.java
@@ -94,4 +94,10 @@ public class BaseDataDimensionalItemObject
     {
         this.aggregateExportAttributeOptionCombo = aggregateExportAttributeOptionCombo;
     }
+
+    @Override
+    public boolean hasDatabaseColumn()
+    {
+        return true;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -161,4 +161,10 @@ public class BaseDimensionalItemObject
     {
         this.aggregationType = aggregationType;
     }
+
+    @Override
+    public boolean hasDatabaseColumn()
+    {
+        return true;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
@@ -91,4 +91,13 @@ public interface DimensionalItemObject
      * should be aggregated across multiple values.
      */
     TotalAggregationType getTotalAggregationType();
+
+    /**
+     * True if this Dimensional Object can be mapped to an analytics database column
+     * Certain Dimensional Objects (such as Program Indicators) are calculated
+     * and are not mapped to a physical DB column.
+     *
+     * @return boolean
+     */
+    boolean hasDatabaseColumn();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -391,4 +391,10 @@ public class ProgramIndicator
     {
         this.formName = formName;
     }
+
+    @Override
+    public boolean hasDatabaseColumn()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
- Ignore sorting directive in Event analytics, if the Dimensional Item
to sort on is a Program Indicator. Without this fix, the SQL engine generates an invalid query, that uses a non existing column for sorting (since PIs are calculated)
- DHIS2-8542

Note: 

As explained in the chat, I took the "easy" approach, that is ignoring the sort directive if the Dimension is not mapped to a "real" column. Let me know, if we should consider more complex approaches (in memory sorting, etc.)
@larshelge, I have add this property `hasDatabaseColumn` to the `DimensionalItemObject`. Potentially, we can remove that and simply check if the item is a PI when building the sort statement.