### PR TITLE
refactor: Removing duplication of code in the call of rule engine [DHIS2-7310]

### DIFF
--- a/dhis-2/DHISFormatter.xml
+++ b/dhis-2/DHISFormatter.xml
@@ -236,6 +236,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperService.java
@@ -28,6 +28,10 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
@@ -35,12 +39,9 @@ import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.rules.models.*;
 
-import java.util.List;
-import java.util.Set;
-
 /**
- * RuleEngine has its own domain model. This service is responsible for converting DHIS domain objects to
- * RuleEngine domain objects and vice versa.
+ * RuleEngine has its own domain model. This service is responsible for
+ * converting DHIS domain objects to RuleEngine domain objects and vice versa.
  *
  * Created by zubair@dhis2.org on 19.10.17.
  */
@@ -52,7 +53,7 @@ public interface ProgramRuleEntityMapperService
     List<Rule> toMappedProgramRules();
 
     /**
-     *@param program The program which provides ProgramRule.
+     * @param program The program which provides ProgramRule.
      * @return A list of mapped Rules for a specific program.
      */
     List<Rule> toMappedProgramRules( Program program );
@@ -77,7 +78,7 @@ public interface ProgramRuleEntityMapperService
     List<RuleVariable> toMappedProgramRuleVariables();
 
     /**
-     *@param programRuleVariables The list of ProgramRuleVariable to be mapped.
+     * @param programRuleVariables The list of ProgramRuleVariable to be mapped.
      * @return A list of mapped RuleVariables for list of programs.
      */
     List<RuleVariable> toMappedProgramRuleVariables( List<ProgramRuleVariable> programRuleVariables );
@@ -88,13 +89,8 @@ public interface ProgramRuleEntityMapperService
      *
      * @return A list of mapped events for the list of DHIS events.
      */
-    List<RuleEvent> toMappedRuleEvents( Set<ProgramStageInstance> programStageInstances, ProgramStageInstance psiToEvaluate );
-
-    /**
-     * @param programStageInstances list of events
-     * @return A list of mapped events for the list of DHIS events.
-     */
-    List<RuleEvent> toMappedRuleEvents( Set<ProgramStageInstance> programStageInstances );
+    List<RuleEvent> toMappedRuleEvents( Set<ProgramStageInstance> programStageInstances,
+        Optional<ProgramStageInstance> psiToEvaluate );
 
     /**
      * @param psiToEvaluate event to converted.

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/config/ProgramRuleConfig.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/config/ProgramRuleConfig.java
@@ -1,0 +1,79 @@
+package org.hisp.dhis.programrule.config;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.constant.ConstantService;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
+import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.programrule.engine.*;
+import org.hisp.dhis.user.CurrentUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Enrico Colasante
+ */
+@Configuration( "ruleEngineConfig" )
+public class ProgramRuleConfig
+{
+    @Autowired
+    private ProgramRuleEntityMapperService programRuleEntityMapperService;
+
+    @Autowired
+    private ProgramRuleVariableService programRuleVariableService;
+
+    @Autowired
+    private OrganisationUnitGroupService organisationUnitGroupService;
+
+    @Autowired
+    private RuleVariableInMemoryMap inMemoryMap;
+
+    @Autowired
+    private CurrentUserService currentUserService;
+
+    @Autowired
+    private ConstantService constantService;
+
+    @Bean( "oldRuleEngine" )
+    public ProgramRuleEngine oldRuleEngine( OldImplementableRuleService oldImplementableRuleService )
+    {
+        return new ProgramRuleEngine( programRuleEntityMapperService, programRuleVariableService,
+            organisationUnitGroupService, inMemoryMap, currentUserService, constantService,
+            oldImplementableRuleService );
+    }
+
+    @Bean( "newRuleEngine" )
+    public ProgramRuleEngine newRuleEngine( NewImplementableRuleService newImplementableRuleService )
+    {
+        return new ProgramRuleEngine( programRuleEntityMapperService, programRuleVariableService,
+            organisationUnitGroupService, inMemoryMap, currentUserService, constantService,
+            newImplementableRuleService );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -28,19 +28,23 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.commons.util.DebugUtils;
+
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.rules.models.RuleEffect;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.collect.Lists;
 
 /**
  * Created by zubair@dhis2.org on 23.10.17.
@@ -48,8 +52,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 @Service( "org.hisp.dhis.programrule.engine.ProgramRuleEngineService" )
-public class DefaultProgramRuleEngineService
-    implements ProgramRuleEngineService
+public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
 {
     // -------------------------------------------------------------------------
     // Dependencies
@@ -63,7 +66,7 @@ public class DefaultProgramRuleEngineService
 
     private final ProgramStageInstanceService programStageInstanceService;
 
-    public DefaultProgramRuleEngineService( ProgramRuleEngine programRuleEngine,
+    public DefaultProgramRuleEngineService( @Qualifier( "oldRuleEngine" ) ProgramRuleEngine programRuleEngine,
         List<RuleActionImplementer> ruleActionImplementers, ProgramInstanceService programInstanceService,
         ProgramStageInstanceService programStageInstanceService )
     {
@@ -82,12 +85,18 @@ public class DefaultProgramRuleEngineService
     public List<RuleEffect> evaluateEnrollmentAndRunEffects( long programInstanceId )
     {
         ProgramInstance programInstance = programInstanceService.getProgramInstance( programInstanceId );
-        List<RuleEffect> ruleEffects = getRuleEffects( programInstance );
+
+        if ( programInstance == null )
+        {
+            return Lists.newArrayList();
+        }
+
+        List<RuleEffect> ruleEffects = getRuleEffects( programInstance, Optional.empty(),
+            programInstance.getProgramStageInstances() );
 
         for ( RuleEffect effect : ruleEffects )
         {
-            ruleActionImplementers.stream().filter( i -> i.accept( effect.ruleAction() ) ).forEach( i ->
-            {
+            ruleActionImplementers.stream().filter( i -> i.accept( effect.ruleAction() ) ).forEach( i -> {
                 log.debug( String.format( "Invoking action implementer: %s", i.getClass().getSimpleName() ) );
 
                 i.implement( effect, programInstance );
@@ -97,39 +106,21 @@ public class DefaultProgramRuleEngineService
     }
 
     @Override
-    public List<RuleEffect> evaluateEnrollment( String programInstanceUid )
-    {
-        ProgramInstance programInstance = programInstanceService.getProgramInstance( programInstanceUid );
-        return getRuleEffects( programInstance );
-    }
-
-    private List<RuleEffect> getRuleEffects( ProgramInstance programInstance )
-    {
-        List<RuleEffect> ruleEffects = new ArrayList<>();
-
-        try
-        {
-            ruleEffects = programRuleEngine.evaluateEnrollment( programInstance );
-        }
-        catch ( Exception ex )
-        {
-            log.error( DebugUtils.getStackTrace( ex ) );
-            log.error( DebugUtils.getStackTrace( ex.getCause() ) );
-        }
-
-        return ruleEffects;
-    }
-
-    @Override
     public List<RuleEffect> evaluateEventAndRunEffects( long programStageInstanceId )
     {
         ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( programStageInstanceId );
-        List<RuleEffect> ruleEffects = getRuleEffects( psi );
+
+        if ( psi == null )
+        {
+            return Lists.newArrayList();
+        }
+
+        List<RuleEffect> ruleEffects = getRuleEffects( psi.getProgramInstance(), Optional.of( psi ),
+            psi.getProgramInstance().getProgramStageInstances() );
 
         for ( RuleEffect effect : ruleEffects )
         {
-            ruleActionImplementers.stream().filter( i -> i.accept( effect.ruleAction() ) ).forEach( i ->
-            {
+            ruleActionImplementers.stream().filter( i -> i.accept( effect.ruleAction() ) ).forEach( i -> {
                 log.debug( String.format( "Invoking action implementer: %s", i.getClass().getSimpleName() ) );
 
                 i.implement( effect, psi );
@@ -139,28 +130,9 @@ public class DefaultProgramRuleEngineService
         return ruleEffects;
     }
 
-    @Override
-    public List<RuleEffect> evaluateEvent( String programStageInstanceUid )
+    private List<RuleEffect> getRuleEffects( ProgramInstance enrollment, Optional<ProgramStageInstance> event,
+        Set<ProgramStageInstance> events )
     {
-        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( programStageInstanceUid );
-        return getRuleEffects( psi );
+        return programRuleEngine.evaluate( enrollment, event, events );
     }
-
-    private List<RuleEffect> getRuleEffects( ProgramStageInstance psi )
-    {
-        List<RuleEffect> ruleEffects = new ArrayList<>();
-
-        try
-        {
-            ruleEffects = programRuleEngine.evaluateEvent( psi );
-        }
-        catch ( Exception ex )
-        {
-            log.error( DebugUtils.getStackTrace( ex ) );
-            log.error( DebugUtils.getStackTrace( ex.getCause() ) );
-        }
-
-        return ruleEffects;
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -32,10 +32,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.ValueType;
@@ -54,8 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
-
-import lombok.extern.slf4j.Slf4j;
+import com.google.common.collect.Lists;
 
 /**
  * Created by zubair@dhis2.org on 19.10.17.
@@ -63,49 +64,71 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Transactional( readOnly = true )
 @Service( "org.hisp.dhis.programrule.engine.ProgramRuleEntityMapperService" )
-public class DefaultProgramRuleEntityMapperService
-    implements ProgramRuleEntityMapperService
+public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService
 {
     private static final String LOCATION_FEEDBACK = "feedback";
 
     private static final String LOCATION_INDICATOR = "indicators";
 
-    private final ImmutableMap<ProgramRuleActionType, Function<ProgramRuleAction, RuleAction>> ACTION_MAPPER =
-        new ImmutableMap.Builder<ProgramRuleActionType, Function<ProgramRuleAction, RuleAction>>()
-            .put( ProgramRuleActionType.ASSIGN, pra -> RuleActionAssign.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
-            .put( ProgramRuleActionType.CREATEEVENT, pra -> RuleActionCreateEvent.create( pra.getContent(), pra.getData(), pra.getLocation() ) )
-            .put( ProgramRuleActionType.DISPLAYKEYVALUEPAIR, this::getLocationBasedDisplayRuleAction )
-            .put( ProgramRuleActionType.DISPLAYTEXT, this::getLocationBasedDisplayRuleAction )
-            .put( ProgramRuleActionType.HIDEFIELD, pra -> RuleActionHideField.create( pra.getContent(), getAssignedParameter( pra ) ) )
-            .put( ProgramRuleActionType.HIDEPROGRAMSTAGE, pra -> RuleActionHideProgramStage.create( pra.getProgramStage().getUid() ) )
-            .put( ProgramRuleActionType.HIDESECTION, pra -> RuleActionHideSection.create( pra.getProgramStageSection().getUid() ) )
-            .put( ProgramRuleActionType.SHOWERROR, pra -> RuleActionShowError.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
-            .put( ProgramRuleActionType.SHOWWARNING, pra -> RuleActionShowWarning.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
-            .put( ProgramRuleActionType.SETMANDATORYFIELD, pra -> RuleActionSetMandatoryField.create( getAssignedParameter( pra ) ) )
-            .put( ProgramRuleActionType.WARNINGONCOMPLETE, pra -> RuleActionWarningOnCompletion.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
-            .put( ProgramRuleActionType.ERRORONCOMPLETE, pra -> RuleActionErrorOnCompletion.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
-        .put( ProgramRuleActionType.SENDMESSAGE, pra -> RuleActionSendMessage.create( pra.getTemplateUid(), pra.getData() ) )
-        .put( ProgramRuleActionType.SCHEDULEMESSAGE, pra -> RuleActionScheduleMessage.create( pra.getTemplateUid(), pra.getData() ) )
-            .build();
+    private final ImmutableMap<ProgramRuleActionType, Function<ProgramRuleAction, RuleAction>> ACTION_MAPPER = new ImmutableMap.Builder<ProgramRuleActionType, Function<ProgramRuleAction, RuleAction>>()
+        .put( ProgramRuleActionType.ASSIGN,
+            pra -> RuleActionAssign.create( pra.getContent(), pra.getData(),
+                getAssignedParameterForAssignAction( pra ) ) )
+        .put( ProgramRuleActionType.CREATEEVENT,
+            pra -> RuleActionCreateEvent.create( pra.getContent(), pra.getData(), pra.getLocation() ) )
+        .put( ProgramRuleActionType.DISPLAYKEYVALUEPAIR, this::getLocationBasedDisplayRuleAction )
+        .put( ProgramRuleActionType.DISPLAYTEXT, this::getLocationBasedDisplayRuleAction )
+        .put( ProgramRuleActionType.HIDEFIELD,
+            pra -> RuleActionHideField.create( pra.getContent(), getAssignedParameter( pra ) ) )
+        .put( ProgramRuleActionType.HIDEPROGRAMSTAGE,
+            pra -> RuleActionHideProgramStage.create( pra.getProgramStage().getUid() ) )
+        .put( ProgramRuleActionType.HIDESECTION,
+            pra -> RuleActionHideSection.create( pra.getProgramStageSection().getUid() ) )
+        .put( ProgramRuleActionType.SHOWERROR,
+            pra -> RuleActionShowError.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
+        .put( ProgramRuleActionType.SHOWWARNING,
+            pra -> RuleActionShowWarning.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
+        .put( ProgramRuleActionType.SETMANDATORYFIELD,
+            pra -> RuleActionSetMandatoryField.create( getAssignedParameter( pra ) ) )
+        .put( ProgramRuleActionType.WARNINGONCOMPLETE,
+            pra -> RuleActionWarningOnCompletion.create( pra.getContent(), pra.getData(),
+                getAssignedParameter( pra ) ) )
+        .put( ProgramRuleActionType.ERRORONCOMPLETE,
+            pra -> RuleActionErrorOnCompletion.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
+        .put( ProgramRuleActionType.SENDMESSAGE,
+            pra -> RuleActionSendMessage.create( pra.getTemplateUid(), pra.getData() ) )
+        .put( ProgramRuleActionType.SCHEDULEMESSAGE,
+            pra -> RuleActionScheduleMessage.create( pra.getTemplateUid(), pra.getData() ) )
+        .build();
 
-    private final ImmutableMap<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, RuleVariable>> VARIABLE_MAPPER =
-        new ImmutableMap.Builder<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, RuleVariable>>()
-            .put( ProgramRuleVariableSourceType.CALCULATED_VALUE, prv -> RuleVariableCalculatedValue.create( prv.getName(), "", RuleValueType.TEXT ) )
-            .put( ProgramRuleVariableSourceType.TEI_ATTRIBUTE, prv -> RuleVariableAttribute.create( prv.getName(), prv.getAttribute().getUid(), toMappedValueType( prv ) ) )
-            .put( ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT, prv -> RuleVariableCurrentEvent.create( prv.getName(), prv.getDataElement().getUid(), toMappedValueType( prv ) ) )
-            .put( ProgramRuleVariableSourceType.DATAELEMENT_PREVIOUS_EVENT, prv -> RuleVariablePreviousEvent.create( prv.getName(), prv.getDataElement().getUid(), toMappedValueType( prv ) ) )
-            .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM, prv -> RuleVariableNewestEvent.create( prv.getName(), prv.getDataElement().getUid(), toMappedValueType( prv ) ) )
-            .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE, prv -> RuleVariableNewestStageEvent.create( prv.getName(),
-                prv.getDataElement().getUid(), prv.getProgramStage().getUid() , toMappedValueType( prv ) ) )
-            .build();
+    private final ImmutableMap<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, RuleVariable>> VARIABLE_MAPPER = new ImmutableMap.Builder<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, RuleVariable>>()
+        .put( ProgramRuleVariableSourceType.CALCULATED_VALUE,
+            prv -> RuleVariableCalculatedValue.create( prv.getName(), "", RuleValueType.TEXT ) )
+        .put( ProgramRuleVariableSourceType.TEI_ATTRIBUTE,
+            prv -> RuleVariableAttribute.create( prv.getName(), prv.getAttribute().getUid(),
+                toMappedValueType( prv ) ) )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT,
+            prv -> RuleVariableCurrentEvent.create( prv.getName(), prv.getDataElement().getUid(),
+                toMappedValueType( prv ) ) )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_PREVIOUS_EVENT,
+            prv -> RuleVariablePreviousEvent.create( prv.getName(), prv.getDataElement().getUid(),
+                toMappedValueType( prv ) ) )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM,
+            prv -> RuleVariableNewestEvent.create( prv.getName(), prv.getDataElement().getUid(),
+                toMappedValueType( prv ) ) )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE,
+            prv -> RuleVariableNewestStageEvent.create( prv.getName(), prv.getDataElement().getUid(),
+                prv.getProgramStage().getUid(), toMappedValueType( prv ) ) )
+        .build();
 
-    private final ImmutableMap<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, ValueType>> VALUE_TYPE_MAPPER = new
-        ImmutableMap.Builder<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, ValueType>>()
-        .put( ProgramRuleVariableSourceType.TEI_ATTRIBUTE, prv -> prv.getAttribute().getValueType()  )
-        .put( ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT, prv -> prv.getDataElement().getValueType()  )
-        .put( ProgramRuleVariableSourceType.DATAELEMENT_PREVIOUS_EVENT, prv -> prv.getDataElement().getValueType()  )
-        .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM, prv -> prv.getDataElement().getValueType()  )
-        .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE, prv -> prv.getDataElement().getValueType()  )
+    private final ImmutableMap<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, ValueType>> VALUE_TYPE_MAPPER = new ImmutableMap.Builder<ProgramRuleVariableSourceType, Function<ProgramRuleVariable, ValueType>>()
+        .put( ProgramRuleVariableSourceType.TEI_ATTRIBUTE, prv -> prv.getAttribute().getValueType() )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT, prv -> prv.getDataElement().getValueType() )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_PREVIOUS_EVENT, prv -> prv.getDataElement().getValueType() )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM,
+            prv -> prv.getDataElement().getValueType() )
+        .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE,
+            prv -> prv.getDataElement().getValueType() )
         .build();
 
     private final CachingMap<String, ValueType> dataElementToValueTypeCache = new CachingMap<>();
@@ -115,7 +138,9 @@ public class DefaultProgramRuleEntityMapperService
     // -------------------------------------------------------------------------
 
     private final ProgramRuleService programRuleService;
+
     private final ProgramRuleVariableService programRuleVariableService;
+
     private final DataElementService dataElementService;
 
     public DefaultProgramRuleEntityMapperService( ProgramRuleService programRuleService,
@@ -171,7 +196,12 @@ public class DefaultProgramRuleEntityMapperService
     @Override
     public List<RuleVariable> toMappedProgramRuleVariables( List<ProgramRuleVariable> programRuleVariables )
     {
-        return programRuleVariables.stream().filter( Objects::nonNull ).map( this::toRuleVariable ).filter( Objects::nonNull ).collect( Collectors.toList() );
+        return programRuleVariables
+            .stream()
+            .filter( Objects::nonNull )
+            .map( this::toRuleVariable )
+            .filter( Objects::nonNull )
+            .collect( Collectors.toList() );
     }
 
     @Override
@@ -183,7 +213,7 @@ public class DefaultProgramRuleEntityMapperService
     @Override
     public RuleEnrollment toMappedRuleEnrollment( ProgramInstance enrollment )
     {
-        if( enrollment == null )
+        if ( enrollment == null )
         {
             return null;
         }
@@ -200,35 +230,28 @@ public class DefaultProgramRuleEntityMapperService
         List<RuleAttributeValue> ruleAttributeValues = Lists.newArrayList();
         if ( enrollment.getEntityInstance() != null )
         {
-            ruleAttributeValues = enrollment.getEntityInstance().getTrackedEntityAttributeValues().stream()
+            ruleAttributeValues = enrollment.getEntityInstance().getTrackedEntityAttributeValues()
+                .stream()
                 .filter( Objects::nonNull )
-                .map( attr -> RuleAttributeValue
-                    .create( attr.getAttribute().getUid(), getTrackedEntityAttributeValue( attr ) ) )
+                .map( attr -> RuleAttributeValue.create( attr.getAttribute().getUid(),
+                    getTrackedEntityAttributeValue( attr ) ) )
                 .collect( Collectors.toList() );
         }
-        return RuleEnrollment.create( enrollment.getUid(), enrollment.getIncidentDate(),
-            enrollment.getEnrollmentDate(), RuleEnrollment.Status.valueOf( enrollment.getStatus().toString() ), orgUnit,
-            orgUnitCode,
+        return RuleEnrollment.create( enrollment.getUid(), enrollment.getIncidentDate(), enrollment.getEnrollmentDate(),
+            RuleEnrollment.Status.valueOf( enrollment.getStatus().toString() ), orgUnit, orgUnitCode,
             ruleAttributeValues, enrollment.getProgram().getName() );
     }
 
     @Override
-    public List<RuleEvent> toMappedRuleEvents ( Set<ProgramStageInstance> programStageInstances, ProgramStageInstance psiToEvaluate )
+    public List<RuleEvent> toMappedRuleEvents( Set<ProgramStageInstance> programStageInstances,
+        Optional<ProgramStageInstance> psiToEvaluate )
     {
-        return programStageInstances.stream().filter( Objects::nonNull )
-            .filter( psi -> !psi.getUid().equals( psiToEvaluate.getUid() ) )
-            .map( psi ->
-            {
-                String orgUnit = getOrgUnit( psi );
-                String orgUnitCode = getOrgUnitCode( psi );
-
-                return RuleEvent.create( psi.getUid(), psi.getProgramStage().getUid(),
-                RuleEvent.Status.valueOf( psi.getStatus().toString() ), ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ), psi.getDueDate(), orgUnit,
-                orgUnitCode,psi.getEventDataValues().stream().filter( Objects::nonNull )
-                .map( dv -> RuleDataValue.create( ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ), psi.getProgramStage().getUid(), dv.getDataElement(), getEventDataValue( dv ) ) )
-                .collect( Collectors.toList() ), psi.getProgramStage().getName() );
-
-            } ).collect( Collectors.toList() );
+        return programStageInstances
+            .stream()
+            .filter( Objects::nonNull )
+            .filter( psi -> !(psiToEvaluate.isPresent() && psi.getUid().equals( psiToEvaluate.get().getUid() )) )
+            .map( this::toMappedRuleEvent )
+            .collect( Collectors.toList() );
     }
 
     @Override
@@ -242,27 +265,17 @@ public class DefaultProgramRuleEntityMapperService
         String orgUnit = getOrgUnit( psi );
         String orgUnitCode = getOrgUnitCode( psi );
 
-        return RuleEvent.create( psi.getUid(), psi.getProgramStage().getUid(), RuleEvent.Status.valueOf( psi.getStatus().toString() ), ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ),
-            psi.getDueDate(), orgUnit,orgUnitCode, psi.getEventDataValues().stream().filter( Objects::nonNull )
-            .map( dv -> RuleDataValue.create( ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ), psi.getProgramStage().getUid(), dv.getDataElement(), getEventDataValue( dv ) ) )
-            .collect( Collectors.toList() ), psi.getProgramStage().getName() );
-    }
-
-    @Override
-    public List<RuleEvent> toMappedRuleEvents( Set<ProgramStageInstance> programStageInstances )
-    {
-        return programStageInstances.stream().filter( Objects::nonNull )
-            .map( psi ->
-            {
-                String orgUnit = getOrgUnit( psi );
-                String orgUnitCode = getOrgUnitCode( psi );
-
-                return RuleEvent.create( psi.getUid(), psi.getProgramStage().getUid(),
-            RuleEvent.Status.valueOf( psi.getStatus().toString() ), ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ), psi.getDueDate(), orgUnit, orgUnitCode,psi.getEventDataValues().stream().filter( Objects::nonNull )
-            .map( dv -> RuleDataValue.create( ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ), psi.getProgramStage().getUid(), dv.getDataElement(), getEventDataValue( dv ) ) )
-            .collect( Collectors.toList() ), psi.getProgramStage().getName() );
-
-            }).collect( Collectors.toList() );
+        return RuleEvent.create( psi.getUid(), psi.getProgramStage().getUid(),
+            RuleEvent.Status.valueOf( psi.getStatus().toString() ),
+            ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ), psi.getDueDate(), orgUnit,
+            orgUnitCode,
+            psi.getEventDataValues()
+                .stream()
+                .filter( Objects::nonNull )
+                .map( dv -> RuleDataValue.create( ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ),
+                    psi.getProgramStage().getUid(), dv.getDataElement(), getEventDataValue( dv ) ) )
+                .collect( Collectors.toList() ),
+            psi.getProgramStage().getName() );
     }
 
     // ---------------------------------------------------------------------
@@ -291,7 +304,7 @@ public class DefaultProgramRuleEntityMapperService
 
     private Rule toRule( ProgramRule programRule )
     {
-        if ( programRule ==  null )
+        if ( programRule == null )
         {
             return null;
         }
@@ -305,7 +318,9 @@ public class DefaultProgramRuleEntityMapperService
         {
             ruleActions = programRuleActions.stream().map( this::toRuleAction ).collect( Collectors.toList() );
 
-            rule = Rule.create( programRule.getProgramStage() != null ? programRule.getProgramStage().getUid() : StringUtils.EMPTY, programRule.getPriority(), programRule.getCondition(), ruleActions, programRule.getName() );
+            rule = Rule.create(
+                programRule.getProgramStage() != null ? programRule.getProgramStage().getUid() : StringUtils.EMPTY,
+                programRule.getPriority(), programRule.getCondition(), ruleActions, programRule.getName() );
         }
         catch ( Exception e )
         {
@@ -319,8 +334,10 @@ public class DefaultProgramRuleEntityMapperService
 
     private RuleAction toRuleAction( ProgramRuleAction programRuleAction )
     {
-        return ACTION_MAPPER.getOrDefault( programRuleAction.getProgramRuleActionType(), pra ->
-            RuleActionAssign.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) ).apply( programRuleAction );
+        return ACTION_MAPPER
+            .getOrDefault( programRuleAction.getProgramRuleActionType(),
+                pra -> RuleActionAssign.create( pra.getContent(), pra.getData(), getAssignedParameter( pra ) ) )
+            .apply( programRuleAction );
     }
 
     private RuleVariable toRuleVariable( ProgramRuleVariable programRuleVariable )
@@ -344,7 +361,8 @@ public class DefaultProgramRuleEntityMapperService
 
     private RuleValueType toMappedValueType( ProgramRuleVariable programRuleVariable )
     {
-        ValueType valueType = VALUE_TYPE_MAPPER.getOrDefault( programRuleVariable.getSourceType(), prv -> ValueType.TEXT ).apply( programRuleVariable );
+        ValueType valueType = VALUE_TYPE_MAPPER
+            .getOrDefault( programRuleVariable.getSourceType(), prv -> ValueType.TEXT ).apply( programRuleVariable );
 
         if ( valueType.isBoolean() )
         {
@@ -362,6 +380,29 @@ public class DefaultProgramRuleEntityMapperService
         }
 
         return RuleValueType.TEXT;
+    }
+
+    private String getAssignedParameterForAssignAction( ProgramRuleAction programRuleAction )
+    {
+        if ( programRuleAction.hasDataElement() )
+        {
+            return programRuleAction.getDataElement().getUid();
+        }
+
+        if ( programRuleAction.hasTrackedEntityAttribute() )
+        {
+            return programRuleAction.getAttribute().getUid();
+        }
+
+        if ( programRuleAction.hasContent() )
+        {
+            return StringUtils.EMPTY;
+        }
+
+        log.warn( String.format( "No location found for ProgramRuleAction: %s in ProgramRule: %s",
+            programRuleAction.getProgramRuleActionType(), programRuleAction.getProgramRule().getUid() ) );
+
+        return StringUtils.EMPTY;
     }
 
     private String getAssignedParameter( ProgramRuleAction programRuleAction )
@@ -393,29 +434,35 @@ public class DefaultProgramRuleEntityMapperService
         {
             if ( LOCATION_FEEDBACK.equals( programRuleAction.getLocation() ) )
             {
-                return RuleActionDisplayText.createForFeedback( programRuleAction.getContent(), programRuleAction.getData() );
+                return RuleActionDisplayText.createForFeedback( programRuleAction.getContent(),
+                    programRuleAction.getData() );
             }
 
             if ( LOCATION_INDICATOR.equals( programRuleAction.getLocation() ) )
             {
-                return RuleActionDisplayText.createForIndicators( programRuleAction.getContent(), programRuleAction.getData() );
+                return RuleActionDisplayText.createForIndicators( programRuleAction.getContent(),
+                    programRuleAction.getData() );
             }
 
-            return RuleActionDisplayText.createForFeedback( programRuleAction.getContent(), programRuleAction.getData() );
+            return RuleActionDisplayText.createForFeedback( programRuleAction.getContent(),
+                programRuleAction.getData() );
         }
         else
         {
             if ( LOCATION_FEEDBACK.equals( programRuleAction.getLocation() ) )
             {
-                return RuleActionDisplayKeyValuePair.createForFeedback( programRuleAction.getContent(), programRuleAction.getData() );
+                return RuleActionDisplayKeyValuePair.createForFeedback( programRuleAction.getContent(),
+                    programRuleAction.getData() );
             }
 
             if ( LOCATION_INDICATOR.equals( programRuleAction.getLocation() ) )
             {
-                return RuleActionDisplayKeyValuePair.createForIndicators( programRuleAction.getContent(), programRuleAction.getData() );
+                return RuleActionDisplayKeyValuePair.createForIndicators( programRuleAction.getContent(),
+                    programRuleAction.getData() );
             }
 
-            return RuleActionDisplayKeyValuePair.createForFeedback( programRuleAction.getContent(), programRuleAction.getData() );
+            return RuleActionDisplayKeyValuePair.createForFeedback( programRuleAction.getContent(),
+                programRuleAction.getData() );
         }
     }
 
@@ -455,8 +502,7 @@ public class DefaultProgramRuleEntityMapperService
 
     private ValueType getValueTypeForDataElement( String dataElementUid )
     {
-        return dataElementToValueTypeCache.get( dataElementUid, () ->
-        {
+        return dataElementToValueTypeCache.get( dataElementUid, () -> {
             DataElement dataElement = dataElementService.getDataElement( dataElementUid );
 
             if ( dataElement == null )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ImplementableRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ImplementableRuleService.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.programrule.engine;
-
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -28,16 +26,14 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package org.hisp.dhis.programrule.engine;
+
 import java.util.List;
 
-import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.programrule.ProgramRule;
 
-/**
- * Created by zubair@dhis2.org on 23.10.17.
- */
-public interface ProgramRuleEngineService
+public interface ImplementableRuleService
 {
-    List<RuleEffect> evaluateEnrollmentAndRunEffects( long enrollment );
-
-    List<RuleEffect> evaluateEventAndRunEffects( long event );
+    List<ProgramRule> getImplementableRules( Program program );
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NewImplementableRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NewImplementableRuleService.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.programrule.engine;
-
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -28,16 +26,25 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package org.hisp.dhis.programrule.engine;
+
 import java.util.List;
 
-import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
-/**
- * Created by zubair@dhis2.org on 23.10.17.
- */
-public interface ProgramRuleEngineService
+@Component
+public class NewImplementableRuleService implements ImplementableRuleService
 {
-    List<RuleEffect> evaluateEnrollmentAndRunEffects( long enrollment );
+    @Autowired
+    private ProgramRuleService programRuleService;
 
-    List<RuleEffect> evaluateEventAndRunEffects( long event );
+    @Override
+    public List<ProgramRule> getImplementableRules( Program program )
+    {
+        return programRuleService.getAllProgramRule();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OldImplementableRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OldImplementableRuleService.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.programrule.engine;
-
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -28,48 +26,37 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import javax.annotation.Nonnull;
+package org.hisp.dhis.programrule.engine;
 
-import org.apache.commons.jexl2.JexlException;
-import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.commons.util.ExpressionUtils;
-import org.hisp.dhis.rules.RuleExpressionEvaluator;
+import java.util.List;
+
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
+import org.hisp.dhis.programrule.ProgramRuleService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import lombok.extern.slf4j.Slf4j;
-
-/**
- * Created by zubair@dhis2.org on 11.10.17.
- */
-@Slf4j
-@Component( "org.hisp.dhis.programrule.engine.ProgramRuleExpressionEvaluator" )
-public class ProgramRuleExpressionEvaluator implements RuleExpressionEvaluator
+@Component
+public class OldImplementableRuleService implements ImplementableRuleService
 {
-    /**
-     * Return string value of boolean output. False will be returned in case
-     * of wrongly created expression
-     *
-     * @param expression to be evaluated.
-     * @return string value of boolean true/false.
-     */
+    @Autowired
+    private ProgramRuleService programRuleService;
 
-    @Nonnull
     @Override
-    public String evaluate( @Nonnull String expression )
+    public List<ProgramRule> getImplementableRules( Program program )
     {
-        String result;
+        List<ProgramRule> permittedRules;
 
-        try
-        {
-            result = ExpressionUtils.evaluate( expression ).toString();
-        }
-        catch ( JexlException je )
-        {
-            result = "false";
+        permittedRules = programRuleService.getImplementableProgramRules( program,
+            ProgramRuleActionType.getNotificationLinkedTypes() );
 
-            log.debug( DebugUtils.getStackTrace( je.getCause() ) );
+        if ( permittedRules.isEmpty() )
+        {
+            return permittedRules;
         }
 
-       return result;
+        return programRuleService.getImplementableProgramRules( program,
+            ProgramRuleActionType.getImplementedActions() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -30,20 +30,16 @@ package org.hisp.dhis.programrule.engine;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.*;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.programrule.*;
@@ -52,31 +48,18 @@ import org.hisp.dhis.rules.RuleEngineContext;
 import org.hisp.dhis.rules.models.*;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.UserAuthorityGroup;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Created by zubair@dhis2.org on 11.10.17.
  */
 @Slf4j
 @Transactional( readOnly = true )
-@Component( "org.hisp.dhis.programrule.engine.ProgramRuleEngine" )
 public class ProgramRuleEngine
 {
     private static final String USER = "USER";
 
-    private static final String REGEX = "d2:inOrgUnitGroup\\( *(([\\d/\\*\\+\\-%\\. ]+)|" +
-        "( *'[^']*'))*( *, *(([\\d/\\*\\+\\-%\\. ]+)|'[^']*'))* *\\)";
-
-    private static final Pattern PATTERN = Pattern.compile( REGEX );
-
     private final ProgramRuleEntityMapperService programRuleEntityMapperService;
-
-    private final ProgramRuleExpressionEvaluator programRuleExpressionEvaluator;
-
-    private final ProgramRuleService programRuleService;
 
     private final ProgramRuleVariableService programRuleVariableService;
 
@@ -88,64 +71,65 @@ public class ProgramRuleEngine
 
     private final ConstantService constantService;
 
+    private final ImplementableRuleService implementableRuleService;
+
     public ProgramRuleEngine( ProgramRuleEntityMapperService programRuleEntityMapperService,
-        ProgramRuleExpressionEvaluator programRuleExpressionEvaluator, ProgramRuleService programRuleService,
         ProgramRuleVariableService programRuleVariableService,
         OrganisationUnitGroupService organisationUnitGroupService, RuleVariableInMemoryMap inMemoryMap,
-        CurrentUserService currentUserService, ConstantService constantService )
+        CurrentUserService currentUserService, ConstantService constantService,
+        ImplementableRuleService implementableRuleService )
     {
 
         checkNotNull( programRuleEntityMapperService );
-        checkNotNull( programRuleExpressionEvaluator );
-        checkNotNull( programRuleService );
         checkNotNull( programRuleVariableService );
         checkNotNull( organisationUnitGroupService );
         checkNotNull( currentUserService );
         checkNotNull( inMemoryMap );
         checkNotNull( constantService );
+        checkNotNull( implementableRuleService );
 
         this.programRuleEntityMapperService = programRuleEntityMapperService;
-        this.programRuleExpressionEvaluator = programRuleExpressionEvaluator;
-        this.programRuleService = programRuleService;
         this.programRuleVariableService = programRuleVariableService;
         this.organisationUnitGroupService = organisationUnitGroupService;
         this.inMemoryMap = inMemoryMap;
         this.currentUserService = currentUserService;
         this.constantService = constantService;
+        this.implementableRuleService = implementableRuleService;
     }
 
-    public List<RuleEffect> evaluateEnrollment(ProgramInstance enrollment )
+    public List<RuleEffect> evaluate( ProgramInstance enrollment, Optional<ProgramStageInstance> programStageInstance,
+        Set<ProgramStageInstance> events )
     {
-        if ( enrollment == null )
-        {
-            return new ArrayList<>();
-        }
-
         List<RuleEffect> ruleEffects = new ArrayList<>();
 
-        List<ProgramRule> implementableProgramRules = getImplementableRules( enrollment.getProgram() );
+        List<ProgramRule> implementableProgramRules = implementableRuleService
+            .getImplementableRules( enrollment.getProgram() );
 
         if ( implementableProgramRules.isEmpty() ) // if implementation does not exist on back end side
         {
             return ruleEffects;
         }
 
-        List<ProgramRuleVariable> programRuleVariables = programRuleVariableService.getProgramRuleVariable( enrollment.getProgram() );
+        List<ProgramRuleVariable> programRuleVariables = programRuleVariableService
+            .getProgramRuleVariable( enrollment.getProgram() );
 
-        RuleEnrollment ruleEnrollment = programRuleEntityMapperService.toMappedRuleEnrollment( enrollment );
-
-        List<RuleEvent> ruleEvents = programRuleEntityMapperService.toMappedRuleEvents( enrollment.getProgramStageInstances() );
-
-        RuleEngine ruleEngine;
+        List<RuleEvent> ruleEvents = getRuleEvents( events, programStageInstance );
 
         try
         {
-            ruleEngine = ruleEngineBuilder( implementableProgramRules, programRuleVariables ).events( ruleEvents ).build();
+            RuleEngine ruleEngine = ruleEngineBuilder( implementableProgramRules, programRuleVariables )
+                .events( ruleEvents )
+                .enrollment( getRuleEnrollment( enrollment ) )
+                .build();
 
-            ruleEffects = ruleEngine.evaluate( ruleEnrollment  ).call();
+            ruleEffects = getRuleEngineEvaluation( ruleEngine, getRuleEnrollment( enrollment ),
+                programStageInstance.map( this::getRuleEvent ) );
 
-            ruleEffects.stream().map( RuleEffect::ruleAction )
-                .forEach( action -> log.debug( String.format( "RuleEngine triggered with result: %s", action.toString() ) ) );
+            ruleEffects
+                .stream()
+                .map( RuleEffect::ruleAction )
+                .forEach(
+                    action -> log.debug( String.format( "RuleEngine triggered with result: %s", action.toString() ) ) );
         }
         catch ( Exception e )
         {
@@ -155,110 +139,62 @@ public class ProgramRuleEngine
         return ruleEffects;
     }
 
-    public List<RuleEffect> evaluateEvent( ProgramStageInstance programStageInstance )
+    private RuleEngine.Builder ruleEngineBuilder( List<ProgramRule> programRules,
+        List<ProgramRuleVariable> programRuleVariables )
     {
-        List<RuleEffect> ruleEffects = new ArrayList<>();
-
-        if ( programStageInstance == null )
-        {
-            return ruleEffects;
-        }
-
-        ProgramInstance enrollment = programStageInstance.getProgramInstance();
-
-        List<ProgramRule> implementableProgramRules = getImplementableRules( enrollment.getProgram() );
-
-        if ( implementableProgramRules.isEmpty() )
-        {
-            return ruleEffects;
-        }
-
-        List<ProgramRuleVariable> programRuleVariables = programRuleVariableService.getProgramRuleVariable( enrollment.getProgram() );
-
-        RuleEnrollment ruleEnrollment = programRuleEntityMapperService.toMappedRuleEnrollment( enrollment );
-
-        List<RuleEvent> ruleEvents = programRuleEntityMapperService.toMappedRuleEvents( enrollment.getProgramStageInstances(), programStageInstance );
-
-        RuleEngine ruleEngine;
-
-        try
-        {
-
-            ruleEngine = ruleEngineBuilder( implementableProgramRules, programRuleVariables ).enrollment( ruleEnrollment ).events( ruleEvents ).build();
-
-            ruleEffects = ruleEngine.evaluate( programRuleEntityMapperService.toMappedRuleEvent( programStageInstance )  ).call();
-
-            ruleEffects.stream().map( RuleEffect::ruleAction )
-                .forEach( action -> log.debug( String.format( "RuleEngine triggered with result: %s", action.toString() ) ) );
-        }
-        catch ( Exception e )
-        {
-            log.error( DebugUtils.getStackTrace( e ) );
-        }
-
-        return ruleEffects;
-    }
-
-    private RuleEngine.Builder ruleEngineBuilder( List<ProgramRule> programRules, List<ProgramRuleVariable> programRuleVariables )
-    {
-        Map<String, List<String>> supplementaryData = new HashMap<>();
-
-        Map<String, String> constantMap = constantService.getConstantMap().entrySet().stream()
+        Map<String, String> constantMap = constantService.getConstantMap().entrySet()
+            .stream()
             .collect( Collectors.toMap( Map.Entry::getKey, v -> v.getValue().toString() ) );
 
-        List<String> orgUnitGroups = new ArrayList<>();
-
-        List<Rule> rules = new ArrayList<>();
-
-        for ( ProgramRule programRule : programRules )
-        {
-            Rule rule = programRuleEntityMapperService.toMappedProgramRule( programRule );
-
-            if ( rule != null )
-            {
-                rules.add( rule );
-
-                Matcher matcher = PATTERN.matcher( StringUtils.defaultIfBlank( programRule.getCondition(), "" ) );
-
-                while ( matcher.find() )
-                {
-                    orgUnitGroups.add( StringUtils.replace( matcher.group( 1 ), "'", "" ) );
-                }
-            }
-        }
-
-        if ( !orgUnitGroups.isEmpty() )
-        {
-            supplementaryData = orgUnitGroups.stream().collect( Collectors.toMap( g -> g,  g -> organisationUnitGroupService.getOrganisationUnitGroup( g ).getMembers()
-                .stream().map( OrganisationUnit::getUid ).collect( Collectors.toList() ) ) );
-        }
+        Map<String, List<String>> supplementaryData = organisationUnitGroupService.getAllOrganisationUnitGroups()
+            .stream()
+            .collect( Collectors.toMap( BaseIdentifiableObject::getUid,
+                g -> g.getMembers().stream().map( OrganisationUnit::getUid ).collect( Collectors.toList() ) ) );
 
         if ( currentUserService.getCurrentUser() != null )
         {
-            supplementaryData.put( USER, currentUserService.getCurrentUser().getUserCredentials().getUserAuthorityGroups().stream().map( UserAuthorityGroup::getUid ).collect( Collectors.toList() ) );
+            supplementaryData.put( USER, currentUserService.getCurrentUser().getUserCredentials()
+                .getUserAuthorityGroups().stream().map( UserAuthorityGroup::getUid ).collect( Collectors.toList() ) );
         }
 
-        return RuleEngineContext
-            .builder( programRuleExpressionEvaluator )
+        return RuleEngineContext.builder()
             .supplementaryData( supplementaryData )
             .calculatedValueMap( inMemoryMap.getVariablesMap() )
-            .rules( rules )
+            .rules( programRuleEntityMapperService.toMappedProgramRules( programRules ) )
             .ruleVariables( programRuleEntityMapperService.toMappedProgramRuleVariables( programRuleVariables ) )
             .constantsValue( constantMap )
-            .build().toEngineBuilder().triggerEnvironment( TriggerEnvironment.SERVER );
+            .build()
+            .toEngineBuilder()
+            .triggerEnvironment( TriggerEnvironment.SERVER );
     }
 
-    private List<ProgramRule> getImplementableRules( Program program )
+    private RuleEvent getRuleEvent( ProgramStageInstance programStageInstance )
     {
-        List<ProgramRule> permittedRules;
+        return programRuleEntityMapperService.toMappedRuleEvent( programStageInstance );
+    }
 
-        permittedRules = programRuleService.getImplementableProgramRules( program, ProgramRuleActionType.getNotificationLinkedTypes() );
+    private List<RuleEvent> getRuleEvents( Set<ProgramStageInstance> events,
+        Optional<ProgramStageInstance> programStageInstance )
+    {
+        return programRuleEntityMapperService.toMappedRuleEvents( events, programStageInstance );
+    }
 
-        if ( permittedRules.isEmpty() )
+    private RuleEnrollment getRuleEnrollment( ProgramInstance enrollment )
+    {
+        return programRuleEntityMapperService.toMappedRuleEnrollment( enrollment );
+    }
+
+    private List<RuleEffect> getRuleEngineEvaluation( RuleEngine ruleEngine, RuleEnrollment enrollment,
+        Optional<RuleEvent> event )
+        throws Exception
+    {
+        if ( !event.isPresent() )
         {
-            return permittedRules;
+            return ruleEngine.evaluate( enrollment ).call();
         }
-
-        return programRuleService.getImplementableProgramRules( program, ProgramRuleActionType.getImplementedActions() );
+        else
+        {
+            return ruleEngine.evaluate( event.get() ).call();
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -30,7 +30,11 @@ package org.hisp.dhis.programrule.engine;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
@@ -133,17 +133,15 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
 
-        doAnswer( invocationOnMock ->
-        {
+        doAnswer( invocationOnMock -> {
             eventType = (ApplicationEvent) invocationOnMock.getArguments()[0];
             return eventType;
-        }).when( publisher ).publishEvent( any() );
+        } ).when( publisher ).publishEvent( any() );
 
-        doAnswer( invocationOnMock ->
-        {
-            logEntry = ( ExternalNotificationLogEntry ) invocationOnMock.getArguments()[0];
+        doAnswer( invocationOnMock -> {
+            logEntry = (ExternalNotificationLogEntry) invocationOnMock.getArguments()[0];
             return logEntry;
-        }).when( loggingService ).save( any() );
+        } ).when( loggingService ).save( any() );
 
         when( loggingService.isValidForSending( anyString() ) ).thenReturn( true );
 
@@ -169,11 +167,10 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
             return eventType;
         } ).when( publisher ).publishEvent( any() );
 
-        doAnswer( invocationOnMock ->
-        {
-            logEntry = ( ExternalNotificationLogEntry ) invocationOnMock.getArguments()[0];
+        doAnswer( invocationOnMock -> {
+            logEntry = (ExternalNotificationLogEntry) invocationOnMock.getArguments()[0];
             return logEntry;
-        }).when( loggingService ).save( any() );
+        } ).when( loggingService ).save( any() );
 
         when( loggingService.isValidForSending( anyString() ) ).thenReturn( true );
 
@@ -195,17 +192,15 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
 
-
         doAnswer( invocationOnMock -> {
             eventType = (ApplicationEvent) invocationOnMock.getArguments()[0];
             return eventType;
         } ).when( publisher ).publishEvent( any() );
 
-        doAnswer( invocationOnMock ->
-        {
-            logEntry = ( ExternalNotificationLogEntry ) invocationOnMock.getArguments()[0];
+        doAnswer( invocationOnMock -> {
+            logEntry = (ExternalNotificationLogEntry) invocationOnMock.getArguments()[0];
             return logEntry;
-        }).when( loggingService ).save( any() );
+        } ).when( loggingService ).save( any() );
 
         when( loggingService.isValidForSending( anyString() ) ).thenReturn( true );
 
@@ -277,19 +272,11 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
         ruleEffectWithActionSendMessage = RuleEffect.create( ruleActionSendMessage );
 
-        setMandatoryFieldFalse = new RuleActionSetMandatoryField()
-        {
-            @Nonnull
-            @Override
-            public String field()
-            {
-                return MANDATORY_FIELD;
-            }
-        };
+        setMandatoryFieldFalse = RuleActionSetMandatoryField.create( MANDATORY_FIELD );
 
         OrganisationUnit organisationUnitA = createOrganisationUnit( 'A' );
 
-        Program programA = createProgram('A', new HashSet<>(), organisationUnitA );
+        Program programA = createProgram( 'A', new HashSet<>(), organisationUnitA );
         ProgramStage programStageA = createProgramStage( 'A', programA );
 
         programRuleA = createProgramRule( 'R', programA );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -52,12 +53,15 @@ import org.mockito.*;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import com.google.common.collect.Sets;
+
 /**
  * Created by zubair@dhis2.org on 04.02.18.
  */
 public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
 {
     private static final String NOTIFICATION_UID = "abc123";
+
     private static final String DATA = "abc123";
 
     @Rule
@@ -97,12 +101,10 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
 
     private List<RuleEffect> ruleEffects;
 
-
     @Before
     public void initTest()
     {
         ruleEffects = new ArrayList<>();
-
 
         setUpInstances();
 
@@ -118,24 +120,23 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     {
         setProgramRuleActionType_ShowError();
 
-        verify( programRuleEngine, never() ).evaluateEnrollment( programInstance );
+        verify( programRuleEngine, never() ).evaluate( programInstance, Optional.empty(), Sets.newHashSet() );
         assertEquals( 0, ruleEffects.size() );
     }
 
     @Test
     public void testWithImplementableActionExist_programInstance()
     {
-        doAnswer( invocationOnMock ->
-        {
+        doAnswer( invocationOnMock -> {
             ruleEffects.add( (RuleEffect) invocationOnMock.getArguments()[0] );
             return ruleEffects;
-        }).when( ruleActionSendMessage ).implement( any(), any( ProgramInstance.class ) );
+        } ).when( ruleActionSendMessage ).implement( any(), any( ProgramInstance.class ) );
 
         List<RuleEffect> effects = new ArrayList<>();
         effects.add( RuleEffect.create( RuleActionSendMessage.create( NOTIFICATION_UID, DATA ) ) );
 
         when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( programInstance );
-        when( programRuleEngine.evaluateEnrollment( any() ) ).thenReturn( effects );
+        when( programRuleEngine.evaluate( any(), any(), any() ) ).thenReturn( effects );
 
         setProgramRuleActionType_SendMessage();
 
@@ -146,14 +147,14 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         assertEquals( 1, ruleEffects.size() );
 
         RuleAction action = ruleEffects.get( 0 ).ruleAction();
-        if ( action instanceof  RuleActionSendMessage )
+        if ( action instanceof RuleActionSendMessage )
         {
             RuleActionSendMessage ruleActionSendMessage = (RuleActionSendMessage) action;
 
             assertEquals( NOTIFICATION_UID, ruleActionSendMessage.notification() );
         }
 
-        verify( programRuleEngine, times( 1 ) ).evaluateEnrollment( argumentCaptor.capture() );
+        verify( programRuleEngine, times( 1 ) ).evaluate( argumentCaptor.capture(), any(), any() );
         assertEquals( programInstance, argumentCaptor.getValue() );
 
         verify( ruleActionSendMessage ).accept( action );
@@ -166,31 +167,30 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     @Test
     public void testWithImplementableActionExist_programStageInstance()
     {
-        doAnswer( invocationOnMock ->
-        {
+        doAnswer( invocationOnMock -> {
             ruleEffects.add( (RuleEffect) invocationOnMock.getArguments()[0] );
             return ruleEffects;
-        }).when( ruleActionSendMessage ).implement( any(), any( ProgramStageInstance.class ) );
+        } ).when( ruleActionSendMessage ).implement( any(), any( ProgramStageInstance.class ) );
 
         List<RuleEffect> effects = new ArrayList<>();
         effects.add( RuleEffect.create( RuleActionSendMessage.create( NOTIFICATION_UID, DATA ) ) );
 
         when( programStageInstanceService.getProgramStageInstance( anyLong() ) ).thenReturn( programStageInstance );
-        when( programRuleEngine.evaluateEvent( any() ) ).thenReturn( effects );
+        when( programRuleEngine.evaluate( any(), any(), any() ) ).thenReturn( effects );
 
         setProgramRuleActionType_SendMessage();
 
-        ArgumentCaptor<ProgramStageInstance> argumentCaptor = ArgumentCaptor.forClass( ProgramStageInstance.class );
+        ArgumentCaptor<Optional> argumentCaptor = ArgumentCaptor.forClass( Optional.class );
 
         List<RuleEffect> ruleEffects = service.evaluateEventAndRunEffects( programStageInstance.getId() );
 
         assertEquals( 1, ruleEffects.size() );
 
-        verify( programRuleEngine, times( 1 ) ).evaluateEvent( argumentCaptor.capture() );
-        assertEquals( programStageInstance, argumentCaptor.getValue() );
+        verify( programRuleEngine, times( 1 ) ).evaluate( any(), argumentCaptor.capture(), any() );
+        assertEquals( programStageInstance, argumentCaptor.getValue().get() );
 
         verify( ruleActionSendMessage ).accept( ruleEffects.get( 0 ).ruleAction() );
-        verify( ruleActionSendMessage ).implement( any( RuleEffect.class ), argumentCaptor.capture() );
+        verify( ruleActionSendMessage ).implement( any( RuleEffect.class ), any( ProgramStageInstance.class ) );
 
         assertEquals( 1, this.ruleEffects.size() );
         assertTrue( this.ruleEffects.get( 0 ).ruleAction() instanceof RuleActionSendMessage );
@@ -204,7 +204,7 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     {
         OrganisationUnit organisationUnitA = createOrganisationUnit( 'A' );
 
-        Program programA = createProgram('A', new HashSet<>(), organisationUnitA );
+        Program programA = createProgram( 'A', new HashSet<>(), organisationUnitA );
         ProgramStage programStageA = createProgramStage( 'A', programA );
 
         programRuleA = createProgramRule( 'R', programA );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
@@ -35,11 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.analytics.AggregationType;
@@ -87,6 +83,7 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueServ
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 import com.google.common.collect.Sets;
 
@@ -96,11 +93,13 @@ import com.google.common.collect.Sets;
 public class ProgramRuleEngineTest extends DhisSpringTest
 {
     private static final SimpleDateFormat simpleDateFormat = new SimpleDateFormat( "yyyy-MM-dd" );
+
     private Program programA;
 
     private Program programS;
 
     private ProgramRule programRuleA;
+
     private ProgramRule programRuleA2;
 
     private ProgramRule programRuleC;
@@ -116,10 +115,13 @@ public class ProgramRuleEngineTest extends DhisSpringTest
     private DataElement dataElementD;
 
     private DataElement dataElementDate;
+
     private DataElement dataElementAge;
+
     private DataElement assignedDataElement;
 
     private EventDataValue eventDataValueDate;
+
     private EventDataValue eventDataValueAge;
 
     private TrackedEntityAttribute attributeA;
@@ -127,6 +129,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
     private TrackedEntityAttribute attributeB;
 
     private OrganisationUnit organisationUnitA;
+
     private OrganisationUnit organisationUnitB;
 
     private String scheduledDate;
@@ -145,6 +148,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
     private Date psEventDate;
 
+    @Qualifier( "oldRuleEngine" )
     @Autowired
     ProgramRuleEngine programRuleEngine;
 
@@ -200,7 +204,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
     private ProgramNotificationTemplateStore programNotificationTemplateStore;
 
     @Override
-    public void setUpTest() throws ParseException
+    public void setUpTest()
+        throws ParseException
     {
         dataElementA = createDataElement( 'A', ValueType.TEXT, AggregationType.NONE, DataElementDomain.TRACKER );
         dataElementB = createDataElement( 'B', ValueType.TEXT, AggregationType.NONE, DataElementDomain.TRACKER );
@@ -243,7 +248,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramInstance programInstance = programInstanceService.getProgramInstance( "UID-P1" );
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluateEnrollment( programInstance );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, Optional.empty(),
+            Sets.newHashSet() );
 
         assertEquals( 1, ruleEffects.size() );
 
@@ -263,7 +269,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( "UID-PS1" );
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluateEvent( programStageInstance );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
+            Optional.of( programStageInstance ), Sets.newHashSet() );
 
         assertEquals( 1, ruleEffects.size() );
 
@@ -283,7 +290,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramInstance programInstance = programInstanceService.getProgramInstance( "UID-PS" );
 
-        List<RuleEffect> ruleEffects = programRuleEngineService.evaluateEnrollmentAndRunEffects( programInstance.getId() );
+        List<RuleEffect> ruleEffects = programRuleEngineService
+            .evaluateEnrollmentAndRunEffects( programInstance.getId() );
 
         assertEquals( 1, ruleEffects.size() );
 
@@ -298,13 +306,15 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         // For duplication detection
 
-        List<RuleEffect> ruleEffects2 = programRuleEngineService.evaluateEnrollmentAndRunEffects( programInstance.getId() );
+        List<RuleEffect> ruleEffects2 = programRuleEngineService
+            .evaluateEnrollmentAndRunEffects( programInstance.getId() );
 
         assertNotNull( ruleEffects2.get( 0 ) );
 
-        assertTrue( ruleEffects2.get( 0 ).ruleAction() instanceof  RuleActionScheduleMessage );
+        assertTrue( ruleEffects2.get( 0 ).ruleAction() instanceof RuleActionScheduleMessage );
 
-        RuleActionScheduleMessage ruleActionScheduleMessage2 = (RuleActionScheduleMessage) ruleEffects2.get( 0 ).ruleAction();
+        RuleActionScheduleMessage ruleActionScheduleMessage2 = (RuleActionScheduleMessage) ruleEffects2.get( 0 )
+            .ruleAction();
 
         assertNotNull( programNotificationTemplateStore.getByUid( ruleActionScheduleMessage2.notification() ) );
 
@@ -319,7 +329,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( "UID-PS12" );
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluateEvent( programStageInstance );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
+            Optional.of( programStageInstance ), Sets.newHashSet() );
 
         assertNotNull( ruleEffects );
         assertEquals( ruleEffects.get( 0 ).data(), "10" );
@@ -332,7 +343,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( "UID-PS13" );
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluateEvent( programStageInstance );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
+            Optional.of( programStageInstance ), Sets.newHashSet() );
 
         assertNotNull( ruleEffects );
         assertEquals( ruleEffects.get( 0 ).data(), "10" );
@@ -373,13 +385,19 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         programStageService.saveProgramStage( programStageB );
         programStageService.saveProgramStage( programStageC );
 
-        ProgramStageDataElement programStageDataElementA = createProgramStageDataElement( programStageA, dataElementA, 1 );
-        ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( programStageB, dataElementB, 2 );
-        ProgramStageDataElement programStageDataElementC = createProgramStageDataElement( programStageC, dataElementC, 3 );
-        ProgramStageDataElement programStageDataElementD = createProgramStageDataElement( programStageC, dataElementD, 4 );
+        ProgramStageDataElement programStageDataElementA = createProgramStageDataElement( programStageA, dataElementA,
+            1 );
+        ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( programStageB, dataElementB,
+            2 );
+        ProgramStageDataElement programStageDataElementC = createProgramStageDataElement( programStageC, dataElementC,
+            3 );
+        ProgramStageDataElement programStageDataElementD = createProgramStageDataElement( programStageC, dataElementD,
+            4 );
 
-        ProgramStageDataElement programStageDataElementDate = createProgramStageDataElement( programStageAge, dataElementDate, 5 );
-        ProgramStageDataElement programStageDataElementAge = createProgramStageDataElement( programStageAge, dataElementAge, 6 );
+        ProgramStageDataElement programStageDataElementDate = createProgramStageDataElement( programStageAge,
+            dataElementDate, 5 );
+        ProgramStageDataElement programStageDataElementAge = createProgramStageDataElement( programStageAge,
+            dataElementAge, 6 );
 
         programStageDataElementService.addProgramStageDataElement( programStageDataElementA );
         programStageDataElementService.addProgramStageDataElement( programStageDataElementB );
@@ -393,10 +411,13 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         programStageB.setSortOrder( 2 );
         programStageC.setSortOrder( 3 );
 
-        programStageA.setProgramStageDataElements( Sets.newHashSet( programStageDataElementA, programStageDataElementB, programStageDataElementDate ) );
+        programStageA.setProgramStageDataElements(
+            Sets.newHashSet( programStageDataElementA, programStageDataElementB, programStageDataElementDate ) );
         programStageAge.setProgramStageDataElements( Sets.newHashSet( programStageDataElementDate ) );
-        programStageB.setProgramStageDataElements( Sets.newHashSet( programStageDataElementA, programStageDataElementB ) );
-        programStageC.setProgramStageDataElements( Sets.newHashSet( programStageDataElementC, programStageDataElementD ) );
+        programStageB
+            .setProgramStageDataElements( Sets.newHashSet( programStageDataElementA, programStageDataElementB ) );
+        programStageC
+            .setProgramStageDataElements( Sets.newHashSet( programStageDataElementC, programStageDataElementD ) );
 
         programStageService.updateProgramStage( programStageA );
         programStageService.updateProgramStage( programStageB );
@@ -416,13 +437,16 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         TrackedEntityInstance entityInstanceS = createTrackedEntityInstance( organisationUnitB );
         entityInstanceService.addTrackedEntityInstance( entityInstanceS );
 
-        TrackedEntityAttributeValue attributeValue = new TrackedEntityAttributeValue( attributeA, entityInstanceA, "test" );
+        TrackedEntityAttributeValue attributeValue = new TrackedEntityAttributeValue( attributeA, entityInstanceA,
+            "test" );
         trackedEntityAttributeValueService.addTrackedEntityAttributeValue( attributeValue );
 
-        TrackedEntityAttributeValue attributeValueB = new TrackedEntityAttributeValue( attributeB, entityInstanceB, "xmen" );
+        TrackedEntityAttributeValue attributeValueB = new TrackedEntityAttributeValue( attributeB, entityInstanceB,
+            "xmen" );
         trackedEntityAttributeValueService.addTrackedEntityAttributeValue( attributeValueB );
 
-        TrackedEntityAttributeValue attributeValueS = new TrackedEntityAttributeValue( attributeB, entityInstanceS, "xmen" );
+        TrackedEntityAttributeValue attributeValueS = new TrackedEntityAttributeValue( attributeB, entityInstanceS,
+            "xmen" );
         trackedEntityAttributeValueService.addTrackedEntityAttributeValue( attributeValueS );
 
         entityInstanceA.setTrackedEntityAttributeValues( Sets.newHashSet( attributeValue ) );
@@ -434,7 +458,6 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         entityInstanceS.setTrackedEntityAttributeValues( Sets.newHashSet( attributeValueS ) );
         entityInstanceService.updateTrackedEntityInstance( entityInstanceS );
 
-
         DateTime testDate1 = DateTime.now();
         testDate1.withTimeAtStartOfDay();
         testDate1 = testDate1.minusDays( 70 );
@@ -444,11 +467,13 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         testDate2.withTimeAtStartOfDay();
         Date enrollmentDate = testDate2.toDate();
 
-        ProgramInstance programInstanceA = programInstanceService.enrollTrackedEntityInstance( entityInstanceA, programA, enrollmentDate, incidenDate, organisationUnitA );
+        ProgramInstance programInstanceA = programInstanceService.enrollTrackedEntityInstance( entityInstanceA,
+            programA, enrollmentDate, incidenDate, organisationUnitA );
         programInstanceA.setUid( "UID-P1" );
         programInstanceService.updateProgramInstance( programInstanceA );
 
-        ProgramInstance programInstanceS = programInstanceService.enrollTrackedEntityInstance( entityInstanceS, programS, enrollmentDate, incidenDate, organisationUnitB );
+        ProgramInstance programInstanceS = programInstanceService.enrollTrackedEntityInstance( entityInstanceS,
+            programS, enrollmentDate, incidenDate, organisationUnitB );
         programInstanceS.setUid( "UID-PS" );
         programInstanceService.updateProgramInstance( programInstanceS );
 
@@ -494,8 +519,8 @@ public class ProgramRuleEngineTest extends DhisSpringTest
         programStageInstanceC.setUid( "UID-PS3" );
         programStageInstanceService.addProgramStageInstance( programStageInstanceC );
 
-        programInstanceA.getProgramStageInstances().addAll( Sets.newHashSet( programStageInstanceA, programStageInstanceB,
-                programStageInstanceC, programStageInstanceAge ) );
+        programInstanceA.getProgramStageInstances().addAll( Sets.newHashSet( programStageInstanceA,
+            programStageInstanceB, programStageInstanceC, programStageInstanceAge ) );
         programInstanceService.updateProgramInstance( programInstanceA );
     }
 
@@ -570,7 +595,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramRuleAction programRuleActionForSendMessage = createProgramRuleAction( 'C', programRuleC );
         programRuleActionForSendMessage.setProgramRuleActionType( ProgramRuleActionType.SENDMESSAGE );
-        programRuleActionForSendMessage.setTemplateUid(  pnt.getUid() );
+        programRuleActionForSendMessage.setTemplateUid( pnt.getUid() );
         programRuleActionForSendMessage.setContent( "STATIC-TEXT" );
         programRuleActionService.addProgramRuleAction( programRuleActionForSendMessage );
 
@@ -587,7 +612,7 @@ public class ProgramRuleEngineTest extends DhisSpringTest
 
         ProgramRuleAction programRuleActionForScheduleMessage = createProgramRuleAction( 'S', programRuleS );
         programRuleActionForScheduleMessage.setProgramRuleActionType( ProgramRuleActionType.SCHEDULEMESSAGE );
-        programRuleActionForScheduleMessage.setTemplateUid(  pnt.getUid() );
+        programRuleActionForScheduleMessage.setTemplateUid( pnt.getUid() );
         programRuleActionForScheduleMessage.setContent( "STATIC-TEXT-SCHEDULE" );
         programRuleActionForScheduleMessage.setData( dataExpression );
         programRuleActionService.addProgramRuleAction( programRuleActionForScheduleMessage );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -32,10 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.ValueType;
@@ -65,40 +62,57 @@ import com.google.common.collect.Sets;
 public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
 {
     private static final String SAMPLE_VALUE_A = "textValueA";
+
     private static final String SAMPLE_VALUE_B = "textValueB";
 
     private List<ProgramRule> programRules = new ArrayList<>();
+
     private List<ProgramRuleVariable> programRuleVariables = new ArrayList<>();
 
     private Program program;
+
     private ProgramStage programStage;
 
     private ProgramRule programRuleA = null;
+
     private ProgramRule programRuleB = null;
+
     private ProgramRule programRuleC = null;
+
     private ProgramRule programRuleD = null;
 
     private ProgramRuleAction assignAction = null;
+
     private ProgramRuleAction sendMessageAction = null;
+
     private ProgramRuleAction displayText = null;
 
     private ProgramRuleVariable programRuleVariableA = null;
+
     private ProgramRuleVariable programRuleVariableB = null;
 
     private OrganisationUnit organisationUnit;
 
     private TrackedEntityAttribute trackedEntityAttribute;
+
     private TrackedEntityAttributeValue trackedEntityAttributeValue;
+
     private DataElement dataElement;
+
     private EventDataValue eventDataValueA;
+
     private EventDataValue eventDataValueB;
 
     private ProgramInstance programInstance;
+
     private ProgramInstance programInstanceB;
+
     private TrackedEntityInstance trackedEntityInstance;
 
     private ProgramStageInstance programStageInstanceA;
+
     private ProgramStageInstance programStageInstanceB;
+
     private ProgramStageInstance programStageInstanceC;
 
     @org.junit.Rule
@@ -181,7 +195,8 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
             if ( variable instanceof RuleVariableAttribute )
             {
                 ruleVariableAttribute = (RuleVariableAttribute) variable;
-                assertEquals( ruleVariableAttribute.trackedEntityAttribute(), programRuleVariableB.getAttribute().getUid() );
+                assertEquals( ruleVariableAttribute.trackedEntityAttribute(),
+                    programRuleVariableB.getAttribute().getUid() );
                 assertEquals( ruleVariableAttribute.name(), programRuleVariableB.getName() );
             }
 
@@ -239,7 +254,8 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
 
-        List<RuleEvent> ruleEvents = subject.toMappedRuleEvents( Sets.newHashSet( programStageInstanceA, programStageInstanceB ), programStageInstanceA  );
+        List<RuleEvent> ruleEvents = subject.toMappedRuleEvents(
+            Sets.newHashSet( programStageInstanceA, programStageInstanceB ), Optional.of( programStageInstanceA ) );
 
         assertEquals( ruleEvents.size(), 1 );
         RuleEvent ruleEvent = ruleEvents.get( 0 );
@@ -264,7 +280,8 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
 
-        List<RuleEvent> ruleEvents = subject.toMappedRuleEvents( Sets.newHashSet( programStageInstanceA, programStageInstanceB )  );
+        List<RuleEvent> ruleEvents = subject
+            .toMappedRuleEvents( Sets.newHashSet( programStageInstanceA, programStageInstanceB ), Optional.empty() );
 
         assertEquals( ruleEvents.size(), 2 );
     }
@@ -290,13 +307,15 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
 
     private void setUpProgramRules()
     {
-        program = createProgram('P' );
+        program = createProgram( 'P' );
         programStage = createProgramStage( 'S', program );
 
         programRuleVariableA = createProgramRuleVariable( 'V', program );
         programRuleVariableB = createProgramRuleVariable( 'W', program );
-        programRuleVariableA = setProgramRuleVariable( programRuleVariableA, ProgramRuleVariableSourceType.CALCULATED_VALUE, program, null, createDataElement( 'D' ), null );
-        programRuleVariableB = setProgramRuleVariable( programRuleVariableB, ProgramRuleVariableSourceType.TEI_ATTRIBUTE, program, null, null, createTrackedEntityAttribute( 'Z' ) );
+        programRuleVariableA = setProgramRuleVariable( programRuleVariableA,
+            ProgramRuleVariableSourceType.CALCULATED_VALUE, program, null, createDataElement( 'D' ), null );
+        programRuleVariableB = setProgramRuleVariable( programRuleVariableB,
+            ProgramRuleVariableSourceType.TEI_ATTRIBUTE, program, null, null, createTrackedEntityAttribute( 'Z' ) );
 
         programRuleVariables.add( programRuleVariableA );
         programRuleVariables.add( programRuleVariableB );
@@ -328,7 +347,8 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
 
         trackedEntityAttribute = createTrackedEntityAttribute( 'A', ValueType.TEXT );
         trackedEntityInstance = createTrackedEntityInstance( 'I', organisationUnit, trackedEntityAttribute );
-        trackedEntityAttributeValue = createTrackedEntityAttributeValue( 'E', trackedEntityInstance, trackedEntityAttribute );
+        trackedEntityAttributeValue = createTrackedEntityAttributeValue( 'E', trackedEntityInstance,
+            trackedEntityAttribute );
         trackedEntityAttributeValue.setValue( SAMPLE_VALUE_A );
         trackedEntityInstance.setTrackedEntityAttributeValues( Sets.newHashSet( trackedEntityAttributeValue ) );
 
@@ -368,7 +388,8 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
         programStageInstanceB.setEventDataValues( Sets.newHashSet( eventDataValueB ) );
     }
 
-    private ProgramRule setProgramRule( ProgramRule programRule, String condition, Set<ProgramRuleAction> ruleActions, Integer priority )
+    private ProgramRule setProgramRule( ProgramRule programRule, String condition, Set<ProgramRuleAction> ruleActions,
+        Integer priority )
     {
         programRule.setPriority( priority );
         programRule.setCondition( condition );
@@ -377,11 +398,12 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
         return programRule;
     }
 
-    private ProgramRuleAction setProgramRuleAction( ProgramRuleAction programRuleActionA, ProgramRuleActionType type, String content, String data )
+    private ProgramRuleAction setProgramRuleAction( ProgramRuleAction programRuleActionA, ProgramRuleActionType type,
+        String content, String data )
     {
         programRuleActionA.setProgramRuleActionType( type );
 
-        if( type == ProgramRuleActionType.ASSIGN )
+        if ( type == ProgramRuleActionType.ASSIGN )
         {
             programRuleActionA.setContent( content );
             programRuleActionA.setData( data );
@@ -394,7 +416,7 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
             programRuleActionA.setData( "true" );
         }
 
-        if( type == ProgramRuleActionType.SENDMESSAGE )
+        if ( type == ProgramRuleActionType.SENDMESSAGE )
         {
             ProgramNotificationTemplate notificationTemplate = new ProgramNotificationTemplate();
             notificationTemplate.setUid( "uid0" );
@@ -405,7 +427,8 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     private ProgramRuleVariable setProgramRuleVariable( ProgramRuleVariable variable,
-       ProgramRuleVariableSourceType sourceType, Program program, ProgramStage programStage, DataElement dataElement, TrackedEntityAttribute attribute )
+        ProgramRuleVariableSourceType sourceType, Program program, ProgramStage programStage, DataElement dataElement,
+        TrackedEntityAttribute attribute )
     {
         variable.setSourceType( sourceType );
         variable.setProgram( program );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
@@ -28,16 +28,25 @@ package org.hisp.dhis.tracker;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.programrule.engine.DefaultProgramRuleEngineService;
-import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Event;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
+import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.converter.TrackerConverterService;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import com.google.common.collect.Lists;
 
 /**
  * @author Enrico Colasante
@@ -46,33 +55,73 @@ import java.util.stream.Collectors;
 public class DefaultTrackerProgramRuleService
     implements TrackerProgramRuleService
 {
-    private final DefaultProgramRuleEngineService programRuleEngineService;
+    private final ProgramRuleEngine programRuleEngine;
 
-    public DefaultTrackerProgramRuleService( DefaultProgramRuleEngineService programRuleEngineService )
+    private final TrackerConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService;
+
+    private final TrackerConverterService<Event, ProgramStageInstance> eventTrackerConverterService;
+
+    public DefaultTrackerProgramRuleService( @Qualifier( "newRuleEngine" ) ProgramRuleEngine programRuleEngine,
+        TrackerConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService,
+        TrackerConverterService<Event, ProgramStageInstance> eventTrackerConverterService )
     {
-        this.programRuleEngineService = programRuleEngineService;
+        this.programRuleEngine = programRuleEngine;
+        this.enrollmentTrackerConverterService = enrollmentTrackerConverterService;
+        this.eventTrackerConverterService = eventTrackerConverterService;
     }
 
     @Override
-    public Map<String, List<RuleEffect>> calculateEnrollmentRuleEffects( TrackerBundle trackerBundle )
+    public Map<String, List<RuleEffect>> calculateEnrollmentRuleEffects( List<Enrollment> enrollments,
+        TrackerBundle bundle )
     {
-        return trackerBundle.getEnrollments()
+        return enrollments
             .stream()
-            .collect( Collectors
-                .toMap(
-                    Enrollment::getEnrollment,
-                    e -> programRuleEngineService
-                        .evaluateEnrollment( e.getEnrollment() ) ) );
+            .collect( Collectors.toMap( Enrollment::getEnrollment, e -> {
+                ProgramInstance enrollment = enrollmentTrackerConverterService.from( e );
+                return programRuleEngine.evaluate( enrollment, Optional.empty(),
+                    getEventsFromEnrollment( e.getEnrollment(), bundle, Lists.newArrayList() ) );
+            } ) );
     }
 
     @Override
-    public Map<String, List<RuleEffect>> calculateEventRuleEffects( TrackerBundle trackerBundle )
+    public Map<String, List<RuleEffect>> calculateEventRuleEffects( List<Event> events, TrackerBundle bundle )
     {
-        return trackerBundle.getEvents()
+        return events
             .stream()
-            .collect( Collectors
-                .toMap(
-                    Event::getEvent,
-                    e -> programRuleEngineService.evaluateEvent( e.getEvent() ) ) );
+            .collect( Collectors.toMap( Event::getEvent, event -> {
+                ProgramInstance enrollment = getEnrollment( bundle, event );
+                return programRuleEngine.evaluate( enrollment,
+                    Optional.of( eventTrackerConverterService.from( event ) ),
+                    getEventsFromEnrollment( enrollment.getUid(), bundle, events ) );
+            } ) );
+    }
+
+    private ProgramInstance getEnrollment( TrackerBundle bundle, Event event )
+    {
+        Optional<Enrollment> bundleEnrollment = bundle.getEnrollments()
+            .stream()
+            .filter( e -> event.getEnrollment().equals( e.getEnrollment() ) )
+            .findAny();
+        return bundleEnrollment.isPresent() ? enrollmentTrackerConverterService.from( bundleEnrollment.get() )
+            : bundle.getPreheat().getEnrollment( TrackerIdScheme.UID, event.getEnrollment() );
+    }
+
+    private Set<ProgramStageInstance> getEventsFromEnrollment( String enrollment, TrackerBundle bundle,
+        List<Event> events )
+    {
+        List<ProgramStageInstance> preheatEvents = bundle.getPreheat().getEvents().values()
+            .stream()
+            .flatMap( psi -> psi.values().stream() )
+            .collect( Collectors.toList() );
+        Stream<ProgramStageInstance> programStageInstances = preheatEvents
+            .stream()
+            .filter( e -> e.getProgramInstance().getUid().equals( enrollment ) );
+        Stream<ProgramStageInstance> bundleEvents = events
+            .stream()
+            .filter( e -> e.getEnrollment().equals( enrollment ) )
+            .map( eventTrackerConverterService::from );
+
+        return Stream.concat( programStageInstances, bundleEvents ).collect( Collectors.toSet() );
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerProgramRuleService.java
@@ -28,11 +28,13 @@ package org.hisp.dhis.tracker;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
-
 import java.util.List;
 import java.util.Map;
+
+import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
 
 /**
  * Calculates rule effects calling rule engine on enrollments or events.
@@ -42,20 +44,23 @@ import java.util.Map;
 public interface TrackerProgramRuleService
 {
     /**
-     * It feeds in enrollments given in {@link TrackerBundle} into rule engine and return a map of provided enrollments and
-     * their associated rule effects which are returned by rule engine.
+     * It feeds in enrollments given in {@link TrackerBundle} into rule engine and
+     * return a map of provided enrollments and their associated rule effects which
+     * are returned by rule engine.
      *
-     * @param trackerBundle
+     * @param enrollments
+     * @param bundle
      * @return Map containing enrollment uid and its associated rule effects.
      */
-    Map<String, List<RuleEffect>> calculateEnrollmentRuleEffects( TrackerBundle trackerBundle );
+    Map<String, List<RuleEffect>> calculateEnrollmentRuleEffects( List<Enrollment> enrollments, TrackerBundle bundle );
 
     /**
-     * It feeds in events given in {@link TrackerBundle} into rule engine and return a map of events and
-     * their associated rule effects.
+     * It feeds in events given in {@link TrackerBundle} into rule engine and return
+     * a map of events and their associated rule effects.
      *
-     * @param trackerBundle
+     * @param events
+     * @param bundle
      * @return Map containing event uid and its associated rule effects.
      */
-    Map<String, List<RuleEffect>> calculateEventRuleEffects( TrackerBundle trackerBundle );
+    Map<String, List<RuleEffect>> calculateEventRuleEffects( List<Event> events, TrackerBundle bundle );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -28,6 +28,13 @@ package org.hisp.dhis.tracker.bundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.cache.HibernateCacheManager;
@@ -45,33 +52,26 @@ import org.hisp.dhis.tracker.FlushMode;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerProgramRuleService;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
-import org.hisp.dhis.tracker.sideeffect.SideEffectHandlerService;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
 import org.hisp.dhis.tracker.report.TrackerBundleReport;
 import org.hisp.dhis.tracker.report.TrackerObjectReport;
 import org.hisp.dhis.tracker.report.TrackerTypeReport;
+import org.hisp.dhis.tracker.sideeffect.SideEffectHandlerService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -105,6 +105,7 @@ public class DefaultTrackerBundleService
     private final ReservedValueService reservedValueService;
 
     private List<TrackerBundleHook> bundleHooks = new ArrayList<>();
+
     private List<SideEffectHandlerService> sideEffectHandlers = new ArrayList<>();
 
     @Autowired( required = false )
@@ -119,8 +120,7 @@ public class DefaultTrackerBundleService
         this.sideEffectHandlers = sideEffectHandlers;
     }
 
-    public DefaultTrackerBundleService(
-        TrackerPreheatService trackerPreheatService,
+    public DefaultTrackerBundleService( TrackerPreheatService trackerPreheatService,
         TrackerConverterService<TrackedEntity, TrackedEntityInstance> trackedEntityTrackerConverterService,
         TrackerConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService,
         TrackerConverterService<Event, ProgramStageInstance> eventTrackerConverterService,
@@ -159,10 +159,10 @@ public class DefaultTrackerBundleService
         TrackerPreheat preheat = trackerPreheatService.preheat( preheatParams );
         trackerBundle.setPreheat( preheat );
 
-        Map<String, List<RuleEffect>> enrollmentRuleEffects =
-            trackerProgramRuleService.calculateEnrollmentRuleEffects( trackerBundle );
-        Map<String, List<RuleEffect>> eventRuleEffects =
-            trackerProgramRuleService.calculateEventRuleEffects( trackerBundle );
+        Map<String, List<RuleEffect>> enrollmentRuleEffects = trackerProgramRuleService
+            .calculateEnrollmentRuleEffects( trackerBundle.getEnrollments(), trackerBundle );
+        Map<String, List<RuleEffect>> eventRuleEffects = trackerProgramRuleService
+            .calculateEventRuleEffects( trackerBundle.getEvents(), trackerBundle );
         trackerBundle.setEnrollmentRuleEffects( enrollmentRuleEffects );
         trackerBundle.setEventRuleEffects( eventRuleEffects );
 
@@ -215,10 +215,11 @@ public class DefaultTrackerBundleService
         for ( int idx = 0; idx < trackedEntities.size(); idx++ )
         {
             TrackedEntity trackedEntity = trackedEntities.get( idx );
-            org.hisp.dhis.trackedentity.TrackedEntityInstance trackedEntityInstance = trackedEntityTrackerConverterService.from(
-                bundle.getPreheat(), trackedEntity );
+            org.hisp.dhis.trackedentity.TrackedEntityInstance trackedEntityInstance = trackedEntityTrackerConverterService
+                .from( bundle.getPreheat(), trackedEntity );
 
-            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.TRACKED_ENTITY, trackedEntityInstance.getUid(), idx );
+            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.TRACKED_ENTITY,
+                trackedEntityInstance.getUid(), idx );
             typeReport.addObjectReport( objectReport );
 
             if ( bundle.getImportStrategy().isCreate() )
@@ -232,9 +233,11 @@ public class DefaultTrackerBundleService
             trackedEntityInstance.setLastUpdatedBy( bundle.getUser() );
 
             session.persist( trackedEntityInstance );
-            bundle.getPreheat().putTrackedEntities( bundle.getIdentifier(), Collections.singletonList( trackedEntityInstance ) );
+            bundle.getPreheat().putTrackedEntities( bundle.getIdentifier(),
+                Collections.singletonList( trackedEntityInstance ) );
 
-            handleTrackedEntityAttributeValues( session, bundle.getPreheat(), trackedEntity.getAttributes(), trackedEntityInstance );
+            handleTrackedEntityAttributeValues( session, bundle.getPreheat(), trackedEntity.getAttributes(),
+                trackedEntityInstance );
 
             if ( FlushMode.OBJECT == bundle.getFlushMode() )
             {
@@ -243,7 +246,8 @@ public class DefaultTrackerBundleService
         }
 
         session.flush();
-        trackedEntities.forEach( o -> bundleHooks.forEach( hook -> hook.postCreate( TrackedEntity.class, o, bundle ) ) );
+        trackedEntities
+            .forEach( o -> bundleHooks.forEach( hook -> hook.postCreate( TrackedEntity.class, o, bundle ) ) );
 
         return typeReport;
     }
@@ -263,7 +267,8 @@ public class DefaultTrackerBundleService
             Enrollment enrollment = enrollments.get( idx );
             ProgramInstance programInstance = enrollmentTrackerConverterService.from( bundle.getPreheat(), enrollment );
 
-            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.ENROLLMENT, programInstance.getUid(), idx );
+            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.ENROLLMENT,
+                programInstance.getUid(), idx );
             typeReport.addObjectReport( objectReport );
 
             if ( bundle.getImportStrategy().isCreate() )
@@ -318,7 +323,8 @@ public class DefaultTrackerBundleService
             Event event = events.get( idx );
             ProgramStageInstance programStageInstance = eventTrackerConverterService.from( bundle.getPreheat(), event );
 
-            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.EVENT, programStageInstance.getUid(), idx );
+            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.EVENT,
+                programStageInstance.getUid(), idx );
             typeReport.addObjectReport( objectReport );
 
             Date now = new Date();
@@ -374,8 +380,8 @@ public class DefaultTrackerBundleService
             org.hisp.dhis.relationship.Relationship toRelationship = relationshipTrackerConverterService
                 .from( bundle.getPreheat(), relationship );
 
-            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.EVENT,
-                toRelationship.getUid(), idx );
+            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.EVENT, toRelationship.getUid(),
+                idx );
             typeReport.addObjectReport( objectReport );
 
             Date now = new Date();
@@ -402,9 +408,9 @@ public class DefaultTrackerBundleService
         return typeReport;
     }
 
-    //-----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
     // Utility Methods
-    //-----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
     private void handleTrackedEntityAttributeValues( Session session, TrackerPreheat preheat,
         List<Attribute> attributes, TrackedEntityInstance trackedEntityInstance )
@@ -415,34 +421,37 @@ public class DefaultTrackerBundleService
         List<String> assignedFileResources = new ArrayList<>();
         List<String> unassignedFileResources = new ArrayList<>();
 
-        Map<String, TrackedEntityAttributeValue> attributeValueMap = trackedEntityInstance.getTrackedEntityAttributeValues().stream()
-            .collect( Collectors.toMap( teav -> teav.getAttribute().getUid(), trackedEntityAttributeValue -> trackedEntityAttributeValue ) );
+        Map<String, TrackedEntityAttributeValue> attributeValueMap = trackedEntityInstance
+            .getTrackedEntityAttributeValues()
+            .stream()
+            .collect( Collectors.toMap( teav -> teav.getAttribute().getUid(),
+                trackedEntityAttributeValue -> trackedEntityAttributeValue ) );
 
         for ( Attribute at : attributes )
         {
-            // TEAV.getValue has a lot of trickery behind it since its being used for encryption, so we can't rely on that to
+            // TEAV.getValue has a lot of trickery behind it since its being used for
+            // encryption, so we can't rely on that to
             // get empty/null values, instead we build a simple list here to compare with.
             if ( StringUtils.isEmpty( at.getValue() ) )
             {
                 attributeValuesForDeletion.add( at.getAttribute() );
 
-                if ( attributeValueMap.containsKey( at.getAttribute() ) &&
-                    attributeValueMap.get( at.getAttribute() ).getAttribute().getValueType().isFile() )
+                if ( attributeValueMap.containsKey( at.getAttribute() )
+                    && attributeValueMap.get( at.getAttribute() ).getAttribute().getValueType().isFile() )
                 {
                     unassignedFileResources.add( attributeValueMap.get( at.getAttribute() ).getValue() );
                 }
             }
 
-            TrackedEntityAttribute attribute = preheat.get( TrackerIdScheme.UID, TrackedEntityAttribute.class, at.getAttribute() );
+            TrackedEntityAttribute attribute = preheat.get( TrackerIdScheme.UID, TrackedEntityAttribute.class,
+                at.getAttribute() );
             TrackedEntityAttributeValue attributeValue = null;
 
             if ( attributeValueMap.containsKey( at.getAttribute() ) )
             {
                 TrackedEntityAttributeValue av = attributeValueMap.get( at.getAttribute() );
 
-                av.setAttribute( attribute )
-                    .setValue( at.getValue() )
-                    .setStoredBy( at.getStoredBy() );
+                av.setAttribute( attribute ).setValue( at.getValue() ).setStoredBy( at.getStoredBy() );
 
                 attributeValue = av;
                 attributeValues.add( attributeValue );
@@ -453,15 +462,13 @@ public class DefaultTrackerBundleService
             {
                 attributeValue = new TrackedEntityAttributeValue();
 
-                attributeValue.setAttribute( attribute )
-                    .setValue( at.getValue() )
-                    .setStoredBy( at.getStoredBy() );
+                attributeValue.setAttribute( attribute ).setValue( at.getValue() ).setStoredBy( at.getStoredBy() );
 
                 attributeValues.add( attributeValue );
             }
 
-            if ( !attributeValuesForDeletion.contains( at.getAttribute() ) &&
-                attributeValue.getAttribute().getValueType().isFile() )
+            if ( !attributeValuesForDeletion.contains( at.getAttribute() )
+                && attributeValue.getAttribute().getValueType().isFile() )
             {
                 assignedFileResources.add( at.getValue() );
             }
@@ -469,7 +476,8 @@ public class DefaultTrackerBundleService
 
         for ( TrackedEntityAttributeValue attributeValue : attributeValues )
         {
-            // since TEAV is the owning side here, we don't bother updating the TE.teav collection
+            // since TEAV is the owning side here, we don't bother updating the TE.teav
+            // collection
             // as it will be reloaded on session clear
             if ( attributeValuesForDeletion.contains( attributeValue.getAttribute().getUid() ) )
             {
@@ -483,8 +491,8 @@ public class DefaultTrackerBundleService
 
             if ( attributeValue.getAttribute().isGenerated() && attributeValue.getAttribute().getTextPattern() != null )
             {
-                reservedValueService.useReservedValue(
-                    attributeValue.getAttribute().getTextPattern(), attributeValue.getValue() );
+                reservedValueService.useReservedValue( attributeValue.getAttribute().getTextPattern(),
+                    attributeValue.getValue() );
             }
         }
 
@@ -520,7 +528,8 @@ public class DefaultTrackerBundleService
 
     private User getUser( User user, String userUid )
     {
-        if ( user != null ) // ıf user already set, reload the user to make sure its loaded in the current tx
+        if ( user != null ) // ıf user already set, reload the user to make sure its loaded in the current
+                            // tx
         {
             return manager.get( User.class, user.getUid() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerProgramRuleBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerProgramRuleBundleServiceTest.java
@@ -28,7 +28,13 @@ package org.hisp.dhis.tracker.bundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Sets;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
@@ -52,18 +58,12 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class TrackerProgramRuleBundleServiceTest
-    extends DhisSpringTest
+public class TrackerProgramRuleBundleServiceTest extends DhisSpringTest
 {
     @Autowired
     private ObjectBundleService objectBundleService;
@@ -87,13 +87,14 @@ public class TrackerProgramRuleBundleServiceTest
     private ProgramRuleActionService programRuleActionService;
 
     @Override
-    protected void setUpTest() throws IOException
+    protected void setUpTest()
+        throws IOException
     {
         renderService = _renderService;
         userService = _userService;
 
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
-            new ClassPathResource( "tracker/event_metadata.json" ).getInputStream(), RenderFormat.JSON );
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService
+            .fromMetadata( new ClassPathResource( "tracker/event_metadata.json" ).getInputStream(), RenderFormat.JSON );
 
         ObjectBundleParams params = new ObjectBundleParams();
         params.setObjectBundleMode( ObjectBundleMode.COMMIT );
@@ -106,8 +107,8 @@ public class TrackerProgramRuleBundleServiceTest
 
         objectBundleService.commit( bundle );
 
-        ProgramRule programRule = createProgramRule( 'A', bundle.getPreheat().get( PreheatIdentifier.UID,
-            Program.class, "BFcipDERJne" ) );
+        ProgramRule programRule = createProgramRule( 'A',
+            bundle.getPreheat().get( PreheatIdentifier.UID, Program.class, "BFcipDERJne" ) );
         programRuleService.addProgramRule( programRule );
 
         ProgramRuleAction programRuleAction = createProgramRuleAction( 'A', programRule );
@@ -120,16 +121,18 @@ public class TrackerProgramRuleBundleServiceTest
     }
 
     @Test
-    public void testRunRuleEngineForEventOnBundleCreate() throws IOException
+    public void testRunRuleEngineForEventOnBundleCreate()
+        throws IOException
     {
-        TrackerBundle trackerBundle = renderService.fromJson( new ClassPathResource( "tracker/event_events.json" ).getInputStream(),
-            TrackerBundleParams.class ).toTrackerBundle();
+        TrackerBundle trackerBundle = renderService
+            .fromJson( new ClassPathResource( "tracker/event_events_and_enrollment.json" ).getInputStream(),
+                TrackerBundleParams.class )
+            .toTrackerBundle();
 
         assertEquals( 8, trackerBundle.getEvents().size() );
 
         List<TrackerBundle> trackerBundles = trackerBundleService.create( TrackerBundleParams.builder()
-            .events( trackerBundle.getEvents() )
-            .build() );
+            .events( trackerBundle.getEvents() ).enrollments( trackerBundle.getEnrollments() ).build() );
 
         assertEquals( 1, trackerBundles.size() );
         assertEquals( trackerBundle.getEvents().size(), trackerBundles.get( 0 ).getEventRuleEffects().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/enrollment.json
@@ -1,0 +1,34 @@
+{
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "created": "2018-01-26T13:48:13.363",
+      "lastUpdated": "2018-01-26T13:48:13.363",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntityType": "nEenWmSyUEp",
+      "trackedEntityInstance": "IOR1AXXl24H",
+      "program": "BFcipDERJne",
+      "status": "ACTIVE",
+      "orgUnit": "PlKwabX2xRW",
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2021-03-28T12:05:00.000",
+      "occurredAt": "2021-03-28T12:05:00.000",
+      "followup": false,
+      "deleted": false
+    }
+  ],
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": "nEenWmSyUEp",
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "clientCreatedAt": "2020-02-20T12:09:21.844",
+      "clientUpdatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": "PlKwabX2xRW",
+      "inactive": false,
+      "deleted": false,
+      "featureType": "NONE"
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -1,0 +1,214 @@
+{
+  "trackedEntities": [
+    {
+      "trackedEntityType": "nEenWmSyUEp",
+      "trackedEntity": "IOR1AXXl24H",
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "clientCreatedAt": "2020-02-20T12:09:21.844",
+      "clientUpdatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": "PlKwabX2xRW",
+      "inactive": false,
+      "deleted": false,
+      "featureType": "NONE",
+      "programOwners": [
+        {
+          "ownerOrgUnit": "cNEZTkdAvmg",
+          "program": "hJUBNVQWl4e",
+          "trackedEntity": "EEFkxTWB55Y"
+        }
+      ]
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "created": "2018-01-26T13:48:13.363",
+      "lastUpdated": "2018-01-26T13:48:13.363",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntityType": "nEenWmSyUEp",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": "BFcipDERJne",
+      "status": "ACTIVE",
+      "orgUnit": "PlKwabX2xRW",
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2021-03-28T12:05:00.000",
+      "occurredAt": "2021-03-28T12:05:00.000",
+      "followup": false,
+      "deleted": false
+    }
+  ],
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.113", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.113", "dataElement": "DSKTW8qFP0z", "value": "2017-01-27T17:00:00.000Z", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "vQaFEJwd8yW",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.115", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.115", "dataElement": "VD2olWcRozZ", "value": "2019-01-28", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "DB6kH3mDTAg",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.116", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.116", "dataElement": "WS3e6pInnuA", "value": "2019-01-27T18:00:00.000Z", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "axjn1txp4oq",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.116", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.116", "dataElement": "h7hXjNVMiRl", "value": "test@dhis2.org", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "ihAktymaeT0",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.121", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.121", "dataElement": "KCLriKKezWO", "value": "123", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "OOPh5soZawq",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.122", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.122", "dataElement": "A8qxpcalLtf", "value": "Test text for LongText data element.", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.122", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.122", "dataElement": "zal5vkVEpV0", "value": "-123", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.122", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.122", "dataElement": "kAfSfT69m0E", "value": "123", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.123", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.123", "dataElement": "wIUShyK7lIa", "value": "/PlKwabX2xRW", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.123", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.123", "dataElement": "ICfA0klVxkd", "value": "23", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "inxOmxgOjzm",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.123", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.123", "dataElement": "xaPkxL28aPx", "value": "1231231", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "Kvm949EFjjv", "value": "123", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "xaQ4gqDYGL9", "value": "0", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "MqGMwzt7M7w", "value": "Test text for Text data element.", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "WdTLfnn4S1I", "value": "4:00", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "gHLdZusV5Wz",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.134", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.133", "dataElement": "hxUvZqnmBDv", "value": "http://dhis2.org", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.135", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.135", "dataElement": "JXF90RhgNiI", "value": "admin", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.136", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.136", "dataElement": "gfEoDU4GtXK", "value": "true", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.136", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.136", "dataElement": "qw67QlOlzdp", "value": "true", "providedElsewhere": false }
+      ]
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment_link.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment_link.json
@@ -1,0 +1,175 @@
+{
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.113", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.113", "dataElement": "DSKTW8qFP0z", "value": "2017-01-27T17:00:00.000Z", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "vQaFEJwd8yW",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.115", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.115", "dataElement": "VD2olWcRozZ", "value": "2019-01-28", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "DB6kH3mDTAg",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.116", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.116", "dataElement": "WS3e6pInnuA", "value": "2019-01-27T18:00:00.000Z", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "axjn1txp4oq",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.116", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.116", "dataElement": "h7hXjNVMiRl", "value": "test@dhis2.org", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "ihAktymaeT0",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.121", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.121", "dataElement": "KCLriKKezWO", "value": "123", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "OOPh5soZawq",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.122", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.122", "dataElement": "A8qxpcalLtf", "value": "Test text for LongText data element.", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.122", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.122", "dataElement": "zal5vkVEpV0", "value": "-123", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.122", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.122", "dataElement": "kAfSfT69m0E", "value": "123", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.123", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.123", "dataElement": "wIUShyK7lIa", "value": "/PlKwabX2xRW", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.123", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.123", "dataElement": "ICfA0klVxkd", "value": "23", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "inxOmxgOjzm",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.123", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.123", "dataElement": "xaPkxL28aPx", "value": "1231231", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "Kvm949EFjjv", "value": "123", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "xaQ4gqDYGL9", "value": "0", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "MqGMwzt7M7w", "value": "Test text for Text data element.", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.124", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.124", "dataElement": "WdTLfnn4S1I", "value": "4:00", "providedElsewhere": false }
+      ]
+    },
+    {
+      "event": "gHLdZusV5Wz",
+      "enrollment": "TvctPPhpD8u",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJne",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "PlKwabX2xRW",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": "HllvX50cXC0",
+      "completedBy": "admin",
+      "dataValues": [
+        { "updatedAt": "2019-01-28T12:10:38.134", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.133", "dataElement": "hxUvZqnmBDv", "value": "http://dhis2.org", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.135", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.135", "dataElement": "JXF90RhgNiI", "value": "admin", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.136", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.136", "dataElement": "gfEoDU4GtXK", "value": "true", "providedElsewhere": false },
+        { "updatedAt": "2019-01-28T12:10:38.136", "storedBy": "admin", "createdAt": "2019-01-28T12:10:38.136", "dataElement": "qw67QlOlzdp", "value": "true", "providedElsewhere": false }
+      ]
+    }
+  ]
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -56,22 +56,23 @@ import org.springframework.stereotype.Service;
 
 }, excludeFilters = @Filter(Configuration.class))
 @Import( {
-        JdbcConfig.class,
-        HibernateConfig.class,
-        FlywayConfig.class,
-        EncryptionConfig.class,
-        ServiceConfig.class,
-        StoreConfig.class,
-        LeaderElectionConfiguration.class,
-        org.hisp.dhis.setting.config.ServiceConfig.class,
-        org.hisp.dhis.external.config.ServiceConfig.class,
-        org.hisp.dhis.dxf2.config.ServiceConfig.class,
-        org.hisp.dhis.support.config.ServiceConfig.class,
-        org.hisp.dhis.validation.config.ServiceConfig.class,
-        org.hisp.dhis.validation.config.StoreConfig.class,
-        org.hisp.dhis.reporting.config.StoreConfig.class,
-        org.hisp.dhis.analytics.config.ServiceConfig.class,
-        org.hisp.dhis.commons.config.JacksonObjectMapperConfig.class} )
+    JdbcConfig.class,
+    HibernateConfig.class,
+    FlywayConfig.class,
+    EncryptionConfig.class,
+    ServiceConfig.class,
+    StoreConfig.class,
+    LeaderElectionConfiguration.class,
+    org.hisp.dhis.setting.config.ServiceConfig.class,
+    org.hisp.dhis.external.config.ServiceConfig.class,
+    org.hisp.dhis.dxf2.config.ServiceConfig.class,
+    org.hisp.dhis.support.config.ServiceConfig.class,
+    org.hisp.dhis.validation.config.ServiceConfig.class,
+    org.hisp.dhis.validation.config.StoreConfig.class,
+    org.hisp.dhis.programrule.config.ProgramRuleConfig.class,
+    org.hisp.dhis.reporting.config.StoreConfig.class,
+    org.hisp.dhis.analytics.config.ServiceConfig.class,
+    org.hisp.dhis.commons.config.JacksonObjectMapperConfig.class } )
 public class WebTestConfiguration
 {
     @Bean( name = "dhisConfigurationProvider" )

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -623,7 +623,7 @@
       <dependency>
         <groupId>org.hisp.dhis.rules</groupId>
         <artifactId>rule-engine</artifactId>
-        <version>2.0.34.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
       </dependency>
 
       <!-- Spring -->


### PR DESCRIPTION
This is a preliminary refactor needed on the core side when we call rule engine to evaluate program rules. 

The main goal of this PR is to remove all the duplicated code derived by the difference in the call of rule engine when the target of the evaluation is an enrollment or an event.