### PR TITLE
fix: Remove usage of clearSession where not needed (#5396)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.organisationunit.hibernate;
-
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -28,11 +26,7 @@ package org.hisp.dhis.organisationunit.hibernate;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.sql.Timestamp;
-import java.util.*;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -57,7 +51,16 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
-import lombok.extern.slf4j.Slf4j;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Kristian Nordal
@@ -109,14 +112,14 @@ public class HibernateOrganisationUnitStore
     {
         final String hql =
             "select count(*) from OrganisationUnit o " +
-            "where o.path like :path " +
-            "and :object in elements(o." + collectionName + ")";
+                "where o.path like :path " +
+                "and :object in elements(o." + collectionName + ")";
 
         Query<Long> query = getTypedQuery( hql );
-            query.setParameter( "path", parent.getPath() + "%" )
+        query.setParameter( "path", parent.getPath() + "%" )
             .setParameter( "object", member );
 
-            return query.getSingleResult();
+        return query.getSingleResult();
     }
 
     @Override
@@ -168,7 +171,7 @@ public class HibernateOrganisationUnitStore
             hql += hlp.whereAnd() + " o.hierarchyLevel <= :maxLevels ";
         }
 
-        hql += "order by o." +  params.getOrderBy().getName();
+        hql += "order by o." + params.getOrderBy().getName();
 
         Query<OrganisationUnit> query = getQuery( hql );
 
@@ -256,7 +259,7 @@ public class HibernateOrganisationUnitStore
             Set<String> dataSetIds = SqlUtils.getArrayAsSet( rs, "ds_uid" );
 
             map.put( organisationUnitId, dataSetIds );
-        });
+        } );
 
         return map;
     }
@@ -271,8 +274,8 @@ public class HibernateOrganisationUnitStore
         if ( box != null && box.length == 4 )
         {
             return getSession().createQuery(
-                    "from OrganisationUnit ou " + "where within(ou.geometry, " + doMakeEnvelopeSql( box ) + ") = true",
-                    OrganisationUnit.class ).getResultList();
+                "from OrganisationUnit ou " + "where within(ou.geometry, " + doMakeEnvelopeSql( box ) + ") = true",
+                OrganisationUnit.class ).getResultList();
         }
         return new ArrayList<>();
     }
@@ -324,8 +327,8 @@ public class HibernateOrganisationUnitStore
     {
         String hql = "select max(ou.hierarchyLevel) from OrganisationUnit ou";
 
-        Query<Integer> query =  getTypedQuery( hql );
-        Integer maxLength =  query.getSingleResult();
+        Query<Integer> query = getTypedQuery( hql );
+        Integer maxLength = query.getSingleResult();
 
         return maxLength != null ? maxLength : 0;
     }
@@ -341,7 +344,7 @@ public class HibernateOrganisationUnitStore
 
             if ( (counter % 400) == 0 )
             {
-                dbmsManager.clearSession();
+                dbmsManager.flushSession();
             }
 
             counter++;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -1394,7 +1394,7 @@ public abstract class AbstractEnrollmentService
         programCache.clear();
         trackedEntityAttributeCache.clear();
 
-        dbmsManager.clearSession();
+        dbmsManager.flushSession();
     }
 
     private void updateDateFields( Enrollment enrollment, ProgramInstance programInstance )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -2381,7 +2381,7 @@ public abstract class AbstractEventService
 
         updateEntities( user );
 
-        dbmsManager.clearSession();
+        dbmsManager.flushSession();
     }
 
     private void updateDateFields( Event event, ProgramStageInstance programStageInstance )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -829,7 +829,7 @@ public abstract class AbstractRelationshipService
         programInstanceCache.clear();
         programStageInstanceCache.clear();
 
-        dbmsManager.clearSession();
+        dbmsManager.flushSession();
     }
 
     protected ImportOptions updateImportOptions( ImportOptions importOptions )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -1288,7 +1288,7 @@ public abstract class AbstractTrackedEntityInstanceService
         trackedEntityCache.clear();
         trackedEntityAttributeCache.clear();
 
-        dbmsManager.clearSession();
+        dbmsManager.flushSession();
     }
 
     private void updateDateFields( TrackedEntityInstance dtoEntityInstance,


### PR DESCRIPTION
* fix: use dbmsManager.flushSession() for forceUpdatePaths

* fix: update tracker importer services to use flush instead of flush+clearr when emptying internal caches