### PR TITLE
fix: calculate metadata pagination total pages

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -32,7 +32,6 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.hamcrest.Matchers;
 import org.hisp.dhis.TestRunStorage;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.dto.ImportSummary;
@@ -45,6 +44,9 @@ import io.restassured.http.ContentType;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -123,7 +125,7 @@ public class RestApiActions
      * Shortcut used in preconditions only.
      * Sends post request to specified endpoint and verifies that request was successful
      *
-     * @param object Body of reqeuest
+     * @param object Body of request
      * @return ID of generated entity.
      */
     public String create( Object object )
@@ -131,7 +133,7 @@ public class RestApiActions
         ApiResponse response = post( object );
 
         response.validate()
-            .statusCode( Matchers.isOneOf( 200, 201 ) );
+            .statusCode(  is(oneOf( 200, 201 ) ) );
 
         return response.extractUid();
     }
@@ -162,7 +164,6 @@ public class RestApiActions
      *
      * @param resourceId         Id of resource
      * @param queryParamsBuilder Query params to append to url
-     * @return
      */
     public ApiResponse get( String resourceId, QueryParamsBuilder queryParamsBuilder )
     {
@@ -183,7 +184,6 @@ public class RestApiActions
      * @param contentType           Content type of the request
      * @param accept                Accepted response Content type
      * @param queryParamsBuilder    Query params to append to url
-     * @return
      */
     public ApiResponse get( String resourceId, String contentType, String accept, QueryParamsBuilder queryParamsBuilder )
     {
@@ -204,7 +204,6 @@ public class RestApiActions
      *
      * @param resourceId            Id of resource
      * @param queryParamsBuilder    Query params to append to url
-     * @return
      */
     public ApiResponse delete( String resourceId, QueryParamsBuilder queryParamsBuilder )
     {
@@ -218,7 +217,6 @@ public class RestApiActions
      * If delete request successful, removes entity from TestRunStorage.
      *
      * @param path Id of resource
-     * @return
      */
     public ApiResponse delete( String path )
     {
@@ -239,7 +237,6 @@ public class RestApiActions
      *
      * @param resourceId Id of resource
      * @param object     Body of request
-     * @return
      */
     public ApiResponse update( String resourceId, Object object )
     {
@@ -280,9 +277,7 @@ public class RestApiActions
         if ( response.containsImportSummaries() )
         {
             List<ImportSummary> importSummaries = response.getSuccessfulImportSummaries();
-            importSummaries.forEach( importSummary -> {
-                TestRunStorage.addCreatedEntity( endpoint, importSummary.getReference() );
-            } );
+            importSummaries.forEach( importSummary -> TestRunStorage.addCreatedEntity( endpoint, importSummary.getReference() ));
             return;
         }
 
@@ -290,9 +285,7 @@ public class RestApiActions
         {
             SchemasActions schemasActions = new SchemasActions();
             response.getTypeReports().stream()
-                .filter( typeReport -> {
-                    return typeReport.getStats().getCreated() != 0 || typeReport.getStats().getImported() != 0;
-                } )
+                .filter( typeReport -> typeReport.getStats().getCreated() != 0 || typeReport.getStats().getImported() != 0)
                 .forEach( tr -> {
                     List<ObjectReport> objectReports = tr.getObjectReports();
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
@@ -64,7 +64,8 @@ public class MetadataPaginationActions
     /**
      * Executes a metadata request using pagination directives
      *
-     * @param filter a List of String, containing the expressions to filter metadata on
+     * @param filter a List of String, containing the expressions to filter metadata
+     *        on
      * @param fields a List of String, containing the name of the fields to return
      * @param sort a List of String, containing the sort expressions
      * @param page the page to return
@@ -77,20 +78,17 @@ public class MetadataPaginationActions
         assert filter != null;
         assert fields != null && !fields.isEmpty();
         assert sort != null && !sort.isEmpty();
-        QueryParamsBuilder params = new QueryParamsBuilder()
-            .add( "filter=" + String.join( ",", filter ) )
-            .add( "fields=" + String.join( ",", fields ) )
-            .add( "order=" + String.join( ",", sort ) )
-            .add( "page=" + page )
-            .add( "pageSize=" + pageSize );
+        QueryParamsBuilder params = new QueryParamsBuilder().add( "filter=" + String.join( ",", filter ) )
+            .add( "fields=" + String.join( ",", fields ) ).add( "order=" + String.join( ",", sort ) )
+            .add( "page=" + page ).add( "pageSize=" + pageSize );
 
         return get( "", params );
 
     }
 
     /**
-     * Executes a metadata request using pagination directives.
-     * Uses a default filter expression
+     * Executes a metadata request using pagination directives. Uses a default
+     * filter expression
      *
      * @param fields a List of String, containing the name of the fields to return
      * @param sort a List of String, containing the sort expressions
@@ -104,8 +102,8 @@ public class MetadataPaginationActions
     }
 
     /**
-     * Executes a metadata request using pagination directives.
-     * Uses a default filter and sort expression
+     * Executes a metadata request using pagination directives. Uses a default
+     * filter and sort expression
      *
      * @param fields a List of String, containing the name of the fields to return
      * @param page the page to return
@@ -119,8 +117,8 @@ public class MetadataPaginationActions
     }
 
     /**
-     * Executes a metadata request using pagination directives.
-     * Uses a default filter, fields and sort expression
+     * Executes a metadata request using pagination directives. Uses a default
+     * filter, fields and sort expression
      *
      * @param page the page to return
      * @param pageSize the number of elements to return for each page
@@ -144,18 +142,15 @@ public class MetadataPaginationActions
     public void assertPagination( ApiResponse response, int expectedTotal, int expectedPageCount, int expectedPageSize,
         int expectedPage )
     {
-        JsonObject pager = response.extractJsonObject( "pager" );
-        assertThat( pager, is( notNullValue() ) );
-        assertThat( Integer.parseInt( pager.get( "pageCount" ).getAsString() ), greaterThan( expectedPageCount ) );
-        assertThat( Integer.parseInt( pager.get( "total" ).getAsString() ), greaterThanOrEqualTo( expectedTotal ) );
+        response.validate().statusCode( 200 ).rootPath( "pager" )
+            .body( "pageCount", greaterThan( expectedPageCount ) )
+            .body( "total", greaterThan( expectedTotal ) )
+            .body( "pageSize", is( expectedPageSize ) )
+            .body( "page", is( expectedPage ) )
+            .body( "nextPage", startsWith( TestConfiguration.get().baseUrl() + endpoint ) )
+            .body( "nextPage", containsString( "pageSize=" + expectedPageSize ) )
+            .body( "nextPage", containsString( "page=" + (expectedPage + 1) ) );
 
-        String nextPage = pager.get( "nextPage" ).getAsString();
-        assertThat( nextPage, startsWith( TestConfiguration.get().baseUrl() + endpoint ) );
-        assertThat( nextPage, containsString( "pageSize=" + expectedPageSize ) );
-        assertThat( nextPage, containsString( "page=" + (expectedPage + 1) ) );
-
-        assertThat( Integer.parseInt( pager.get( "pageSize" ).getAsString() ), Matchers.is( expectedPageSize ) );
-        assertThat( Integer.parseInt( pager.get( "page" ).getAsString() ), Matchers.is( expectedPage ) );
     }
 
     private List<String> toParamList( String string )

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
@@ -1,0 +1,165 @@
+package org.hisp.dhis.actions.metadata;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.hisp.dhis.helpers.config.TestConfiguration;
+
+import com.google.gson.JsonObject;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class MetadataPaginationActions
+    extends
+    RestApiActions
+{
+    public static String DEFAULT_METADATA_FIELDS = "displayName,shortName,id,lastUpdated,created,displayDescription,code,publicAccess,access,href,level,displayName,publicAccess,lastUpdated,order";
+
+    public static String DEFAULT_METADATA_FILTER = "name:ne:default";
+
+    public static String DEFAULT_METADATA_SORT = "displayName:ASC";
+
+    public MetadataPaginationActions( String endpoint )
+    {
+        super( endpoint );
+    }
+
+    /**
+     * Executes a metadata request using pagination directives
+     *
+     * @param filter a List of String, containing the expressions to filter metadata on
+     * @param fields a List of String, containing the name of the fields to return
+     * @param sort a List of String, containing the sort expressions
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( List<String> filter, List<String> fields, List<String> sort, int page,
+        int pageSize )
+    {
+        assert filter != null;
+        assert fields != null && !fields.isEmpty();
+        assert sort != null && !sort.isEmpty();
+        QueryParamsBuilder params = new QueryParamsBuilder()
+            .add( "filter=" + String.join( ",", filter ) )
+            .add( "fields=" + String.join( ",", fields ) )
+            .add( "order=" + String.join( ",", sort ) )
+            .add( "page=" + page )
+            .add( "pageSize=" + pageSize );
+
+        return get( "", params );
+
+    }
+
+    /**
+     * Executes a metadata request using pagination directives.
+     * Uses a default filter expression
+     *
+     * @param fields a List of String, containing the name of the fields to return
+     * @param sort a List of String, containing the sort expressions
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( List<String> fields, List<String> sort, int page, int pageSize )
+    {
+        return getPaginated( toParamList( DEFAULT_METADATA_FILTER ), fields, sort, page, pageSize );
+    }
+
+    /**
+     * Executes a metadata request using pagination directives.
+     * Uses a default filter and sort expression
+     *
+     * @param fields a List of String, containing the name of the fields to return
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( List<String> fields, int page, int pageSize )
+    {
+        return getPaginated( toParamList( DEFAULT_METADATA_FILTER ), fields, toParamList( DEFAULT_METADATA_SORT ), page,
+            pageSize );
+    }
+
+    /**
+     * Executes a metadata request using pagination directives.
+     * Uses a default filter, fields and sort expression
+     *
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( int page, int pageSize )
+    {
+        return getPaginated( toParamList( DEFAULT_METADATA_FILTER ), toParamList( DEFAULT_METADATA_FIELDS ),
+            toParamList( DEFAULT_METADATA_SORT ), page, pageSize );
+    }
+
+    /**
+     * Assert on the pagination ("pager") data within the API response
+     *
+     * @param response an {@see ApiResponse} object
+     * @param expectedTotal the expected minimum total number of metadata items
+     * @param expectedPageCount the expected minimum total number of pages
+     * @param expectedPageSize the expected value for page size
+     * @param expectedPage the expected value for the page
+     */
+    public void assertPagination( ApiResponse response, int expectedTotal, int expectedPageCount, int expectedPageSize,
+        int expectedPage )
+    {
+        JsonObject pager = response.extractJsonObject( "pager" );
+        assertThat( pager, is( notNullValue() ) );
+        assertThat( Integer.parseInt( pager.get( "pageCount" ).getAsString() ), greaterThan( expectedPageCount ) );
+        assertThat( Integer.parseInt( pager.get( "total" ).getAsString() ), greaterThanOrEqualTo( expectedTotal ) );
+
+        String nextPage = pager.get( "nextPage" ).getAsString();
+        assertThat( nextPage, startsWith( TestConfiguration.get().baseUrl() + endpoint ) );
+        assertThat( nextPage, containsString( "pageSize=" + expectedPageSize ) );
+        assertThat( nextPage, containsString( "page=" + (expectedPage + 1) ) );
+
+        assertThat( Integer.parseInt( pager.get( "pageSize" ).getAsString() ), Matchers.is( expectedPageSize ) );
+        assertThat( Integer.parseInt( pager.get( "page" ).getAsString() ), Matchers.is( expectedPage ) );
+    }
+
+    private List<String> toParamList( String string )
+    {
+        return Arrays.asList( string.split( "," ) );
+    }
+}

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
@@ -90,8 +90,7 @@ public class OptionActions
         if ( optionIds != null )
         {
             JsonArray options = new JsonArray();
-            for ( String optionID : optionIds
-            )
+            for ( String optionID : optionIds )
             {
                 JsonObject option = new JsonObject();
                 option.addProperty( "id", optionID );

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -1,16 +1,18 @@
 package org.hisp.dhis.dto;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.gson.JsonObject;
+
 import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -27,7 +29,6 @@ public class ApiResponse
     /**
      * Extracts uid when only one object was created.
      *
-     * @return
      */
     public String extractUid()
     {
@@ -52,7 +53,6 @@ public class ApiResponse
      * Extracts uids from import summaries.
      * Use when more than one object was created.
      *
-     * @return
      */
     public List<String> extractUids()
     {
@@ -113,7 +113,7 @@ public class ApiResponse
 
     public boolean containsImportSummaries()
     {
-        return getContentType().contains( "json" ) ? !CollectionUtils.isEmpty( getImportSummaries() ) : false;
+        return getContentType().contains("json") && !CollectionUtils.isEmpty(getImportSummaries());
     }
 
     public List<ImportSummary> getImportSummaries()
@@ -132,7 +132,8 @@ public class ApiResponse
             case "ImportSummaries":
                 return this.extractList( pathToImportSummaries + "importSummaries", ImportSummary.class );
             case "ImportSummary":
-                return Arrays.asList( this.raw.jsonPath().getObject( pathToImportSummaries, ImportSummary.class ) );
+                return Collections
+                    .singletonList( this.raw.jsonPath().getObject( pathToImportSummaries, ImportSummary.class ) );
             }
 
         }
@@ -154,9 +155,7 @@ public class ApiResponse
     public List<ImportSummary> getSuccessfulImportSummaries()
     {
         return getImportSummaries().stream()
-            .filter( is -> {
-                return is.getStatus().equalsIgnoreCase( "SUCCESS" );
-            } )
+            .filter( is -> is.getStatus().equalsIgnoreCase( "SUCCESS" ))
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -113,7 +113,7 @@ public class ApiResponse
 
     public boolean containsImportSummaries()
     {
-        return getContentType().contains("json") && !CollectionUtils.isEmpty(getImportSummaries());
+        return getContentType().contains( "json" ) && !CollectionUtils.isEmpty( getImportSummaries() );
     }
 
     public List<ImportSummary> getImportSummaries()

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.metadata;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.actions.LoginActions;
+import org.hisp.dhis.actions.metadata.MetadataPaginationActions;
+import org.hisp.dhis.actions.metadata.OptionActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hisp.dhis.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FIELDS;
+import static org.hisp.dhis.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FILTER;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class MetadataPaginationTest
+    extends
+    ApiTest
+{
+    private MetadataPaginationActions paginationActions;
+
+    private int startPage = 1;
+    private int pageSize = 5;
+    @BeforeEach
+    public void setUp()
+    {
+        LoginActions loginActions = new LoginActions();
+        OptionActions optionActions = new OptionActions();
+        paginationActions = new MetadataPaginationActions( "/optionSets" );
+        loginActions.loginAsSuperUser();
+
+        for ( int i = 0; i < 100; i++ )
+        {
+            optionActions.createOptionSet( RandomStringUtils.randomAlphabetic( 10 ), "INTEGER", (String[]) null );
+        }
+    }
+
+    @Test
+    public void checkPaginationResultsForcingInMemoryPagination()
+    {
+        // this test forces the metadata query engine to execute an "in memory" sorting and pagination
+        // since the sort ("order") value is set to 'displayName' that is a "virtual" field (that is, not a database column)
+        // The metadata query engine can not execute a sql query using this field, since it does not exist
+        // on the table. Therefore, the engine loads the entire content of the table in memory and
+        // executes a sort + pagination "in memory"
+
+        ApiResponse response = paginationActions.getPaginated( startPage, pageSize );
+
+        response.validate().statusCode( 200 );
+
+        paginationActions.assertPagination( response, 100, 100 / pageSize, pageSize, startPage);
+    }
+
+    @Test
+    public void checkPaginationResultsForcingDatabaseOnlyPagination()
+    {
+        // this test forces the metadata query engine to execute the query (including pagination) on the database only.
+        // The sort ("order") value is set to 'id' that is mapped to a DB column.
+
+        ApiResponse response = paginationActions.getPaginated(
+            Arrays.asList( DEFAULT_METADATA_FILTER.split( "," ) ),
+            Arrays.asList( DEFAULT_METADATA_FIELDS.split( "," ) ),
+            Collections.singletonList("id:ASC"),
+            startPage, pageSize );
+
+        response.validate().statusCode( 200 );
+
+        paginationActions.assertPagination( response, 100, 100 / pageSize, pageSize, startPage);
+    }
+
+}

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -118,6 +118,7 @@ public class MetadataPaginationTest
         paginationActions = new MetadataPaginationActions( "/optionSets" );
         loginActions.loginAsSuperUser();
 
+        // Creates 100 Option Sets
         for ( int i = 0; i < 100; i++ )
         {
             optionActions.createOptionSet( RandomStringUtils.randomAlphabetic( 10 ), "INTEGER", (String[]) null );

--- a/dhis-2/dhis-e2e-test/src/test/resources/setup/metadata.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/setup/metadata.json
@@ -411,7 +411,6 @@
       "id": "dIVt4l5vIOa",
       "created": "2019-02-05T13:45:36.361",
       "name": "TA First name",
-      "name": "TA First name",
       "shortName": "TA First name",
       "aggregationType": "NONE",
       "programScope": false,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
@@ -28,16 +28,17 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.MoreObjects;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.user.User;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import com.google.common.base.MoreObjects;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -28,11 +28,22 @@ package org.hisp.dhis.webapi.controller;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Enums;
-import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -41,7 +52,6 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.common.SubscribableObject;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
@@ -116,17 +126,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -137,6 +141,10 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     protected static final WebOptions NO_WEB_OPTIONS = new WebOptions( new HashMap<>() );
 
     protected static final String DEFAULTS = "INCLUDE";
+
+    private Cache<String,Integer> paginationCountCache = new Cache2kBuilder<String, Integer>() {}
+        .expireAfterWrite( 1, TimeUnit.MINUTES )
+        .build();
 
     //--------------------------------------------------------------------------
     // Dependencies
@@ -230,12 +238,13 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         }
 
         List<T> entities = getEntityList( metadata, options, filters, orders );
+
         Pager pager = metadata.getPager();
 
         if ( options.hasPaging() && pager == null )
         {
-            pager = new Pager( options.getPage(), entities.size(), options.getPageSize() );
-            entities = PagerUtils.pageCollection( entities, pager );
+            long count = paginationCountCache.computeIfAbsent( calculatePaginationCountKey(currentUser, filters, options), () -> count( metadata, options, filters, orders ) );
+            pager = new Pager( options.getPage(), count, options.getPageSize() );
         }
 
         postProcessResponseEntities( entities, options, rpParameters );
@@ -1166,6 +1175,13 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return entityList;
     }
 
+    private int count( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
+    {
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
+            options.getRootJunction() );
+        return queryService.count( query );
+    }
+
     private List<T> getEntity( String uid )
     {
         return getEntity( uid, NO_WEB_OPTIONS );
@@ -1417,5 +1433,11 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         }
 
         return entitySimpleName;
+    }
+
+    private String calculatePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
+    {
+        return currentUser.getUsername() + "." + getEntityName() + "." + String.join( "|", filters ) + "."
+            + options.getRootJunction().name();
     }
 }


### PR DESCRIPTION
- DHIS2-8754

This fix addresses an issue introduced with this PR: https://github.com/dhis2/dhis2-core/commit/b132f0685b9040f194ee5bb932fc08317e0a6aa8

The `Pager` object requires a "total" value in order to properly calculate the number of pages. The "total" is **now** passed to the `Pager` object and it's calculated by executing a count query using the same filter and sorting criteria used for the original query.
If the Metadata Query engine requires an in-memory query (because a filter or sort field is non-persisted), then the pagination is executed in memory by the Query Engine and no longer in the controller.