### PR TITLE
fix: Fix wrong use of getCurrentUser()

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -1314,7 +1314,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
 
         if ( userCredentials != null )
         {
-            return userCredentials.getUser();
+            return userCredentials.getUserInfo();
         }
 
         return null;


### PR DESCRIPTION
HibernateIdentifiableObjectStore:getCurrentUser() wrongly uses .getUser()
method on the UserCredentials to retrieve the current user. This is wrong,
this returns the user that created the object. The correct method should
be .getUserInfo()

Issue: [DHIS2-8963]
Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>