### PR TITLE
fix: prevent audit StackOverFlow error with Relationship

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipItem.java
@@ -28,19 +28,21 @@ package org.hisp.dhis.relationship;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
 /**
  * @author Stian Sandvold
  */
-public class RelationshipItem
-    implements EmbeddedObject
+public class RelationshipItem implements EmbeddedObject
 {
     private int id;
 
@@ -69,6 +71,7 @@ public class RelationshipItem
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonSerialize( as = BaseIdentifiableObject.class )
     public Relationship getRelationship()
     {
         return relationship;
@@ -81,6 +84,7 @@ public class RelationshipItem
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonSerialize( as = BaseIdentifiableObject.class )
     public TrackedEntityInstance getTrackedEntityInstance()
     {
         return trackedEntityInstance;
@@ -93,6 +97,7 @@ public class RelationshipItem
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonSerialize( as = BaseIdentifiableObject.class )
     public ProgramInstance getProgramInstance()
     {
         return programInstance;
@@ -105,6 +110,7 @@ public class RelationshipItem
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonSerialize( as = BaseIdentifiableObject.class )
     public ProgramStageInstance getProgramStageInstance()
     {
         return programStageInstance;


### PR DESCRIPTION
The Auditing component fails to serialize to Json self-referencing TEIs.
When a TEI (tei A) has a relationship with another TEI (tei B), and tei B
references tei A, the Jackson parser fails with a Stack Overflow Error.
Please note that the StackOverflow exception **DOES NOT block** the operation (saving the TEI): the error stack is printed in the application log and the auditing does not take place.

This fix uses a Jackson annotation on the RelationshipItem class that "forces"
the serialization to only serialize the "simple" information of the linked Tei and
avoid recursion into the "relationship" attribute.

![tei-relationship](https://user-images.githubusercontent.com/300784/82452184-38231900-9aaf-11ea-8f31-37acc5b7a587.png)

