### PR TITLE
[2.33]  fix: Calculates metadata pagination total pages (#5324)

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -1,5 +1,7 @@
+package org.hisp.dhis.actions;
+
 /*
- * Copyright (c) 2004-2018, University of Oslo
+ * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,7 +28,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.actions;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 import java.io.File;
 import java.util.List;
@@ -53,9 +56,6 @@ import org.hisp.dhis.dto.ObjectReport;
 
 import java.io.File;
 import java.util.List;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.oneOf;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -147,8 +147,6 @@ public class RestApiActions
      */
     public ApiResponse get()
     {
-<<<<<<< HEAD
-=======
         return get( "" );
     }
 
@@ -162,7 +160,6 @@ public class RestApiActions
     {
         String path = queryParamsBuilder == null ? "" : queryParamsBuilder.build();
 
->>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
         Response response = this.given()
             .contentType( ContentType.TEXT )
             .when()
@@ -174,16 +171,9 @@ public class RestApiActions
     /**
      * Sends get request with provided path and queryParams appended to URL.
      *
-<<<<<<< HEAD
      * @param path        Id of resource
      * @param queryParams Query params to append to url
      * @return
-=======
-     * @param resourceId            Id of resource
-     * @param contentType           Content type of the request
-     * @param accept                Accepted response Content type
-     * @param queryParamsBuilder    Query params to append to url
->>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
      */
     public ApiResponse get( String path, String queryParams )
     {
@@ -199,8 +189,6 @@ public class RestApiActions
      * Sends delete request to specified resource.
      * If delete request successful, removes entity from TestRunStorage.
      *
-<<<<<<< HEAD
-=======
      * @param resourceId            Id of resource
      * @param queryParamsBuilder    Query params to append to url
      */
@@ -235,14 +223,9 @@ public class RestApiActions
     /**
      * Sends PUT request to specified resource.
      *
-<<<<<<< HEAD
      * @param path   Id of resource
      * @param object Body of request
      * @return
-=======
-     * @param resourceId Id of resource
-     * @param object     Body of request
->>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
      */
     public ApiResponse update( String path, Object object )
     {
@@ -272,7 +255,8 @@ public class RestApiActions
         if ( response.containsImportSummaries() )
         {
             List<ImportSummary> importSummaries = response.getSuccessfulImportSummaries();
-            importSummaries.forEach( importSummary -> TestRunStorage.addCreatedEntity( endpoint, importSummary.getReference() ));
+            importSummaries
+                .forEach( importSummary -> TestRunStorage.addCreatedEntity( endpoint, importSummary.getReference() ) );
             return;
         }
 
@@ -280,7 +264,8 @@ public class RestApiActions
         {
             SchemasActions schemasActions = new SchemasActions();
             response.getTypeReports().stream()
-                .filter( typeReport -> typeReport.getStats().getCreated() != 0 || typeReport.getStats().getImported() != 0)
+                .filter(
+                    typeReport -> typeReport.getStats().getCreated() != 0 || typeReport.getStats().getImported() != 0 )
                 .forEach( tr -> {
                     List<ObjectReport> objectReports = tr.getObjectReports();
 
@@ -302,7 +287,6 @@ public class RestApiActions
         {
             TestRunStorage.addCreatedEntity( endpoint, response.extractUid() );
         }
-
     }
 }
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -28,6 +28,16 @@
 
 package org.hisp.dhis.actions;
 
+import java.io.File;
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.hisp.dhis.TestRunStorage;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.dto.ImportSummary;
+import org.hisp.dhis.dto.ObjectReport;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.http.ContentType;
@@ -43,6 +53,9 @@ import org.hisp.dhis.dto.ObjectReport;
 
 import java.io.File;
 import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -98,7 +111,7 @@ public class RestApiActions
      * Shortcut used in preconditions only.
      * Sends post request to specified endpoint and verifies that request was successful
      *
-     * @param object Body of reqeuest
+     * @param object Body of request
      * @return ID of generated entity.
      */
     public String create( Object object )
@@ -106,7 +119,7 @@ public class RestApiActions
         ApiResponse response = post( object );
 
         response.validate()
-            .statusCode( Matchers.isOneOf( 200, 201 ) );
+            .statusCode(  is(oneOf( 200, 201 ) ) );
 
         return response.extractUid();
     }
@@ -134,6 +147,22 @@ public class RestApiActions
      */
     public ApiResponse get()
     {
+<<<<<<< HEAD
+=======
+        return get( "" );
+    }
+
+    /**
+     * Sends get request with provided path and queryParams appended to URL.
+     *
+     * @param resourceId         Id of resource
+     * @param queryParamsBuilder Query params to append to url
+     */
+    public ApiResponse get( String resourceId, QueryParamsBuilder queryParamsBuilder )
+    {
+        String path = queryParamsBuilder == null ? "" : queryParamsBuilder.build();
+
+>>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
         Response response = this.given()
             .contentType( ContentType.TEXT )
             .when()
@@ -145,9 +174,16 @@ public class RestApiActions
     /**
      * Sends get request with provided path and queryParams appended to URL.
      *
+<<<<<<< HEAD
      * @param path        Id of resource
      * @param queryParams Query params to append to url
      * @return
+=======
+     * @param resourceId            Id of resource
+     * @param contentType           Content type of the request
+     * @param accept                Accepted response Content type
+     * @param queryParamsBuilder    Query params to append to url
+>>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
      */
     public ApiResponse get( String path, String queryParams )
     {
@@ -163,8 +199,24 @@ public class RestApiActions
      * Sends delete request to specified resource.
      * If delete request successful, removes entity from TestRunStorage.
      *
+<<<<<<< HEAD
+=======
+     * @param resourceId            Id of resource
+     * @param queryParamsBuilder    Query params to append to url
+     */
+    public ApiResponse delete( String resourceId, QueryParamsBuilder queryParamsBuilder )
+    {
+        String path = queryParamsBuilder == null ? "" : queryParamsBuilder.build();
+
+        return delete( resourceId + path );
+    }
+
+    /**
+     * Sends delete request to specified resource.
+     * If delete request successful, removes entity from TestRunStorage.
+     *
+>>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
      * @param path Id of resource
-     * @return
      */
     public ApiResponse delete( String path )
     {
@@ -183,9 +235,14 @@ public class RestApiActions
     /**
      * Sends PUT request to specified resource.
      *
+<<<<<<< HEAD
      * @param path   Id of resource
      * @param object Body of request
      * @return
+=======
+     * @param resourceId Id of resource
+     * @param object     Body of request
+>>>>>>> e9c8211bea... fix: calculate metadata pagination total pages (#5324)
      */
     public ApiResponse update( String path, Object object )
     {
@@ -215,9 +272,7 @@ public class RestApiActions
         if ( response.containsImportSummaries() )
         {
             List<ImportSummary> importSummaries = response.getSuccessfulImportSummaries();
-            importSummaries.forEach( importSummary -> {
-                TestRunStorage.addCreatedEntity( endpoint, importSummary.getReference() );
-            } );
+            importSummaries.forEach( importSummary -> TestRunStorage.addCreatedEntity( endpoint, importSummary.getReference() ));
             return;
         }
 
@@ -225,9 +280,7 @@ public class RestApiActions
         {
             SchemasActions schemasActions = new SchemasActions();
             response.getTypeReports().stream()
-                .filter( typeReport -> {
-                    return typeReport.getStats().getCreated() != 0 || typeReport.getStats().getImported() != 0;
-                } )
+                .filter( typeReport -> typeReport.getStats().getCreated() != 0 || typeReport.getStats().getImported() != 0)
                 .forEach( tr -> {
                     List<ObjectReport> objectReports = tr.getObjectReports();
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
@@ -1,0 +1,160 @@
+package org.hisp.dhis.actions.metadata;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.hisp.dhis.helpers.config.TestConfiguration;
+
+import com.google.gson.JsonObject;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class MetadataPaginationActions
+    extends
+    RestApiActions
+{
+    public static String DEFAULT_METADATA_FIELDS = "displayName,shortName,id,lastUpdated,created,displayDescription,code,publicAccess,access,href,level,displayName,publicAccess,lastUpdated,order";
+
+    public static String DEFAULT_METADATA_FILTER = "name:ne:default";
+
+    public static String DEFAULT_METADATA_SORT = "displayName:ASC";
+
+    public MetadataPaginationActions( String endpoint )
+    {
+        super( endpoint );
+    }
+
+    /**
+     * Executes a metadata request using pagination directives
+     *
+     * @param filter a List of String, containing the expressions to filter metadata
+     *        on
+     * @param fields a List of String, containing the name of the fields to return
+     * @param sort a List of String, containing the sort expressions
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( List<String> filter, List<String> fields, List<String> sort, int page,
+        int pageSize )
+    {
+        assert filter != null;
+        assert fields != null && !fields.isEmpty();
+        assert sort != null && !sort.isEmpty();
+        QueryParamsBuilder params = new QueryParamsBuilder().add( "filter=" + String.join( ",", filter ) )
+            .add( "fields=" + String.join( ",", fields ) ).add( "order=" + String.join( ",", sort ) )
+            .add( "page=" + page ).add( "pageSize=" + pageSize );
+
+        return get( "", params );
+
+    }
+
+    /**
+     * Executes a metadata request using pagination directives. Uses a default
+     * filter expression
+     *
+     * @param fields a List of String, containing the name of the fields to return
+     * @param sort a List of String, containing the sort expressions
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( List<String> fields, List<String> sort, int page, int pageSize )
+    {
+        return getPaginated( toParamList( DEFAULT_METADATA_FILTER ), fields, sort, page, pageSize );
+    }
+
+    /**
+     * Executes a metadata request using pagination directives. Uses a default
+     * filter and sort expression
+     *
+     * @param fields a List of String, containing the name of the fields to return
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( List<String> fields, int page, int pageSize )
+    {
+        return getPaginated( toParamList( DEFAULT_METADATA_FILTER ), fields, toParamList( DEFAULT_METADATA_SORT ), page,
+            pageSize );
+    }
+
+    /**
+     * Executes a metadata request using pagination directives. Uses a default
+     * filter, fields and sort expression
+     *
+     * @param page the page to return
+     * @param pageSize the number of elements to return for each page
+     * @return an {@see ApiResponse} object
+     */
+    public ApiResponse getPaginated( int page, int pageSize )
+    {
+        return getPaginated( toParamList( DEFAULT_METADATA_FILTER ), toParamList( DEFAULT_METADATA_FIELDS ),
+            toParamList( DEFAULT_METADATA_SORT ), page, pageSize );
+    }
+
+    /**
+     * Assert on the pagination ("pager") data within the API response
+     *
+     * @param response an {@see ApiResponse} object
+     * @param expectedTotal the expected minimum total number of metadata items
+     * @param expectedPageCount the expected minimum total number of pages
+     * @param expectedPageSize the expected value for page size
+     * @param expectedPage the expected value for the page
+     */
+    public void assertPagination( ApiResponse response, int expectedTotal, int expectedPageCount, int expectedPageSize,
+        int expectedPage )
+    {
+        response.validate().statusCode( 200 ).rootPath( "pager" )
+            .body( "pageCount", greaterThan( expectedPageCount ) )
+            .body( "total", greaterThan( expectedTotal ) )
+            .body( "pageSize", is( expectedPageSize ) )
+            .body( "page", is( expectedPage ) )
+            .body( "nextPage", startsWith( TestConfiguration.get().baseUrl() + endpoint ) )
+            .body( "nextPage", containsString( "pageSize=" + expectedPageSize ) )
+            .body( "nextPage", containsString( "page=" + (expectedPage + 1) ) );
+
+    }
+
+    private List<String> toParamList( String string )
+    {
+        return Arrays.asList( string.split( "," ) );
+    }
+}

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
@@ -143,8 +143,8 @@ public class MetadataPaginationActions
         int expectedPage )
     {
         response.validate().statusCode( 200 ).rootPath( "pager" )
-            .body( "pageCount", greaterThan( expectedPageCount ) )
-            .body( "total", greaterThan( expectedTotal ) )
+            .body( "pageCount", greaterThanOrEqualTo( expectedPageCount ) )
+            .body( "total", greaterThanOrEqualTo( expectedTotal ) )
             .body( "pageSize", is( expectedPageSize ) )
             .body( "page", is( expectedPage ) )
             .body( "nextPage", startsWith( TestConfiguration.get().baseUrl() + endpoint ) )

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
@@ -90,8 +90,7 @@ public class OptionActions
         if ( optionIds != null )
         {
             JsonArray options = new JsonArray();
-            for ( String optionID : optionIds
-            )
+            for ( String optionID : optionIds )
             {
                 JsonObject option = new JsonObject();
                 option.addProperty( "id", optionID );

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -159,7 +159,7 @@ public class ApiResponse
     public List<ImportSummary> getSuccessfulImportSummaries()
     {
         return getImportSummaries().stream()
-            .filter( is -> is.getStatus().equalsIgnoreCase( "SUCCESS" ))
+            .filter( is -> is.getStatus().equalsIgnoreCase( "SUCCESS" ) )
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -1,6 +1,11 @@
 
 package org.hisp.dhis.dto;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import com.google.gson.JsonObject;
 import io.restassured.http.ContentType;
 import io.restassured.mapper.ObjectMapperType;
@@ -29,7 +34,6 @@ public class ApiResponse
     /**
      * Extracts uid when only one object was created.
      *
-     * @return
      */
     public String extractUid()
     {
@@ -54,7 +58,6 @@ public class ApiResponse
      * Extracts uids from import summaries.
      * Use when more than one object was created.
      *
-     * @return
      */
     public List<String> extractUids()
     {
@@ -133,7 +136,8 @@ public class ApiResponse
             case "ImportSummaries":
                 return this.extractList( pathToImportSummaries + "importSummaries", ImportSummary.class );
             case "ImportSummary":
-                return Arrays.asList( this.raw.jsonPath().getObject( pathToImportSummaries, ImportSummary.class ) );
+                return Collections
+                    .singletonList( this.raw.jsonPath().getObject( pathToImportSummaries, ImportSummary.class ) );
             }
 
         }
@@ -155,9 +159,7 @@ public class ApiResponse
     public List<ImportSummary> getSuccessfulImportSummaries()
     {
         return getImportSummaries().stream()
-            .filter( is -> {
-                return is.getStatus().equalsIgnoreCase( "SUCCESS" );
-            } )
+            .filter( is -> is.getStatus().equalsIgnoreCase( "SUCCESS" ))
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -1,88 +1,32 @@
-/*
- * Copyright (c) 2004-2018, University of Oslo
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of the HISP project nor the names of its contributors may
- * be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-/*
- * Copyright (c) 2004-2018, University of Oslo
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of the HISP project nor the names of its contributors may
- * be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-/*
- * Copyright (c) 2004-2018, University of Oslo
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of the HISP project nor the names of its contributors may
- * be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package org.hisp.dhis.metadata;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hisp.dhis.ApiTest;

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2004-2018, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.metadata;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.actions.LoginActions;
+import org.hisp.dhis.actions.metadata.MetadataPaginationActions;
+import org.hisp.dhis.actions.metadata.OptionActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hisp.dhis.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FIELDS;
+import static org.hisp.dhis.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FILTER;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class MetadataPaginationTest
+    extends
+    ApiTest
+{
+    private MetadataPaginationActions paginationActions;
+
+    private int startPage = 1;
+    private int pageSize = 5;
+    @BeforeEach
+    public void setUp()
+    {
+        LoginActions loginActions = new LoginActions();
+        OptionActions optionActions = new OptionActions();
+        paginationActions = new MetadataPaginationActions( "/optionSets" );
+        loginActions.loginAsSuperUser();
+
+        // Creates 100 Option Sets
+        for ( int i = 0; i < 100; i++ )
+        {
+            optionActions.createOptionSet( RandomStringUtils.randomAlphabetic( 10 ), "INTEGER", (String[]) null );
+        }
+    }
+
+    @Test
+    public void checkPaginationResultsForcingInMemoryPagination()
+    {
+        // this test forces the metadata query engine to execute an "in memory" sorting and pagination
+        // since the sort ("order") value is set to 'displayName' that is a "virtual" field (that is, not a database column)
+        // The metadata query engine can not execute a sql query using this field, since it does not exist
+        // on the table. Therefore, the engine loads the entire content of the table in memory and
+        // executes a sort + pagination "in memory"
+
+        ApiResponse response = paginationActions.getPaginated( startPage, pageSize );
+
+        response.validate().statusCode( 200 );
+
+        paginationActions.assertPagination( response, 100, 100 / pageSize, pageSize, startPage);
+    }
+
+    @Test
+    public void checkPaginationResultsForcingDatabaseOnlyPagination()
+    {
+        // this test forces the metadata query engine to execute the query (including pagination) on the database only.
+        // The sort ("order") value is set to 'id' that is mapped to a DB column.
+
+        ApiResponse response = paginationActions.getPaginated(
+            Arrays.asList( DEFAULT_METADATA_FILTER.split( "," ) ),
+            Arrays.asList( DEFAULT_METADATA_FIELDS.split( "," ) ),
+            Collections.singletonList("id:ASC"),
+            startPage, pageSize );
+
+        response.validate().statusCode( 200 );
+
+        paginationActions.assertPagination( response, 100, 100 / pageSize, pageSize, startPage);
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -38,7 +40,6 @@ import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.query.planner.QueryPlan;
 import org.hisp.dhis.query.planner.QueryPlanner;
 import org.springframework.stereotype.Component;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Default implementation of QueryService which works with IdObjects.
@@ -99,10 +100,13 @@ public class DefaultQueryService
     @Override
     public int count( Query query )
     {
-        query.setFirstResult( 0 );
-        query.setMaxResults( Integer.MAX_VALUE );
+        Query cloned = Query.from( query );
 
-        return queryObjects( query ).size();
+        cloned.clearOrders();
+        cloned.setFirstResult( 0 );
+        cloned.setMaxResults( Integer.MAX_VALUE );
+
+        return countObjects( cloned );
     }
 
     @Override
@@ -134,6 +138,24 @@ public class DefaultQueryService
     //---------------------------------------------------------------------------------------------
     // Helper methods
     //---------------------------------------------------------------------------------------------
+
+    private int countObjects( Query query )
+    {
+        List<? extends IdentifiableObject> objects;
+        QueryPlan queryPlan = queryPlanner.planQuery( query );
+        Query pQuery = queryPlan.getPersistedQuery();
+        Query npQuery = queryPlan.getNonPersistedQuery();
+        if ( !npQuery.isEmpty() )
+        {
+            npQuery.setObjects( criteriaQueryEngine.query( pQuery ) );
+            objects = inMemoryQueryEngine.query( npQuery );
+            return objects.size();
+        }
+        else
+        {
+            return criteriaQueryEngine.count( pQuery );
+        }
+    }
 
     private List<? extends IdentifiableObject> queryObjects( Query query )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
@@ -28,16 +28,17 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.MoreObjects;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.user.User;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import com.google.common.base.MoreObjects;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.query.planner;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -41,6 +43,7 @@ import org.hisp.dhis.query.Conjunction;
 import org.hisp.dhis.query.Criterion;
 import org.hisp.dhis.query.Disjunction;
 import org.hisp.dhis.query.Junction;
+import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.Restriction;
 import org.hisp.dhis.schema.Property;
@@ -48,8 +51,6 @@ import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 
 /**
@@ -80,10 +81,9 @@ public class DefaultQueryPlanner implements QueryPlanner
         // if only one filter, always set to Junction.Type AND
         Junction.Type junctionType = query.getCriterions().size() <= 1 ? Junction.Type.AND : query.getRootJunctionType();
         
-        if ( Junction.Type.OR == junctionType && !persistedOnly && !isFilterOnPersistedFieldOnly( query ))
+        if ( (!isFilterOnPersistedFieldOnly( query ) || Junction.Type.OR == junctionType) && !persistedOnly )
         {
-            return QueryPlan.QueryPlanBuilder
-                .newBuilder()
+            return QueryPlan.QueryPlanBuilder.newBuilder()
                 .persistedQuery( Query.from( query.getSchema() ).setPlannedQuery( true ) )
                 .nonPersistedQuery( Query.from( query ).setPlannedQuery( true ) )
                 .build();
@@ -327,6 +327,15 @@ public class DefaultQueryPlanner implements QueryPlanner
                 {
                     return false;
                 }
+            }
+        }
+
+        for ( Order order : query.getOrders() )
+        {
+
+            if ( !persistedFields.contains( order.getProperty().getName() ) )
+            {
+                return false;
             }
         }
         return true;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -32,7 +32,6 @@ import com.google.common.base.Enums;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import org.hisp.dhis.attribute.AttributeService;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -41,10 +40,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
+import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -52,7 +56,6 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.common.SubscribableObject;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
@@ -126,7 +129,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -137,6 +139,10 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     protected static final WebOptions NO_WEB_OPTIONS = new WebOptions( new HashMap<>() );
 
     protected static final String DEFAULTS = "INCLUDE";
+
+    private Cache<String,Integer> paginationCountCache = new Cache2kBuilder<String, Integer>() {}
+        .expireAfterWrite( 1, TimeUnit.MINUTES )
+        .build();
 
     //--------------------------------------------------------------------------
     // Dependencies
@@ -223,12 +229,13 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         }
 
         List<T> entities = getEntityList( metadata, options, filters, orders );
+
         Pager pager = metadata.getPager();
 
         if ( options.hasPaging() && pager == null )
         {
-            pager = new Pager( options.getPage(), entities.size(), options.getPageSize() );
-            entities = PagerUtils.pageCollection( entities, pager );
+            long count = paginationCountCache.computeIfAbsent( calculatePaginationCountKey(currentUser, filters, options), () -> count( metadata, options, filters, orders ) );
+            pager = new Pager( options.getPage(), count, options.getPageSize() );
         }
 
         postProcessResponseEntities( entities, options, rpParameters );
@@ -1159,6 +1166,13 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return entityList;
     }
 
+    private int count( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
+    {
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
+            options.getRootJunction() );
+        return queryService.count( query );
+    }
+
     private List<T> getEntity( String uid )
     {
         return getEntity( uid, NO_WEB_OPTIONS );
@@ -1410,5 +1424,11 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         }
 
         return entitySimpleName;
+    }
+
+    private String calculatePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
+    {
+        return currentUser.getUsername() + "." + getEntityName() + "." + String.join( "|", filters ) + "."
+            + options.getRootJunction().name();
     }
 }


### PR DESCRIPTION
- DHIS2-8754

This fix addresses an issue introduced with this PR: b132f06

The `Pager` object requires a "total" value in order to properly calculate the number of pages. The "total" is **now** passed to the `Pager` object and it's calculated by executing a count query using the same filter and sorting criteria used for the original query.
If the Metadata Query engine requires an in-memory query (because a filter or sort field is non-persisted), then the pagination is executed in memory by the Query Engine and no longer in the controller.

* fix: use Restassured assertions

(cherry picked from commit e9c8211)

