### PR TITLE
fix: [DHIS2-8627] resource tables still using integer ids instead of bigint (master)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboNameResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboNameResourceTable.java
@@ -64,7 +64,7 @@ public class CategoryOptionComboNameResourceTable
     public String getCreateTempTableStatement()
     {
         return "create table " + getTempTableName() +
-            " (categoryoptioncomboid integer not null primary key, " +
+            " (categoryoptioncomboid bigint not null primary key, " +
             "categoryoptioncomboname varchar(255), approvallevel integer, " +
             "startdate date, enddate date)";
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboResourceTable.java
@@ -57,9 +57,9 @@ public class CategoryOptionComboResourceTable
     public String getCreateTempTableStatement()
     {
         String sql = "CREATE TABLE " + getTempTableName() + " (" +
-            "dataelementid INTEGER NOT NULL, " +
+            "dataelementid BIGINT NOT NULL, " +
             "dataelementuid VARCHAR(11) NOT NULL, " +
-            "categoryoptioncomboid INTEGER NOT NULL, " +
+            "categoryoptioncomboid BIGINT NOT NULL, " +
             "categoryoptioncombouid VARCHAR(11) NOT NULL)";
 
         return sql;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryResourceTable.java
@@ -64,7 +64,7 @@ public class CategoryResourceTable
     public String getCreateTempTableStatement()
     {
         String statement = "create table " + getTempTableName() + " (" +
-            "categoryoptioncomboid integer not null, " +
+            "categoryoptioncomboid bigint not null, " +
             "categoryoptioncomboname varchar(255), ";
 
         for ( Category category : objects )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalMinLevelResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalMinLevelResourceTable.java
@@ -59,10 +59,10 @@ public class DataApprovalMinLevelResourceTable
     public String getCreateTempTableStatement()
     {
         String sql = "create table " + getTempTableName() + "(" +
-            "workflowid integer not null, " +
-            "periodid integer not null, " +
-            "organisationunitid integer not null, " +
-            "attributeoptioncomboid integer not null, " +
+            "workflowid bigint not null, " +
+            "periodid bigint not null, " +
+            "organisationunitid bigint not null, " +
+            "attributeoptioncomboid bigint not null, " +
             "minlevel integer not null, " +
             "primary key (workflowid,periodid,attributeoptioncomboid,organisationunitid))";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalRemapLevelResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalRemapLevelResourceTable.java
@@ -71,8 +71,8 @@ public class DataApprovalRemapLevelResourceTable
     public String getCreateTempTableStatement()
     {
         String sql = "create table " + getTempTableName() + "(" +
-            "workflowid integer not null, " +
-            "dataapprovallevelid integer not null, " +
+            "workflowid bigint not null, " +
+            "dataapprovallevelid bigint not null, " +
             "level integer not null, " +
             "primary key (workflowid,dataapprovallevelid))";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementGroupSetResourceTable.java
@@ -61,7 +61,7 @@ public class DataElementGroupSetResourceTable
     public String getCreateTempTableStatement()
     {
         String statement = "create table " + getTempTableName() + " (" +
-            "dataelementid integer not null, " +
+            "dataelementid bigint not null, " +
             "dataelementname varchar(230), ";
 
         for ( DataElementGroupSet groupSet : objects )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementResourceTable.java
@@ -63,14 +63,14 @@ public class DataElementResourceTable
     public String getCreateTempTableStatement()
     {
         String sql = "CREATE TABLE " + getTempTableName() + " (" +
-            "dataelementid INTEGER NOT NULL PRIMARY KEY, " +
+            "dataelementid BIGINT NOT NULL PRIMARY KEY, " +
             "dataelementuid CHARACTER(11), " +
             "dataelementname VARCHAR(230), " +
-            "datasetid INTEGER, " +
+            "datasetid BIGINT, " +
             "datasetuid CHARACTER(11), " +
             "datasetname VARCHAR(230), " +
             "datasetapprovallevel INTEGER, " +
-            "workflowid INTEGER, " +
+            "workflowid BIGINT, " +
             "periodtypeid INTEGER, " +
             "periodtypename VARCHAR(230))";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataSetOrganisationUnitCategoryResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataSetOrganisationUnitCategoryResourceTable.java
@@ -70,8 +70,8 @@ public class DataSetOrganisationUnitCategoryResourceTable
     public String getCreateTempTableStatement()
     {
         return "create table " + getTempTableName() + " " +
-            "(datasetid integer not null, organisationunitid integer not null, " +
-            "attributeoptioncomboid integer not null, costartdate date, coenddate date)";
+            "(datasetid bigint not null, organisationunitid bigint not null, " +
+            "attributeoptioncomboid bigint not null, costartdate date, coenddate date)";
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/IndicatorGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/IndicatorGroupSetResourceTable.java
@@ -61,7 +61,7 @@ public class IndicatorGroupSetResourceTable
     public String getCreateTempTableStatement()
     {
         String statement = "create table " + getTempTableName() + " (" +
-            "indicatorid integer not null, " +
+            "indicatorid bigint not null, " +
             "indicatorname varchar(230), ";
 
         for ( IndicatorGroupSet groupSet : objects )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitGroupSetResourceTable.java
@@ -69,7 +69,7 @@ public class OrganisationUnitGroupSetResourceTable
     public String getCreateTempTableStatement()
     {
         String statement = "create table " + getTempTableName() + " (" +
-            "organisationunitid integer not null, " +
+            "organisationunitid bigint not null, " +
             "organisationunitname varchar(230), " +
             "startdate date, ";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitStructureResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitStructureResourceTable.java
@@ -74,7 +74,7 @@ public class OrganisationUnitStructureResourceTable
         StringBuilder sql = new StringBuilder();
 
         sql.append( "create table " ).append( getTempTableName() ).
-            append( " (organisationunitid integer not null primary key, organisationunituid character(11), level integer" );
+            append( " (organisationunitid bigint not null primary key, organisationunituid character(11), level integer" );
 
         for ( int k = 1 ; k <= organisationUnitLevels; k++ )
         {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
@@ -69,7 +69,7 @@ public class PeriodResourceTable
     {
         String sql =
             "create table " + getTempTableName() +
-            " (periodid integer not null primary key, iso varchar(15) not null, daysno integer not null, startdate date not null, enddate date not null, year integer not null";
+            " (periodid bigint not null primary key, iso varchar(15) not null, daysno integer not null, startdate date not null, enddate date not null, year integer not null";
 
         for ( PeriodType periodType : PeriodType.PERIOD_TYPES )
         {


### PR DESCRIPTION
The following resource tables were using "integer" datatype for ids which should be "bigint" datatype from 2.32 onwards.
_categoryoptioncomboname
_categorystructure
_dataelementcategoryoptioncombo
_dataelementgroupsetstructure
_dataelementstructure
_datasetorganisationunitcategory
_dateperiodstructure
_indicatorgroupsetstructure
_organisationunitgroupsetstructure
_orgunitstructure
_periodstructure
__dataapprovalremaplevel
_dataapprovalminlevel