### PR TITLE
fix: Add null-check before checking value length

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -1200,7 +1200,9 @@ public abstract class AbstractEnrollmentService
                 continue;
             }
 
-            if ( attributeValueMap.get( trackedEntityAttribute.getUid() ).length() > TEA_VALUE_MAX_LENGTH )
+            String attributeValue = attributeValueMap.get( trackedEntityAttribute.getUid() );
+
+            if ( attributeValue != null && attributeValue.length() > TEA_VALUE_MAX_LENGTH )
             {
                 // We shorten the value to first 25 characters, since we dont want to post a 1200+ string back.
                 importConflicts.add( new ImportConflict( "Attribute.value", String.format( "Value exceeds the character limit of %s characters: '%s...'", TEA_VALUE_MAX_LENGTH, attributeValueMap.get( trackedEntityAttribute.getUid() ).substring( 0, 25 ) ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -1248,7 +1248,7 @@ public abstract class AbstractTrackedEntityInstanceService
                     continue;
                 }
 
-                if ( attribute.getValue().length() > TEA_VALUE_MAX_LENGTH )
+                if ( attribute.getValue() != null && attribute.getValue().length() > TEA_VALUE_MAX_LENGTH )
                 {
                     // We shorten the value to first 25 characters, since we dont want to post a 1200+ string back.
                     importConflicts.add( new ImportConflict( "Attribute.value", String.format( "Value exceeds the character limit of %s characters: '%s...'", TEA_VALUE_MAX_LENGTH, attribute.getValue().substring( 0, 25 ) ) ) );


### PR DESCRIPTION
Adds a null-check before checking the length of a value. The code is checking all te-attributes for program/tet, regardless if a value was supplied or not, so some instances can be null.