### PR TITLE
[2.32] fix: analytics: retain unresolved Indicators

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -500,12 +500,8 @@ public class DefaultAnalyticsService
                 {
                     String permKey = DimensionItem.asItemKey( dimensionItems );
 
-                    Map<DimensionalItemObject, Double> valueMap = permutationDimensionItemValueMap.get( permKey );
-
-                    if ( valueMap == null )
-                    {
-                        continue;
-                    }
+                    Map<DimensionalItemObject, Double> valueMap = permutationDimensionItemValueMap
+                        .getOrDefault( permKey, new HashMap<>() );
 
                     Period period = filterPeriod != null ? filterPeriod : (Period) DimensionItem.getPeriodItem( dimensionItems );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceIndicatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceIndicatorTest.java
@@ -95,6 +95,18 @@ public class AnalyticsServiceIndicatorTest
         dataElementService.addDataElement( dataElementA );
     }
 
+    @Test
+    public void verifyIndicatorWithStaticValuesIsComputedAndValueReturned()
+    {
+        IndicatorType indicatorTypeB = createIndicatorType( 'B' );
+        indicatorService.addIndicatorType( indicatorTypeB );
+        Indicator indicatorF = createIndicator( 'F', indicatorTypeB, "1", "5" );
+        Grid grid = this.analyticsService.getAggregatedDataValues( createParamsWithRootIndicator( indicatorF ) );
+
+        assertThat( grid.getRow( 0 ).get( 0 ), is( "mindicatorF" ) );
+        assertThat( grid.getRow( 0 ).get( 2 ), is( 20.0 ) );
+    }
+
     /**
      * IndicatorF -> IndicatorG -> IndicatorH -> IndicatorI
      *


### PR DESCRIPTION
- DHIS2-7862
- If an analytics query contains Indicators which contain constants or
  static values (e.g. 100, 1), do not exit early and continue processing
the indicator expressions.

(cherry picked from commit 6ee1d2f1b21852302f2ea5fd137edbb5978b1767)