### PR TITLE
fix: Change Age's ValueType from Date to Integer [DHIS2-7872]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -66,13 +66,13 @@ public enum ValueType
     USERNAME( String.class, false ),
     COORDINATE( Point.class, true ),
     ORGANISATION_UNIT( OrganisationUnit.class, false ),
-    AGE( Date.class, false ),
+    AGE( Integer.class, false ),
     URL( String.class, false ),
     FILE_RESOURCE( String.class, false ),
     IMAGE( String.class, false);
 
     public static final Set<ValueType> INTEGER_TYPES = ImmutableSet.of(
-        INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE );
+        AGE, INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE );
 
     public static final Set<ValueType> DECIMAL_TYPES =ImmutableSet.of(
         NUMBER, UNIT_INTERVAL, PERCENTAGE );
@@ -84,7 +84,7 @@ public enum ValueType
         TEXT, LONG_TEXT, LETTER, TIME, USERNAME, EMAIL, PHONE_NUMBER, URL );
 
     public static final Set<ValueType> DATE_TYPES = ImmutableSet.of(
-        DATE, DATETIME, AGE );
+        DATE, DATETIME );
 
     public static final Set<ValueType> FILE_TYPES = ImmutableSet.of(
         FILE_RESOURCE, IMAGE );


### PR DESCRIPTION
The Age seems to have the wrong type. Currently, it's set to Date.class.
But Age seems to make more sense as an Integer. If one wants to use a Date, the Date type is available as a ValueType itself.

The other way to fix it would be to keep the Age as a Date.class and change the UI to treat Age ValueTypes and date/calendar input, instead of plain text input.