### PR TITLE
fix: Invalid weekly period year reference

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateTimeUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateTimeUnit.java
@@ -182,7 +182,7 @@ public class DateTimeUnit
     }
 
     /**
-     * Get the year for the week this DateTime unit falls in, based ISO calendar system 
+     * Get the year for the week this DateTime unit falls in, based on the ISO calendar system
      * where the week year starts in the first week with at least 4 days in that year.
      * 
      * @return a year

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateTimeUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateTimeUnit.java
@@ -37,6 +37,9 @@ import org.joda.time.LocalDateTime;
 import org.joda.time.chrono.ISOChronology;
 
 import javax.validation.constraints.NotNull;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.IsoFields;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -176,6 +179,20 @@ public class DateTimeUnit
     public int getYear()
     {
         return year;
+    }
+
+    /**
+     * Get the year for the week this DateTime unit falls in, based ISO calendar system 
+     * where the week year starts in the first week with at least 4 days in that year.
+     * 
+     * @return a year
+     */
+    public int getWeekYear()
+    {
+        final ZonedDateTime now = ZonedDateTime.of( this.year, this.month, this.day, this.hour, this.minute, this.second, 0,
+            ZoneId.systemDefault() );
+
+        return now.get( IsoFields.WEEK_BASED_YEAR );
     }
 
     public void setYear( int year )

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/calendar/DateTimeUnitTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/calendar/DateTimeUnitTest.java
@@ -142,4 +142,18 @@ public class DateTimeUnitTest
 
         dateTimeUnit.toJodaDateTime();
     }
+
+    @Test
+    public void testYearOfWeek()
+    {
+        assertEquals( 2020, getDateTimeUnit( 2019, Calendar.DECEMBER, 31 ).getWeekYear() );
+        assertEquals( 2019, getDateTimeUnit( 2019, Calendar.DECEMBER, 29 ).getWeekYear() );
+    }
+    
+    private DateTimeUnit getDateTimeUnit( int year, int month, int day )
+    {
+        java.util.Calendar cal = new GregorianCalendar( year, month, day );
+        Date date = cal.getTime();
+        return DateTimeUnit.fromJdkDate( date );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.resourcetable.ResourceTable;
 import org.hisp.dhis.resourcetable.ResourceTableType;
 
@@ -101,7 +102,16 @@ public class PeriodResourceTable
             if ( period != null && period.isValid() )
             {
                 final String isoDate = period.getIsoDate();
-                final int year = PeriodType.getCalendar().fromIso( period.getStartDate() ).getYear();
+                int year;
+
+                if ( period.getPeriodType().equalsName( WeeklyPeriodType.NAME ) )
+                {
+                    year = PeriodType.getCalendar().fromIso( period.getStartDate() ).getWeekYear();
+                }
+                else
+                {
+                    year = PeriodType.getCalendar().fromIso( period.getStartDate() ).getYear();
+                }
 
                 if ( !uniqueIsoDates.add( isoDate ) )
                 {


### PR DESCRIPTION
- DHIS2-5990
- This fix corrects an error during the `_periodstructure` generation process. The process
assigns the wrong year to a week that belongs to the following year.

Example: `2019-12-31`
The week of 2019-12-31, according to the ISO calendar system, belongs to 2020, because 4 or more days of the week fall in 2020.