### PR TITLE
Fix: (2.33) Extend d2:hasValue support for ANTLR expr

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/d2HasValue.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/d2HasValue.java
@@ -44,7 +44,7 @@ public class d2HasValue
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.visit( ctx.item( 0 ) );
+        visitor.visit( ctx.expr( 0 ) );
 
         return true;
     }
@@ -52,6 +52,6 @@ public class d2HasValue
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return "(" + visitor.visitAllowingNulls( ctx.item( 0 ) ) + " is not null)";
+        return "(" + visitor.visitAllowingNulls( ctx.expr( 0 ) ) + " is not null)";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -283,6 +283,13 @@ public class ProgramSqlGeneratorFunctionsTest
     }
 
     @Test
+    public void testHasValueProgramVariable()
+    {
+        String sql = test( "d2:hasValue(V{creation_date})" );
+        assertThat( sql, is( "(created is not null)" ) );
+    }
+
+    @Test
     public void testMinutesBetween()
     {
         String sql = test( "d2:minutesBetween(#{ProgrmStagA.DataElmentA},#{ProgrmStagB.DataElmentB})" );

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -67,7 +67,7 @@ expr
     |   fun='d2:countIfCondition(' WS* stageDataElement ',' WS* stringLiteral WS* ')'
     |   fun='d2:countIfValue(' WS* stageDataElement WS* ',' WS* numStringLiteral WS*  ')'
     |   fun='d2:daysBetween(' compareDate ',' compareDate ')'
-    |   fun='d2:hasValue(' item ')'
+    |   fun='d2:hasValue(' expr ')'
     |   fun='d2:maxValue(' ( item | compareDate ) ')'
     |   fun='d2:minutesBetween(' compareDate ',' compareDate ')'
     |   fun='d2:minValue(' ( item | compareDate ) ')'


### PR DESCRIPTION
Previously d2:hasValue only supported DataElements and TrackedEntityAttributes. This change will extend hasValue support to include ProgramVariables so now all three formats are supported.
```
hasValue(#{ProgrmStagA.DataElmentA})
hasValue(A{Attribute0A})
hasValue(V{creation_date})
```