### PR TITLE
fix: Upgrade Jetty to prevent startup failure

### DIFF
--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.13.v20161014</version>
+        <version>9.4.27.v20200227</version>
         <configuration>
           <systemProperties>
             <systemProperty>


### PR DESCRIPTION
Upgrade Jetty maven plugin to prevent failure to startup with mvn jetty:run-war

Issue: [DHIS2-8566]