### PR TITLE
fix: [DHIS2-8783] Add content length for file downloads supporting 3.0 servlet spec (master 2.35)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceContentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceContentStore.java
@@ -47,6 +47,13 @@ public interface FileResourceContentStore
      * @return a ByteSource which provides a stream to the content or null if the content cannot be found or read.
      */
     InputStream getFileResourceContent( String key );
+    
+    /**
+     * Get the content length of a FileResource from the file store.
+     * @param key the key.
+     * @return the content length
+     */
+    long getFileResourceContentLength( String key );
 
     /**
      * Save the contents of the byte array to the file store.
@@ -99,7 +106,6 @@ public interface FileResourceContentStore
      * Copies the content of a stream to the resource stored under key to the output stream.
      * @param key the key used to store a resource
      * @param output the output stream to copy the stream into
-     * @return the file content length
      */
-    long copyContent( String key, OutputStream output ) throws IOException, NoSuchElementException;
+    void copyContent( String key, OutputStream output ) throws IOException, NoSuchElementException;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -42,7 +42,7 @@ import java.util.NoSuchElementException;
 public interface FileResourceService
 {
     FileResource getFileResource( String uid );
-
+    
     List<FileResource> getFileResources( List<String> uids );
 
     List<FileResource> getOrphanedFileResources();
@@ -65,7 +65,7 @@ public interface FileResourceService
      * @throws IOException
      * @throws NoSuchElementException
      */
-    long copyFileResourceContent( FileResource fileResource, OutputStream outputStream )
+    void copyFileResourceContent( FileResource fileResource, OutputStream outputStream )
         throws IOException, NoSuchElementException;
 
     boolean fileResourceExists( String uid );
@@ -79,4 +79,6 @@ public interface FileResourceService
     List<FileResource> getExpiredFileResources( FileResourceRetentionStrategy retentionStrategy );
 
     List<FileResource> getAllUnProcessedImagesFiles();
+    
+    long getFileResourceContentLength( FileResource fileResource );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -117,7 +117,7 @@ public class DefaultFileResourceService
     {
         return checkStorageStatus( fileResourceStore.getByUid( uid ) );
     }
-
+    
     @Override
     @Transactional( readOnly = true )
     public List<FileResource> getFileResources( List<String> uids )
@@ -210,13 +210,20 @@ public class DefaultFileResourceService
     {
         return fileResourceContentStore.getFileResourceContent( fileResource.getStorageKey() );
     }
+    
+    @Override
+    @Transactional( readOnly = true )
+    public long getFileResourceContentLength( FileResource fileResource )
+    {
+        return fileResourceContentStore.getFileResourceContentLength( fileResource.getStorageKey() );
+    }
 
     @Override
     @Transactional( readOnly = true )
-    public long copyFileResourceContent( FileResource fileResource, OutputStream outputStream )
+    public void copyFileResourceContent( FileResource fileResource, OutputStream outputStream )
         throws IOException, NoSuchElementException
     {
-        return fileResourceContentStore.copyContent( fileResource.getStorageKey(), outputStream );
+        fileResourceContentStore.copyContent( fileResource.getStorageKey(), outputStream );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/JCloudsFileResourceContentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/JCloudsFileResourceContentStore.java
@@ -208,6 +208,19 @@ public class JCloudsFileResourceContentStore
             return null;
         }
     }
+    
+    @Override
+    public long getFileResourceContentLength( String key )
+    {
+        final Blob blob = getBlob( key );
+
+        if ( blob == null )
+        {
+            return 0;
+        }
+
+        return blob.getMetadata().getContentMetadata().getContentLength();
+    }
 
     @Override
     public String saveFileResourceContent( FileResource fileResource, byte[] bytes )
@@ -237,7 +250,7 @@ public class JCloudsFileResourceContentStore
     @Override
     public String saveFileResourceContent( FileResource fileResource, File file )
     {
-        Blob blob = createBlob( fileResource, StringUtils.EMPTY, file );
+        Blob blob = createBlob( fileResource, StringUtils.EMPTY, file, fileResource.getContentMd5() );
 
         if ( blob == null )
         {
@@ -274,8 +287,6 @@ public class JCloudsFileResourceContentStore
         {
             File file = entry.getValue();
 
-            fileResource.setContentLength( file.length() );
-
             String contentMd5;
 
             try
@@ -289,8 +300,7 @@ public class JCloudsFileResourceContentStore
                 return null;
             }
 
-            fileResource.setContentMd5( contentMd5 );
-            blob = createBlob( fileResource, entry.getKey().getDimension(), file );
+            blob = createBlob( fileResource, entry.getKey().getDimension(), file, contentMd5 );
 
             if ( blob != null )
             {
@@ -356,7 +366,7 @@ public class JCloudsFileResourceContentStore
     }
 
     @Override
-    public long copyContent( String key, OutputStream output )
+    public void copyContent( String key, OutputStream output )
         throws IOException, NoSuchElementException
     {
         if ( !blobExists( key ) )
@@ -370,8 +380,6 @@ public class JCloudsFileResourceContentStore
         {
             IOUtils.copy( in, output );
         }
-
-        return blob.getMetadata().getContentMetadata().getContentLength();
     }
 
     // -------------------------------------------------------------------------
@@ -397,19 +405,19 @@ public class JCloudsFileResourceContentStore
     {
         return blobStore.blobBuilder( fileResource.getStorageKey() )
             .payload( bytes )
-            .contentLength( fileResource.getContentLength() )
+            .contentLength( bytes.length )
             .contentMD5( HashCode.fromString( fileResource.getContentMd5() ) )
             .contentType( fileResource.getContentType() )
             .contentDisposition( "filename=" + fileResource.getName() )
             .build();
     }
 
-    private Blob createBlob( FileResource fileResource, String fileDimension, File file )
+    private Blob createBlob( FileResource fileResource, String fileDimension, File file, String contentMd5 )
     {
         return blobStore.blobBuilder( StringUtils.join( fileResource.getStorageKey(), fileDimension ) )
             .payload( file )
-            .contentLength( fileResource.getContentLength() )
-            .contentMD5( HashCode.fromString( fileResource.getContentMd5() ) )
+            .contentLength( file.length() )
+            .contentMD5( HashCode.fromString( contentMd5 ) )
             .contentType( fileResource.getContentType() )
             .contentDisposition( "filename=" + fileResource.getName() + fileDimension )
             .build();

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -130,7 +130,7 @@ public class FileResourceController
         }
 
         response.setContentType( fileResource.getContentType() );
-        response.setContentLength( new Long( fileResource.getContentLength() ).intValue() );
+        response.setHeader( HttpHeaders.CONTENT_LENGTH, String.valueOf( fileResourceService.getFileResourceContentLength( fileResource ) ) );
         response.setHeader( HttpHeaders.CONTENT_DISPOSITION, "filename=" + fileResource.getName() );
 
         try

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -524,10 +524,11 @@ public class DataValueController
 
         response.setContentType( fileResource.getContentType() );
         response.setHeader( HttpHeaders.CONTENT_DISPOSITION, "filename=" + fileResource.getName() );
+        response.setHeader( HttpHeaders.CONTENT_LENGTH, String.valueOf( fileResourceService.getFileResourceContentLength( fileResource ) ) );
         setNoStore( response );
         try
         {
-            response.setContentLengthLong( fileResourceService.copyFileResourceContent( fileResource, response.getOutputStream() ) );
+           fileResourceService.copyFileResourceContent( fileResource, response.getOutputStream() );
         }
         catch ( IOException e )
         {


### PR DESCRIPTION
Supporting servlet spec 3.0 dependency by changing "setContentLengthLong()" into "setHeader()".

Also changing the order of method invocation. Content length is set before the inputstream is copied into outputstream. 
