### PR TITLE
fix: hide encrypted password when using Jackson ObjectMapper

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -389,7 +389,7 @@ public class UserCredentials
     @Override
     public String getName()
     {
-        return userInfo!= null ? userInfo.getName() : username;
+        return userInfo != null ? userInfo.getName() : username;
     }
 
     /**
@@ -529,7 +529,7 @@ public class UserCredentials
     }
 
     @Override
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.WRITE_ONLY )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     @Property( value = PropertyType.PASSWORD, access = Access.WRITE_ONLY )
     @PropertyRange( min = 8, max = 60 )


### PR DESCRIPTION
When using Jackson ObjectMapper directly  we are currently exposing the encrypted password in json/xml, for node serializers we automatically hide this field (property type is set to PASSWORD) so its not a problem when using the web-api etc normally, but since we have started using object mapper for audits this means that the encrypted password is available on the audit topic if any changes happens to a user.

This PR aligns the behavior to that of the node serializer, so that password fields can only be written to, not read from.