### PR TITLE
fix: update call to removed /api/me/profile.json endpoint (DHIS2-8788)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.menu.ui.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.menu.ui.js
@@ -960,7 +960,7 @@
             });
             var userProfilePromise = jQuery.ajax({
                 type: "GET",
-                url: dhis2.settings.getBaseUrl() + "/api/me/profile.json",
+                url: dhis2.settings.getBaseUrl() + "/api/me.json",
                 dataType: "json"
             });
 


### PR DESCRIPTION
The endpoint `/api/me/profile.json` does not exist, this should be `/api/me.json`

See [DHIS2-8788](https://jira.dhis2.org/browse/DHIS2-8788) - this should probably be back-ported to 2.34 and 2.33.

Note that these core-embedded javascript libraries should almost certainly be **removed** from the core in 2.35 (see [DHIS2-8859](https://jira.dhis2.org/browse/DHIS2-8859)).