### PR TITLE
fix: [DHIS2-9051] incorrect pagination when using query parameter in metadata list api(2.35)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -243,7 +243,17 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         if ( options.hasPaging() && pager == null )
         {
-            long count = paginationCountCache.computeIfAbsent( calculatePaginationCountKey(currentUser, filters, options), () -> count( metadata, options, filters, orders ) );
+            long count;
+            if ( options.getOptions().containsKey( "query" ) )
+            {
+                count = entities.size();
+                entities = entities.stream().skip( (options.getPage() - 1) * options.getPageSize() ).limit( options.getPageSize() ).collect( Collectors.toList() );
+            }
+            else
+            {
+                count = paginationCountCache.computeIfAbsent( calculatePaginationCountKey(currentUser, filters, options), () -> count( metadata, options, filters, orders ) );
+            }
+            
             pager = new Pager( options.getPage(), count, options.getPageSize() );
         }
 


### PR DESCRIPTION
When using the "query" parameter in metadata listing apis, the pagination is incorrect and always returns total count. The "query" parameter flow will now have correct pagination done in memory (not in the db). So there is no performance difference, except that the pagination numbers are now correct. 