### PR TITLE
chore: add support for conditional format

### DIFF
--- a/dhis-2/DHISFormatter.xml
+++ b/dhis-2/DHISFormatter.xml
@@ -247,5 +247,8 @@
 <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
 <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
 </profile>
 </profiles>


### PR DESCRIPTION
This setting allows using conditional formatting tags into the code. A conditional formatting prevents the automatic formatter to format blocks of code:

```
// @formatter:off
IN_USER_ORG_UNIT_HIERARCHY_CACHE = cacheProvider.newCacheBuilder( Boolean.class )
    .forRegion( "inUserOuHierarchy" )
    .expireAfterWrite( 3, TimeUnit.HOURS )
    .withInitialCapacity( 1000 )
    .forceInMemory()
    .withMaximumSize( SystemUtils.isTestRun(env.getActiveProfiles() ) ? 0 : 20000 ).build();
// @formatter:on
```