### PR TITLE
fix: CategoryCombo w/o Option causes api/dataElementOperands 500

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
@@ -156,6 +156,7 @@ public class CategoryCombo
     public List<List<CategoryOption>> getCategoryOptionsAsLists()
     {
         return categories.stream()
+            .filter( ca -> !ca.getCategoryOptions().isEmpty() )
             .map( ca -> ca.getCategoryOptions() )
             .collect( Collectors.toList() );
     }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-2696