### PR TITLE
fix: reduce metadata calls for SMS

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>com.github.dhis2</groupId>
       <artifactId>sms-compression</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.1</version>
     </dependency>
 
     <!-- Security -->

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -111,10 +111,10 @@ public class AggregateDataSetSMSListener
         String per = subm.getPeriod();
         UID aocid = subm.getAttributeOptionCombo();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
-        User user = userService.getUser( subm.getUserID().uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        User user = userService.getUser( subm.getUserID().getUID() );
 
-        DataSet dataSet = dataSetService.getDataSet( dsid.uid );
+        DataSet dataSet = dataSetService.getDataSet( dsid.getUID() );
         if ( dataSet == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_DATASET.set( dsid ) );
@@ -126,7 +126,7 @@ public class AggregateDataSetSMSListener
             throw new SMSProcessingException( SMSResponse.INVALID_PERIOD.set( per ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
@@ -188,7 +188,7 @@ public class AggregateDataSetSMSListener
             UID cocid = smsdv.getCategoryOptionCombo();
             String combid = deid + "-" + cocid;
 
-            DataElement de = dataElementService.getDataElement( deid.uid );
+            DataElement de = dataElementService.getDataElement( deid.getUID() );
             if ( de == null )
             {
                 log.warn( String.format( "Data element [%s] does not exist. Continuing with submission...", deid ) );
@@ -196,7 +196,7 @@ public class AggregateDataSetSMSListener
                 continue;
             }
 
-            CategoryOptionCombo coc = categoryService.getCategoryOptionCombo( cocid.uid );
+            CategoryOptionCombo coc = categoryService.getCategoryOptionCombo( cocid.getUID() );
             if ( coc == null )
             {
                 log.warn( String.format( "Category Option Combo [%s] does not exist. Continuing with submission...",

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -78,6 +78,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
@@ -227,7 +228,7 @@ public abstract class CompressionSMSListener
         SMSSubmissionReader reader = new SMSSubmissionReader();
         try
         {
-            return reader.readHeader( smsBytes );
+            return reader.readHeader( Objects.requireNonNull( smsBytes ) );
         }
         catch ( Exception e )
         {
@@ -257,7 +258,7 @@ public abstract class CompressionSMSListener
     private List<SMSMetadata.ID> getTypeUidsBefore( Class<? extends IdentifiableObject> klass, Date lastSyncDate )
     {
         return identifiableObjectManager.getUidsCreatedBefore( klass, lastSyncDate ).stream()
-            .map( o -> new SMSMetadata.ID( o ) ).collect( Collectors.toList() );
+            .map( SMSMetadata.ID::new ).collect( Collectors.toList() );
     }
 
     protected List<Object> saveNewEvent( String eventUid, OrganisationUnit orgUnit, ProgramStage programStage,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -50,7 +50,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
-import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -68,7 +67,6 @@ import org.hisp.dhis.smscompression.models.UID;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -215,7 +213,7 @@ public abstract class CompressionSMSListener
     private void checkUser( SMSSubmission subm )
     {
         UID userid = subm.getUserID();
-        User user = userService.getUser( userid.uid );
+        User user = userService.getUser( userid.getUID() );
 
         if ( user == null )
         {
@@ -251,11 +249,7 @@ public abstract class CompressionSMSListener
         meta.organisationUnits = getTypeUidsBefore( OrganisationUnit.class, lastSyncDate );
         meta.programStages = getTypeUidsBefore( ProgramStage.class, lastSyncDate );
         meta.relationshipTypes = getTypeUidsBefore( RelationshipType.class, lastSyncDate );
-        meta.relationships = getTypeUidsBefore( Relationship.class, lastSyncDate );
-        meta.trackedEntityInstances = getTypeUidsBefore( TrackedEntityInstance.class, lastSyncDate );
         meta.dataSets = getTypeUidsBefore( DataSet.class, lastSyncDate );
-        meta.enrollments = getTypeUidsBefore( ProgramInstance.class, lastSyncDate );
-        meta.events = getTypeUidsBefore( ProgramStageInstance.class, lastSyncDate );
 
         return meta;
     }
@@ -307,7 +301,7 @@ public abstract class CompressionSMSListener
                 UID deid = dv.getDataElement();
                 String val = dv.getValue();
 
-                DataElement de = dataElementService.getDataElement( deid.uid );
+                DataElement de = dataElementService.getDataElement( deid.getUID() );
                 // TODO: Is this the correct way of handling errors here?
                 if ( de == null )
                 {
@@ -323,7 +317,7 @@ public abstract class CompressionSMSListener
                     continue;
                 }
 
-                EventDataValue eventDataValue = new EventDataValue( deid.uid, dv.getValue(), user.getUsername() );
+                EventDataValue eventDataValue = new EventDataValue( deid.getUID(), dv.getValue(), user.getUsername() );
                 eventDataValue.setAutoFields();
                 dataElementsAndEventDataValues.put( de, eventDataValue );
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
@@ -75,7 +75,7 @@ public class DeleteEventSMSListener
         DeleteSMSSubmission subm = (DeleteSMSSubmission) submission;
 
         UID eventid = subm.getEvent();
-        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( eventid.uid );
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( eventid.getUID() );
         if ( psi == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_EVENT.set( eventid ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -124,15 +124,15 @@ public class EnrollmentSMSListener
         UID tetid = subm.getTrackedEntityType();
         UID ouid = subm.getOrgUnit();
         UID enrollmentid = subm.getEnrollment();
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
 
-        Program program = programService.getProgram( progid.uid );
+        Program program = programService.getProgram( progid.getUID() );
         if ( program == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_PROGRAM.set( progid ) );
         }
 
-        TrackedEntityType entityType = trackedEntityTypeService.getTrackedEntityType( tetid.uid );
+        TrackedEntityType entityType = trackedEntityTypeService.getTrackedEntityType( tetid.getUID() );
         if ( entityType == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_TETYPE.set( tetid ) );
@@ -144,18 +144,18 @@ public class EnrollmentSMSListener
         }
 
         TrackedEntityInstance entityInstance;
-        boolean teiExists = teiService.trackedEntityInstanceExists( teiUID.uid );
+        boolean teiExists = teiService.trackedEntityInstanceExists( teiUID.getUID() );
 
         if ( teiExists )
         {
             log.info( String.format( "Given TEI [%s] exists. Updating...", teiUID ) );
-            entityInstance = teiService.getTrackedEntityInstance( teiUID.uid );
+            entityInstance = teiService.getTrackedEntityInstance( teiUID.getUID() );
         }
         else
         {
             log.info( String.format( "Given TEI [%s] does not exist. Creating...", teiUID ) );
             entityInstance = new TrackedEntityInstance();
-            entityInstance.setUid( teiUID.uid );
+            entityInstance.setUid( teiUID.getUID() );
             entityInstance.setOrganisationUnit( orgUnit );
             entityInstance.setTrackedEntityType( entityType );
         }
@@ -173,15 +173,15 @@ public class EnrollmentSMSListener
             teiService.createTrackedEntityInstance( entityInstance, attributeValues );
         }
 
-        TrackedEntityInstance tei = teiService.getTrackedEntityInstance( teiUID.uid );
+        TrackedEntityInstance tei = teiService.getTrackedEntityInstance( teiUID.getUID() );
 
         // TODO: Unsure about this handling for enrollments, this needs to be
         // checked closely
         ProgramInstance enrollment;
-        boolean enrollmentExists = programInstanceService.programInstanceExists( enrollmentid.uid );
+        boolean enrollmentExists = programInstanceService.programInstanceExists( enrollmentid.getUID() );
         if ( enrollmentExists )
         {
-            enrollment = programInstanceService.getProgramInstance( enrollmentid.uid );
+            enrollment = programInstanceService.getProgramInstance( enrollmentid.getUID() );
             // Update these dates in case they've changed
             enrollment.setEnrollmentDate( enrollmentDate );
             enrollment.setIncidentDate( incidentDate );
@@ -189,7 +189,7 @@ public class EnrollmentSMSListener
         else
         {
             enrollment = programInstanceService.enrollTrackedEntityInstance( tei, program, enrollmentDate, incidentDate,
-                orgUnit, enrollmentid.uid );
+                orgUnit, enrollmentid.getUID() );
         }
         if ( enrollment == null )
         {
@@ -200,7 +200,7 @@ public class EnrollmentSMSListener
         programInstanceService.updateProgramInstance( enrollment );
 
         // We now check if the enrollment has events to process
-        User user = userService.getUser( subm.getUserID().uid );
+        User user = userService.getUser( subm.getUserID().getUID() );
         List<Object> errorUIDs = new ArrayList<>();
         if ( subm.getEvents() != null )
         {
@@ -283,7 +283,8 @@ public class EnrollmentSMSListener
         UID attribUID = SMSAttributeValue.getAttribute();
         String val = SMSAttributeValue.getValue();
 
-        TrackedEntityAttribute attribute = trackedEntityAttributeService.getTrackedEntityAttribute( attribUID.uid );
+        TrackedEntityAttribute attribute = trackedEntityAttributeService
+            .getTrackedEntityAttribute( attribUID.getUID() );
         if ( attribute == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_ATTRIB.set( attribUID ) );
@@ -306,26 +307,26 @@ public class EnrollmentSMSListener
         UID aocid = event.getAttributeOptionCombo();
         UID orgunitid = event.getOrgUnit();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgunitid.uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgunitid.getUID() );
         if ( orgUnit == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_ORGUNIT.set( orgunitid ) );
         }
 
-        ProgramStage programStage = programStageService.getProgramStage( stageid.uid );
+        ProgramStage programStage = programStageService.getProgramStage( stageid.getUID() );
         if ( programStage == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_STAGE.set( stageid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
         }
 
-        List<Object> errorUIDs = saveNewEvent( event.getEvent().uid, orgUnit, programStage, programInstance, sms, aoc,
-            user, event.getValues(), event.getEventStatus(), event.getEventDate(), event.getDueDate(),
+        List<Object> errorUIDs = saveNewEvent( event.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+            aoc, user, event.getValues(), event.getEventStatus(), event.getEventDate(), event.getDueDate(),
             event.getCoordinates() );
 
         return errorUIDs;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -70,7 +70,7 @@ public class RelationshipSMSListener
 {
     private enum RelationshipDir
     {
-        FROM, TO;
+        FROM, TO
     }
 
     private final RelationshipService relationshipService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -110,7 +110,7 @@ public class RelationshipSMSListener
         UID toid = subm.getTo();
         UID typeid = subm.getRelationshipType();
 
-        RelationshipType relType = relationshipTypeService.getRelationshipType( typeid.uid );
+        RelationshipType relType = relationshipTypeService.getRelationshipType( typeid.getUID() );
 
         if ( relType == null )
         {
@@ -126,7 +126,7 @@ public class RelationshipSMSListener
         // auto-generated
         if ( subm.getRelationship() != null )
         {
-            rel.setUid( subm.getRelationship().uid );
+            rel.setUid( subm.getRelationship().getUID() );
         }
 
         rel.setRelationshipType( relType );
@@ -152,7 +152,7 @@ public class RelationshipSMSListener
         switch ( relEnt )
         {
         case TRACKED_ENTITY_INSTANCE:
-            TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( objId.uid );
+            TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( objId.getUID() );
             if ( tei == null )
             {
                 throw new SMSProcessingException( SMSResponse.INVALID_TEI.set( objId ) );
@@ -161,7 +161,7 @@ public class RelationshipSMSListener
             break;
 
         case PROGRAM_INSTANCE:
-            ProgramInstance progInst = programInstanceService.getProgramInstance( objId.uid );
+            ProgramInstance progInst = programInstanceService.getProgramInstance( objId.getUID() );
             if ( progInst == null )
             {
                 throw new SMSProcessingException( SMSResponse.INVALID_ENROLL.set( objId ) );
@@ -170,7 +170,7 @@ public class RelationshipSMSListener
             break;
 
         case PROGRAM_STAGE_INSTANCE:
-            ProgramStageInstance stageInst = programStageInstanceService.getProgramStageInstance( objId.uid );
+            ProgramStageInstance stageInst = programStageInstanceService.getProgramStageInstance( objId.getUID() );
             if ( stageInst == null )
             {
                 throw new SMSProcessingException( SMSResponse.INVALID_EVENT.set( objId ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -94,16 +94,16 @@ public class SimpleEventSMSListener
         UID aocid = subm.getAttributeOptionCombo();
         UID progid = subm.getEventProgram();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
-        User user = userService.getUser( subm.getUserID().uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        User user = userService.getUser( subm.getUserID().getUID() );
 
-        Program program = programService.getProgram( subm.getEventProgram().uid );
+        Program program = programService.getProgram( subm.getEventProgram().getUID() );
         if ( program == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_PROGRAM.set( progid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
@@ -145,8 +145,8 @@ public class SimpleEventSMSListener
         }
         ProgramStage programStage = programStages.iterator().next();
 
-        List<Object> errorUIDs = saveNewEvent( subm.getEvent().uid, orgUnit, programStage, programInstance, sms, aoc,
-            user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
+        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+            aoc, user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
             subm.getCoordinates() );
         if ( !errorUIDs.isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -96,29 +96,29 @@ public class TrackerEventSMSListener
         UID enrolmentid = subm.getEnrollment();
         UID aocid = subm.getAttributeOptionCombo();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
-        User user = userService.getUser( subm.getUserID().uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        User user = userService.getUser( subm.getUserID().getUID() );
 
-        ProgramInstance programInstance = programInstanceService.getProgramInstance( enrolmentid.uid );
+        ProgramInstance programInstance = programInstanceService.getProgramInstance( enrolmentid.getUID() );
         if ( programInstance == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_ENROLL.set( enrolmentid ) );
         }
 
-        ProgramStage programStage = programStageService.getProgramStage( stageid.uid );
+        ProgramStage programStage = programStageService.getProgramStage( stageid.getUID() );
         if ( programStage == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_STAGE.set( stageid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
         }
 
-        List<Object> errorUIDs = saveNewEvent( subm.getEvent().uid, orgUnit, programStage, programInstance, sms, aoc,
-            user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
+        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+            aoc, user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
             subm.getCoordinates() );
         if ( !errorUIDs.isEmpty() )
         {


### PR DESCRIPTION
This PR includes a fix and refactor:
1. The calls to retrieve all TEI, event, enrolment and relationship UIDs is not made anymore.
2. The requests to get UIDs from SMS submissions is done via public methods.