### PR TITLE
fix: Uid was null, causing Postgres constraint exceptions [DHIS2-8832]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -244,6 +244,8 @@ public class MapController
 
     private void mergeMapView( MapView view )
     {
+        view.setAutoFields();
+
         dimensionService.mergeAnalyticalObject( view );
         dimensionService.mergeEventAnalyticalObject( view );
 


### PR DESCRIPTION
When saving a new Map with a Layer/MapView, we were facing the DB exception (2.32)