### PR TITLE
Refactor: Rename acronyms to camel case in SMS library 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>com.github.dhis2</groupId>
       <artifactId>sms-compression</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -185,9 +185,9 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.JasperTimm</groupId>
+      <groupId>com.github.dhis2</groupId>
       <artifactId>sms-compression</artifactId>
-      <version>update-case</version>
+      <version>0.2.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -185,9 +185,9 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.dhis2</groupId>
+      <groupId>com.github.JasperTimm</groupId>
       <artifactId>sms-compression</artifactId>
-      <version>0.2.1</version>
+      <version>update-case</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -110,10 +110,10 @@ public class AggregateDataSetSMSListener
         String per = subm.getPeriod();
         UID aocid = subm.getAttributeOptionCombo();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
-        User user = userService.getUser( subm.getUserID().uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        User user = userService.getUser( subm.getUserID().getUID() );
 
-        DataSet dataSet = dataSetService.getDataSet( dsid.uid );
+        DataSet dataSet = dataSetService.getDataSet( dsid.getUID() );
         if ( dataSet == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_DATASET.set( dsid ) );
@@ -125,7 +125,7 @@ public class AggregateDataSetSMSListener
             throw new SMSProcessingException( SMSResponse.INVALID_PERIOD.set( per ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
@@ -187,7 +187,7 @@ public class AggregateDataSetSMSListener
             UID cocid = smsdv.getCategoryOptionCombo();
             String combid = deid + "-" + cocid;
 
-            DataElement de = dataElementService.getDataElement( deid.uid );
+            DataElement de = dataElementService.getDataElement( deid.getUID() );
             if ( de == null )
             {
                 log.warn( String.format( "Data element [%s] does not exist. Continuing with submission...", deid ) );
@@ -195,7 +195,7 @@ public class AggregateDataSetSMSListener
                 continue;
             }
 
-            CategoryOptionCombo coc = categoryService.getCategoryOptionCombo( cocid.uid );
+            CategoryOptionCombo coc = categoryService.getCategoryOptionCombo( cocid.getUID() );
             if ( coc == null )
             {
                 log.warn( String.format( "Category Option Combo [%s] does not exist. Continuing with submission...",

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -28,10 +28,6 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
@@ -53,12 +49,12 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -67,10 +63,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Component( "org.hisp.dhis.sms.listener.AggregateDatasetSMSListener" )
+@Component( "org.hisp.dhis.sms.listener.AggregateDatasetSmsListener" )
 @Transactional
 public class AggregateDataSetSMSListener
     extends
@@ -100,45 +100,45 @@ public class AggregateDataSetSMSListener
     }
 
     @Override
-    protected SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException
     {
-        AggregateDatasetSMSSubmission subm = (AggregateDatasetSMSSubmission) submission;
+        AggregateDatasetSmsSubmission subm = (AggregateDatasetSmsSubmission) submission;
 
-        UID ouid = subm.getOrgUnit();
-        UID dsid = subm.getDataSet();
+        Uid ouid = subm.getOrgUnit();
+        Uid dsid = subm.getDataSet();
         String per = subm.getPeriod();
-        UID aocid = subm.getAttributeOptionCombo();
+        Uid aocid = subm.getAttributeOptionCombo();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
-        User user = userService.getUser( subm.getUserID().getUID() );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUid() );
+        User user = userService.getUser( subm.getUserId().getUid() );
 
-        DataSet dataSet = dataSetService.getDataSet( dsid.getUID() );
+        DataSet dataSet = dataSetService.getDataSet( dsid.getUid() );
         if ( dataSet == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_DATASET.set( dsid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_DATASET.set( dsid ) );
         }
 
         Period period = PeriodType.getPeriodFromIsoString( per );
         if ( period == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_PERIOD.set( per ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_PERIOD.set( per ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUid() );
         if ( aoc == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_AOC.set( aocid ) );
         }
 
         if ( !dataSet.hasOrganisationUnit( orgUnit ) )
         {
-            throw new SMSProcessingException( SMSResponse.OU_NOTIN_DATASET.set( ouid, dsid ) );
+            throw new SMSProcessingException( SmsResponse.OU_NOTIN_DATASET.set( ouid, dsid ) );
         }
 
         if ( dataSetService.isLocked( null, dataSet, period, orgUnit, aoc, null ) )
         {
-            throw new SMSProcessingException( SMSResponse.DATASET_LOCKED.set( dsid, per ) );
+            throw new SMSProcessingException( SmsResponse.DATASET_LOCKED.set( dsid, per ) );
         }
 
         List<Object> errorElems = submitDataValues( subm.getValues(), period, orgUnit, aoc, user );
@@ -160,18 +160,18 @@ public class AggregateDataSetSMSListener
 
         if ( !errorElems.isEmpty() )
         {
-            return SMSResponse.WARN_DVERR.setList( errorElems );
+            return SmsResponse.WARN_DVERR.setList( errorElems );
         }
         else if ( subm.getValues() == null || subm.getValues().isEmpty() )
         {
             // TODO: Should we save if there are no data values?
-            return SMSResponse.WARN_DVEMPTY;
+            return SmsResponse.WARN_DVEMPTY;
         }
 
-        return SMSResponse.SUCCESS;
+        return SmsResponse.SUCCESS;
     }
 
-    private List<Object> submitDataValues( List<SMSDataValue> values, Period period, OrganisationUnit orgUnit,
+    private List<Object> submitDataValues( List<SmsDataValue> values, Period period, OrganisationUnit orgUnit,
         CategoryOptionCombo aoc, User user )
     {
         ArrayList<Object> errorElems = new ArrayList<>();
@@ -181,13 +181,13 @@ public class AggregateDataSetSMSListener
             return errorElems;
         }
 
-        for ( SMSDataValue smsdv : values )
+        for ( SmsDataValue smsdv : values )
         {
-            UID deid = smsdv.getDataElement();
-            UID cocid = smsdv.getCategoryOptionCombo();
+            Uid deid = smsdv.getDataElement();
+            Uid cocid = smsdv.getCategoryOptionCombo();
             String combid = deid + "-" + cocid;
 
-            DataElement de = dataElementService.getDataElement( deid.getUID() );
+            DataElement de = dataElementService.getDataElement( deid.getUid() );
             if ( de == null )
             {
                 log.warn( String.format( "Data element [%s] does not exist. Continuing with submission...", deid ) );
@@ -195,7 +195,7 @@ public class AggregateDataSetSMSListener
                 continue;
             }
 
-            CategoryOptionCombo coc = categoryService.getCategoryOptionCombo( cocid.getUID() );
+            CategoryOptionCombo coc = categoryService.getCategoryOptionCombo( cocid.getUid() );
             if ( coc == null )
             {
                 log.warn( String.format( "Category Option Combo [%s] does not exist. Continuing with submission...",

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/BaseSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/BaseSMSListener.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsListener;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.incoming.SmsMessageStatus;
-import org.hisp.dhis.smscompression.SMSResponse;
+import org.hisp.dhis.smscompression.SmsResponse;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.ImmutableMap;
@@ -87,7 +87,7 @@ public abstract class BaseSMSListener
         LOGGER.getOrDefault( WARNING, log::info ).accept( NO_SMS_CONFIG );
     }
 
-    protected void sendSMSResponse( SMSResponse resp, IncomingSms sms, int messageID )
+    protected void sendSMSResponse( SmsResponse resp, IncomingSms sms, int messageID )
     {
         // A response code < 100 is either success or just a warning
         SmsMessageStatus status = resp.getCode() < 100 ? SmsMessageStatus.PROCESSED : SmsMessageStatus.FAILED;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
-import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -66,7 +65,6 @@ import org.hisp.dhis.smscompression.models.UID;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -214,7 +212,7 @@ public abstract class CompressionSMSListener
     private void checkUser( SMSSubmission subm )
     {
         UID userid = subm.getUserID();
-        User user = userService.getUser( userid.uid );
+        User user = userService.getUser( userid.getUID() );
 
         if ( user == null )
         {
@@ -250,11 +248,7 @@ public abstract class CompressionSMSListener
         meta.organisationUnits = getTypeUidsBefore( OrganisationUnit.class, lastSyncDate );
         meta.programStages = getTypeUidsBefore( ProgramStage.class, lastSyncDate );
         meta.relationshipTypes = getTypeUidsBefore( RelationshipType.class, lastSyncDate );
-        meta.relationships = getTypeUidsBefore( Relationship.class, lastSyncDate );
-        meta.trackedEntityInstances = getTypeUidsBefore( TrackedEntityInstance.class, lastSyncDate );
         meta.dataSets = getTypeUidsBefore( DataSet.class, lastSyncDate );
-        meta.enrollments = getTypeUidsBefore( ProgramInstance.class, lastSyncDate );
-        meta.events = getTypeUidsBefore( ProgramStageInstance.class, lastSyncDate );
 
         return meta;
     }
@@ -306,7 +300,7 @@ public abstract class CompressionSMSListener
                 UID deid = dv.getDataElement();
                 String val = dv.getValue();
 
-                DataElement de = dataElementService.getDataElement( deid.uid );
+                DataElement de = dataElementService.getDataElement( deid.getUID() );
                 // TODO: Is this the correct way of handling errors here?
                 if ( de == null )
                 {
@@ -322,7 +316,7 @@ public abstract class CompressionSMSListener
                     continue;
                 }
 
-                EventDataValue eventDataValue = new EventDataValue( deid.uid, dv.getValue(), user.getUsername() );
+                EventDataValue eventDataValue = new EventDataValue( deid.getUID(), dv.getValue(), user.getUsername() );
                 eventDataValue.setAutoFields();
                 dataElementsAndEventDataValues.put( de, eventDataValue );
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.message.MessageSender;
@@ -47,6 +48,8 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
@@ -63,6 +66,7 @@ import org.hisp.dhis.smscompression.models.UID;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -244,6 +248,13 @@ public abstract class CompressionSMSListener
         meta.trackedEntityAttributes = getTypeUidsBefore( TrackedEntityAttribute.class, lastSyncDate );
         meta.programs = getTypeUidsBefore( Program.class, lastSyncDate );
         meta.organisationUnits = getTypeUidsBefore( OrganisationUnit.class, lastSyncDate );
+        meta.programStages = getTypeUidsBefore( ProgramStage.class, lastSyncDate );
+        meta.relationshipTypes = getTypeUidsBefore( RelationshipType.class, lastSyncDate );
+        meta.relationships = getTypeUidsBefore( Relationship.class, lastSyncDate );
+        meta.trackedEntityInstances = getTypeUidsBefore( TrackedEntityInstance.class, lastSyncDate );
+        meta.dataSets = getTypeUidsBefore( DataSet.class, lastSyncDate );
+        meta.enrollments = getTypeUidsBefore( ProgramInstance.class, lastSyncDate );
+        meta.events = getTypeUidsBefore( ProgramStageInstance.class, lastSyncDate );
 
         return meta;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -51,17 +51,17 @@ import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.SMSSubmissionReader;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.SmsSubmissionReader;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmissionHeader;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -93,7 +93,7 @@ public abstract class CompressionSMSListener
     extends
     BaseSMSListener
 {
-    protected abstract SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected abstract SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException;
 
     protected abstract boolean handlesType( SubmissionType type );
@@ -153,7 +153,7 @@ public abstract class CompressionSMSListener
             return false;
         }
 
-        SMSSubmissionHeader header = getHeader( sms );
+        SmsSubmissionHeader header = getHeader( sms );
         if ( header == null )
         {
             // If the header is null we simply accept any listener
@@ -166,17 +166,17 @@ public abstract class CompressionSMSListener
     @Override
     public void receive( IncomingSms sms )
     {
-        SMSSubmissionReader reader = new SMSSubmissionReader();
-        SMSSubmissionHeader header = getHeader( sms );
+        SmsSubmissionReader reader = new SmsSubmissionReader();
+        SmsSubmissionHeader header = getHeader( sms );
         if ( header == null )
         {
             // Error with the header, we have no message ID, use -1
-            sendSMSResponse( SMSResponse.HEADER_ERROR, sms, -1 );
+            sendSMSResponse( SmsResponse.HEADER_ERROR, sms, -1 );
             return;
         }
 
-        SMSMetadata meta = getMetadata( header.getLastSyncDate() );
-        SMSSubmission subm = null;
+        SmsMetadata meta = getMetadata( header.getLastSyncDate() );
+        SmsSubmission subm = null;
         try
         {
             subm = reader.readSubmission( SmsUtils.getBytes( sms ), meta );
@@ -184,15 +184,15 @@ public abstract class CompressionSMSListener
         catch ( Exception e )
         {
             log.error( e.getMessage() );
-            sendSMSResponse( SMSResponse.READ_ERROR, sms, header.getSubmissionID() );
+            sendSMSResponse( SmsResponse.READ_ERROR, sms, header.getSubmissionId() );
             return;
         }
 
-        // TODO: Can be removed - debugging line to check SMS submissions
+        // TODO: Can be removed - debugging line to check Sms submissions
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        log.info( String.format( "New received SMS submission decoded as: %s", gson.toJson( subm ) ) );
+        log.info( String.format( "New received Sms submission decoded as: %s", gson.toJson( subm ) ) );
 
-        SMSResponse resp = null;
+        SmsResponse resp = null;
         try
         {
             checkUser( subm );
@@ -201,29 +201,29 @@ public abstract class CompressionSMSListener
         catch ( SMSProcessingException e )
         {
             log.error( e.getMessage() );
-            sendSMSResponse( e.getResp(), sms, header.getSubmissionID() );
+            sendSMSResponse( e.getResp(), sms, header.getSubmissionId() );
             return;
         }
 
-        log.info( String.format( "SMS Response: ", resp.toString() ) );
-        sendSMSResponse( resp, sms, header.getSubmissionID() );
+        log.info( String.format( "Sms Response: ", resp.toString() ) );
+        sendSMSResponse( resp, sms, header.getSubmissionId() );
     }
 
-    private void checkUser( SMSSubmission subm )
+    private void checkUser( SmsSubmission subm )
     {
-        UID userid = subm.getUserID();
-        User user = userService.getUser( userid.getUID() );
+        Uid userid = subm.getUserId();
+        User user = userService.getUser( userid.getUid() );
 
         if ( user == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_USER.set( userid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_USER.set( userid ) );
         }
     }
 
-    private SMSSubmissionHeader getHeader( IncomingSms sms )
+    private SmsSubmissionHeader getHeader( IncomingSms sms )
     {
         byte[] smsBytes = SmsUtils.getBytes( sms );
-        SMSSubmissionReader reader = new SMSSubmissionReader();
+        SmsSubmissionReader reader = new SmsSubmissionReader();
         try
         {
             return reader.readHeader( smsBytes );
@@ -236,9 +236,9 @@ public abstract class CompressionSMSListener
         }
     }
 
-    private SMSMetadata getMetadata( Date lastSyncDate )
+    private SmsMetadata getMetadata( Date lastSyncDate )
     {
-        SMSMetadata meta = new SMSMetadata();
+        SmsMetadata meta = new SmsMetadata();
         meta.dataElements = getTypeUidsBefore( DataElement.class, lastSyncDate );
         meta.categoryOptionCombos = getTypeUidsBefore( CategoryOptionCombo.class, lastSyncDate );
         meta.users = getTypeUidsBefore( User.class, lastSyncDate );
@@ -253,19 +253,19 @@ public abstract class CompressionSMSListener
         return meta;
     }
 
-    private List<SMSMetadata.ID> getTypeUidsBefore( Class<? extends IdentifiableObject> klass, Date lastSyncDate )
+    private List<SmsMetadata.Id> getTypeUidsBefore( Class<? extends IdentifiableObject> klass, Date lastSyncDate )
     {
         return identifiableObjectManager.getUidsCreatedBefore( klass, lastSyncDate ).stream()
-            .map( o -> new SMSMetadata.ID( o ) ).collect( Collectors.toList() );
+            .map( o -> new SmsMetadata.Id( o ) ).collect( Collectors.toList() );
     }
 
     protected List<Object> saveNewEvent( String eventUid, OrganisationUnit orgUnit, ProgramStage programStage,
-        ProgramInstance programInstance, IncomingSms sms, CategoryOptionCombo aoc, User user, List<SMSDataValue> values,
-        SMSEventStatus eventStatus, Date eventDate, Date dueDate, GeoPoint coordinates )
+        ProgramInstance programInstance, IncomingSms sms, CategoryOptionCombo aoc, User user, List<SmsDataValue> values,
+        SmsEventStatus eventStatus, Date eventDate, Date dueDate, GeoPoint coordinates )
     {
-        ArrayList<Object> errorUIDs = new ArrayList<>();
+        ArrayList<Object> errorUids = new ArrayList<>();
         ProgramStageInstance programStageInstance;
-        // If we aren't given a UID for the event, it will be auto-generated
+        // If we aren't given a Uid for the event, it will be auto-generated
         if ( programStageInstanceService.programStageInstanceExists( eventUid ) )
         {
             programStageInstance = programStageInstanceService.getProgramStageInstance( eventUid );
@@ -286,7 +286,7 @@ public abstract class CompressionSMSListener
         programStageInstance.setStatus( getCoreEventStatus( eventStatus ) );
         programStageInstance.setGeometry( convertGeoPointToGeometry( coordinates ) );
 
-        if ( eventStatus.equals( SMSEventStatus.COMPLETED ) )
+        if ( eventStatus.equals( SmsEventStatus.COMPLETED ) )
         {
             programStageInstance.setCompletedBy( user.getUsername() );
             programStageInstance.setCompletedDate( new Date() );
@@ -295,18 +295,18 @@ public abstract class CompressionSMSListener
         Map<DataElement, EventDataValue> dataElementsAndEventDataValues = new HashMap<>();
         if ( values != null )
         {
-            for ( SMSDataValue dv : values )
+            for ( SmsDataValue dv : values )
             {
-                UID deid = dv.getDataElement();
+                Uid deid = dv.getDataElement();
                 String val = dv.getValue();
 
-                DataElement de = dataElementService.getDataElement( deid.getUID() );
+                DataElement de = dataElementService.getDataElement( deid.getUid() );
                 // TODO: Is this the correct way of handling errors here?
                 if ( de == null )
                 {
                     log.warn( String
                         .format( "Given data element [%s] could not be found. Continuing with submission...", deid ) );
-                    errorUIDs.add( deid );
+                    errorUids.add( deid );
                     continue;
                 }
                 else if ( val == null || StringUtils.isEmpty( val ) )
@@ -316,7 +316,7 @@ public abstract class CompressionSMSListener
                     continue;
                 }
 
-                EventDataValue eventDataValue = new EventDataValue( deid.getUID(), dv.getValue(), user.getUsername() );
+                EventDataValue eventDataValue = new EventDataValue( deid.getUid(), dv.getValue(), user.getUsername() );
                 eventDataValue.setAutoFields();
                 dataElementsAndEventDataValues.put( de, eventDataValue );
             }
@@ -325,10 +325,10 @@ public abstract class CompressionSMSListener
         programStageInstanceService.saveEventDataValuesAndSaveProgramStageInstance( programStageInstance,
             dataElementsAndEventDataValues );
 
-        return errorUIDs;
+        return errorUids;
     }
 
-    private EventStatus getCoreEventStatus( SMSEventStatus eventStatus )
+    private EventStatus getCoreEventStatus( SmsEventStatus eventStatus )
     {
         switch ( eventStatus )
         {
@@ -349,7 +349,7 @@ public abstract class CompressionSMSListener
         }
     }
 
-    protected ProgramStatus getCoreProgramStatus( SMSEnrollmentStatus enrollmentStatus )
+    protected ProgramStatus getCoreProgramStatus( SmsEnrollmentStatus enrollmentStatus )
     {
         switch ( enrollmentStatus )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
@@ -38,11 +38,11 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.UserService;
@@ -69,21 +69,21 @@ public class DeleteEventSMSListener
     }
 
     @Override
-    protected SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException
     {
-        DeleteSMSSubmission subm = (DeleteSMSSubmission) submission;
+        DeleteSmsSubmission subm = (DeleteSmsSubmission) submission;
 
-        UID eventid = subm.getEvent();
-        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( eventid.getUID() );
+        Uid eventid = subm.getEvent();
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( eventid.getUid() );
         if ( psi == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_EVENT.set( eventid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_EVENT.set( eventid ) );
         }
 
         programStageInstanceService.deleteProgramStageInstance( psi );
 
-        return SMSResponse.SUCCESS;
+        return SmsResponse.SUCCESS;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
@@ -75,7 +75,7 @@ public class DeleteEventSMSListener
         DeleteSMSSubmission subm = (DeleteSMSSubmission) submission;
 
         UID eventid = subm.getEvent();
-        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( eventid.uid );
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( eventid.getUID() );
         if ( psi == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_EVENT.set( eventid ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -44,13 +44,13 @@ import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSEvent;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsEvent;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -111,50 +111,50 @@ public class EnrollmentSMSListener
     }
 
     @Override
-    protected SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException
     {
-        EnrollmentSMSSubmission subm = (EnrollmentSMSSubmission) submission;
+        EnrollmentSmsSubmission subm = (EnrollmentSmsSubmission) submission;
 
         Date enrollmentDate = subm.getEnrollmentDate();
         Date incidentDate = subm.getIncidentDate();
-        UID teiUID = subm.getTrackedEntityInstance();
-        UID progid = subm.getTrackerProgram();
-        UID tetid = subm.getTrackedEntityType();
-        UID ouid = subm.getOrgUnit();
-        UID enrollmentid = subm.getEnrollment();
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        Uid teiUid = subm.getTrackedEntityInstance();
+        Uid progid = subm.getTrackerProgram();
+        Uid tetid = subm.getTrackedEntityType();
+        Uid ouid = subm.getOrgUnit();
+        Uid enrollmentid = subm.getEnrollment();
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUid() );
 
-        Program program = programService.getProgram( progid.getUID() );
+        Program program = programService.getProgram( progid.getUid() );
         if ( program == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_PROGRAM.set( progid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_PROGRAM.set( progid ) );
         }
 
-        TrackedEntityType entityType = trackedEntityTypeService.getTrackedEntityType( tetid.getUID() );
+        TrackedEntityType entityType = trackedEntityTypeService.getTrackedEntityType( tetid.getUid() );
         if ( entityType == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_TETYPE.set( tetid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_TETYPE.set( tetid ) );
         }
 
         if ( !program.hasOrganisationUnit( orgUnit ) )
         {
-            throw new SMSProcessingException( SMSResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
+            throw new SMSProcessingException( SmsResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
         }
 
         TrackedEntityInstance entityInstance;
-        boolean teiExists = teiService.trackedEntityInstanceExists( teiUID.getUID() );
+        boolean teiExists = teiService.trackedEntityInstanceExists( teiUid.getUid() );
 
         if ( teiExists )
         {
-            log.info( String.format( "Given TEI [%s] exists. Updating...", teiUID ) );
-            entityInstance = teiService.getTrackedEntityInstance( teiUID.getUID() );
+            log.info( String.format( "Given TEI [%s] exists. Updating...", teiUid ) );
+            entityInstance = teiService.getTrackedEntityInstance( teiUid.getUid() );
         }
         else
         {
-            log.info( String.format( "Given TEI [%s] does not exist. Creating...", teiUID ) );
+            log.info( String.format( "Given TEI [%s] does not exist. Creating...", teiUid ) );
             entityInstance = new TrackedEntityInstance();
-            entityInstance.setUid( teiUID.getUID() );
+            entityInstance.setUid( teiUid.getUid() );
             entityInstance.setOrganisationUnit( orgUnit );
             entityInstance.setTrackedEntityType( entityType );
         }
@@ -172,15 +172,15 @@ public class EnrollmentSMSListener
             teiService.createTrackedEntityInstance( entityInstance, attributeValues );
         }
 
-        TrackedEntityInstance tei = teiService.getTrackedEntityInstance( teiUID.getUID() );
+        TrackedEntityInstance tei = teiService.getTrackedEntityInstance( teiUid.getUid() );
 
         // TODO: Unsure about this handling for enrollments, this needs to be
         // checked closely
         ProgramInstance enrollment;
-        boolean enrollmentExists = programInstanceService.programInstanceExists( enrollmentid.getUID() );
+        boolean enrollmentExists = programInstanceService.programInstanceExists( enrollmentid.getUid() );
         if ( enrollmentExists )
         {
-            enrollment = programInstanceService.getProgramInstance( enrollmentid.getUID() );
+            enrollment = programInstanceService.getProgramInstance( enrollmentid.getUid() );
             // Update these dates in case they've changed
             enrollment.setEnrollmentDate( enrollmentDate );
             enrollment.setIncidentDate( incidentDate );
@@ -188,22 +188,22 @@ public class EnrollmentSMSListener
         else
         {
             enrollment = programInstanceService.enrollTrackedEntityInstance( tei, program, enrollmentDate, incidentDate,
-                orgUnit, enrollmentid.getUID() );
+                orgUnit, enrollmentid.getUid() );
         }
         if ( enrollment == null )
         {
-            throw new SMSProcessingException( SMSResponse.ENROLL_FAILED.set( teiUID, progid ) );
+            throw new SMSProcessingException( SmsResponse.ENROLL_FAILED.set( teiUid, progid ) );
         }
         enrollment.setStatus( getCoreProgramStatus( subm.getEnrollmentStatus() ) );
         enrollment.setGeometry( convertGeoPointToGeometry( subm.getCoordinates() ) );
         programInstanceService.updateProgramInstance( enrollment );
 
         // We now check if the enrollment has events to process
-        User user = userService.getUser( subm.getUserID().getUID() );
+        User user = userService.getUser( subm.getUserId().getUid() );
         List<Object> errorUIDs = new ArrayList<>();
         if ( subm.getEvents() != null )
         {
-            for ( SMSEvent event : subm.getEvents() )
+            for ( SmsEvent event : subm.getEvents() )
             {
                 errorUIDs.addAll( processEvent( event, user, enrollment, sms ) );
             }
@@ -211,16 +211,16 @@ public class EnrollmentSMSListener
 
         if ( !errorUIDs.isEmpty() )
         {
-            return SMSResponse.WARN_DVERR.setList( errorUIDs );
+            return SmsResponse.WARN_DVERR.setList( errorUIDs );
         }
 
         if ( attributeValues == null || attributeValues.isEmpty() )
         {
             // TODO: Is this correct handling?
-            return SMSResponse.WARN_AVEMPTY;
+            return SmsResponse.WARN_AVEMPTY;
         }
 
-        return SMSResponse.SUCCESS;
+        return SmsResponse.SUCCESS;
     }
 
     private void updateAttributeValues( Set<TrackedEntityAttributeValue> attributeValues,
@@ -265,7 +265,7 @@ public class EnrollmentSMSListener
         return (type == SubmissionType.ENROLLMENT);
     }
 
-    private Set<TrackedEntityAttributeValue> getSMSAttributeValues( EnrollmentSMSSubmission submission,
+    private Set<TrackedEntityAttributeValue> getSMSAttributeValues( EnrollmentSmsSubmission submission,
         TrackedEntityInstance entityInstance )
     {
         if ( submission.getValues() == null )
@@ -276,22 +276,22 @@ public class EnrollmentSMSListener
             .collect( Collectors.toSet() );
     }
 
-    protected TrackedEntityAttributeValue createTrackedEntityValue( SMSAttributeValue SMSAttributeValue,
+    protected TrackedEntityAttributeValue createTrackedEntityValue( SmsAttributeValue SMSAttributeValue,
         TrackedEntityInstance tei )
     {
-        UID attribUID = SMSAttributeValue.getAttribute();
+        Uid attribUid = SMSAttributeValue.getAttribute();
         String val = SMSAttributeValue.getValue();
 
         TrackedEntityAttribute attribute = trackedEntityAttributeService
-            .getTrackedEntityAttribute( attribUID.getUID() );
+            .getTrackedEntityAttribute( attribUid.getUid() );
         if ( attribute == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_ATTRIB.set( attribUID ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_ATTRIB.set( attribUid ) );
         }
         else if ( val == null )
         {
             // TODO: Is this an error we can't recover from?
-            throw new SMSProcessingException( SMSResponse.NULL_ATTRIBVAL.set( attribUID ) );
+            throw new SMSProcessingException( SmsResponse.NULL_ATTRIBVAL.set( attribUid ) );
         }
         TrackedEntityAttributeValue trackedEntityAttributeValue = new TrackedEntityAttributeValue();
         trackedEntityAttributeValue.setAttribute( attribute );
@@ -300,31 +300,31 @@ public class EnrollmentSMSListener
         return trackedEntityAttributeValue;
     }
 
-    protected List<Object> processEvent( SMSEvent event, User user, ProgramInstance programInstance, IncomingSms sms )
+    protected List<Object> processEvent( SmsEvent event, User user, ProgramInstance programInstance, IncomingSms sms )
     {
-        UID stageid = event.getProgramStage();
-        UID aocid = event.getAttributeOptionCombo();
-        UID orgunitid = event.getOrgUnit();
+        Uid stageid = event.getProgramStage();
+        Uid aocid = event.getAttributeOptionCombo();
+        Uid orgunitid = event.getOrgUnit();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgunitid.getUID() );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgunitid.getUid() );
         if ( orgUnit == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_ORGUNIT.set( orgunitid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_ORGUNIT.set( orgunitid ) );
         }
 
-        ProgramStage programStage = programStageService.getProgramStage( stageid.getUID() );
+        ProgramStage programStage = programStageService.getProgramStage( stageid.getUid() );
         if ( programStage == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_STAGE.set( stageid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_STAGE.set( stageid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUid() );
         if ( aoc == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_AOC.set( aocid ) );
         }
 
-        List<Object> errorUIDs = saveNewEvent( event.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+        List<Object> errorUIDs = saveNewEvent( event.getEvent().getUid(), orgUnit, programStage, programInstance, sms,
             aoc, user, event.getValues(), event.getEventStatus(), event.getEventDate(), event.getDueDate(),
             event.getCoordinates() );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -123,15 +123,15 @@ public class EnrollmentSMSListener
         UID tetid = subm.getTrackedEntityType();
         UID ouid = subm.getOrgUnit();
         UID enrollmentid = subm.getEnrollment();
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
 
-        Program program = programService.getProgram( progid.uid );
+        Program program = programService.getProgram( progid.getUID() );
         if ( program == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_PROGRAM.set( progid ) );
         }
 
-        TrackedEntityType entityType = trackedEntityTypeService.getTrackedEntityType( tetid.uid );
+        TrackedEntityType entityType = trackedEntityTypeService.getTrackedEntityType( tetid.getUID() );
         if ( entityType == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_TETYPE.set( tetid ) );
@@ -143,18 +143,18 @@ public class EnrollmentSMSListener
         }
 
         TrackedEntityInstance entityInstance;
-        boolean teiExists = teiService.trackedEntityInstanceExists( teiUID.uid );
+        boolean teiExists = teiService.trackedEntityInstanceExists( teiUID.getUID() );
 
         if ( teiExists )
         {
             log.info( String.format( "Given TEI [%s] exists. Updating...", teiUID ) );
-            entityInstance = teiService.getTrackedEntityInstance( teiUID.uid );
+            entityInstance = teiService.getTrackedEntityInstance( teiUID.getUID() );
         }
         else
         {
             log.info( String.format( "Given TEI [%s] does not exist. Creating...", teiUID ) );
             entityInstance = new TrackedEntityInstance();
-            entityInstance.setUid( teiUID.uid );
+            entityInstance.setUid( teiUID.getUID() );
             entityInstance.setOrganisationUnit( orgUnit );
             entityInstance.setTrackedEntityType( entityType );
         }
@@ -172,15 +172,15 @@ public class EnrollmentSMSListener
             teiService.createTrackedEntityInstance( entityInstance, attributeValues );
         }
 
-        TrackedEntityInstance tei = teiService.getTrackedEntityInstance( teiUID.uid );
+        TrackedEntityInstance tei = teiService.getTrackedEntityInstance( teiUID.getUID() );
 
         // TODO: Unsure about this handling for enrollments, this needs to be
         // checked closely
         ProgramInstance enrollment;
-        boolean enrollmentExists = programInstanceService.programInstanceExists( enrollmentid.uid );
+        boolean enrollmentExists = programInstanceService.programInstanceExists( enrollmentid.getUID() );
         if ( enrollmentExists )
         {
-            enrollment = programInstanceService.getProgramInstance( enrollmentid.uid );
+            enrollment = programInstanceService.getProgramInstance( enrollmentid.getUID() );
             // Update these dates in case they've changed
             enrollment.setEnrollmentDate( enrollmentDate );
             enrollment.setIncidentDate( incidentDate );
@@ -188,7 +188,7 @@ public class EnrollmentSMSListener
         else
         {
             enrollment = programInstanceService.enrollTrackedEntityInstance( tei, program, enrollmentDate, incidentDate,
-                orgUnit, enrollmentid.uid );
+                orgUnit, enrollmentid.getUID() );
         }
         if ( enrollment == null )
         {
@@ -199,7 +199,7 @@ public class EnrollmentSMSListener
         programInstanceService.updateProgramInstance( enrollment );
 
         // We now check if the enrollment has events to process
-        User user = userService.getUser( subm.getUserID().uid );
+        User user = userService.getUser( subm.getUserID().getUID() );
         List<Object> errorUIDs = new ArrayList<>();
         if ( subm.getEvents() != null )
         {
@@ -282,7 +282,8 @@ public class EnrollmentSMSListener
         UID attribUID = SMSAttributeValue.getAttribute();
         String val = SMSAttributeValue.getValue();
 
-        TrackedEntityAttribute attribute = trackedEntityAttributeService.getTrackedEntityAttribute( attribUID.uid );
+        TrackedEntityAttribute attribute = trackedEntityAttributeService
+            .getTrackedEntityAttribute( attribUID.getUID() );
         if ( attribute == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_ATTRIB.set( attribUID ) );
@@ -305,26 +306,26 @@ public class EnrollmentSMSListener
         UID aocid = event.getAttributeOptionCombo();
         UID orgunitid = event.getOrgUnit();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgunitid.uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( orgunitid.getUID() );
         if ( orgUnit == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_ORGUNIT.set( orgunitid ) );
         }
 
-        ProgramStage programStage = programStageService.getProgramStage( stageid.uid );
+        ProgramStage programStage = programStageService.getProgramStage( stageid.getUID() );
         if ( programStage == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_STAGE.set( stageid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
         }
 
-        List<Object> errorUIDs = saveNewEvent( event.getEvent().uid, orgUnit, programStage, programInstance, sms, aoc,
-            user, event.getValues(), event.getEventStatus(), event.getEventDate(), event.getDueDate(),
+        List<Object> errorUIDs = saveNewEvent( event.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+            aoc, user, event.getValues(), event.getEventStatus(), event.getEventDate(), event.getDueDate(),
             event.getCoordinates() );
 
         return errorUIDs;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -83,6 +84,8 @@ public class EnrollmentSMSListener
 
     private final ProgramInstanceService programInstanceService;
 
+    private final TrackedEntityAttributeValueService attributeValueService;
+
     private final ProgramStageService programStageService;
 
     private final UserService userService;
@@ -92,7 +95,8 @@ public class EnrollmentSMSListener
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
         DataElementService dataElementService, ProgramStageService programStageService,
-        ProgramStageInstanceService programStageInstanceService, TrackedEntityInstanceService teiService,
+        ProgramStageInstanceService programStageInstanceService,
+        TrackedEntityAttributeValueService attributeValueService, TrackedEntityInstanceService teiService,
         ProgramInstanceService programInstanceService, IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
@@ -102,6 +106,7 @@ public class EnrollmentSMSListener
         this.teiService = teiService;
         this.programStageService = programStageService;
         this.programInstanceService = programInstanceService;
+        this.attributeValueService = attributeValueService;
         this.userService = userService;
     }
 
@@ -158,6 +163,7 @@ public class EnrollmentSMSListener
 
         if ( teiExists )
         {
+            updateAttributeValues( attributeValues, entityInstance.getTrackedEntityAttributeValues() );
             entityInstance.setTrackedEntityAttributeValues( attributeValues );
             teiService.updateTrackedEntityInstance( entityInstance );
         }
@@ -215,6 +221,42 @@ public class EnrollmentSMSListener
         }
 
         return SMSResponse.SUCCESS;
+    }
+
+    private void updateAttributeValues( Set<TrackedEntityAttributeValue> attributeValues,
+        Set<TrackedEntityAttributeValue> oldAttributeValues )
+    {
+        // Update existing and add new values
+        for ( TrackedEntityAttributeValue attributeValue : attributeValues )
+        {
+            TrackedEntityAttributeValue oldAttributeValue = findAttributeValue( attributeValue, oldAttributeValues );
+            if ( oldAttributeValue != null )
+            {
+                oldAttributeValue.setValue( attributeValue.getValue() );
+                attributeValueService.updateTrackedEntityAttributeValue( oldAttributeValue );
+            }
+            else
+            {
+                attributeValueService.addTrackedEntityAttributeValue( attributeValue );
+            }
+        }
+
+        // Delete any that don't exist anymore
+        for ( TrackedEntityAttributeValue oldAttributeValue : oldAttributeValues )
+        {
+            if ( findAttributeValue( oldAttributeValue, attributeValues ) == null )
+            {
+                attributeValueService.deleteTrackedEntityAttributeValue( oldAttributeValue );
+            }
+        }
+    }
+
+    private TrackedEntityAttributeValue findAttributeValue( TrackedEntityAttributeValue attributeValue,
+        Set<TrackedEntityAttributeValue> attributeValues )
+    {
+        return attributeValues.stream()
+            .filter( v -> v.getAttribute().getUid().equals( attributeValue.getAttribute().getUid() ) ).findAny()
+            .orElse( null );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -46,11 +46,11 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -101,20 +101,20 @@ public class RelationshipSMSListener
     }
 
     @Override
-    protected SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException
     {
-        RelationshipSMSSubmission subm = (RelationshipSMSSubmission) submission;
+        RelationshipSmsSubmission subm = (RelationshipSmsSubmission) submission;
 
-        UID fromid = subm.getFrom();
-        UID toid = subm.getTo();
-        UID typeid = subm.getRelationshipType();
+        Uid fromid = subm.getFrom();
+        Uid toid = subm.getTo();
+        Uid typeid = subm.getRelationshipType();
 
-        RelationshipType relType = relationshipTypeService.getRelationshipType( typeid.getUID() );
+        RelationshipType relType = relationshipTypeService.getRelationshipType( typeid.getUid() );
 
         if ( relType == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_RELTYPE.set( typeid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_RELTYPE.set( typeid ) );
         }
 
         RelationshipItem fromItem = createRelationshipItem( relType, RelationshipDir.FROM, fromid );
@@ -122,11 +122,11 @@ public class RelationshipSMSListener
 
         Relationship rel = new Relationship();
 
-        // If we aren't given a UID for the relationship, it will be
+        // If we aren't given a Uid for the relationship, it will be
         // auto-generated
         if ( subm.getRelationship() != null )
         {
-            rel.setUid( subm.getRelationship().getUID() );
+            rel.setUid( subm.getRelationship().getUid() );
         }
 
         rel.setRelationshipType( relType );
@@ -139,10 +139,10 @@ public class RelationshipSMSListener
 
         relationshipService.addRelationship( rel );
 
-        return SMSResponse.SUCCESS;
+        return SmsResponse.SUCCESS;
     }
 
-    private RelationshipItem createRelationshipItem( RelationshipType relType, RelationshipDir dir, UID objId )
+    private RelationshipItem createRelationshipItem( RelationshipType relType, RelationshipDir dir, Uid objId )
     {
         RelationshipItem relItem = new RelationshipItem();
         RelationshipEntity fromEnt = relType.getFromConstraint().getRelationshipEntity();
@@ -152,28 +152,28 @@ public class RelationshipSMSListener
         switch ( relEnt )
         {
         case TRACKED_ENTITY_INSTANCE:
-            TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( objId.getUID() );
+            TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( objId.getUid() );
             if ( tei == null )
             {
-                throw new SMSProcessingException( SMSResponse.INVALID_TEI.set( objId ) );
+                throw new SMSProcessingException( SmsResponse.INVALID_TEI.set( objId ) );
             }
             relItem.setTrackedEntityInstance( tei );
             break;
 
         case PROGRAM_INSTANCE:
-            ProgramInstance progInst = programInstanceService.getProgramInstance( objId.getUID() );
+            ProgramInstance progInst = programInstanceService.getProgramInstance( objId.getUid() );
             if ( progInst == null )
             {
-                throw new SMSProcessingException( SMSResponse.INVALID_ENROLL.set( objId ) );
+                throw new SMSProcessingException( SmsResponse.INVALID_ENROLL.set( objId ) );
             }
             relItem.setProgramInstance( progInst );
             break;
 
         case PROGRAM_STAGE_INSTANCE:
-            ProgramStageInstance stageInst = programStageInstanceService.getProgramStageInstance( objId.getUID() );
+            ProgramStageInstance stageInst = programStageInstanceService.getProgramStageInstance( objId.getUid() );
             if ( stageInst == null )
             {
-                throw new SMSProcessingException( SMSResponse.INVALID_EVENT.set( objId ) );
+                throw new SMSProcessingException( SmsResponse.INVALID_EVENT.set( objId ) );
             }
             relItem.setProgramStageInstance( stageInst );
             break;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -110,7 +110,7 @@ public class RelationshipSMSListener
         UID toid = subm.getTo();
         UID typeid = subm.getRelationshipType();
 
-        RelationshipType relType = relationshipTypeService.getRelationshipType( typeid.uid );
+        RelationshipType relType = relationshipTypeService.getRelationshipType( typeid.getUID() );
 
         if ( relType == null )
         {
@@ -126,7 +126,7 @@ public class RelationshipSMSListener
         // auto-generated
         if ( subm.getRelationship() != null )
         {
-            rel.setUid( subm.getRelationship().uid );
+            rel.setUid( subm.getRelationship().getUID() );
         }
 
         rel.setRelationshipType( relType );
@@ -152,7 +152,7 @@ public class RelationshipSMSListener
         switch ( relEnt )
         {
         case TRACKED_ENTITY_INSTANCE:
-            TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( objId.uid );
+            TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( objId.getUID() );
             if ( tei == null )
             {
                 throw new SMSProcessingException( SMSResponse.INVALID_TEI.set( objId ) );
@@ -161,7 +161,7 @@ public class RelationshipSMSListener
             break;
 
         case PROGRAM_INSTANCE:
-            ProgramInstance progInst = programInstanceService.getProgramInstance( objId.uid );
+            ProgramInstance progInst = programInstanceService.getProgramInstance( objId.getUID() );
             if ( progInst == null )
             {
                 throw new SMSProcessingException( SMSResponse.INVALID_ENROLL.set( objId ) );
@@ -170,7 +170,7 @@ public class RelationshipSMSListener
             break;
 
         case PROGRAM_STAGE_INSTANCE:
-            ProgramStageInstance stageInst = programStageInstanceService.getProgramStageInstance( objId.uid );
+            ProgramStageInstance stageInst = programStageInstanceService.getProgramStageInstance( objId.getUID() );
             if ( stageInst == null )
             {
                 throw new SMSProcessingException( SMSResponse.INVALID_EVENT.set( objId ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SMSProcessingException.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SMSProcessingException.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.smscompression.SMSResponse;
+import org.hisp.dhis.smscompression.SmsResponse;
 
 public class SMSProcessingException
     extends
@@ -40,16 +40,16 @@ public class SMSProcessingException
      */
     private static final long serialVersionUID = 353425388316643481L;
 
-    private SMSResponse resp;
+    private SmsResponse resp;
 
     private Throwable err;
 
-    public SMSProcessingException( SMSResponse resp )
+    public SMSProcessingException( SmsResponse resp )
     {
         this.resp = resp;
     }
 
-    public SMSProcessingException( SMSResponse resp, Throwable err )
+    public SMSProcessingException( SmsResponse resp, Throwable err )
     {
         this.resp = resp;
         this.err = err;
@@ -61,7 +61,7 @@ public class SMSProcessingException
         return resp.getDescription();
     }
 
-    public SMSResponse getResp()
+    public SmsResponse getResp()
     {
         return resp;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -94,16 +94,16 @@ public class SimpleEventSMSListener
         UID aocid = subm.getAttributeOptionCombo();
         UID progid = subm.getEventProgram();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
-        User user = userService.getUser( subm.getUserID().uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        User user = userService.getUser( subm.getUserID().getUID() );
 
-        Program program = programService.getProgram( subm.getEventProgram().uid );
+        Program program = programService.getProgram( subm.getEventProgram().getUID() );
         if ( program == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_PROGRAM.set( progid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
@@ -145,8 +145,8 @@ public class SimpleEventSMSListener
         }
         ProgramStage programStage = programStages.iterator().next();
 
-        List<Object> errorUIDs = saveNewEvent( subm.getEvent().uid, orgUnit, programStage, programInstance, sms, aoc,
-            user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
+        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+            aoc, user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
             subm.getCoordinates() );
         if ( !errorUIDs.isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -44,11 +44,11 @@ import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -85,33 +85,33 @@ public class SimpleEventSMSListener
     }
 
     @Override
-    protected SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException
     {
-        SimpleEventSMSSubmission subm = (SimpleEventSMSSubmission) submission;
+        SimpleEventSmsSubmission subm = (SimpleEventSmsSubmission) submission;
 
-        UID ouid = subm.getOrgUnit();
-        UID aocid = subm.getAttributeOptionCombo();
-        UID progid = subm.getEventProgram();
+        Uid ouid = subm.getOrgUnit();
+        Uid aocid = subm.getAttributeOptionCombo();
+        Uid progid = subm.getEventProgram();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
-        User user = userService.getUser( subm.getUserID().getUID() );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUid() );
+        User user = userService.getUser( subm.getUserId().getUid() );
 
-        Program program = programService.getProgram( subm.getEventProgram().getUID() );
+        Program program = programService.getProgram( subm.getEventProgram().getUid() );
         if ( program == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_PROGRAM.set( progid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_PROGRAM.set( progid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUid() );
         if ( aoc == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_AOC.set( aocid ) );
         }
 
         if ( !program.hasOrganisationUnit( orgUnit ) )
         {
-            throw new SMSProcessingException( SMSResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
+            throw new SMSProcessingException( SmsResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
         }
 
         List<ProgramInstance> programInstances = new ArrayList<>(
@@ -134,31 +134,31 @@ public class SimpleEventSMSListener
         else if ( programInstances.size() > 1 )
         {
             // TODO: Are we sure this is a problem we can't recover from?
-            throw new SMSProcessingException( SMSResponse.MULTI_PROGRAMS.set( progid ) );
+            throw new SMSProcessingException( SmsResponse.MULTI_PROGRAMS.set( progid ) );
         }
 
         ProgramInstance programInstance = programInstances.get( 0 );
         Set<ProgramStage> programStages = programInstance.getProgram().getProgramStages();
         if ( programStages.size() > 1 )
         {
-            throw new SMSProcessingException( SMSResponse.MULTI_STAGES.set( progid ) );
+            throw new SMSProcessingException( SmsResponse.MULTI_STAGES.set( progid ) );
         }
         ProgramStage programStage = programStages.iterator().next();
 
-        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUid(), orgUnit, programStage, programInstance, sms,
             aoc, user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
             subm.getCoordinates() );
         if ( !errorUIDs.isEmpty() )
         {
-            return SMSResponse.WARN_DVERR.setList( errorUIDs );
+            return SmsResponse.WARN_DVERR.setList( errorUIDs );
         }
         else if ( subm.getValues() == null || subm.getValues().isEmpty() )
         {
             // TODO: Should we save the event if there are no data values?
-            return SMSResponse.WARN_DVEMPTY;
+            return SmsResponse.WARN_DVEMPTY;
         }
 
-        return SMSResponse.SUCCESS;
+        return SmsResponse.SUCCESS;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -43,11 +43,11 @@ import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSConsts.SubmissionType;
-import org.hisp.dhis.smscompression.SMSResponse;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
-import org.hisp.dhis.smscompression.models.UID;
+import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
+import org.hisp.dhis.smscompression.SmsResponse;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.Uid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -86,51 +86,51 @@ public class TrackerEventSMSListener
     }
 
     @Override
-    protected SMSResponse postProcess( IncomingSms sms, SMSSubmission submission )
+    protected SmsResponse postProcess( IncomingSms sms, SmsSubmission submission )
         throws SMSProcessingException
     {
-        TrackerEventSMSSubmission subm = (TrackerEventSMSSubmission) submission;
+        TrackerEventSmsSubmission subm = (TrackerEventSmsSubmission) submission;
 
-        UID ouid = subm.getOrgUnit();
-        UID stageid = subm.getProgramStage();
-        UID enrolmentid = subm.getEnrollment();
-        UID aocid = subm.getAttributeOptionCombo();
+        Uid ouid = subm.getOrgUnit();
+        Uid stageid = subm.getProgramStage();
+        Uid enrolmentid = subm.getEnrollment();
+        Uid aocid = subm.getAttributeOptionCombo();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
-        User user = userService.getUser( subm.getUserID().getUID() );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUid() );
+        User user = userService.getUser( subm.getUserId().getUid() );
 
-        ProgramInstance programInstance = programInstanceService.getProgramInstance( enrolmentid.getUID() );
+        ProgramInstance programInstance = programInstanceService.getProgramInstance( enrolmentid.getUid() );
         if ( programInstance == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_ENROLL.set( enrolmentid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_ENROLL.set( enrolmentid ) );
         }
 
-        ProgramStage programStage = programStageService.getProgramStage( stageid.getUID() );
+        ProgramStage programStage = programStageService.getProgramStage( stageid.getUid() );
         if ( programStage == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_STAGE.set( stageid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_STAGE.set( stageid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUid() );
         if ( aoc == null )
         {
-            throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
+            throw new SMSProcessingException( SmsResponse.INVALID_AOC.set( aocid ) );
         }
 
-        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUid(), orgUnit, programStage, programInstance, sms,
             aoc, user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
             subm.getCoordinates() );
         if ( !errorUIDs.isEmpty() )
         {
-            return SMSResponse.WARN_DVERR.setList( errorUIDs );
+            return SmsResponse.WARN_DVERR.setList( errorUIDs );
         }
         else if ( subm.getValues() == null || subm.getValues().isEmpty() )
         {
             // TODO: Should we save the event if there are no data values?
-            return SMSResponse.WARN_DVEMPTY;
+            return SmsResponse.WARN_DVEMPTY;
         }
 
-        return SMSResponse.SUCCESS;
+        return SmsResponse.SUCCESS;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -96,29 +96,29 @@ public class TrackerEventSMSListener
         UID enrolmentid = subm.getEnrollment();
         UID aocid = subm.getAttributeOptionCombo();
 
-        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.uid );
-        User user = userService.getUser( subm.getUserID().uid );
+        OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUID() );
+        User user = userService.getUser( subm.getUserID().getUID() );
 
-        ProgramInstance programInstance = programInstanceService.getProgramInstance( enrolmentid.uid );
+        ProgramInstance programInstance = programInstanceService.getProgramInstance( enrolmentid.getUID() );
         if ( programInstance == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_ENROLL.set( enrolmentid ) );
         }
 
-        ProgramStage programStage = programStageService.getProgramStage( stageid.uid );
+        ProgramStage programStage = programStageService.getProgramStage( stageid.getUID() );
         if ( programStage == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_STAGE.set( stageid ) );
         }
 
-        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.uid );
+        CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( aocid.getUID() );
         if ( aoc == null )
         {
             throw new SMSProcessingException( SMSResponse.INVALID_AOC.set( aocid ) );
         }
 
-        List<Object> errorUIDs = saveNewEvent( subm.getEvent().uid, orgUnit, programStage, programInstance, sms, aoc,
-            user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
+        List<Object> errorUIDs = saveNewEvent( subm.getEvent().getUID(), orgUnit, programStage, programInstance, sms,
+            aoc, user, subm.getValues(), subm.getEventStatus(), subm.getEventDate(), subm.getDueDate(),
             subm.getCoordinates() );
         if ( !errorUIDs.isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
@@ -45,9 +45,9 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.models.AggregateDatasetSMSSubmission;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.models.AggregateDatasetSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -154,7 +154,7 @@ public class AggregateDataSetSMSListenerTest
 
     @Before
     public void initTest()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         subject = new AggregateDataSetSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
@@ -220,7 +220,7 @@ public class AggregateDataSetSMSListenerTest
     }
 
     private void setUpInstances()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         organisationUnit = createOrganisationUnit( 'O' );
         user = createUser( 'U' );
@@ -233,25 +233,25 @@ public class AggregateDataSetSMSListenerTest
 
         incomingSmsAggregate = createSMSFromSubmission( createAggregateDatasetSubmission() );
 
-        AggregateDatasetSMSSubmission subm = createAggregateDatasetSubmission();
+        AggregateDatasetSmsSubmission subm = createAggregateDatasetSubmission();
         subm.setValues( null );
         incomingSmsAggregateNoValues = createSMSFromSubmission( subm );
     }
 
-    private AggregateDatasetSMSSubmission createAggregateDatasetSubmission()
+    private AggregateDatasetSmsSubmission createAggregateDatasetSubmission()
     {
-        AggregateDatasetSMSSubmission subm = new AggregateDatasetSMSSubmission();
+        AggregateDatasetSmsSubmission subm = new AggregateDatasetSmsSubmission();
 
-        subm.setUserID( user.getUid() );
+        subm.setUserId( user.getUid() );
         subm.setOrgUnit( organisationUnit.getUid() );
         subm.setDataSet( dataSet.getUid() );
         subm.setComplete( true );
         subm.setAttributeOptionCombo( categoryOptionCombo.getUid() );
         subm.setPeriod( "2019W16" );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "12345678" ) );
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "12345678" ) );
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/CompressionSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/CompressionSMSListenerTest.java
@@ -30,10 +30,10 @@ package org.hisp.dhis.sms.listener;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.sms.incoming.IncomingSms;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSSubmissionWriter;
-import org.hisp.dhis.smscompression.models.SMSMetadata;
-import org.hisp.dhis.smscompression.models.SMSSubmission;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
 import org.hisp.dhis.user.User;
 
 import java.util.Base64;
@@ -53,13 +53,13 @@ public abstract class CompressionSMSListenerTest
 
     protected static final String ATTRIBUTE_VALUE = "TEST";
 
-    protected IncomingSms createSMSFromSubmission( SMSSubmission subm )
-        throws SMSCompressionException
+    protected IncomingSms createSMSFromSubmission( SmsSubmission subm )
+        throws SmsCompressionException
     {
         User user = createUser( 'U' );
-        SMSMetadata meta = new SMSMetadata();
+        SmsMetadata meta = new SmsMetadata();
         meta.lastSyncDate = new Date();
-        SMSSubmissionWriter writer = new SMSSubmissionWriter( meta );
+        SmsSubmissionWriter writer = new SmsSubmissionWriter( meta );
         String smsText = Base64.getEncoder().encodeToString( writer.compress( subm ) );
 
         IncomingSms incomingSms = new IncomingSms();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
@@ -39,8 +39,8 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.models.DeleteSMSSubmission;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -122,7 +122,7 @@ public class DeleteEventSMSListenerTest
 
     @Before
     public void initTest()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         subject = new DeleteEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
@@ -157,7 +157,7 @@ public class DeleteEventSMSListenerTest
     }
 
     private void setUpInstances()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         user = createUser( 'U' );
         user.setPhoneNumber( ORIGINATOR );
@@ -168,13 +168,13 @@ public class DeleteEventSMSListenerTest
         incomingSmsDelete = createSMSFromSubmission( createDeleteSubmission() );
     }
 
-    private DeleteSMSSubmission createDeleteSubmission()
+    private DeleteSmsSubmission createDeleteSubmission()
     {
-        DeleteSMSSubmission subm = new DeleteSMSSubmission();
+        DeleteSmsSubmission subm = new DeleteSmsSubmission();
 
-        subm.setUserID( user.getUid() );
+        subm.setUserId( user.getUid() );
         subm.setEvent( programStageInstance.getUid() );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -49,14 +49,14 @@ import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEnrollmentStatus;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
-import org.hisp.dhis.smscompression.models.EnrollmentSMSSubmission;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.models.EnrollmentSmsSubmission;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SMSAttributeValue;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SMSEvent;
+import org.hisp.dhis.smscompression.models.SmsAttributeValue;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.SmsEvent;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -198,7 +198,7 @@ public class EnrollmentSMSListenerTest
 
     @Before
     public void initTest()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         subject = new EnrollmentSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
@@ -319,7 +319,7 @@ public class EnrollmentSMSListenerTest
     }
 
     private void setUpInstances()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         trackedEntityType = createTrackedEntityType( 'T' );
         organisationUnit = createOrganisationUnit( 'O' );
@@ -365,11 +365,11 @@ public class EnrollmentSMSListenerTest
         incomingSmsEnrollmentEventNoValues = createSMSFromSubmission( createEnrollmentSubmissionEventNoValues() );
     }
 
-    private EnrollmentSMSSubmission createEnrollmentSubmissionNoEvents()
+    private EnrollmentSmsSubmission createEnrollmentSubmissionNoEvents()
     {
-        EnrollmentSMSSubmission subm = new EnrollmentSMSSubmission();
+        EnrollmentSmsSubmission subm = new EnrollmentSmsSubmission();
 
-        subm.setUserID( user.getUid() );
+        subm.setUserId( user.getUid() );
         subm.setOrgUnit( organisationUnit.getUid() );
         subm.setTrackerProgram( program.getUid() );
         subm.setTrackedEntityType( trackedEntityType.getUid() );
@@ -377,47 +377,47 @@ public class EnrollmentSMSListenerTest
         subm.setEnrollment( programInstance.getUid() );
         subm.setEnrollmentDate( new Date() );
         subm.setIncidentDate( new Date() );
-        subm.setEnrollmentStatus( SMSEnrollmentStatus.ACTIVE );
+        subm.setEnrollmentStatus( SmsEnrollmentStatus.ACTIVE );
         subm.setCoordinates( new GeoPoint( 59.9399586f, 10.7195609f ) );
-        ArrayList<SMSAttributeValue> values = new ArrayList<>();
-        values.add( new SMSAttributeValue( trackedEntityAttribute.getUid(), ATTRIBUTE_VALUE ) );
+        ArrayList<SmsAttributeValue> values = new ArrayList<>();
+        values.add( new SmsAttributeValue( trackedEntityAttribute.getUid(), ATTRIBUTE_VALUE ) );
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    private EnrollmentSMSSubmission createEnrollmentSubmissionWithEvents()
+    private EnrollmentSmsSubmission createEnrollmentSubmissionWithEvents()
     {
-        EnrollmentSMSSubmission subm = createEnrollmentSubmissionNoEvents();
+        EnrollmentSmsSubmission subm = createEnrollmentSubmissionNoEvents();
 
-        ArrayList<SMSEvent> events = new ArrayList<>();
+        ArrayList<SmsEvent> events = new ArrayList<>();
         events.add( createEvent() );
         subm.setEvents( events );
         return subm;
     }
 
-    private SMSEvent createEvent()
+    private SmsEvent createEvent()
     {
-        SMSEvent event = new SMSEvent();
+        SmsEvent event = new SmsEvent();
         event.setOrgUnit( organisationUnit.getUid() );
         event.setProgramStage( programStage.getUid() );
         event.setAttributeOptionCombo( categoryOptionCombo.getUid() );
         event.setEvent( programStageInstance.getUid() );
-        event.setEventStatus( SMSEventStatus.COMPLETED );
+        event.setEventStatus( SmsEventStatus.COMPLETED );
         event.setEventDate( new Date() );
         event.setDueDate( new Date() );
         event.setCoordinates( new GeoPoint( 59.9399586f, 10.7195609f ) );
-        ArrayList<SMSDataValue> eventValues = new ArrayList<>();
-        eventValues.add( new SMSDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "10" ) );
+        ArrayList<SmsDataValue> eventValues = new ArrayList<>();
+        eventValues.add( new SmsDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "10" ) );
         event.setValues( eventValues );
 
         return event;
     }
 
-    private EnrollmentSMSSubmission createEnrollmentSubmissionWithNulls()
+    private EnrollmentSmsSubmission createEnrollmentSubmissionWithNulls()
     {
-        EnrollmentSMSSubmission subm = createEnrollmentSubmissionNoEvents();
+        EnrollmentSmsSubmission subm = createEnrollmentSubmissionNoEvents();
         subm.setEnrollmentDate( null );
         subm.setIncidentDate( null );
         subm.setCoordinates( null );
@@ -426,34 +426,34 @@ public class EnrollmentSMSListenerTest
         return subm;
     }
 
-    private EnrollmentSMSSubmission createEnrollmentSubmissionNoAttribs()
+    private EnrollmentSmsSubmission createEnrollmentSubmissionNoAttribs()
     {
-        EnrollmentSMSSubmission subm = createEnrollmentSubmissionNoEvents();
+        EnrollmentSmsSubmission subm = createEnrollmentSubmissionNoEvents();
         subm.setValues( null );
 
         return subm;
     }
 
-    private EnrollmentSMSSubmission createEnrollmentSubmissionEventWithNulls()
+    private EnrollmentSmsSubmission createEnrollmentSubmissionEventWithNulls()
     {
-        EnrollmentSMSSubmission subm = createEnrollmentSubmissionNoEvents();
-        SMSEvent event = createEvent();
+        EnrollmentSmsSubmission subm = createEnrollmentSubmissionNoEvents();
+        SmsEvent event = createEvent();
         event.setEventDate( null );
         event.setDueDate( null );
         event.setCoordinates( null );
-        ArrayList<SMSEvent> events = new ArrayList<>();
+        ArrayList<SmsEvent> events = new ArrayList<>();
         events.add( event );
         subm.setEvents( events );
 
         return subm;
     }
 
-    private EnrollmentSMSSubmission createEnrollmentSubmissionEventNoValues()
+    private EnrollmentSmsSubmission createEnrollmentSubmissionEventNoValues()
     {
-        EnrollmentSMSSubmission subm = createEnrollmentSubmissionNoEvents();
-        SMSEvent event = createEvent();
+        EnrollmentSmsSubmission subm = createEnrollmentSubmissionNoEvents();
+        SmsEvent event = createEvent();
         event.setValues( null );
-        ArrayList<SMSEvent> events = new ArrayList<>();
+        ArrayList<SmsEvent> events = new ArrayList<>();
         events.add( event );
         subm.setEvents( events );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.Before;
@@ -140,6 +141,9 @@ public class EnrollmentSMSListenerTest
     private ProgramInstanceService programInstanceService;
 
     @Mock
+    private TrackedEntityAttributeValueService attributeValueService;
+
+    @Mock
     private IdentifiableObjectManager identifiableObjectManager;
 
     EnrollmentSMSListener subject;
@@ -198,7 +202,7 @@ public class EnrollmentSMSListenerTest
     {
         subject = new EnrollmentSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageService, programStageInstanceService, teiService, programInstanceService,
+            programStageService, programStageInstanceService, attributeValueService, teiService, programInstanceService,
             identifiableObjectManager );
 
         setUpInstances();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.models.RelationshipSMSSubmission;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
@@ -143,7 +143,7 @@ public class RelationshipSMSListenerTest
 
     @Before
     public void initTest()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         subject = new RelationshipSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
@@ -181,7 +181,7 @@ public class RelationshipSMSListenerTest
     }
 
     private void setUpInstances()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         user = createUser( 'U' );
         user.setPhoneNumber( ORIGINATOR );
@@ -199,16 +199,16 @@ public class RelationshipSMSListenerTest
         incomingSmsRelationship = createSMSFromSubmission( createRelationshipSubmission() );
     }
 
-    private RelationshipSMSSubmission createRelationshipSubmission()
+    private RelationshipSmsSubmission createRelationshipSubmission()
     {
-        RelationshipSMSSubmission subm = new RelationshipSMSSubmission();
+        RelationshipSmsSubmission subm = new RelationshipSmsSubmission();
 
-        subm.setUserID( user.getUid() );
+        subm.setUserId( user.getUid() );
         subm.setRelationshipType( relationshipType.getUid() );
         subm.setRelationship( "uf3svrmpzOj" );
         subm.setFrom( programInstance.getUid() );
         subm.setTo( programInstance.getUid() );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -45,11 +45,11 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.SimpleEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -154,7 +154,7 @@ public class SimpleEventSMSListenerTest
 
     @Before
     public void initTest()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         subject = new SimpleEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
@@ -230,7 +230,7 @@ public class SimpleEventSMSListenerTest
     }
 
     private void setUpInstances()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         organisationUnit = createOrganisationUnit( 'O' );
         program = createProgram( 'P' );
@@ -256,30 +256,30 @@ public class SimpleEventSMSListenerTest
         incomingSmsSimpleEventNoValues = createSMSFromSubmission( createSimpleEventSubmissionNoValues() );
     }
 
-    private SimpleEventSMSSubmission createSimpleEventSubmission()
+    private SimpleEventSmsSubmission createSimpleEventSubmission()
     {
-        SimpleEventSMSSubmission subm = new SimpleEventSMSSubmission();
+        SimpleEventSmsSubmission subm = new SimpleEventSmsSubmission();
 
-        subm.setUserID( user.getUid() );
+        subm.setUserId( user.getUid() );
         subm.setOrgUnit( organisationUnit.getUid() );
         subm.setEventProgram( program.getUid() );
         subm.setAttributeOptionCombo( categoryOptionCombo.getUid() );
         subm.setEvent( programStageInstance.getUid() );
-        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setEventStatus( SmsEventStatus.COMPLETED );
         subm.setEventDate( new Date() );
         subm.setDueDate( new Date() );
         subm.setCoordinates( new GeoPoint( 59.9399586f, 10.7195609f ) );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "true" ) );
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "true" ) );
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    private SimpleEventSMSSubmission createSimpleEventSubmissionWithNulls()
+    private SimpleEventSmsSubmission createSimpleEventSubmissionWithNulls()
     {
-        SimpleEventSMSSubmission subm = createSimpleEventSubmission();
+        SimpleEventSmsSubmission subm = createSimpleEventSubmission();
         subm.setEventDate( null );
         subm.setDueDate( null );
         subm.setCoordinates( null );
@@ -287,9 +287,9 @@ public class SimpleEventSMSListenerTest
         return subm;
     }
 
-    private SimpleEventSMSSubmission createSimpleEventSubmissionNoValues()
+    private SimpleEventSmsSubmission createSimpleEventSubmissionNoValues()
     {
-        SimpleEventSMSSubmission subm = createSimpleEventSubmission();
+        SimpleEventSmsSubmission subm = createSimpleEventSubmission();
         subm.setValues( null );
 
         return subm;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
@@ -47,11 +47,11 @@ import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SMSCompressionException;
-import org.hisp.dhis.smscompression.SMSConsts.SMSEventStatus;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
 import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SMSDataValue;
-import org.hisp.dhis.smscompression.models.TrackerEventSMSSubmission;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
@@ -161,7 +161,7 @@ public class TrackerEventSMSListenerTest
 
     @Before
     public void initTest()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         subject = new TrackerEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
@@ -238,7 +238,7 @@ public class TrackerEventSMSListenerTest
     }
 
     private void setUpInstances()
-        throws SMSCompressionException
+        throws SmsCompressionException
     {
         organisationUnit = createOrganisationUnit( 'O' );
         program = createProgram( 'P' );
@@ -268,31 +268,31 @@ public class TrackerEventSMSListenerTest
         incomingSmsTrackerEventNoValues = createSMSFromSubmission( createTrackerEventSubmissionNoValues() );
     }
 
-    private TrackerEventSMSSubmission createTrackerEventSubmission()
+    private TrackerEventSmsSubmission createTrackerEventSubmission()
     {
-        TrackerEventSMSSubmission subm = new TrackerEventSMSSubmission();
+        TrackerEventSmsSubmission subm = new TrackerEventSmsSubmission();
 
-        subm.setUserID( user.getUid() );
+        subm.setUserId( user.getUid() );
         subm.setOrgUnit( organisationUnit.getUid() );
         subm.setProgramStage( programStage.getUid() );
         subm.setAttributeOptionCombo( categoryOptionCombo.getUid() );
         subm.setEnrollment( programInstance.getUid() );
         subm.setEvent( programStageInstance.getUid() );
-        subm.setEventStatus( SMSEventStatus.COMPLETED );
+        subm.setEventStatus( SmsEventStatus.COMPLETED );
         subm.setEventDate( new Date() );
         subm.setDueDate( new Date() );
         subm.setCoordinates( new GeoPoint( 59.9399586f, 10.7195609f ) );
-        ArrayList<SMSDataValue> values = new ArrayList<>();
-        values.add( new SMSDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "10" ) );
+        ArrayList<SmsDataValue> values = new ArrayList<>();
+        values.add( new SmsDataValue( categoryOptionCombo.getUid(), dataElement.getUid(), "10" ) );
         subm.setValues( values );
-        subm.setSubmissionID( 1 );
+        subm.setSubmissionId( 1 );
 
         return subm;
     }
 
-    private TrackerEventSMSSubmission createTrackerEventSubmissionWithNulls()
+    private TrackerEventSmsSubmission createTrackerEventSubmissionWithNulls()
     {
-        TrackerEventSMSSubmission subm = createTrackerEventSubmission();
+        TrackerEventSmsSubmission subm = createTrackerEventSubmission();
         subm.setEventDate( null );
         subm.setDueDate( null );
         subm.setCoordinates( null );
@@ -300,9 +300,9 @@ public class TrackerEventSMSListenerTest
         return subm;
     }
 
-    private TrackerEventSMSSubmission createTrackerEventSubmissionNoValues()
+    private TrackerEventSmsSubmission createTrackerEventSubmissionNoValues()
     {
-        TrackerEventSMSSubmission subm = createTrackerEventSubmission();
+        TrackerEventSmsSubmission subm = createTrackerEventSubmission();
         subm.setValues( null );
 
         return subm;


### PR DESCRIPTION
This PR simply updates all references to the change in the SMS compression library where all acronyms are written as camel case instead of upper case.

This PR needs to wait on two things:
~~1. The reference in the compression library needs to use the dhis2 version, once this PR is merged: https://github.com/dhis2/sms-compression/pull/5~~
2. The previous PR with fixes should be merged first: https://github.com/dhis2/dhis2-core/pull/5347