### PR TITLE
fix: Use TrackedEntityAttributeValueService to update values in SMS submissions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.message.MessageSender;
@@ -49,6 +50,8 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
@@ -65,6 +68,7 @@ import org.hisp.dhis.smscompression.models.UID;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -245,6 +249,13 @@ public abstract class CompressionSMSListener
         meta.trackedEntityAttributes = getTypeUidsBefore( TrackedEntityAttribute.class, lastSyncDate );
         meta.programs = getTypeUidsBefore( Program.class, lastSyncDate );
         meta.organisationUnits = getTypeUidsBefore( OrganisationUnit.class, lastSyncDate );
+        meta.programStages = getTypeUidsBefore( ProgramStage.class, lastSyncDate );
+        meta.relationshipTypes = getTypeUidsBefore( RelationshipType.class, lastSyncDate );
+        meta.relationships = getTypeUidsBefore( Relationship.class, lastSyncDate );
+        meta.trackedEntityInstances = getTypeUidsBefore( TrackedEntityInstance.class, lastSyncDate );
+        meta.dataSets = getTypeUidsBefore( DataSet.class, lastSyncDate );
+        meta.enrollments = getTypeUidsBefore( ProgramInstance.class, lastSyncDate );
+        meta.events = getTypeUidsBefore( ProgramStageInstance.class, lastSyncDate );
 
         return meta;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -230,9 +230,11 @@ public class EnrollmentSMSListener
         // Update existing and add new values
         for ( TrackedEntityAttributeValue attributeValue : attributeValues )
         {
-            if ( containsAttributeValue( attributeValue, oldAttributeValues ) )
+            TrackedEntityAttributeValue oldAttributeValue = findAttributeValue( attributeValue, oldAttributeValues );
+            if ( oldAttributeValue != null )
             {
-                attributeValueService.updateTrackedEntityAttributeValue( attributeValue );
+                oldAttributeValue.setValue( attributeValue.getValue() );
+                attributeValueService.updateTrackedEntityAttributeValue( oldAttributeValue );
             }
             else
             {
@@ -243,18 +245,19 @@ public class EnrollmentSMSListener
         // Delete any that don't exist anymore
         for ( TrackedEntityAttributeValue oldAttributeValue : oldAttributeValues )
         {
-            if ( !containsAttributeValue( oldAttributeValue, attributeValues ) )
+            if ( findAttributeValue( oldAttributeValue, attributeValues ) == null )
             {
                 attributeValueService.deleteTrackedEntityAttributeValue( oldAttributeValue );
             }
         }
     }
 
-    private boolean containsAttributeValue( TrackedEntityAttributeValue attributeValue,
+    private TrackedEntityAttributeValue findAttributeValue( TrackedEntityAttributeValue attributeValue,
         Set<TrackedEntityAttributeValue> attributeValues )
     {
         return attributeValues.stream()
-            .anyMatch( v -> v.getAttribute().getUid().equals( attributeValue.getAttribute().getUid() ) );
+            .filter( v -> v.getAttribute().getUid().equals( attributeValue.getAttribute().getUid() ) ).findAny()
+            .orElse( null );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -84,6 +85,8 @@ public class EnrollmentSMSListener
 
     private final ProgramInstanceService programInstanceService;
 
+    private final TrackedEntityAttributeValueService attributeValueService;
+
     private final ProgramStageService programStageService;
 
     private final UserService userService;
@@ -93,7 +96,8 @@ public class EnrollmentSMSListener
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
         DataElementService dataElementService, ProgramStageService programStageService,
-        ProgramStageInstanceService programStageInstanceService, TrackedEntityInstanceService teiService,
+        ProgramStageInstanceService programStageInstanceService,
+        TrackedEntityAttributeValueService attributeValueService, TrackedEntityInstanceService teiService,
         ProgramInstanceService programInstanceService, IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
@@ -103,6 +107,7 @@ public class EnrollmentSMSListener
         this.teiService = teiService;
         this.programStageService = programStageService;
         this.programInstanceService = programInstanceService;
+        this.attributeValueService = attributeValueService;
         this.userService = userService;
     }
 
@@ -159,6 +164,7 @@ public class EnrollmentSMSListener
 
         if ( teiExists )
         {
+            updateAttributeValues( attributeValues, entityInstance.getTrackedEntityAttributeValues() );
             entityInstance.setTrackedEntityAttributeValues( attributeValues );
             teiService.updateTrackedEntityInstance( entityInstance );
         }
@@ -216,6 +222,39 @@ public class EnrollmentSMSListener
         }
 
         return SMSResponse.SUCCESS;
+    }
+
+    private void updateAttributeValues( Set<TrackedEntityAttributeValue> attributeValues,
+        Set<TrackedEntityAttributeValue> oldAttributeValues )
+    {
+        // Update existing and add new values
+        for ( TrackedEntityAttributeValue attributeValue : attributeValues )
+        {
+            if ( containsAttributeValue( attributeValue, oldAttributeValues ) )
+            {
+                attributeValueService.updateTrackedEntityAttributeValue( attributeValue );
+            }
+            else
+            {
+                attributeValueService.addTrackedEntityAttributeValue( attributeValue );
+            }
+        }
+
+        // Delete any that don't exist anymore
+        for ( TrackedEntityAttributeValue oldAttributeValue : oldAttributeValues )
+        {
+            if ( !containsAttributeValue( oldAttributeValue, attributeValues ) )
+            {
+                attributeValueService.deleteTrackedEntityAttributeValue( oldAttributeValue );
+            }
+        }
+    }
+
+    private boolean containsAttributeValue( TrackedEntityAttributeValue attributeValue,
+        Set<TrackedEntityAttributeValue> attributeValues )
+    {
+        return attributeValues.stream()
+            .anyMatch( v -> v.getAttribute().getUid().equals( attributeValue.getAttribute().getUid() ) );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.Before;
@@ -141,6 +142,9 @@ public class EnrollmentSMSListenerTest
     private ProgramInstanceService programInstanceService;
 
     @Mock
+    private TrackedEntityAttributeValueService attributeValueService;
+
+    @Mock
     private IdentifiableObjectManager identifiableObjectManager;
 
     private EnrollmentSMSListener subject;
@@ -199,7 +203,7 @@ public class EnrollmentSMSListenerTest
     {
         subject = new EnrollmentSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageService, programStageInstanceService, teiService, programInstanceService,
+            programStageService, programStageInstanceService, attributeValueService, teiService, programInstanceService,
             identifiableObjectManager );
 
         setUpInstances();


### PR DESCRIPTION
This PR contains two fixes:
1. Ensure the TrackedEntityAttributeValueService is used in the SMS compression listener when processing enrolment submissions. 
2. Ensure all metadata is retrieved when initialising the Compression listener (some types were missing), for use with hashing of UIDs.