### PR TITLE
[2.34.0] fix: Prevent invalid query when using PI as sort item (#5195)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -42,10 +42,18 @@ import javax.persistence.QueryTimeoutException;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.EventOutputType;
+import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.programIndicator.DefaultProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.DimensionItemType;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.legend.Legend;
@@ -134,19 +142,29 @@ public abstract class AbstractJdbcEventAnalyticsManager
 
         if ( params.isSorting() )
         {
-            sql += "order by ";
-
-            for ( DimensionalItemObject item : params.getAsc() )
-            {
-                sql += quoteAlias( item.getUid() ) + " asc,";
-            }
-
-            for  ( DimensionalItemObject item : params.getDesc() )
-            {
-                sql += quoteAlias( item.getUid() ) + " desc,";
-            }
+            sql += "order by " + getSortColumns( params, SortOrder.ASC ) + getSortColumns( params, SortOrder.DESC );
 
             sql = TextUtils.removeLastComma( sql ) + " ";
+        }
+
+        return sql;
+    }
+
+    private String getSortColumns(EventQueryParams params , SortOrder order) {
+
+        String sql = "";
+
+        for ( DimensionalItemObject item : order.equals( SortOrder.ASC ) ? params.getAsc() : params.getDesc() )
+        {
+            if ( item.getDimensionItemType().equals( DimensionItemType.PROGRAM_INDICATOR ) )
+            {
+                sql += quote( item.getUid() );
+            }
+            else
+            {
+                sql += quoteAlias( item.getUid() );
+            }
+            sql += order.equals( SortOrder.ASC ) ? " asc," : " desc,";
         }
 
         return sql;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -33,21 +33,41 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.hisp.dhis.DhisConvenienceTest.createProgram;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
+import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.programIndicator.DefaultProgramIndicatorSubqueryBuilder;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.QuarterlyPeriodType;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.system.grid.ListGrid;
@@ -270,6 +290,42 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
     public void verifyLastAggregationTypeSubquery()
     {
         verifyFirstOrLastAggregationTypeSubquery( AnalyticsAggregationType.LAST );
+    }
+
+    @Test
+    public void verifySortClauseHandlesProgramIndicators()
+    {
+        Program program = createProgram( 'P' );
+        ProgramIndicator piA = createProgramIndicator( 'A', program, ".", "." );
+        piA.setUid( "TLKx7vllb1I" );
+
+        ProgramIndicator piB = createProgramIndicator( 'B', program, ".", "." );
+        piA.setUid( "CCKx3gllb2P" );
+
+        OrganisationUnit ouA = createOrganisationUnit( 'A' );
+        Period peA = PeriodType.getPeriodFromIsoString( "201501" );
+
+        DataElement deA = createDataElement( 'A' );
+        deA.setUid( "ZE4cgllb2P");
+
+        DataQueryParams params = DataQueryParams.newBuilder().withDataType( DataType.NUMERIC )
+            .withTableName( "analytics" ).withPeriodType( QuarterlyPeriodType.NAME )
+            .withAggregationType( AnalyticsAggregationType.fromAggregationType( AggregationType.DEFAULT ) )
+            .addDimension( new BaseDimensionalObject( DATA_X_DIM_ID, DimensionType.PROGRAM_INDICATOR, getList( piA, piB ) ) )
+            .addFilter( new BaseDimensionalObject( ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, getList( ouA ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.DATA_X, getList( peA ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, getList( peA ) ) ).build();
+
+        final EventQueryParams.Builder eventQueryParamsBuilder = new EventQueryParams.Builder( params )
+            .withProgram( program )
+            .addAscSortItem( piA )
+            .addDescSortItem( piB )
+            .addAscSortItem( deA );
+
+        final String sql = subject.getEventsOrEnrollmentsSql( eventQueryParamsBuilder.build(), 100 );
+
+        assertThat( sql, containsString(
+            "order by \"" + piA.getUid() + "\" asc,ax.\"" + deA.getUid() + "\" asc,\"" + piB.getUid() + "\"" ) );
     }
 
     private void verifyFirstOrLastAggregationTypeSubquery( AnalyticsAggregationType analyticsAggregationType )


### PR DESCRIPTION
* fix: Prevent invalid query when using PI as sort item

- DHIS2-8542
- Fix event/enrollment query generation process, by referencing a
Program Indicator alias (as uid) in the "order by" clause (instead of a column name)

* chore: style

(cherry picked from commit 59232d19c6ddb4d5ad3af58ab5c5894a930c0446)