### PR TITLE
[2.34.0] fix: preventing class cast exception during conversion [DHIS2-8580]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1718,9 +1718,9 @@ public class DataQueryParams
 
             String permKey = StringUtils.join( keys, DIMENSION_SEP );
 
-            Double value = aggregatedDataMap.get( key );
+            Number number = aggregatedDataMap.get( key );
 
-            permutationMap.putEntry( permKey, dimItemObject, value );
+            permutationMap.putEntry( permKey, dimItemObject, number != null ? number.doubleValue() : null );
         }
 
         return permutationMap;


### PR DESCRIPTION
It also prevents a possible NPE case the Map element is null

(cherry picked from commit 6b2c082f13fc7566b4cf0c2e098731637e3ea0e7)