### PR TITLE
fix: [DHIS2-8691] Clearing cache from maintenance cleares appCache

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -190,10 +190,4 @@ public interface AppManager
      */
     boolean markAppToDelete( App app );
 
-    /**
-     * Event handler for {@link ApplicationCacheClearedEvent}.
-     *
-     * @param event the {@link ApplicationCacheClearedEvent}.
-     */
-    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -340,7 +340,9 @@ public class DefaultAppManager
     public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
     {
         appCache.invalidateAll();
-        log.info( "App cache cleared" );
+        reloadApps();
+        log.info( "App cache cleared and reloaded" );
+        
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -335,16 +335,6 @@ public class DefaultAppManager
         return getAppStorageServiceByApp( app ).getAppResource( app, pageName );
     }
 
-    @Override
-    @EventListener
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
-        appCache.invalidateAll();
-        reloadApps();
-        log.info( "App cache cleared and reloaded" );
-        
-    }
-
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Using spring application event publishers and listeners, we have started clearing certain caches (including appCache in AppManager), which empties the app list until the next reloadApps() is invoked. 