### PR TITLE
chore: Force line ending in committed files to be LF

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -440,14 +440,15 @@
                 <file>${rootDir}/DHISFormatter.xml</file>
                 <version>4.9.0</version>
               </eclipse>
-              <trimTrailingWhitespace />
-              <removeUnusedImports />
+              <trimTrailingWhitespace/>
+              <removeUnusedImports/>
               <importOrder>
                 <order>
                   java,javax,org,com
                 </order>
               </importOrder>
             </java>
+            <lineEndings>UNIX</lineEndings>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
The formatter will force all files in the commit to use LF (UNIX) line ends.

In this way we are trying to avoid to have different files with different line ends.

This will result sometimes in difficult PRs, because the whole file will be changed, but github has the "Hide whitespace changes" option that will ignore line endings.