### PR TITLE
fix: Set DB Locale in UserContext for struts I18nInterceptor

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/I18nInterceptor.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/I18nInterceptor.java
@@ -33,10 +33,15 @@ import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.interceptor.Interceptor;
 import ognl.NoSuchPropertyException;
 import ognl.Ognl;
+import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.i18n.locale.LocaleManager;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserSettingKey;
+import org.hisp.dhis.user.UserSettingService;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -70,6 +75,21 @@ public class I18nInterceptor
     {
         this.localeManager = localeManager;
     }
+
+    private CurrentUserService currentUserService;
+
+    public void setCurrentUserService( CurrentUserService currentUserService )
+    {
+        this.currentUserService = currentUserService;
+    }
+
+    private UserSettingService userSettingService;
+
+    public void setUserSettingService( UserSettingService userSettingService )
+    {
+        this.userSettingService = userSettingService;
+    }
+
 
     // -------------------------------------------------------------------------
     // AroundInterceptor implementation
@@ -135,6 +155,16 @@ public class I18nInterceptor
         catch ( NoSuchPropertyException ignored )
         {
         }
+
+        // ---------------------------------------------------------------------
+        // Set the current User DB Locale in UserContext
+        // ---------------------------------------------------------------------
+
+        User currentUser = currentUserService.getCurrentUser();
+        Locale dbLocale = (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE, currentUser );
+
+        UserContext.setUser( currentUser );
+        UserContext.setUserSetting( UserSettingKey.DB_LOCALE, dbLocale );
 
         return invocation.invoke();
     }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/beans.xml
@@ -474,6 +474,8 @@
   <bean id="org.hisp.dhis.interceptor.I18nInterceptor" class="org.hisp.dhis.interceptor.I18nInterceptor">
     <property name="i18nManager" ref="org.hisp.dhis.i18n.I18nManager" />
     <property name="localeManager" ref="org.hisp.dhis.i18n.locale.LocaleManager" />
+    <property name="currentUserService" ref="org.hisp.dhis.user.CurrentUserService" />
+    <property name="userSettingService" ref="org.hisp.dhis.user.UserSettingService"/>
   </bean>
 
   <bean id="org.hisp.dhis.interceptor.SystemSettingInterceptor" class="org.hisp.dhis.interceptor.SystemSettingInterceptor">


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-4086

Spring mvc **TranslationInterceptor** doesn't apply for **Struts actions** such as  **LoadFormAction** used in DataEntry app.
Therefore  db_locale is always null ( getting from **UserContext.getUserSetting**  ) in function **BaseIdentifiableObject.getTranslation()**
 
So we have to set db locale in Struts interceptor


         // ---------------------------------------------------------------------
         // Set the current User DB Locale in UserContext
         // ---------------------------------------------------------------------

         User currentUser = currentUserService.getCurrentUser();
         Locale dbLocale = (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE, currentUser );

         UserContext.setUser( currentUser );
         UserContext.setUserSetting( UserSettingKey.DB_LOCALE, dbLocale );`