### PR TITLE
fix: init DataElement proxy before caching it

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -28,10 +28,27 @@ package org.hisp.dhis.dxf2.events.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.SimpleCacheBuilder;
@@ -77,6 +94,7 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.hibernate.HibernateUtils;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.FeatureType;
@@ -130,36 +148,22 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Slf4j
 public abstract class AbstractEventService
-    implements EventService
+    implements
+    EventService
 {
-    public static final List<String> STATIC_EVENT_COLUMNS = Arrays.asList( EVENT_ID, EVENT_ENROLLMENT_ID, EVENT_CREATED_ID,
-        EVENT_LAST_UPDATED_ID, EVENT_STORED_BY_ID, EVENT_COMPLETED_BY_ID, EVENT_COMPLETED_DATE_ID,
+    public static final List<String> STATIC_EVENT_COLUMNS = Arrays.asList( EVENT_ID, EVENT_ENROLLMENT_ID,
+        EVENT_CREATED_ID, EVENT_LAST_UPDATED_ID, EVENT_STORED_BY_ID, EVENT_COMPLETED_BY_ID, EVENT_COMPLETED_DATE_ID,
         EVENT_EXECUTION_DATE_ID, EVENT_DUE_DATE_ID, EVENT_ORG_UNIT_ID, EVENT_ORG_UNIT_NAME, EVENT_STATUS_ID,
-        EVENT_PROGRAM_STAGE_ID, EVENT_PROGRAM_ID,
-        EVENT_ATTRIBUTE_OPTION_COMBO_ID, EVENT_DELETED, EVENT_GEOMETRY );
+        EVENT_PROGRAM_STAGE_ID, EVENT_PROGRAM_ID, EVENT_ATTRIBUTE_OPTION_COMBO_ID, EVENT_DELETED, EVENT_GEOMETRY );
 
     // -------------------------------------------------------------------------
     // Dependencies
@@ -325,11 +329,8 @@ public abstract class AbstractEventService
     private CachingMap<String, User> userCache = new CachingMap<>();
 
     private static Cache<DataElement> DATA_ELEM_CACHE = new SimpleCacheBuilder<DataElement>()
-        .forRegion( "dataElementCache" )
-        .expireAfterAccess( 60, TimeUnit.MINUTES )
-        .withInitialCapacity( 1000 )
-        .withMaximumSize( 50000 )
-        .build();
+        .forRegion( "dataElementCache" ).expireAfterAccess( 60, TimeUnit.MINUTES ).withInitialCapacity( 1000 )
+        .withMaximumSize( 50000 ).build();
 
     // -------------------------------------------------------------------------
     // CREATE
@@ -402,8 +403,8 @@ public abstract class AbstractEventService
 
         if ( jobId != null )
         {
-            notifier.notify( jobId, NotificationLevel.INFO, "Import done. Completed in " + clock.time() + ".", true ).
-                addJobSummary( jobId, importSummaries, ImportSummaries.class );
+            notifier.notify( jobId, NotificationLevel.INFO, "Import done. Completed in " + clock.time() + ".", true )
+                .addJobSummary( jobId, importSummaries, ImportSummaries.class );
         }
         else
         {
@@ -451,9 +452,10 @@ public abstract class AbstractEventService
     }
 
     /**
-     * Filters out Events which are already present in the database (regardless of the 'deleted' state)
+     * Filters out Events which are already present in the database (regardless of
+     * the 'deleted' state)
      *
-     * @param events          Events to import
+     * @param events Events to import
      * @param importSummaries ImportSummaries used for import
      * @return Events that is possible to import (pass validation)
      */
@@ -462,25 +464,20 @@ public abstract class AbstractEventService
 
         List<String> conflictingEventUids = checkForExistingEventsIncludingDeleted( events, importSummaries );
 
-        return events.stream()
-            .filter( e -> !conflictingEventUids.contains( e.getEvent() ) )
+        return events.stream().filter( e -> !conflictingEventUids.contains( e.getEvent() ) )
             .collect( Collectors.toList() );
     }
 
     private List<String> checkForExistingEventsIncludingDeleted( List<Event> events, ImportSummaries importSummaries )
     {
         List<String> foundEvents = programStageInstanceService.getProgramStageInstanceUidsIncludingDeleted(
-            events.stream()
-                .map( Event::getEvent )
-                .collect( Collectors.toList() )
-        );
+            events.stream().map( Event::getEvent ).collect( Collectors.toList() ) );
 
         for ( String foundEventUid : foundEvents )
         {
             ImportSummary is = new ImportSummary( ImportStatus.ERROR,
-                "Event " + foundEventUid + " already exists or was deleted earlier" )
-                .setReference( foundEventUid )
-                .incrementIgnored();
+                "Event " + foundEventUid + " already exists or was deleted earlier" ).setReference( foundEventUid )
+                    .incrementIgnored();
 
             importSummaries.addImportSummary( is );
         }
@@ -501,7 +498,8 @@ public abstract class AbstractEventService
 
             if ( jobId != null )
             {
-                notifier.notify( jobId, NotificationLevel.INFO, "Import done", true ).addJobSummary( jobId, importSummaries, ImportSummaries.class );
+                notifier.notify( jobId, NotificationLevel.INFO, "Import done", true ).addJobSummary( jobId,
+                    importSummaries, ImportSummaries.class );
             }
 
             return importSummaries;
@@ -510,7 +508,8 @@ public abstract class AbstractEventService
         {
             log.error( DebugUtils.getStackTrace( ex ) );
             notifier.notify( jobId, ERROR, "Process failed: " + ex.getMessage(), true );
-            return new ImportSummaries().addImportSummary( new ImportSummary( ImportStatus.ERROR, "The import process failed: " + ex.getMessage() ) );
+            return new ImportSummaries().addImportSummary(
+                new ImportSummary( ImportStatus.ERROR, "The import process failed: " + ex.getMessage() ) );
         }
     }
 
@@ -522,8 +521,7 @@ public abstract class AbstractEventService
         {
             return new ImportSummary( ImportStatus.ERROR,
                 "Event " + event.getEvent() + " already exists or was deleted earlier" )
-                .setReference( event.getEvent() )
-                .incrementIgnored();
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
         importOptions = updateImportOptions( importOptions );
@@ -532,23 +530,29 @@ public abstract class AbstractEventService
 
         if ( EventStatus.ACTIVE == event.getStatus() && event.getEventDate() == null )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event date is required. " ).setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR, "Event date is required. " ).setReference( event.getEvent() )
+                .incrementIgnored();
         }
 
-        if ( programStageInstance != null && (programStageInstance.isDeleted() || importOptions.getImportStrategy().isCreate()) )
+        if ( programStageInstance != null
+            && (programStageInstance.isDeleted() || importOptions.getImportStrategy().isCreate()) )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event ID " + event.getEvent() + " was already used and/or deleted. This event can not be modified." )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Event ID " + event.getEvent() + " was already used and/or deleted. This event can not be modified." )
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
-        if ( programStageInstance == null && !StringUtils.isEmpty( event.getEvent() ) && !CodeGenerator.isValidUid( event.getEvent() ) )
+        if ( programStageInstance == null && !StringUtils.isEmpty( event.getEvent() )
+            && !CodeGenerator.isValidUid( event.getEvent() ) )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event.event did not point to a valid event: " + event.getEvent() )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Event.event did not point to a valid event: " + event.getEvent() ).setReference( event.getEvent() )
+                    .incrementIgnored();
         }
 
         Program program = getProgram( importOptions.getIdSchemes().getProgramIdScheme(), event.getProgram() );
-        ProgramStage programStage = getProgramStage( importOptions.getIdSchemes().getProgramStageIdScheme(), event.getProgramStage() );
+        ProgramStage programStage = getProgramStage( importOptions.getIdSchemes().getProgramStageIdScheme(),
+            event.getProgramStage() );
         OrganisationUnit organisationUnit = getOrganisationUnit( importOptions.getIdSchemes(), event.getOrgUnit() );
         TrackedEntityInstance entityInstance = getTrackedEntityInstance( event.getTrackedEntityInstance() );
         ProgramInstance programInstance = getProgramInstance( event.getEnrollment() );
@@ -556,42 +560,53 @@ public abstract class AbstractEventService
 
         if ( organisationUnit == null )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event.orgUnit does not point to a valid organisation unit: " + event.getOrgUnit() )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Event.orgUnit does not point to a valid organisation unit: " + event.getOrgUnit() )
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
         if ( program == null )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event.program does not point to a valid program: " + event.getProgram() )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Event.program does not point to a valid program: " + event.getProgram() )
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
-        programStage = programStage == null && program.isWithoutRegistration() ? program.getProgramStageByStage( 1 ) : programStage;
+        programStage = programStage == null && program.isWithoutRegistration() ? program.getProgramStageByStage( 1 )
+            : programStage;
 
         if ( programStage == null )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event.programStage does not point to a valid programStage: " + event.getProgramStage() );
+            return new ImportSummary( ImportStatus.ERROR,
+                "Event.programStage does not point to a valid programStage: " + event.getProgramStage() );
         }
 
         if ( program.isRegistration() )
         {
             if ( entityInstance == null )
             {
-                return new ImportSummary( ImportStatus.ERROR, "Event.trackedEntityInstance does not point to a valid tracked entity instance: "
-                    + event.getTrackedEntityInstance() ).setReference( event.getEvent() ).incrementIgnored();
+                return new ImportSummary( ImportStatus.ERROR,
+                    "Event.trackedEntityInstance does not point to a valid tracked entity instance: "
+                        + event.getTrackedEntityInstance() ).setReference( event.getEvent() ).incrementIgnored();
             }
 
             if ( programInstance == null )
             {
-                List<ProgramInstance> programInstances = new ArrayList<>( programInstanceService.getProgramInstances( entityInstance, program, ProgramStatus.ACTIVE ) );
+                List<ProgramInstance> programInstances = new ArrayList<>(
+                    programInstanceService.getProgramInstances( entityInstance, program, ProgramStatus.ACTIVE ) );
 
                 if ( programInstances.isEmpty() )
                 {
-                    return new ImportSummary( ImportStatus.ERROR, "Tracked entity instance: " + entityInstance.getUid() + " is not enrolled in program: " + program.getUid() ).setReference( event.getEvent() ).incrementIgnored();
+                    return new ImportSummary( ImportStatus.ERROR, "Tracked entity instance: " + entityInstance.getUid()
+                        + " is not enrolled in program: " + program.getUid() ).setReference( event.getEvent() )
+                            .incrementIgnored();
                 }
                 else if ( programInstances.size() > 1 )
                 {
-                    return new ImportSummary( ImportStatus.ERROR, "Tracked entity instance: " + entityInstance.getUid() + " has multiple active enrollments in program: " + program.getUid() ).setReference( event.getEvent() ).incrementIgnored();
+                    return new ImportSummary( ImportStatus.ERROR,
+                        "Tracked entity instance: " + entityInstance.getUid()
+                            + " has multiple active enrollments in program: " + program.getUid() )
+                                .setReference( event.getEvent() ).incrementIgnored();
                 }
 
                 programInstance = programInstances.get( 0 );
@@ -599,8 +614,9 @@ public abstract class AbstractEventService
 
             if ( !programStage.getRepeatable() && programInstance.hasProgramStageInstance( programStage ) )
             {
-                return new ImportSummary( ImportStatus.ERROR, "Program stage is not repeatable and an event already exists" )
-                    .setReference( event.getEvent() ).incrementIgnored();
+                return new ImportSummary( ImportStatus.ERROR,
+                    "Program stage is not repeatable and an event already exists" ).setReference( event.getEvent() )
+                        .incrementIgnored();
             }
         }
         else
@@ -628,8 +644,9 @@ public abstract class AbstractEventService
             }
             else if ( programInstances.size() > 1 )
             {
-                return new ImportSummary( ImportStatus.ERROR, "Multiple active program instances exists for program: " + program.getUid() )
-                    .setReference( event.getEvent() ).incrementIgnored();
+                return new ImportSummary( ImportStatus.ERROR,
+                    "Multiple active program instances exists for program: " + program.getUid() )
+                        .setReference( event.getEvent() ).incrementIgnored();
             }
 
             programInstance = programInstances.get( 0 );
@@ -644,19 +661,22 @@ public abstract class AbstractEventService
 
         if ( !programInstance.getProgram().hasOrganisationUnit( organisationUnit ) )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Program is not assigned to this organisation unit: " + event.getOrgUnit() )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Program is not assigned to this organisation unit: " + event.getOrgUnit() )
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
         validateExpiryDays( importOptions, event, program, programStageInstance );
 
         if ( event.getGeometry() != null )
         {
-            if ( programStage.getFeatureType().equals( FeatureType.NONE ) || !programStage.getFeatureType().value().equals( event.getGeometry().getGeometryType() ) )
+            if ( programStage.getFeatureType().equals( FeatureType.NONE )
+                || !programStage.getFeatureType().value().equals( event.getGeometry().getGeometryType() ) )
             {
                 return new ImportSummary( ImportStatus.ERROR,
-                    "Geometry (" + event.getGeometry().getGeometryType() + ") does not conform to the feature type (" + programStage.getFeatureType().value() + ") specified for the program stage: " + programStage.getUid() )
-                    .setReference( event.getEvent() ).incrementIgnored();
+                    "Geometry (" + event.getGeometry().getGeometryType() + ") does not conform to the feature type ("
+                        + programStage.getFeatureType().value() + ") specified for the program stage: "
+                        + programStage.getUid() ).setReference( event.getEvent() ).incrementIgnored();
             }
 
             event.getGeometry().setSRID( GeoUtils.SRID );
@@ -671,12 +691,16 @@ public abstract class AbstractEventService
             }
             catch ( IOException e )
             {
-                return new ImportSummary( ImportStatus.ERROR, "Invalid longitude or latitude for property 'coordinates'." ).setReference( event.getEvent() ).incrementIgnored();
+                return new ImportSummary( ImportStatus.ERROR,
+                    "Invalid longitude or latitude for property 'coordinates'." ).setReference( event.getEvent() )
+                        .incrementIgnored();
             }
         }
 
         List<String> errors = trackerAccessManager.canCreate( importOptions.getUser(),
-            new ProgramStageInstance( programInstance, programStage ).setOrganisationUnit( organisationUnit ).setStatus( event.getStatus() ), false );
+            new ProgramStageInstance( programInstance, programStage ).setOrganisationUnit( organisationUnit )
+                .setStatus( event.getStatus() ),
+            false );
 
         if ( !errors.isEmpty() )
         {
@@ -686,7 +710,8 @@ public abstract class AbstractEventService
             return importSummary;
         }
 
-        return saveEvent( program, programInstance, programStage, programStageInstance, organisationUnit, event, assignedUser, importOptions, bulkImport );
+        return saveEvent( program, programInstance, programStage, programStageInstance, organisationUnit, event,
+            assignedUser, importOptions, bulkImport );
     }
 
     // -------------------------------------------------------------------------
@@ -820,11 +845,13 @@ public abstract class AbstractEventService
 
             if ( params.getProgramStage().getProgram().isRegistration() && user != null || !user.isSuper() )
             {
-                ProgramInstance enrollment = programInstanceService.getProgramInstance( event.get( EVENT_ENROLLMENT_ID ) );
+                ProgramInstance enrollment = programInstanceService
+                    .getProgramInstance( event.get( EVENT_ENROLLMENT_ID ) );
 
                 if ( enrollment != null && enrollment.getEntityInstance() != null )
                 {
-                    if ( !trackerOwnershipAccessManager.hasAccess( user, enrollment.getEntityInstance(), params.getProgramStage().getProgram() ) )
+                    if ( !trackerOwnershipAccessManager.hasAccess( user, enrollment.getEntityInstance(),
+                        params.getProgramStage().getProgram() ) )
                     {
                         continue;
                     }
@@ -866,26 +893,22 @@ public abstract class AbstractEventService
     @Override
     public int getAnonymousEventReadyForSynchronizationCount( Date skipChangedBefore )
     {
-        EventSearchParams params = new EventSearchParams()
-            .setProgramType( ProgramType.WITHOUT_REGISTRATION )
-            .setIncludeDeleted( true )
-            .setSynchronizationQuery( true )
-            .setSkipChangedBefore( skipChangedBefore );
+        EventSearchParams params = new EventSearchParams().setProgramType( ProgramType.WITHOUT_REGISTRATION )
+            .setIncludeDeleted( true ).setSynchronizationQuery( true ).setSkipChangedBefore( skipChangedBefore );
 
         return eventStore.getEventCount( params, null );
     }
 
     @Override
-    public Events getAnonymousEventsForSync( int pageSize, Date skipChangedBefore, Map<String, Set<String>> psdesWithSkipSyncTrue )
+    public Events getAnonymousEventsForSync( int pageSize, Date skipChangedBefore,
+        Map<String, Set<String>> psdesWithSkipSyncTrue )
     {
-        // A page is not specified here as it would lead to SQLGrammarException after a successful sync of few pages
+        // A page is not specified here as it would lead to SQLGrammarException after a
+        // successful sync of few pages
         // (total count will change and offset won't be valid)
 
-        EventSearchParams params = new EventSearchParams()
-            .setProgramType( ProgramType.WITHOUT_REGISTRATION )
-            .setIncludeDeleted( true )
-            .setSynchronizationQuery( true )
-            .setPageSize( pageSize )
+        EventSearchParams params = new EventSearchParams().setProgramType( ProgramType.WITHOUT_REGISTRATION )
+            .setIncludeDeleted( true ).setSynchronizationQuery( true ).setPageSize( pageSize )
             .setSkipChangedBefore( skipChangedBefore );
 
         Events anonymousEvents = new Events();
@@ -928,7 +951,8 @@ public abstract class AbstractEventService
 
     @Transactional( readOnly = true )
     @Override
-    public Event getEvent( ProgramStageInstance programStageInstance, boolean isSynchronizationQuery, boolean skipOwnershipCheck )
+    public Event getEvent( ProgramStageInstance programStageInstance, boolean isSynchronizationQuery,
+        boolean skipOwnershipCheck )
     {
         if ( programStageInstance == null )
         {
@@ -944,7 +968,8 @@ public abstract class AbstractEventService
         }
 
         event.setFollowup( programStageInstance.getProgramInstance().getFollowup() );
-        event.setEnrollmentStatus( EnrollmentStatus.fromProgramStatus( programStageInstance.getProgramInstance().getStatus() ) );
+        event.setEnrollmentStatus(
+            EnrollmentStatus.fromProgramStatus( programStageInstance.getProgramInstance().getStatus() ) );
         event.setStatus( programStageInstance.getStatus() );
         event.setEventDate( DateUtils.getIso8601NoTz( programStageInstance.getExecutionDate() ) );
         event.setDueDate( DateUtils.getIso8601NoTz( programStageInstance.getDueDate() ) );
@@ -1008,14 +1033,12 @@ public abstract class AbstractEventService
         }
         else
         {
-            Set<String> dataElementsToSync = programStageInstance.getProgramStage().getProgramStageDataElements().stream()
-                .filter( psde -> !psde.getSkipSynchronization() )
-                .map( psde -> psde.getDataElement().getUid() )
+            Set<String> dataElementsToSync = programStageInstance.getProgramStage().getProgramStageDataElements()
+                .stream().filter( psde -> !psde.getSkipSynchronization() ).map( psde -> psde.getDataElement().getUid() )
                 .collect( Collectors.toSet() );
 
             dataValues = programStageInstance.getEventDataValues().stream()
-                .filter( dv -> dataElementsToSync.contains( dv.getDataElement() ) )
-                .collect( Collectors.toSet() );
+                .filter( dv -> dataElementsToSync.contains( dv.getDataElement() ) ).collect( Collectors.toSet() );
         }
 
         for ( EventDataValue dataValue : dataValues )
@@ -1064,8 +1087,7 @@ public abstract class AbstractEventService
 
         event.setRelationships( programStageInstance.getRelationshipItems().stream()
             .map( ( r ) -> relationshipService.getRelationship( r.getRelationship(), RelationshipParams.FALSE, user ) )
-            .collect( Collectors.toSet() )
-        );
+            .collect( Collectors.toSet() ) );
 
         return event;
     }
@@ -1078,8 +1100,9 @@ public abstract class AbstractEventService
         Date lastUpdatedStartDate, Date lastUpdatedEndDate, String lastUpdatedDuration, EventStatus status,
         CategoryOptionCombo attributeOptionCombo, IdSchemes idSchemes, Integer page, Integer pageSize,
         boolean totalPages, boolean skipPaging, List<Order> orders, List<String> gridOrders, boolean includeAttributes,
-        Set<String> events, Boolean skipEventId, AssignedUserSelectionMode assignedUserSelectionMode, Set<String> assignedUsers,
-        Set<String> filters, Set<String> dataElements, boolean includeAllDataElements, boolean includeDeleted )
+        Set<String> events, Boolean skipEventId, AssignedUserSelectionMode assignedUserSelectionMode,
+        Set<String> assignedUsers, Set<String> filters, Set<String> dataElements, boolean includeAllDataElements,
+        boolean includeDeleted )
     {
         User user = currentUserService.getCurrentUser();
         UserCredentials userCredentials = user.getUserCredentials();
@@ -1130,12 +1153,15 @@ public abstract class AbstractEventService
 
         if ( !StringUtils.isEmpty( trackedEntityInstance ) && tei == null )
         {
-            throw new IllegalQueryException( "Tracked entity instance is specified but does not exist: " + trackedEntityInstance );
+            throw new IllegalQueryException(
+                "Tracked entity instance is specified but does not exist: " + trackedEntityInstance );
         }
 
-        if ( attributeOptionCombo != null && !userCredentials.isSuper() && !aclService.canDataRead( user, attributeOptionCombo ) )
+        if ( attributeOptionCombo != null && !userCredentials.isSuper()
+            && !aclService.canDataRead( user, attributeOptionCombo ) )
         {
-            throw new IllegalQueryException( "User has no access to attribute category option combo: " + attributeOptionCombo.getUid() );
+            throw new IllegalQueryException(
+                "User has no access to attribute category option combo: " + attributeOptionCombo.getUid() );
         }
 
         if ( events != null && filters != null )
@@ -1175,40 +1201,21 @@ public abstract class AbstractEventService
         if ( assignedUserSelectionMode != null && assignedUsers != null && !assignedUsers.isEmpty()
             && !assignedUserSelectionMode.equals( AssignedUserSelectionMode.PROVIDED ) )
         {
-            throw new IllegalQueryException( "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
+            throw new IllegalQueryException(
+                "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
         }
 
-        return params
-            .setProgram( pr )
-            .setProgramStage( ps )
-            .setOrgUnit( ou )
-            .setTrackedEntityInstance( tei )
-            .setProgramStatus( programStatus )
-            .setFollowUp( followUp )
-            .setOrgUnitSelectionMode( orgUnitSelectionMode )
-            .setAssignedUserSelectionMode( assignedUserSelectionMode )
-            .setAssignedUsers( assignedUsers )
-            .setStartDate( startDate )
-            .setEndDate( endDate )
-            .setDueDateStart( dueDateStart )
-            .setDueDateEnd( dueDateEnd )
-            .setLastUpdatedStartDate( lastUpdatedStartDate )
-            .setLastUpdatedEndDate( lastUpdatedEndDate )
-            .setLastUpdatedDuration( lastUpdatedDuration )
-            .setEventStatus( status )
-            .setCategoryOptionCombo( attributeOptionCombo )
-            .setIdSchemes( idSchemes )
-            .setPage( page )
-            .setPageSize( pageSize )
-            .setTotalPages( totalPages )
-            .setSkipPaging( skipPaging )
-            .setSkipEventId( skipEventId )
-            .setIncludeAttributes( includeAttributes )
-            .setIncludeAllDataElements( includeAllDataElements )
-            .setOrders( orders )
-            .setGridOrders( gridOrders )
-            .setEvents( events )
-            .setIncludeDeleted( includeDeleted );
+        return params.setProgram( pr ).setProgramStage( ps ).setOrgUnit( ou ).setTrackedEntityInstance( tei )
+            .setProgramStatus( programStatus ).setFollowUp( followUp ).setOrgUnitSelectionMode( orgUnitSelectionMode )
+            .setAssignedUserSelectionMode( assignedUserSelectionMode ).setAssignedUsers( assignedUsers )
+            .setStartDate( startDate ).setEndDate( endDate ).setDueDateStart( dueDateStart ).setDueDateEnd( dueDateEnd )
+            .setLastUpdatedStartDate( lastUpdatedStartDate ).setLastUpdatedEndDate( lastUpdatedEndDate )
+            .setLastUpdatedDuration( lastUpdatedDuration ).setEventStatus( status )
+            .setCategoryOptionCombo( attributeOptionCombo ).setIdSchemes( idSchemes ).setPage( page )
+            .setPageSize( pageSize ).setTotalPages( totalPages ).setSkipPaging( skipPaging )
+            .setSkipEventId( skipEventId ).setIncludeAttributes( includeAttributes )
+            .setIncludeAllDataElements( includeAllDataElements ).setOrders( orders ).setGridOrders( gridOrders )
+            .setEvents( events ).setIncludeDeleted( includeDeleted );
     }
 
     // -------------------------------------------------------------------------
@@ -1217,7 +1224,8 @@ public abstract class AbstractEventService
 
     @Transactional
     @Override
-    public ImportSummaries updateEvents( List<Event> events, ImportOptions importOptions, boolean singleValue, boolean clearSession )
+    public ImportSummaries updateEvents( List<Event> events, ImportOptions importOptions, boolean singleValue,
+        boolean clearSession )
     {
         ImportSummaries importSummaries = new ImportSummaries();
         importOptions = updateImportOptions( importOptions );
@@ -1253,7 +1261,8 @@ public abstract class AbstractEventService
 
     @Transactional
     @Override
-    public ImportSummary updateEvent( Event event, boolean singleValue, ImportOptions importOptions, boolean bulkUpdate )
+    public ImportSummary updateEvent( Event event, boolean singleValue, ImportOptions importOptions,
+        boolean bulkUpdate )
     {
         importOptions = updateImportOptions( importOptions );
 
@@ -1274,10 +1283,12 @@ public abstract class AbstractEventService
             return importSummary.incrementIgnored();
         }
 
-        if ( programStageInstance != null && (programStageInstance.isDeleted() || importOptions.getImportStrategy().isCreate()) )
+        if ( programStageInstance != null
+            && (programStageInstance.isDeleted() || importOptions.getImportStrategy().isCreate()) )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Event ID " + event.getEvent() + " was already used and/or deleted. This event can not be modified." )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Event ID " + event.getEvent() + " was already used and/or deleted. This event can not be modified." )
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
         List<String> errors = trackerAccessManager.canUpdate( importOptions.getUser(), programStageInstance, false );
@@ -1298,7 +1309,8 @@ public abstract class AbstractEventService
 
         if ( program == null )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Program '" + event.getProgram() + "' for event '" + event.getEvent() + "' was not found." );
+            return new ImportSummary( ImportStatus.ERROR,
+                "Program '" + event.getProgram() + "' for event '" + event.getEvent() + "' was not found." );
         }
 
         errors = validateEvent( event, programStageInstance.getProgramInstance(), importOptions );
@@ -1306,7 +1318,8 @@ public abstract class AbstractEventService
         if ( !errors.isEmpty() )
         {
             importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.getConflicts().addAll( errors.stream().map( s -> new ImportConflict( "Event", s ) ).collect( Collectors.toList() ) );
+            importSummary.getConflicts()
+                .addAll( errors.stream().map( s -> new ImportConflict( "Event", s ) ).collect( Collectors.toList() ) );
             importSummary.incrementIgnored();
 
             return importSummary;
@@ -1325,10 +1338,12 @@ public abstract class AbstractEventService
             dueDate = DateUtils.parseDate( event.getDueDate() );
         }
 
-        String storedBy = getValidUsername( event.getStoredBy(), null, User.username( importOptions.getUser(), Constants.UNKNOWN ) );
+        String storedBy = getValidUsername( event.getStoredBy(), null,
+            User.username( importOptions.getUser(), Constants.UNKNOWN ) );
         programStageInstance.setStoredBy( storedBy );
 
-        String completedBy = getValidUsername( event.getCompletedBy(), null, User.username( importOptions.getUser(), Constants.UNKNOWN ) );
+        String completedBy = getValidUsername( event.getCompletedBy(), null,
+            User.username( importOptions.getUser(), Constants.UNKNOWN ) );
 
         if ( event.getStatus() != programStageInstance.getStatus()
             && programStageInstance.getStatus() == EventStatus.COMPLETED )
@@ -1387,21 +1402,24 @@ public abstract class AbstractEventService
 
             try
             {
-                aoc = getAttributeOptionCombo( program.getCategoryCombo(),
-                    event.getAttributeCategoryOptions(), event.getAttributeOptionCombo(), idScheme );
+                aoc = getAttributeOptionCombo( program.getCategoryCombo(), event.getAttributeCategoryOptions(),
+                    event.getAttributeOptionCombo(), idScheme );
             }
             catch ( IllegalQueryException ex )
             {
                 importSummary.setStatus( ImportStatus.ERROR );
-                importSummary.getConflicts().add( new ImportConflict( ex.getMessage(), event.getAttributeCategoryOptions() ) );
+                importSummary.getConflicts()
+                    .add( new ImportConflict( ex.getMessage(), event.getAttributeCategoryOptions() ) );
                 return importSummary.incrementIgnored();
             }
         }
 
-        if ( aoc != null && aoc.isDefault() && program.getCategoryCombo() != null && !program.getCategoryCombo().isDefault() )
+        if ( aoc != null && aoc.isDefault() && program.getCategoryCombo() != null
+            && !program.getCategoryCombo().isDefault() )
         {
             importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.getConflicts().add( new ImportConflict( "attributeOptionCombo", "Default attribute option combo is not allowed since program has non-default category combo" ) );
+            importSummary.getConflicts().add( new ImportConflict( "attributeOptionCombo",
+                "Default attribute option combo is not allowed since program has non-default category combo" ) );
             return importSummary.incrementIgnored();
         }
 
@@ -1410,19 +1428,23 @@ public abstract class AbstractEventService
             programStageInstance.setAttributeOptionCombo( aoc );
         }
 
-        Date eventDate = programStageInstance.getExecutionDate() != null ? programStageInstance.getExecutionDate() : programStageInstance.getDueDate();
+        Date eventDate = programStageInstance.getExecutionDate() != null ? programStageInstance.getExecutionDate()
+            : programStageInstance.getDueDate();
 
         validateAttributeOptionComboDate( aoc, eventDate );
 
         if ( event.getGeometry() != null )
         {
-            if ( programStageInstance.getProgramStage().getFeatureType().equals( FeatureType.NONE ) ||
-                !programStageInstance.getProgramStage().getFeatureType().value().equals( event.getGeometry().getGeometryType() ) )
+            if ( programStageInstance.getProgramStage().getFeatureType().equals( FeatureType.NONE )
+                || !programStageInstance.getProgramStage().getFeatureType().value()
+                    .equals( event.getGeometry().getGeometryType() ) )
             {
-                return new ImportSummary( ImportStatus.ERROR, String.format(
-                    "Geometry '%s' does not conform to the feature type '%s' specified for the program stage: '%s'",
-                    programStageInstance.getProgramStage().getUid(), event.getGeometry().getGeometryType(), programStageInstance.getProgramStage().getFeatureType().value() ) )
-                    .setReference( event.getEvent() ).incrementIgnored();
+                return new ImportSummary( ImportStatus.ERROR,
+                    String.format(
+                        "Geometry '%s' does not conform to the feature type '%s' specified for the program stage: '%s'",
+                        programStageInstance.getProgramStage().getUid(), event.getGeometry().getGeometryType(),
+                        programStageInstance.getProgramStage().getFeatureType().value() ) )
+                            .setReference( event.getEvent() ).incrementIgnored();
             }
 
             event.getGeometry().setSRID( GeoUtils.SRID );
@@ -1452,7 +1474,8 @@ public abstract class AbstractEventService
         saveTrackedEntityComment( programStageInstance, event, storedBy );
         preheatDataElementsCache( event, importOptions );
 
-        eventDataValueService.processDataValues( programStageInstance, event, singleValue, importOptions, importSummary, DATA_ELEM_CACHE );
+        eventDataValueService.processDataValues( programStageInstance, event, singleValue, importOptions, importSummary,
+            DATA_ELEM_CACHE );
 
         programStageInstanceService.updateProgramStageInstance( programStageInstance );
 
@@ -1507,11 +1530,10 @@ public abstract class AbstractEventService
     {
         IdScheme dataElementIdScheme = importOptions.getIdSchemes().getDataElementIdScheme();
 
-        Set<String> dataElementIdentificators = event.getDataValues().stream()
-            .map( DataValue::getDataElement )
+        Set<String> dataElementIdentificators = event.getDataValues().stream().map( DataValue::getDataElement )
             .collect( Collectors.toSet() );
 
-        //Should happen in the most of the cases
+        // Should happen in the most of the cases
         if ( dataElementIdScheme.isNull() || dataElementIdScheme.is( IdentifiableProperty.UID ) )
         {
             List<DataElement> dataElements = manager.getObjects( DataElement.class, IdentifiableProperty.UID,
@@ -1521,7 +1543,7 @@ public abstract class AbstractEventService
         }
         else
         {
-            //Slower, but shouldn't happen so often
+            // Slower, but shouldn't happen so often
             dataElementIdentificators.forEach( deId -> getDataElement( dataElementIdScheme, deId ) );
         }
     }
@@ -1558,7 +1580,8 @@ public abstract class AbstractEventService
             return;
         }
 
-        List<String> errors = trackerAccessManager.canUpdate( currentUserService.getCurrentUser(), programStageInstance, false );
+        List<String> errors = trackerAccessManager.canUpdate( currentUserService.getCurrentUser(), programStageInstance,
+            false );
 
         if ( !errors.isEmpty() )
         {
@@ -1621,7 +1644,8 @@ public abstract class AbstractEventService
         {
             ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( uid );
 
-            List<String> errors = trackerAccessManager.canDelete( currentUserService.getCurrentUser(), programStageInstance, false );
+            List<String> errors = trackerAccessManager.canDelete( currentUserService.getCurrentUser(),
+                programStageInstance, false );
 
             if ( !errors.isEmpty() )
             {
@@ -1632,16 +1656,19 @@ public abstract class AbstractEventService
 
             if ( programStageInstance.getProgramStage().getProgram().isRegistration() )
             {
-                entityInstanceService.updateTrackedEntityInstance( programStageInstance.getProgramInstance().getEntityInstance() );
+                entityInstanceService
+                    .updateTrackedEntityInstance( programStageInstance.getProgramInstance().getEntityInstance() );
             }
 
-            ImportSummary importSummary = new ImportSummary( ImportStatus.SUCCESS, "Deletion of event " + uid + " was successful" ).incrementDeleted();
+            ImportSummary importSummary = new ImportSummary( ImportStatus.SUCCESS,
+                "Deletion of event " + uid + " was successful" ).incrementDeleted();
             importSummary.setReference( uid );
             return importSummary;
         }
         else
         {
-            return new ImportSummary( ImportStatus.SUCCESS, "Event " + uid + " cannot be deleted as it is not present in the system" ).incrementIgnored();
+            return new ImportSummary( ImportStatus.SUCCESS,
+                "Event " + uid + " cannot be deleted as it is not present in the system" ).incrementIgnored();
         }
     }
 
@@ -1686,7 +1713,8 @@ public abstract class AbstractEventService
             Query query = Query.from( schemaService.getDynamicSchema( OrganisationUnit.class ) );
             query.setUser( user );
             query.add( Restrictions.in( "id", orgUnits ) );
-            queryService.query( query ).forEach( ou -> organisationUnitCache.put( ou.getUid(), (OrganisationUnit) ou ) );
+            queryService.query( query )
+                .forEach( ou -> organisationUnitCache.put( ou.getUid(), (OrganisationUnit) ou ) );
         }
 
         if ( !programIds.isEmpty() )
@@ -1702,7 +1730,8 @@ public abstract class AbstractEventService
                 for ( Program program : programs )
                 {
                     programCache.put( program.getUid(), program );
-                    programStageCache.putAll( program.getProgramStages().stream().collect( Collectors.toMap( ProgramStage::getUid, ps -> ps ) ) );
+                    programStageCache.putAll( program.getProgramStages().stream()
+                        .collect( Collectors.toMap( ProgramStage::getUid, ps -> ps ) ) );
 
                     for ( ProgramStage programStage : program.getProgramStages() )
                     {
@@ -1717,18 +1746,19 @@ public abstract class AbstractEventService
 
         if ( !eventIds.isEmpty() )
         {
-            eventSyncService.getEvents( (List<String>) eventIds ).forEach( psi -> programStageInstanceCache.put( psi.getUid(), psi ) );
+            eventSyncService.getEvents( (List<String>) eventIds )
+                .forEach( psi -> programStageInstanceCache.put( psi.getUid(), psi ) );
 
-            manager.getObjects( TrackedEntityInstance.class, IdentifiableProperty.UID,
-                events.stream()
-                    .filter( event -> event.getTrackedEntityInstance() != null )
-                    .map( Event::getTrackedEntityInstance ).collect( Collectors.toSet() ) )
+            manager
+                .getObjects( TrackedEntityInstance.class, IdentifiableProperty.UID,
+                    events.stream().filter( event -> event.getTrackedEntityInstance() != null )
+                        .map( Event::getTrackedEntityInstance ).collect( Collectors.toSet() ) )
                 .forEach( tei -> trackedEntityInstanceCache.put( tei.getUid(), tei ) );
 
-            manager.getObjects( ProgramInstance.class, IdentifiableProperty.UID,
-                events.stream()
-                    .filter( event -> event.getEnrollment() != null )
-                    .map( Event::getEnrollment ).collect( Collectors.toSet() ) )
+            manager
+                .getObjects( ProgramInstance.class, IdentifiableProperty.UID,
+                    events.stream().filter( event -> event.getEnrollment() != null ).map( Event::getEnrollment )
+                        .collect( Collectors.toSet() ) )
                 .forEach( tei -> programInstanceCache.put( tei.getUid(), tei ) );
         }
 
@@ -1737,7 +1767,8 @@ public abstract class AbstractEventService
             Query query = Query.from( schemaService.getDynamicSchema( User.class ) );
             query.setUser( user );
             query.add( Restrictions.in( "id", userIds ) );
-            queryService.query( query ).forEach( assignedUser -> userCache.put( assignedUser.getUid(), (User) assignedUser ) );
+            queryService.query( query )
+                .forEach( assignedUser -> userCache.put( assignedUser.getUid(), (User) assignedUser ) );
         }
     }
 
@@ -1786,7 +1817,8 @@ public abstract class AbstractEventService
         if ( !errors.isEmpty() )
         {
             importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.getConflicts().addAll( errors.stream().map( s -> new ImportConflict( "Event", s ) ).collect( Collectors.toList() ) );
+            importSummary.getConflicts()
+                .addAll( errors.stream().map( s -> new ImportConflict( "Event", s ) ).collect( Collectors.toList() ) );
             importSummary.incrementIgnored();
 
             return importSummary;
@@ -1808,8 +1840,10 @@ public abstract class AbstractEventService
 
         User user = importOptions.getUser();
 
-        String storedBy = getValidUsername( event.getStoredBy(), importSummary, User.username( user, Constants.UNKNOWN ) );
-        String completedBy = getValidUsername( event.getCompletedBy(), importSummary, User.username( user, Constants.UNKNOWN ) );
+        String storedBy = getValidUsername( event.getStoredBy(), importSummary,
+            User.username( user, Constants.UNKNOWN ) );
+        String completedBy = getValidUsername( event.getCompletedBy(), importSummary,
+            User.username( user, Constants.UNKNOWN ) );
 
         CategoryOptionCombo aoc;
 
@@ -1825,7 +1859,8 @@ public abstract class AbstractEventService
             }
             catch ( IllegalQueryException ex )
             {
-                importSummary.getConflicts().add( new ImportConflict( ex.getMessage(), event.getAttributeCategoryOptions() ) );
+                importSummary.getConflicts()
+                    .add( new ImportConflict( ex.getMessage(), event.getAttributeCategoryOptions() ) );
                 importSummary.setStatus( ImportStatus.ERROR );
                 return importSummary.incrementIgnored();
             }
@@ -1835,9 +1870,11 @@ public abstract class AbstractEventService
             aoc = (CategoryOptionCombo) getDefaultObject( CategoryOptionCombo.class );
         }
 
-        if ( aoc != null && aoc.isDefault() && program.getCategoryCombo() != null && !program.getCategoryCombo().isDefault() )
+        if ( aoc != null && aoc.isDefault() && program.getCategoryCombo() != null
+            && !program.getCategoryCombo().isDefault() )
         {
-            importSummary.getConflicts().add( new ImportConflict( "attributeOptionCombo", "Default attribute option combo is not allowed since program has non-default category combo" ) );
+            importSummary.getConflicts().add( new ImportConflict( "attributeOptionCombo",
+                "Default attribute option combo is not allowed since program has non-default category combo" ) );
             importSummary.setStatus( ImportStatus.ERROR );
             return importSummary.incrementIgnored();
         }
@@ -1851,7 +1888,8 @@ public abstract class AbstractEventService
         if ( !errors.isEmpty() )
         {
             importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.getConflicts().addAll( errors.stream().map( s -> new ImportConflict( "CategoryOptionCombo", s ) ).collect( Collectors.toList() ) );
+            importSummary.getConflicts().addAll( errors.stream()
+                .map( s -> new ImportConflict( "CategoryOptionCombo", s ) ).collect( Collectors.toList() ) );
             importSummary.incrementIgnored();
 
             return importSummary;
@@ -1862,8 +1900,8 @@ public abstract class AbstractEventService
             if ( programStageInstance == null )
             {
                 programStageInstance = createProgramStageInstance( event, programStage, programInstance,
-                    organisationUnit, dueDate, executionDate, event.getStatus().getValue(),
-                    completedBy, storedBy, event.getEvent(), aoc, assignedUser, importOptions, importSummary );
+                    organisationUnit, dueDate, executionDate, event.getStatus().getValue(), completedBy, storedBy,
+                    event.getEvent(), aoc, assignedUser, importOptions, importSummary );
 
                 if ( program.isRegistration() )
                 {
@@ -1873,8 +1911,8 @@ public abstract class AbstractEventService
             else
             {
                 updateProgramStageInstance( event, programStage, programInstance, organisationUnit, dueDate,
-                    executionDate, event.getStatus().getValue(), completedBy, storedBy,
-                    programStageInstance, aoc, assignedUser, importOptions, importSummary );
+                    executionDate, event.getStatus().getValue(), completedBy, storedBy, programStageInstance, aoc,
+                    assignedUser, importOptions, importSummary );
             }
 
             if ( !importOptions.isSkipLastUpdated() )
@@ -1888,9 +1926,12 @@ public abstract class AbstractEventService
         if ( dryRun && programStageInstance == null )
         {
 
-            log.error( "The request is a dry run and at the same time the programStageInstance is null. This will lead to NullPointerException. Stopping it now." );
+            log.error(
+                "The request is a dry run and at the same time the programStageInstance is null. This will lead to NullPointerException. Stopping it now." );
             importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.setDescription( "The request is a dryRun. However, the provided event does not point to a valid event: " + event.getEvent() + ". Cannot continue." );
+            importSummary.setDescription(
+                "The request is a dryRun. However, the provided event does not point to a valid event: "
+                    + event.getEvent() + ". Cannot continue." );
 
             return importSummary.setReference( event.getEvent() ).incrementIgnored();
         }
@@ -1918,7 +1959,8 @@ public abstract class AbstractEventService
         {
             if ( programStageInstance.isCompleted() )
             {
-                eventPublisher.publishEvent( new ProgramStageCompletionNotificationEvent( this, programStageInstance.getId() ) );
+                eventPublisher
+                    .publishEvent( new ProgramStageCompletionNotificationEvent( this, programStageInstance.getId() ) );
                 eventPublisher.publishEvent( new StageCompletionEvaluationEvent( this, programStageInstance.getId() ) );
             }
 
@@ -1931,8 +1973,8 @@ public abstract class AbstractEventService
 
     private ProgramStageInstance createProgramStageInstance( Event event, ProgramStage programStage,
         ProgramInstance programInstance, OrganisationUnit organisationUnit, Date dueDate, Date executionDate,
-        int status, String completedBy, String storedBy, String programStageInstanceIdentifier,
-        CategoryOptionCombo aoc, User assignedUser, ImportOptions importOptions, ImportSummary importSummary )
+        int status, String completedBy, String storedBy, String programStageInstanceIdentifier, CategoryOptionCombo aoc,
+        User assignedUser, ImportOptions importOptions, ImportSummary importSummary )
     {
         ProgramStageInstance programStageInstance = new ProgramStageInstance();
 
@@ -1957,8 +1999,8 @@ public abstract class AbstractEventService
     }
 
     private void updateProgramStageInstance( Event event, ProgramStage programStage, ProgramInstance programInstance,
-        OrganisationUnit organisationUnit, Date dueDate, Date executionDate, int status,
-        String completedBy, String storedBy, ProgramStageInstance programStageInstance, CategoryOptionCombo aoc, User assignedUser,
+        OrganisationUnit organisationUnit, Date dueDate, Date executionDate, int status, String completedBy,
+        String storedBy, ProgramStageInstance programStageInstance, CategoryOptionCombo aoc, User assignedUser,
         ImportOptions importOptions, ImportSummary importSummary )
     {
         programStageInstance.setProgramInstance( programInstance );
@@ -1998,12 +2040,14 @@ public abstract class AbstractEventService
             programStageInstance.setAutoFields();
             programStageInstanceService.addProgramStageInstance( programStageInstance );
 
-            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary, DATA_ELEM_CACHE );
+            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary,
+                DATA_ELEM_CACHE );
             programStageInstanceService.updateProgramStageInstance( programStageInstance );
         }
         else
         {
-            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary, DATA_ELEM_CACHE );
+            eventDataValueService.processDataValues( programStageInstance, event, false, importOptions, importSummary,
+                DATA_ELEM_CACHE );
             programStageInstanceService.updateProgramStageInstance( programStageInstance );
         }
     }
@@ -2041,8 +2085,8 @@ public abstract class AbstractEventService
         {
             if ( importSummary != null )
             {
-                importSummary.getConflicts().add( new ImportConflict( "Username",
-                    userName + " is more than " + UserCredentials.USERNAME_MAX_LENGTH + " characters, using current username instead" ) );
+                importSummary.getConflicts().add( new ImportConflict( "Username", userName + " is more than "
+                    + UserCredentials.USERNAME_MAX_LENGTH + " characters, using current username instead" ) );
             }
 
             return fallbackUsername;
@@ -2147,7 +2191,8 @@ public abstract class AbstractEventService
             {
                 programCache.put( id, program );
 
-                programStageCache.putAll( program.getProgramStages().stream().collect( Collectors.toMap( ProgramStage::getUid, ps -> ps ) ) );
+                programStageCache.putAll(
+                    program.getProgramStages().stream().collect( Collectors.toMap( ProgramStage::getUid, ps -> ps ) ) );
 
                 cacheDataElements( program.getProgramStages() );
             }
@@ -2193,7 +2238,25 @@ public abstract class AbstractEventService
 
     private DataElement getDataElement( IdScheme idScheme, String id )
     {
-        return DATA_ELEM_CACHE.get( id, s -> manager.getObject( DataElement.class, idScheme, id ) ).orElse( null );
+        DataElement result = null;
+        final Optional<DataElement> dataElement = DATA_ELEM_CACHE.get( id );
+        if ( !dataElement.isPresent() )
+        {
+            DataElement dm = manager.getObject( DataElement.class, idScheme, id );
+            if ( dm != null )
+            {
+                // Init the DataElement Hibernate proxy, before stuffing it in cache
+                // so that the security-related collection are initialized
+                HibernateUtils.initializeProxy( dm );
+                DATA_ELEM_CACHE.put( id, dm );
+                result = dm;
+            }
+        }
+        else
+        {
+            result = dataElement.get();
+        }
+        return result;
     }
 
     private CategoryOption getCategoryOption( IdScheme idScheme, String id )
@@ -2279,16 +2342,18 @@ public abstract class AbstractEventService
 
             if ( option.getEndDate() != null && date.compareTo( option.getEndDate() ) > 0 )
             {
-                throw new IllegalQueryException( "Event date " + i18nFormat.formatDate( date )
-                    + " is after end date " + i18nFormat.formatDate( option.getEndDate() )
-                    + " for attributeOption '" + option.getName() + "'" );
+                throw new IllegalQueryException( "Event date " + i18nFormat.formatDate( date ) + " is after end date "
+                    + i18nFormat.formatDate( option.getEndDate() ) + " for attributeOption '" + option.getName()
+                    + "'" );
             }
         }
     }
 
-    private void validateExpiryDays( ImportOptions importOptions, Event event, Program program, ProgramStageInstance programStageInstance )
+    private void validateExpiryDays( ImportOptions importOptions, Event event, Program program,
+        ProgramStageInstance programStageInstance )
     {
-        if ( importOptions == null || importOptions.getUser() == null || importOptions.getUser().isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
+        if ( importOptions == null || importOptions.getUser() == null
+            || importOptions.getUser().isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
         {
             return;
         }
@@ -2346,7 +2411,8 @@ public abstract class AbstractEventService
 
                     if ( today.after( DateUtils.getDateAfterAddition( period.getEndDate(), program.getExpiryDays() ) ) )
                     {
-                        throw new IllegalQueryException( "The program's expiry date has passed. It is not possible to make changes to this event" );
+                        throw new IllegalQueryException(
+                            "The program's expiry date has passed. It is not possible to make changes to this event" );
                     }
                 }
                 else
@@ -2363,7 +2429,8 @@ public abstract class AbstractEventService
 
                     if ( DateUtils.parseDate( referenceDate ).before( period.getStartDate() ) )
                     {
-                        throw new IllegalQueryException( "The event's date belongs to an expired period. It is not possble to create such event" );
+                        throw new IllegalQueryException(
+                            "The event's date belongs to an expired period. It is not possble to create such event" );
                     }
                 }
             }
@@ -2455,7 +2522,8 @@ public abstract class AbstractEventService
         updateTrackedEntityInstance( Lists.newArrayList( programStageInstance ), user, bulkUpdate );
     }
 
-    private void updateTrackedEntityInstance( List<ProgramStageInstance> programStageInstances, User user, boolean bulkUpdate )
+    private void updateTrackedEntityInstance( List<ProgramStageInstance> programStageInstances, User user,
+        boolean bulkUpdate )
     {
         for ( ProgramStageInstance programStageInstance : programStageInstances )
         {
@@ -2472,7 +2540,8 @@ public abstract class AbstractEventService
                 {
                     if ( programStageInstance.getProgramInstance().getEntityInstance() != null )
                     {
-                        trackedEntityInstancesToUpdate.add( programStageInstance.getProgramInstance().getEntityInstance() );
+                        trackedEntityInstancesToUpdate
+                            .add( programStageInstance.getProgramInstance().getEntityInstance() );
                     }
                 }
             }
@@ -2525,7 +2594,8 @@ public abstract class AbstractEventService
 
             if ( attrOptCombo == null )
             {
-                throw new IllegalQueryException( "Attribute option combo does not exist for given category combo and category options" );
+                throw new IllegalQueryException(
+                    "Attribute option combo does not exist for given category combo and category options" );
             }
         }
         else if ( attributeOptionCombo != null )
@@ -2622,7 +2692,8 @@ public abstract class AbstractEventService
 
         if ( programInstance.getStatus().equals( ProgramStatus.COMPLETED ) )
         {
-            if ( importOptions == null || importOptions.getUser() == null || importOptions.getUser().isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
+            if ( importOptions == null || importOptions.getUser() == null
+                || importOptions.getUser().isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
             {
                 return errors;
             }
@@ -2638,7 +2709,9 @@ public abstract class AbstractEventService
 
             if ( referenceDate.after( DateUtils.removeTimeStamp( programInstance.getEndDate() ) ) )
             {
-                errors.add( "Not possible to add event to a completed enrollment. Event created date ( " + referenceDate + " ) is after enrollment completed date ( " + DateUtils.removeTimeStamp( programInstance.getEndDate() ) + " )." );
+                errors.add( "Not possible to add event to a completed enrollment. Event created date ( " + referenceDate
+                    + " ) is after enrollment completed date ( "
+                    + DateUtils.removeTimeStamp( programInstance.getEndDate() ) + " )." );
             }
         }
 


### PR DESCRIPTION
In order to prevent a **potential** issue with a cached Hibernate object and session,
the DataElement is now initialized to fetch all collections before setting it
into the cache.