### PR TITLE
[2.33] fix: Remove Program Instance creation from controller

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -72,21 +72,6 @@ public class ProgramController
     private ProgramService programService;
 
     @Override
-    protected void postCreateEntity( Program program )
-    {
-        if ( program.isWithoutRegistration() )
-        {
-            ProgramInstance programInstance = new ProgramInstance();
-            programInstance.setEnrollmentDate( new Date() );
-            programInstance.setIncidentDate( new Date() );
-            programInstance.setProgram( program );
-            programInstance.setStatus( ProgramStatus.ACTIVE );
-
-            programInstanceService.addProgramInstance( programInstance );
-        }
-    }
-
-    @Override
     @SuppressWarnings( "unchecked" )
     protected List<Program> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
         throws QueryParserException


### PR DESCRIPTION
When a Program of type "WITHOUT REGISTRATION" is created through the
`/program`` end-point, two Program Instances are automatically created,
instead of one.
This fix, removes the Program Instance creation from the ``ProgramController`
class.