### PR TITLE
fix: correct flyway version number for 2.35

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v35/V2_35_2__Update_data_sync_job_parameters_with_system_setting_value.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v35/V2_35_2__Update_data_sync_job_parameters_with_system_setting_value.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.db.migration.v34;
+package org.hisp.dhis.db.migration.v35;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -57,15 +57,15 @@ import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 /**
  * @author David Katuscak <katuscak.d@gmail.com>
  */
-public class V2_34_19__Update_data_sync_job_parameters_with_system_setting_value extends BaseJavaMigration
+public class V2_35_2__Update_data_sync_job_parameters_with_system_setting_value extends BaseJavaMigration
 {
-    private static final Logger log = LoggerFactory.getLogger( V2_34_19__Update_data_sync_job_parameters_with_system_setting_value.class );
+    private static final Logger log = LoggerFactory.getLogger( V2_35_2__Update_data_sync_job_parameters_with_system_setting_value.class );
     private static final String DATA_VALUES_SYNC_PAGE_SIZE_KEY = "syncDataValuesPageSize";
 
     private final ObjectReader reader;
     private final ObjectWriter writer;
 
-    public V2_34_19__Update_data_sync_job_parameters_with_system_setting_value()
+    public V2_35_2__Update_data_sync_job_parameters_with_system_setting_value()
     {
         ObjectMapper mapper = new ObjectMapper();
         mapper.activateDefaultTyping( BasicPolymorphicTypeValidator.builder().allowIfBaseType( JobParameters.class ).build() );


### PR DESCRIPTION
Davids PR was merged after 2.34 (and 2.34.0 patch) branches were branched out. So the flyway version number in the PR https://github.com/dhis2/dhis2-core/pull/4913 , should be updated to 2.35.x (2.35.2 in this case)