### PR TITLE
fix: Force analytics Grid values to Double

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -525,7 +525,7 @@ public class DefaultAnalyticsService
 
                         grid.addRow()
                             .addValues( DimensionItem.getItemIdentifiers( row ) )
-                            .addValue( AnalyticsUtils.getRoundedValue( dataSourceParams, indicator.getDecimals(), value.getValue() ) );
+                            .addValue( AnalyticsUtils.getRoundedValue( dataSourceParams, indicator.getDecimals(), value.getValue() ).doubleValue() );
 
                         if ( params.isIncludeNumDen() )
                         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceIndicatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceIndicatorTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.data;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_ORGUNIT;
@@ -599,6 +600,29 @@ public class AnalyticsServiceIndicatorTest
         this.analyticsService.getAggregatedDataValues( createParamsWithRootIndicator( indicatorA, indicatorB, indicatorC ) );
     }
 
+    @Test
+    public void verifyGridAlwaysContainValueOfDoubleType()
+    {
+        // Given
+        IndicatorType indicatorTypeAny = createIndicatorType( 'B' );
+        indicatorService.addIndicatorType( indicatorTypeAny );
+
+        Indicator indicatorA = createIndicator( 'A', indicatorTypeAny );
+
+        indicatorA.setUid( "mindicatorA" );
+        indicatorA.setNumerator( "1" );
+        indicatorA.setDenominator( "1" );
+        indicatorA.setDecimals( 0 );
+
+        indicatorService.addIndicator( indicatorA );
+
+        // When
+        Grid grid = this.analyticsService.getAggregatedDataValues( createParamsWithRootIndicator( indicatorA ) );
+
+        // Then
+        assertThat( grid.getColumn( 2 ).get( 0 ), is( instanceOf( Double.class ) ) );
+    }
+
     private Indicator createIndicator( char uniqueCharacter, IndicatorType type, String numerator )
     {
         Indicator indicator = createIndicator( uniqueCharacter, type );
@@ -611,11 +635,15 @@ public class AnalyticsServiceIndicatorTest
         return indicator;
     }
 
-    private Indicator createIndicator( char uniqueCharacter, IndicatorType type, String numerator, String denominator)
+    private Indicator createIndicator( char uniqueCharacter, IndicatorType type, String numerator, String denominator )
     {
-        Indicator indicator = createIndicator(uniqueCharacter, type, numerator);
-        indicator.setDenominator(denominator);
+        Indicator indicator = createIndicator( uniqueCharacter, type );
 
+        indicator.setUid( "mindicator" + uniqueCharacter );
+        indicator.setNumerator( numerator );
+        indicator.setDenominator( denominator );
+
+        indicatorService.addIndicator( indicator );
         return indicator;
     }
 


### PR DESCRIPTION
- DHIS2-8580
- If an Indicator has 0 number of Decimals set, the Grid should still
retain all the values as `Double` type