### PR TITLE
ci: fix logs not being attached after pipeline failure

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -118,7 +118,7 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-e2e-test") {
-                                        sh "docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} logs web > ${DOCKER_VARIANT}logs.txt"
+                                        sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} logs web > ${DOCKER_VARIANT}logs.txt"
                                         archiveArtifacts artifacts: "${DOCKER_VARIANT}logs.txt"
                                     }
                                 }

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -123,7 +123,7 @@ pipeline {
                                     }
                                 }
                             }
-                            always {
+                            cleanup {
                                 script {
                                     dir("dhis-2/dhis-e2e-test") {
                                         sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} down -v --remove-orphans"

--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -118,7 +118,7 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-e2e-test") {
-                                        sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} logs web > ${DOCKER_VARIANT}logs.txt"
+                                        sh "docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} logs web > ${DOCKER_VARIANT}logs.txt"
                                         archiveArtifacts artifacts: "${DOCKER_VARIANT}logs.txt"
                                     }
                                 }


### PR DESCRIPTION
Problem: jenkins executes 'always' stage before 'failure' stage, so when we try to attach the logs, the containers are already aborted and there are no logs. The solution is to use the 'cleanup' stage instead of 'always', so that containers are stopped after attaching logs. 