### PR TITLE
fix: [DHIS2-8691] Remove appCache clearing event listener

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -183,10 +183,4 @@ public interface AppManager
      */
     boolean markAppToDelete( App app );
 
-    /**
-     * Event handler for {@link ApplicationCacheClearedEvent}.
-     *
-     * @param event the {@link ApplicationCacheClearedEvent}.
-     */
-    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -335,14 +335,6 @@ public class DefaultAppManager
         return getAppStorageServiceByApp( app ).getAppResource( app, pageName );
     }
 
-    @Override
-    @EventListener
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
-        appCache.invalidateAll();
-        log.info( "App cache cleared" );
-    }
-
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------


### PR DESCRIPTION
When performing clear cache operation in data administration -> maintenance -> clear system cache, the user installed apps were disappearing. This was because appCache was not write through and clearing it without invoking reloadApps() will cause appList to always be empty. This event listener is now removed. 