### PR TITLE
feat: Period offset for Indicator formula

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateUnitPeriodTypeParser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateUnitPeriodTypeParser.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.period.BiWeeklyPeriodType;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.WeeklyAbstractPeriodType;
 
+import java.io.Serializable;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.WeekFields;
@@ -45,7 +46,7 @@ import java.util.regex.PatternSyntaxException;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class DateUnitPeriodTypeParser implements PeriodTypeParser
+public class DateUnitPeriodTypeParser implements PeriodTypeParser, Serializable
 {
     private final Map<String, Pattern> compileCache = Maps.newHashMap();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -109,7 +109,7 @@ public class BaseDimensionalItemObject
     {
         return getPropertyValue( idScheme );
     }
-    
+
     @Override
     public TotalAggregationType getTotalAggregationType()
     {
@@ -175,7 +175,7 @@ public class BaseDimensionalItemObject
     {
         return periodOffset;
     }
-    
+
     public void setPeriodOffset( int periodOffset )
     {
         this.periodOffset = periodOffset;
@@ -185,11 +185,19 @@ public class BaseDimensionalItemObject
     public boolean equals( Object o )
     {
         if ( this == o )
+        {
             return true;
+        }
+
         if ( o == null || getClass() != o.getClass() )
+        {
             return false;
+        }
+
         if ( !super.equals( o ) )
+        {
             return false;
+        }
 
         final BaseDimensionalItemObject that = (BaseDimensionalItemObject) o;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -175,14 +175,8 @@ public class BaseDimensionalItemObject
     {
         return periodOffset;
     }
-
-    @Override
-    public void resetPeriodOffset()
-    {
-        this.periodOffset = 0;
-    }
-
-    public void setPeriodOffset(int periodOffset )
+    
+    public void setPeriodOffset( int periodOffset )
     {
         this.periodOffset = periodOffset;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -63,7 +63,7 @@ public class BaseDimensionalItemObject
      * A value representing a period offset that can be applied to Dimensional Item
      * Object within a Indicator formula
      */
-    protected int periodOffset = 0;
+    protected transient int periodOffset = 0;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -188,10 +188,14 @@ public class BaseDimensionalItemObject
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+            return true;
+        if ( o == null || getClass() != o.getClass() )
+            return false;
+        if ( !super.equals( o ) )
+            return false;
 
         final BaseDimensionalItemObject that = (BaseDimensionalItemObject) o;
 
@@ -199,7 +203,8 @@ public class BaseDimensionalItemObject
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = super.hashCode();
         result = 31 * result + periodOffset;
         return result;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -59,6 +59,12 @@ public class BaseDimensionalItemObject
      */
     protected AggregationType aggregationType;
 
+    /**
+     * A value representing a period offset that can be applied to Dimensional Item
+     * Object within a Indicator formula
+     */
+    protected int periodOffset = 0;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -160,5 +166,42 @@ public class BaseDimensionalItemObject
     public void setAggregationType( AggregationType aggregationType )
     {
         this.aggregationType = aggregationType;
+    }
+
+    @Override
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public int getPeriodOffset()
+    {
+        return periodOffset;
+    }
+
+    @Override
+    public void resetPeriodOffset()
+    {
+        this.periodOffset = 0;
+    }
+
+    public void setPeriodOffset(int periodOffset )
+    {
+        this.periodOffset = periodOffset;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        final BaseDimensionalItemObject that = (BaseDimensionalItemObject) o;
+
+        return periodOffset == that.periodOffset;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + periodOffset;
+        return result;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionItemObjectValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionItemObjectValue.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.analytics.data;
+package org.hisp.dhis.common;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -34,7 +34,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 
 @Getter
 @AllArgsConstructor
-public class DimensionItemWithValue
+public class DimensionItemObjectValue
 {
     private final DimensionalItemObject dimensionalItemObject;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
@@ -68,6 +68,11 @@ public class DimensionalItemId
      */
     private String id2;
 
+    /**
+     * The period offset
+     */
+    private Integer periodOffset = 0;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -76,6 +81,13 @@ public class DimensionalItemId
     {
         this.dimensionItemType = dimensionItemType;
         this.id0 = id0;
+    }
+
+    public DimensionalItemId( DimensionItemType dimensionItemType, String id0, Integer periodOffset )
+    {
+        this.dimensionItemType = dimensionItemType;
+        this.id0 = id0;
+        this.periodOffset = periodOffset;
     }
 
     public DimensionalItemId( DimensionItemType dimensionItemType, String id0, String id1 )
@@ -91,6 +103,16 @@ public class DimensionalItemId
         this.id0 = id0;
         this.id1 = id1;
         this.id2 = id2;
+    }
+
+    public DimensionalItemId( DimensionItemType dimensionItemType, String id0, String id1, String id2,
+        int periodOffset )
+    {
+        this.dimensionItemType = dimensionItemType;
+        this.id0 = id0;
+        this.id1 = id1;
+        this.id2 = id2;
+        this.periodOffset = periodOffset;
     }
 
     // -------------------------------------------------------------------------
@@ -150,7 +172,8 @@ public class DimensionalItemId
         return Objects.equals( this.dimensionItemType, that.dimensionItemType )
             && Objects.equals( this.id0, that.id0 )
             && Objects.equals( this.id1, that.id1 )
-            && Objects.equals( this.id2, that.id2 );
+            && Objects.equals( this.id2, that.id2 )
+            && this.periodOffset.equals( that.periodOffset );
     }
 
     @Override
@@ -158,9 +181,10 @@ public class DimensionalItemId
     {
         int result = dimensionItemType.hashCode();
 
-        result = 31 * result + ( id0 == null ? 0 : id0.hashCode() );
-        result = 31 * result + ( id1 == null ? 0 : id1.hashCode() );
-        result = 31 * result + ( id2 == null ? 0 : id2.hashCode() );
+        result = 31 * result + (id0 == null ? 0 : id0.hashCode());
+        result = 31 * result + (id1 == null ? 0 : id1.hashCode());
+        result = 31 * result + (id2 == null ? 0 : id2.hashCode());
+        result = 31 * result + periodOffset;
 
         return result;
     }
@@ -173,6 +197,7 @@ public class DimensionalItemId
             .add( "id0", id0 )
             .add( "id1", id1 )
             .add( "id2", id2 )
+            .add( "periodOffset", periodOffset )
             .toString();
     }
 
@@ -198,5 +223,10 @@ public class DimensionalItemId
     public String getId2()
     {
         return id2;
+    }
+
+    public Integer getPeriodOffset()
+    {
+        return periodOffset;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
@@ -91,4 +91,18 @@ public interface DimensionalItemObject
      * should be aggregated across multiple values.
      */
     TotalAggregationType getTotalAggregationType();
+
+    /**
+     * Gets a Period Offset: the offset can be applied within an Indicator formula
+     * in order to "shift" the query period by the offset value (e.g. Jan 2020 with
+     * offset 1 becomes Feb 2020). An offset with value 0 means no offset.
+     * 
+     * @return an int.
+     */
+    int getPeriodOffset();
+
+    /**
+     * Set the Period Offset to 0
+     */
+    void resetPeriodOffset();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
@@ -100,9 +100,4 @@ public interface DimensionalItemObject
      * @return an int.
      */
     int getPeriodOffset();
-
-    /**
-     * Set the Period Offset to 0
-     */
-    void resetPeriodOffset();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.comparator.ObjectStringValueComparator;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -503,7 +504,13 @@ public class DimensionalObjectUtils
      */
     public static Set<DimensionalItemObject> getDataElements( Collection<DataElementOperand> operands )
     {
-        return operands.stream().map( DataElementOperand::getDataElement ).collect( Collectors.toSet() );
+        return operands.stream().map( o -> {
+
+            DataElement dataElement = o.getDataElement();
+            dataElement.setPeriodOffset( o.getPeriodOffset() );
+            return dataElement;
+
+        } ).collect( Collectors.toSet() );
     }
 
     /**
@@ -517,7 +524,13 @@ public class DimensionalObjectUtils
     {
         return operands.stream()
             .filter( o -> o.getCategoryOptionCombo() != null )
-            .map( DataElementOperand::getCategoryOptionCombo )
+            .map( o -> {
+
+                CategoryOptionCombo coc = o.getCategoryOptionCombo();
+                coc.setPeriodOffset( o.getPeriodOffset() );
+                return coc;
+                
+            } )
             .collect( Collectors.toSet() );
     }
 
@@ -532,7 +545,13 @@ public class DimensionalObjectUtils
     {
         return operands.stream()
             .filter( o -> o.getAttributeOptionCombo() != null )
-            .map( DataElementOperand::getAttributeOptionCombo )
+            .map( o -> {
+
+                CategoryOptionCombo aoc = o.getAttributeOptionCombo();
+                aoc.setPeriodOffset( o.getPeriodOffset() );
+                return aoc;
+
+            } )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -725,4 +725,15 @@ public class DimensionalObjectUtils
             .map( DimensionalItemObject::getShortName )
             .collect( Collectors.joining( COL_SEP ) );
     }
+
+    /**
+     * Transforms a List of {@see DimensionItemObjectValue} into a Map of
+     * {@see DimensionalItemObject} and value
+     */
+    public static Map<DimensionalItemObject, Double> convertToDimItemValueMap(
+        List<DimensionItemObjectValue> dimensionItemObjectValues )
+    {
+        return dimensionItemObjectValues.stream().collect( Collectors
+            .toMap( DimensionItemObjectValue::getDimensionalItemObject, DimensionItemObjectValue::getValue ) );
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ListMap.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ListMap.java
@@ -79,6 +79,14 @@ public class ListMap<T, V>
         }
     }
 
+    public void putAll( ListMap<T, V> map )
+    {
+        for ( T key : map.keySet() )
+        {
+            putValues( key, map.get( key ) );
+        }
+    }
+
     public Collection<V> allValues()
     {
         Collection<V> results = new ArrayList<>();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ListMap.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ListMap.java
@@ -27,11 +27,18 @@ package org.hisp.dhis.common;
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
+ * Mapping between keys T and a list of values V.
+ *
  * @author Lars Helge Overland
  */
 public class ListMap<T, V>
@@ -46,7 +53,7 @@ public class ListMap<T, V>
     {
         super();
     }
-    
+
     public ListMap( ListMap<T, V> listMap )
     {
         super( listMap );
@@ -89,49 +96,49 @@ public class ListMap<T, V>
 
     public Collection<V> allValues()
     {
-        Collection<V> results = new ArrayList<>();
-        
+        List<V> results = new ArrayList<>();
+
         for ( Map.Entry<T, List<V>> entry: entrySet() )
         {
             results.addAll( entry.getValue() );
         }
-        
+
         return results;
     }
 
     public Set<V> uniqueValues( )
     {
         Set<V> results = new HashSet<>();
-        
+
         for ( Map.Entry<T, List<V>> entry: entrySet() )
         {
             results.addAll( entry.getValue() );
         }
-        
+
         return results;
     }
 
     public boolean containsValue( T key, V value )
     {
         List<V> list = this.get( key );
-        
+
         if ( list == null )
         {
             return false;
         }
-        
+
         if ( list.contains( value ) )
         {
             return true;
         }
-        
+
         return false;
     }
 
     /**
      * Produces a ListMap based on the given list of values. The key for
      * each entry is produced by applying the given keyMapper function.
-     * 
+     *
      * @param values the values of the map.
      * @param keyMapper the function producing the key for each entry.
      * @return a ListMap.
@@ -139,22 +146,22 @@ public class ListMap<T, V>
     public static <T, V> ListMap<T, V> getListMap( List<V> values, Function<V, T> keyMapper )
     {
         ListMap<T, V> map = new ListMap<>();
-        
+
         for ( V value : values )
         {
             T key = keyMapper.apply( value );
-            
+
             map.putValue( key, value );
         }
-        
+
         return map;
     }
 
     /**
      * Produces a ListMap based on the given list of values. The key for
      * each entry is produced by applying the given keyMapper function. The value
-     * for each entry is produced by applying the given valueMapper function. 
-     * 
+     * for each entry is produced by applying the given valueMapper function.
+     *
      * @param values the values of the map.
      * @param keyMapper the function producing the key for each entry.
      * @param valueMapper the function producing the value for each entry.
@@ -163,15 +170,15 @@ public class ListMap<T, V>
     public static <T, U, V> ListMap<T, U> getListMap( List<V> values, Function<V, T> keyMapper, Function<V, U> valueMapper )
     {
         ListMap<T, U> map = new ListMap<>();
-        
+
         for ( V value : values )
         {
             T key = keyMapper.apply( value );
             U val = valueMapper.apply( value );
-            
+
             map.putValue( key, val );
         }
-        
+
         return map;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
@@ -39,13 +39,14 @@ import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.category.CategoryCombo;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * @author Lars Helge Overland
  */
 @JacksonXmlRootElement( localName = "dataSetElement", namespace = DxfNamespaces.DXF_2_0 )
-public class DataSetElement implements EmbeddedObject
+public class DataSetElement implements EmbeddedObject, Serializable
 {
     /**
      * The database internal identifier for this Object.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -75,6 +75,12 @@ public class Period
      */
     private transient String isoPeriod;
 
+    /**
+     * Transient boolean. If true, this Period has been created as a consequence of
+     * a Dimensional Item Object having an Offset Period value higher/lower than 0
+     */
+    private transient boolean shifted = false;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -403,5 +409,15 @@ public class Period
     public void setPeriodType( PeriodType periodType )
     {
         this.periodType = periodType;
+    }
+
+    public boolean isShifted()
+    {
+        return shifted;
+    }
+
+    public void setShifted( boolean shifted )
+    {
+        this.shifted = shifted;
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectUtilsTest.java
@@ -350,4 +350,22 @@ public class DimensionalObjectUtilsTest
 
         assertEquals( "DE ShortNameA DE ShortNameB DE ShortNameC", name );
     }
+
+    @Test
+    public void testConvertToDimItemValueMap()
+    {
+        DataElement deA = new DataElement( "DE NameA" );
+        DataElement deB = new DataElement( "DE NameB" );
+        DataElement deC = new DataElement( "DE NameC" );
+
+        List<DimensionItemObjectValue> list = Lists.newArrayList( new DimensionItemObjectValue( deA, 10D ),
+            new DimensionItemObjectValue( deB, 20D ), new DimensionItemObjectValue( deC, 30D ) );
+
+        final Map<DimensionalItemObject, Double> asMap = DimensionalObjectUtils.convertToDimItemValueMap( list );
+
+        assertEquals( asMap.size(), 3 );
+        assertEquals( asMap.get( deA).intValue(), 10 );
+        assertEquals( asMap.get( deB).intValue(), 20 );
+        assertEquals( asMap.get( deC).intValue(), 30 );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1720,10 +1720,8 @@ public class DataQueryParams
             // Generate final permutation key
             final String permKey = StringUtils.join( keys, DIMENSION_SEP );
 
-            for ( DimensionItemObjectValue dimWithValue : dimensionItemObjectValues)
+            for ( DimensionItemObjectValue dimWithValue : dimensionItemObjectValues )
             {
-                //Number number = dimWithValue.getValue();
-
                 if ( !permutationMap.containsKey( permKey ) )
                 {
                     permutationMap.put( permKey, Lists.newArrayList( dimWithValue ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -50,7 +50,7 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.analytics.data.DimensionItemWithValue;
+import org.hisp.dhis.common.DimensionItemObjectValue;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
@@ -1704,10 +1704,10 @@ public class DataQueryParams
      * @return a mapping of permutation keys and mappings of data element operands
      *         and values.
      */
-    public static Map<String, List<DimensionItemWithValue>> getPermutationDimensionalItemValueMap(
-        MultiValuedMap<String, DimensionItemWithValue> aggregatedDataMap )
+    public static Map<String, List<DimensionItemObjectValue>> getPermutationDimensionalItemValueMap(
+        MultiValuedMap<String, DimensionItemObjectValue> aggregatedDataMap )
     {
-        Map<String, List<DimensionItemWithValue>> permutationMap = new HashMap<>();
+        Map<String, List<DimensionItemObjectValue>> permutationMap = new HashMap<>();
 
         for ( String key : aggregatedDataMap.keySet() )
         {
@@ -1715,12 +1715,12 @@ public class DataQueryParams
             List<String> keys = Lists.newArrayList( key.split( DIMENSION_SEP ) );
             keys.remove( DX_INDEX );
 
-            final Collection<DimensionItemWithValue> dimensionItemWithValues = aggregatedDataMap.get( key );
+            final Collection<DimensionItemObjectValue> dimensionItemObjectValues = aggregatedDataMap.get( key );
 
             // Generate final permutation key
             final String permKey = StringUtils.join( keys, DIMENSION_SEP );
 
-            for ( DimensionItemWithValue dimWithValue : dimensionItemWithValues )
+            for ( DimensionItemObjectValue dimWithValue : dimensionItemObjectValues)
             {
                 //Number number = dimWithValue.getValue();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -1401,7 +1401,7 @@ public class DefaultAnalyticsService
                     ArrayUtils.remove( row.toArray( new Object[0] ), valueIndex ),
                     DimensionalObject.DIMENSION_SEP );
 
-                final DimensionalItemObject dimensionalItemObject = findDimensionalItem( (String) row.get( dataIndex ), items ).get( 0 );
+                final DimensionalItemObject dimensionalItemObject = AnalyticsUtils.findDimensionalItems( (String) row.get( dataIndex ), items ).get( 0 );
                 DimensionalItemObject clone = dimensionalItemObject;
                 if ( dimensionalItemObject.getPeriodOffset() != 0 )
                 {
@@ -1424,19 +1424,6 @@ public class DefaultAnalyticsService
         }
         
         return result;
-    }
-
-    /**
-     * Filters by uid and returns one ore more {@see DimensionalItemObject} from a
-     * List
-     * 
-     * @param uid a uid to filter {@see DimensionalItemObject} on
-     * @param items the filtered List
-     * @return a List only containing the  {@see DimensionalItemObject} matching the uid
-     */
-    private List<DimensionalItemObject> findDimensionalItem( String uid, List<DimensionalItemObject> items )
-    {
-        return items.stream().filter( dio -> dio.getUid().equals( uid ) ).collect( Collectors.toList() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -1328,9 +1328,8 @@ public class DefaultAnalyticsService
      * and values based on the given query.
      *
      * @param params the {@link DataQueryParams}.
-     * @return
      */
-    private Map<String, List<DimensionItemObjectValue>> getPermutationDimensionItemValueMap(DataQueryParams params )
+    private Map<String, List<DimensionItemObjectValue>> getPermutationDimensionItemValueMap( DataQueryParams params )
     {
         List<Indicator> indicators = asTypedList( params.getIndicators() );
 
@@ -1403,6 +1402,7 @@ public class DefaultAnalyticsService
 
                 final DimensionalItemObject dimensionalItemObject = AnalyticsUtils.findDimensionalItems( (String) row.get( dataIndex ), items ).get( 0 );
                 DimensionalItemObject clone = dimensionalItemObject;
+                // 
                 if ( dimensionalItemObject.getPeriodOffset() != 0 )
                 {
                     List<Object> periodOffsetRow = getPeriodOffsetRow( grid, dimensionalItemObject,
@@ -1415,7 +1415,6 @@ public class DefaultAnalyticsService
 
                     } // TODO throw exception?
                     clone = SerializationUtils.clone( dimensionalItemObject );
-                    clone.resetPeriodOffset();
                 }
 
                 result.put( key,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -1381,7 +1381,7 @@ public class DefaultAnalyticsService
             return result;
         }
 
-        BiFunction<Integer, Integer, Integer> replaceIndexIfMissing = (Integer index, Integer defaultIndex ) 
+        BiFunction<Integer, Integer, Integer> replaceIndexIfMissing = (Integer index, Integer defaultIndex )
                 -> index == -1 ? defaultIndex : index;
 
         final int dataIndex = replaceIndexIfMissing.apply( grid.getIndexOfHeader( DATA_X_DIM_ID ), 0 );
@@ -1402,7 +1402,7 @@ public class DefaultAnalyticsService
 
                 final DimensionalItemObject dimensionalItemObject = AnalyticsUtils.findDimensionalItems( (String) row.get( dataIndex ), items ).get( 0 );
                 DimensionalItemObject clone = dimensionalItemObject;
-                // 
+
                 if ( dimensionalItemObject.getPeriodOffset() != 0 )
                 {
                     List<Object> periodOffsetRow = getPeriodOffsetRow( grid, dimensionalItemObject,
@@ -1413,7 +1413,8 @@ public class DefaultAnalyticsService
                             new DimensionItemObjectValue( dimensionalItemObject,
                                 (Double) periodOffsetRow.get( valueIndex ) ) );
 
-                    } // TODO throw exception?
+                    }
+
                     clone = SerializationUtils.clone( dimensionalItemObject );
                 }
 
@@ -1421,7 +1422,7 @@ public class DefaultAnalyticsService
                     new DimensionItemObjectValue( clone, (Double) row.get( valueIndex ) ) );
             }
         }
-        
+
         return result;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -38,6 +38,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
@@ -49,10 +50,12 @@ import org.hisp.dhis.analytics.Partitions;
 import org.hisp.dhis.analytics.QueryPlanner;
 import org.hisp.dhis.analytics.QueryPlannerParams;
 import org.hisp.dhis.analytics.QueryValidator;
+import org.hisp.dhis.analytics.offset.PeriodOffsetUtils;
 import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.analytics.table.PartitionUtils;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DataDimensionItemType;
+import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -248,7 +251,7 @@ public class DefaultQueryPlanner
      * with one filter for each period type. Sets the dimension names and filter
      * names respectively.
      *
-     * @param the {@link DataQueryParams}.
+     * @param params the {@link DataQueryParams} object.
      * @return a list of {@link DataQueryParams}.
      */
     @Override
@@ -262,7 +265,7 @@ public class DefaultQueryPlanner
         }
         else if ( !params.getPeriods().isEmpty() )
         {
-            ListMap<String, DimensionalItemObject> periodTypePeriodMap = PartitionUtils.getPeriodTypePeriodMap( params.getPeriods() );
+            ListMap<String, DimensionalItemObject> periodTypePeriodMap = PeriodOffsetUtils.getPeriodTypePeriodMap( params );
 
             for ( String periodType : periodTypePeriodMap.keySet() )
             {
@@ -270,7 +273,7 @@ public class DefaultQueryPlanner
                     .addOrSetDimensionOptions( PERIOD_DIM_ID, DimensionType.PERIOD, periodType.toLowerCase(), periodTypePeriodMap.get( periodType ) )
                     .withPeriodType( periodType ).build();
 
-                queries.add( query );
+                queries.add( removeOffsetPeriodsIfNotNeeded (query) );
             }
         }
         else if ( !params.getFilterPeriods().isEmpty() )
@@ -300,6 +303,29 @@ public class DefaultQueryPlanner
         logQuerySplit( queries, "period type" );
 
         return queries;
+    }
+
+    private DataQueryParams removeOffsetPeriodsIfNotNeeded( DataQueryParams params )
+    {
+        final List<DimensionalItemObject> items = params.getDataElements();
+
+        final boolean hasOffset = items.stream().filter( dio -> dio.getDimensionItemType() != null )
+                .filter( dio -> dio.getDimensionItemType().equals( DimensionItemType.DATA_ELEMENT ) )
+                .anyMatch( dio -> dio.getPeriodOffset() != 0 );
+
+        if ( !hasOffset )
+        {
+            List<DimensionalItemObject> nonShiftedPeriods = params.getPeriods().stream()
+                    .filter( dio -> (!((Period) dio).isShifted()) ).collect( Collectors.toList() );
+
+            // TODO is there a better way to "replace" periods?
+            final DimensionalObject periodDimension = params.getDimension("pe");
+            periodDimension.getItems().clear();
+            periodDimension.getItems().addAll( nonShiftedPeriods );
+
+            return DataQueryParams.newBuilder( params ).removeDimension( "pe").addDimension( periodDimension ).build();
+        }
+        return params;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionItemWithValue.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionItemWithValue.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.expression.dataitem;
+package org.hisp.dhis.analytics.data;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,39 +28,15 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.common.DimensionItemType.*;
-import static org.hisp.dhis.parser.expression.ParserUtils.assumeExpressionProgramAttribute;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hisp.dhis.common.DimensionalItemObject;
 
-import org.hisp.dhis.common.DimensionalItemId;
-import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-
-/**
- * Expression item ProgramAttribute
- *
- * @author Jim Grace
- */
-public class DimItemProgramAttribute
-    extends DimensionalItem
+@Getter
+@AllArgsConstructor
+public class DimensionItemWithValue
 {
-    @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
-        CommonExpressionVisitor visitor )
-    {
-        assumeExpressionProgramAttribute( ctx );
+    private final DimensionalItemObject dimensionalItemObject;
 
-        return new DimensionalItemId( PROGRAM_ATTRIBUTE,
-            ctx.uid0.getText(),
-            ctx.uid1.getText() );
-    }
-
-    @Override
-    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        assumeExpressionProgramAttribute( ctx );
-
-        return ctx.uid0.getText() + "." +
-            ctx.uid1.getText() +
-            (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
-    }
+    private final Double value;
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/offset/PeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/offset/PeriodOffsetUtils.java
@@ -1,0 +1,152 @@
+package org.hisp.dhis.analytics.offset;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.table.PartitionUtils;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.ListMap;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+
+public class PeriodOffsetUtils
+{
+    /**
+     * Creates an associative Map between Period Types (e.g. Month, Quarter, etc.) and
+     * Periods extracted from a {@see DataQueryParams} object.
+     * 
+     * Each map value may also contain periods that are derived from Period
+     * offsets applied to elements from the "data" dimension of the {@see DataQueryParams}
+     *
+     * @param params a DataQueryParams object
+     */
+    public static ListMap<String, DimensionalItemObject> getPeriodTypePeriodMap( DataQueryParams params )
+    {
+        if ( params == null || params.getPeriods().isEmpty() )
+        {
+            return new ListMap<>();
+        }
+
+        ListMap<String, DimensionalItemObject> periodTypePeriodMap = PartitionUtils.getPeriodTypePeriodMap( params.getPeriods() );
+
+        DimensionalObject dimension = params.getDimension( DATA_X_DIM_ID );
+        if ( dimension == null )
+        {
+            return periodTypePeriodMap;
+        }
+        List<DimensionalItemObject> items = dimension.getItems();
+        ListMap<String, DimensionalItemObject> shiftedMap = new ListMap<>();
+
+        for ( DimensionalItemObject item : items )
+        {
+            if ( item.getPeriodOffset() != 0 )
+            {
+                shiftedMap.putAll( addPeriodOffset( periodTypePeriodMap, item.getPeriodOffset() ) );
+            }
+        }
+
+        Set<DimensionalItemObject> dimensionalItemObjects = shiftedMap.uniqueValues();
+        for ( DimensionalItemObject dimensionalItemObject : dimensionalItemObjects )
+        {
+            Period period = (Period) dimensionalItemObject;
+            if ( !periodTypePeriodMap.containsValue( period.getPeriodType().getName(), dimensionalItemObject ) )
+            {
+                periodTypePeriodMap.putValue( period.getPeriodType().getName(), dimensionalItemObject );
+            }
+        }
+
+        return periodTypePeriodMap;
+    }
+
+    /**
+     * Shifts the given Period in the past or future based on the offset value.
+     * 
+     * Example:
+     * 
+     * Period: 202001 , Offset: 1 -> Period: 202002
+     * Period: 2020 , Offset: -1 -> Period: 2019
+     * 
+     * @param period a Period
+     * @param periodOffset a positive or negative integer
+     * @return A Period
+     */
+    public static Period shiftPeriod( Period period, int periodOffset )
+    {
+        if ( periodOffset == 0 )
+        {
+            return period;
+        }
+
+        PeriodType periodType = period.getPeriodType();
+        Period p;
+        if ( periodOffset > 0 )
+        {
+            p = periodType.getNextPeriod( period, periodOffset );
+        }
+        else
+        {
+            p = periodType.getPreviousPeriod( period, periodOffset );
+        }
+
+        p.setShifted( true );
+        return p;
+    }
+
+    /**
+     *
+     * @param map
+     * @param periodOffset
+     * @return
+     */
+    private static ListMap<String, DimensionalItemObject> addPeriodOffset( ListMap<String, DimensionalItemObject> map,
+        int periodOffset )
+    {
+        ListMap<String, DimensionalItemObject> periodTypeOffsetMap = new ListMap<>();
+        Collection<DimensionalItemObject> dimensionalItemObjects = map.allValues();
+        for ( DimensionalItemObject dimensionalItemObject : dimensionalItemObjects )
+        {
+            Period currentPeriod = (Period) dimensionalItemObject;
+            Period shifted = shiftPeriod( currentPeriod, periodOffset );
+
+            if ( !map.containsValue( currentPeriod.getPeriodType().getName(), shifted ) )
+            {
+                periodTypeOffsetMap.putValue( currentPeriod.getPeriodType().getName(), shifted );
+            }
+        }
+
+        return periodTypeOffsetMap;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -886,5 +887,20 @@ public class AnalyticsUtils
     {
         return periods.stream().map( d -> (Period) d ).map( Period::getIsoDate )
             .anyMatch( date -> date.equals( period ) );
+    }
+
+    /**
+     * Filters a List by Dimensional Item Object UID and returns one ore more
+     * {@see DimensionalItemObject} matching the given UID
+     *
+     * @param uid a uid to filter {@see DimensionalItemObject} on
+     * @param items the filtered List
+     * @return a List only containing the {@see DimensionalItemObject} matching the
+     *         uid
+     */
+    public static List<DimensionalItemObject> findDimensionalItems( String uid, List<DimensionalItemObject> items )
+    {
+        return items.stream().filter( dio -> dio.getUid() != null && dio.getUid().equals( uid ) )
+            .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -873,4 +873,18 @@ public class AnalyticsUtils
     {
         throw new IllegalQueryException( new ErrorMessage( errorCode, args ) );
     }
+
+    /**
+     * Checks of the given Period string (iso) matches at least one Periods in the
+     * given list
+     * 
+     * @param period a Period as iso date String (e.g. 202001 for Jan 2020)
+     * @param periods a List of DimensionalItemObject of type Period
+     * @return true, if the Period is found in the list
+     */
+    public static boolean isPeriodInPeriods( String period, List<DimensionalItemObject> periods )
+    {
+        return periods.stream().map( d -> (Period) d ).map( Period::getIsoDate )
+            .anyMatch( date -> date.equals( period ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -878,7 +878,7 @@ public class AnalyticsUtils
     /**
      * Checks of the given Period string (iso) matches at least one Periods in the
      * given list
-     * 
+     *
      * @param period a Period as iso date String (e.g. 202001 for Jan 2020)
      * @param periods a List of DimensionalItemObject of type Period
      * @return true, if the Period is found in the list
@@ -900,7 +900,8 @@ public class AnalyticsUtils
      */
     public static List<DimensionalItemObject> findDimensionalItems( String uid, List<DimensionalItemObject> items )
     {
-        return items.stream().filter( dio -> dio.getUid() != null && dio.getUid().equals( uid ) )
+        return items.stream()
+            .filter( dio -> dio.getUid() != null && dio.getUid().equals( uid ) )
             .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.period.PeriodType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static org.hisp.dhis.analytics.DataQueryParams.DX_INDEX;
@@ -183,8 +184,11 @@ public class PeriodOffsetUtils
             return null;
         }
 
-        final int dataIndex = grid.getIndexOfHeader( DATA_X_DIM_ID );
-        final int periodIndex = grid.getIndexOfHeader( PERIOD_DIM_ID );
+        BiFunction<Integer, Integer, Integer> replaceIndexIfMissing = (Integer index, Integer defaultIndex )
+                -> index == -1 ? defaultIndex : index;
+
+        final int dataIndex = replaceIndexIfMissing.apply( grid.getIndexOfHeader( DATA_X_DIM_ID ), 0 );
+        final int periodIndex = replaceIndexIfMissing.apply( grid.getIndexOfHeader( PERIOD_DIM_ID ), 1 );
 
         Period shifted = offset != 0 ? shiftPeriod( PeriodType.getPeriodFromIsoString( isoPeriod ), offset )
             : PeriodType.getPeriodFromIsoString( isoPeriod );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.DimensionItemObjectValue;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -303,18 +304,18 @@ public class QueryPlannerTest
     @Test
     public void testGetPermutationDimensionalItemValueMapCocEnabled()
     {
-        MultiValuedMap<String, DimensionItemWithValue> aggregatedDataMap = new ArrayListValuedHashMap<>();
+        MultiValuedMap<String, DimensionItemObjectValue> aggregatedDataMap = new ArrayListValuedHashMap<>();
         
-        aggregatedDataMap.put( makeKey( deA, coc, ouA, "2000Q1" ), new DimensionItemWithValue( deA, 1d ) );
-        aggregatedDataMap.put( makeKey( deA, coc, ouA, "2000Q2" ), new DimensionItemWithValue( deA, 2d ) );
-        aggregatedDataMap.put( makeKey( deA, coc, ouB, "2000Q1" ), new DimensionItemWithValue( deA, 3d ) );
-        aggregatedDataMap.put( makeKey( deA, coc, ouB, "2000Q2" ), new DimensionItemWithValue( deA, 4d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q1" ), new DimensionItemWithValue( deB, 5d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q2" ), new DimensionItemWithValue( deB, 6d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q1" ), new DimensionItemWithValue( deB, 7d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q2" ), new DimensionItemWithValue( deB, 8d ) );
+        aggregatedDataMap.put( makeKey( deA, coc, ouA, "2000Q1" ), new DimensionItemObjectValue( deA, 1d ) );
+        aggregatedDataMap.put( makeKey( deA, coc, ouA, "2000Q2" ), new DimensionItemObjectValue( deA, 2d ) );
+        aggregatedDataMap.put( makeKey( deA, coc, ouB, "2000Q1" ), new DimensionItemObjectValue( deA, 3d ) );
+        aggregatedDataMap.put( makeKey( deA, coc, ouB, "2000Q2" ), new DimensionItemObjectValue( deA, 4d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q1" ), new DimensionItemObjectValue( deB, 5d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q2" ), new DimensionItemObjectValue( deB, 6d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q1" ), new DimensionItemObjectValue( deB, 7d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q2" ), new DimensionItemObjectValue( deB, 8d ) );
 
-        Map<String, List<DimensionItemWithValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
+        Map<String, List<DimensionItemObjectValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
 
         assertNotNull( permutationMap );
 
@@ -323,10 +324,10 @@ public class QueryPlannerTest
         String ouBQ1Key = ouB.getUid() + DIMENSION_SEP + "2000Q1";
         String ouBQ2Key = ouB.getUid() + DIMENSION_SEP + "2000Q2";
 
-        List<DimensionItemWithValue> ouAQ1 = permutationMap.get( ouAQ1Key );
-        List<DimensionItemWithValue> ouAQ2 = permutationMap.get( ouAQ2Key );
-        List<DimensionItemWithValue> ouBQ1 = permutationMap.get( ouBQ1Key );
-        List<DimensionItemWithValue> ouBQ2 = permutationMap.get( ouBQ2Key );
+        List<DimensionItemObjectValue> ouAQ1 = permutationMap.get( ouAQ1Key );
+        List<DimensionItemObjectValue> ouAQ2 = permutationMap.get( ouAQ2Key );
+        List<DimensionItemObjectValue> ouBQ1 = permutationMap.get( ouBQ1Key );
+        List<DimensionItemObjectValue> ouBQ2 = permutationMap.get( ouBQ2Key );
 
         assertEquals( 2, ouAQ1.size() );
         assertEquals( 2, ouAQ2.size() );
@@ -361,18 +362,18 @@ public class QueryPlannerTest
     @Test
     public void testGetPermutationDimensionalItemValueMapCocDisabled()
     {
-        MultiValuedMap<String, DimensionItemWithValue> aggregatedDataMap = new ArrayListValuedHashMap<>();
+        MultiValuedMap<String, DimensionItemObjectValue> aggregatedDataMap = new ArrayListValuedHashMap<>();
 
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200101", new DimensionItemWithValue( deA, 1d ) );
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200102", new DimensionItemWithValue( deA, 2d ) );
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200101", new DimensionItemWithValue( deA, 3d ) );
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200102", new DimensionItemWithValue( deA, 4d ) );
-        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200101", new DimensionItemWithValue( deB, 5d ) );
-        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200102", new DimensionItemWithValue( deB, 6d ) );
-        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200101", new DimensionItemWithValue( deB, 7d ) );
-        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200102", new DimensionItemWithValue( deB, 8d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200101", new DimensionItemObjectValue( deA, 1d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200102", new DimensionItemObjectValue( deA, 2d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200101", new DimensionItemObjectValue( deA, 3d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200102", new DimensionItemObjectValue( deA, 4d ) );
+        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200101", new DimensionItemObjectValue( deB, 5d ) );
+        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "200102", new DimensionItemObjectValue( deB, 6d ) );
+        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200101", new DimensionItemObjectValue( deB, 7d ) );
+        aggregatedDataMap.put( deB.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "200102", new DimensionItemObjectValue( deB, 8d ) );
 
-        Map<String, List<DimensionItemWithValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
+        Map<String, List<DimensionItemObjectValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
 
         assertNotNull( permutationMap );
 
@@ -381,10 +382,10 @@ public class QueryPlannerTest
         String ouBM1Key = ouB.getUid() + DIMENSION_SEP + "200101";
         String ouBM2Key = ouB.getUid() + DIMENSION_SEP + "200102";
 
-        List<DimensionItemWithValue> ouAM1 = permutationMap.get( ouAM1Key );
-        List<DimensionItemWithValue> ouAM2 = permutationMap.get( ouAM2Key );
-        List<DimensionItemWithValue> ouBM1 = permutationMap.get( ouBM1Key );
-        List<DimensionItemWithValue> ouBM2 = permutationMap.get( ouBM2Key );
+        List<DimensionItemObjectValue> ouAM1 = permutationMap.get( ouAM1Key );
+        List<DimensionItemObjectValue> ouAM2 = permutationMap.get( ouAM2Key );
+        List<DimensionItemObjectValue> ouBM1 = permutationMap.get( ouBM1Key );
+        List<DimensionItemObjectValue> ouBM2 = permutationMap.get( ouBM2Key );
 
         assertEquals( 2, ouAM1.size() );
         assertEquals( 2, ouAM2.size() );
@@ -419,19 +420,19 @@ public class QueryPlannerTest
     @Test
     public void testGetPermutationDimensionalItemValueMap()
     {
-        MultiValuedMap<String, DimensionItemWithValue> aggregatedDataMap = new ArrayListValuedHashMap<>();
+        MultiValuedMap<String, DimensionItemObjectValue> aggregatedDataMap = new ArrayListValuedHashMap<>();
 
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "2000Q1", new DimensionItemWithValue( deA, 1d ) );
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "2000Q2", new DimensionItemWithValue( deA, 2d ) );
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "2000Q1", new DimensionItemWithValue( deA, 3d ) );
-        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "2000Q2", new DimensionItemWithValue( deA, 4d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "2000Q1", new DimensionItemObjectValue( deA, 1d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouA.getUid() + DIMENSION_SEP + "2000Q2", new DimensionItemObjectValue( deA, 2d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "2000Q1", new DimensionItemObjectValue( deA, 3d ) );
+        aggregatedDataMap.put( deA.getUid() + DIMENSION_SEP + ouB.getUid() + DIMENSION_SEP + "2000Q2", new DimensionItemObjectValue( deA, 4d ) );
 
-        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q1"), new DimensionItemWithValue( deB, 5d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q2"), new DimensionItemWithValue( deB, 6d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q1"), new DimensionItemWithValue( deB, 7d ) );
-        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q2"), new DimensionItemWithValue( deB, 8d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q1"), new DimensionItemObjectValue( deB, 5d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouA, "2000Q2"), new DimensionItemObjectValue( deB, 6d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q1"), new DimensionItemObjectValue( deB, 7d ) );
+        aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q2"), new DimensionItemObjectValue( deB, 8d ) );
 
-        Map<String, List<DimensionItemWithValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
+        Map<String, List<DimensionItemObjectValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
 
         assertNotNull( permutationMap );
 
@@ -440,10 +441,10 @@ public class QueryPlannerTest
         String ouBQ1Key = ouB.getUid() + DIMENSION_SEP + "2000Q1";
         String ouBQ2Key = ouB.getUid() + DIMENSION_SEP + "2000Q2";
 
-        List<DimensionItemWithValue> ouAQ1 = permutationMap.get( ouAQ1Key );
-        List<DimensionItemWithValue> ouAQ2 = permutationMap.get( ouAQ2Key );
-        List<DimensionItemWithValue> ouBQ1 = permutationMap.get( ouBQ1Key );
-        List<DimensionItemWithValue> ouBQ2 = permutationMap.get( ouBQ2Key );
+        List<DimensionItemObjectValue> ouAQ1 = permutationMap.get( ouAQ1Key );
+        List<DimensionItemObjectValue> ouAQ2 = permutationMap.get( ouAQ2Key );
+        List<DimensionItemObjectValue> ouBQ1 = permutationMap.get( ouBQ1Key );
+        List<DimensionItemObjectValue> ouBQ2 = permutationMap.get( ouBQ2Key );
 
         assertEquals( 2, ouAQ1.size() );
         assertEquals( 2, ouAQ2.size() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.analytics.QueryPlannerParams;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DimensionItemObjectValue;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -315,7 +314,9 @@ public class QueryPlannerTest
         aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q1" ), new DimensionItemObjectValue( deB, 7d ) );
         aggregatedDataMap.put( makeKey( deB, coc, ouB, "2000Q2" ), new DimensionItemObjectValue( deB, 8d ) );
 
-        Map<String, List<DimensionItemObjectValue>> permutationMap = DataQueryParams.getPermutationDimensionalItemValueMap( aggregatedDataMap );
+        // Method under test //
+        Map<String, List<DimensionItemObjectValue>> permutationMap = DataQueryParams
+            .getPermutationDimensionalItemValueMap( aggregatedDataMap );
 
         assertNotNull( permutationMap );
 
@@ -334,29 +335,26 @@ public class QueryPlannerTest
         assertEquals( 2, ouBQ1.size() );
         assertEquals( 2, ouBQ2.size() );
 
-        BaseDimensionalItemObject deACoc = new BaseDimensionalItemObject( deA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + coc.getUid() );
-        BaseDimensionalItemObject deBCoc = new BaseDimensionalItemObject( deB.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + coc.getUid() );
+        List<DimensionItemObjectValue> ouAQ1Expected = new ArrayList<>();
+        ouAQ1Expected.add( new DimensionItemObjectValue( deA, 1d ) );
+        ouAQ1Expected.add( new DimensionItemObjectValue( deB, 5d ) );
 
-        Map<DimensionalItemObject, Double> ouAQ1Expected = new HashMap<>();
-        ouAQ1Expected.put( deACoc, 1d );
-        ouAQ1Expected.put( deBCoc, 5d );
+        List<DimensionItemObjectValue> ouAQ2Expected = new ArrayList<>();
+        ouAQ2Expected.add( new DimensionItemObjectValue( deA, 2d ));
+        ouAQ2Expected.add( new DimensionItemObjectValue( deB, 6d ));
 
-        Map<DimensionalItemObject, Double> ouAQ2Expected = new HashMap<>();
-        ouAQ2Expected.put( deACoc, 2d );
-        ouAQ2Expected.put( deBCoc, 6d );
+        List<DimensionItemObjectValue> ouBQ1Expected = new ArrayList<>();
+        ouBQ1Expected.add( new DimensionItemObjectValue( deA, 3d ));
+        ouBQ1Expected.add( new DimensionItemObjectValue( deB, 7d ));
 
-        Map<DimensionalItemObject, Double> ouBQ1Expected = new HashMap<>();
-        ouBQ1Expected.put( deACoc, 3d );
-        ouBQ1Expected.put( deBCoc, 7d );
+        List<DimensionItemObjectValue> ouBQ2Expected = new ArrayList<>();
+        ouBQ2Expected.add( new DimensionItemObjectValue( deA, 4d ));
+        ouBQ2Expected.add( new DimensionItemObjectValue( deB, 8d ));
 
-        Map<DimensionalItemObject, Double> ouBQ2Expected = new HashMap<>();
-        ouBQ2Expected.put( deACoc, 4d );
-        ouBQ2Expected.put( deBCoc, 8d );
-// FIXME luciano
-//        assertEquals( ouAQ1Expected, ouAQ1 );
-//        assertEquals( ouAQ2Expected, ouAQ2 );
-//        assertEquals( ouBQ1Expected, ouBQ1 );
-//        assertEquals( ouBQ2Expected, ouBQ2 );
+        assertCollectionsMatch( ouAQ1Expected, ouAQ1 );
+        assertCollectionsMatch( ouAQ2Expected, ouAQ2 );
+        assertCollectionsMatch( ouBQ1Expected, ouBQ1 );
+        assertCollectionsMatch( ouBQ2Expected, ouBQ2 );
     }
 
     @Test
@@ -392,29 +390,27 @@ public class QueryPlannerTest
         assertEquals( 2, ouBM1.size() );
         assertEquals( 2, ouBM2.size() );
 
-        BaseDimensionalItemObject deACoc = new BaseDimensionalItemObject( deA.getUid() );
-        BaseDimensionalItemObject deBCoc = new BaseDimensionalItemObject( deB.getUid() );
 
-        Map<DimensionalItemObject, Double> ouAM1Expected = new HashMap<>();
-        ouAM1Expected.put( deACoc, 1d );
-        ouAM1Expected.put( deBCoc, 5d );
+        List<DimensionItemObjectValue> ouAM1Expected = new ArrayList<>();
+        ouAM1Expected.add( new DimensionItemObjectValue( deA, 1d ) );
+        ouAM1Expected.add( new DimensionItemObjectValue( deB, 5d ) );
 
-        Map<DimensionalItemObject, Double> ouAM2Expected = new HashMap<>();
-        ouAM2Expected.put( deACoc, 2d );
-        ouAM2Expected.put( deBCoc, 6d );
+        List<DimensionItemObjectValue> ouAM2Expected = new ArrayList<>();
+        ouAM2Expected.add( new DimensionItemObjectValue( deA, 2d ) );
+        ouAM2Expected.add( new DimensionItemObjectValue( deB, 6d ) );
 
-        Map<DimensionalItemObject, Double> ouBM1Expected = new HashMap<>();
-        ouBM1Expected.put( deACoc, 3d );
-        ouBM1Expected.put( deBCoc, 7d );
+        List<DimensionItemObjectValue> ouBM1Expected = new ArrayList<>();
+        ouBM1Expected.add( new DimensionItemObjectValue( deA, 3d ) );
+        ouBM1Expected.add( new DimensionItemObjectValue( deB, 7d ) );
 
-        Map<DimensionalItemObject, Double> ouBM2Expected = new HashMap<>();
-        ouBM2Expected.put( deACoc, 4d );
-        ouBM2Expected.put( deBCoc, 8d );
-// FIXME luciano
-//        assertEquals( ouAM1Expected, ouAM1.get(1).getDimensionalItemObject() );
-//        assertEquals( ouAM2Expected, ouAM2 );
-//        assertEquals( ouBM1Expected, ouBM1 );
-//        assertEquals( ouBM2Expected, ouBM2 );
+        List<DimensionItemObjectValue> ouBM2Expected = new ArrayList<>();
+        ouBM2Expected.add( new DimensionItemObjectValue( deA, 4d ) );
+        ouBM2Expected.add( new DimensionItemObjectValue( deB, 8d ) );
+
+        assertCollectionsMatch( ouAM1Expected, ouAM1 );
+        assertCollectionsMatch( ouAM2Expected, ouAM2 );
+        assertCollectionsMatch( ouBM1Expected, ouBM1 );
+        assertCollectionsMatch( ouBM2Expected, ouBM2 );
     }
 
     @Test
@@ -451,29 +447,26 @@ public class QueryPlannerTest
         assertEquals( 2, ouBQ1.size() );
         assertEquals( 2, ouBQ2.size() );
 
-        BaseDimensionalItemObject deACoc = new BaseDimensionalItemObject( deA.getUid() );
-        BaseDimensionalItemObject deBCoc = new BaseDimensionalItemObject( deB.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + coc.getUid() );
+        List<DimensionItemObjectValue> ouAQ1Expected = new ArrayList<>();
+        ouAQ1Expected.add( new DimensionItemObjectValue( deA, 1d ) );
+        ouAQ1Expected.add( new DimensionItemObjectValue( deB, 5d ) );
 
-        Map<DimensionalItemObject, Double> ouAQ1Expected = new HashMap<>();
-        ouAQ1Expected.put( deACoc, 1d );
-        ouAQ1Expected.put( deBCoc, 5d );
+        List<DimensionItemObjectValue> ouAQ2Expected = new ArrayList<>();
+        ouAQ2Expected.add( new DimensionItemObjectValue( deA, 2d ) );
+        ouAQ2Expected.add( new DimensionItemObjectValue( deB, 6d ) );
 
-        Map<DimensionalItemObject, Double> ouAQ2Expected = new HashMap<>();
-        ouAQ2Expected.put( deACoc, 2d );
-        ouAQ2Expected.put( deBCoc, 6d );
+        List<DimensionItemObjectValue> ouBQ1Expected = new ArrayList<>();
+        ouBQ1Expected.add( new DimensionItemObjectValue( deA, 3d ) );
+        ouBQ1Expected.add( new DimensionItemObjectValue( deB, 7d ) );
 
-        Map<DimensionalItemObject, Double> ouBQ1Expected = new HashMap<>();
-        ouBQ1Expected.put( deACoc, 3d );
-        ouBQ1Expected.put( deBCoc, 7d );
+        List<DimensionItemObjectValue> ouBQ2Expected = new ArrayList<>();
+        ouBQ2Expected.add( new DimensionItemObjectValue( deA, 4d ) );
+        ouBQ2Expected.add( new DimensionItemObjectValue( deB, 8d ) );
 
-        Map<DimensionalItemObject, Double> ouBQ2Expected = new HashMap<>();
-        ouBQ2Expected.put( deACoc, 4d );
-        ouBQ2Expected.put( deBCoc, 8d );
-// FIXME luciano
-//        assertEquals( ouAQ1Expected, ouAQ1 );
-//        assertEquals( ouAQ2Expected, ouAQ2 );
-//        assertEquals( ouBQ1Expected, ouBQ1 );
-//        assertEquals( ouBQ2Expected, ouBQ2 );
+        assertCollectionsMatch( ouAQ1Expected, ouAQ1 );
+        assertCollectionsMatch( ouAQ2Expected, ouAQ2 );
+        assertCollectionsMatch( ouBQ1Expected, ouBQ1 );
+        assertCollectionsMatch( ouBQ2Expected, ouBQ2 );
     }
 
     /**
@@ -1222,6 +1215,18 @@ public class QueryPlannerTest
         for ( DimensionalObject filter : params.getFilters() )
         {
             assertNotNull( filter.getDimensionName() );
+        }
+    }
+
+    private void assertCollectionsMatch(List<DimensionItemObjectValue> collection, final List<DimensionItemObjectValue> in )
+    {
+        Function<String, Double> findValueByUid = ( String uid ) -> in.stream()
+                .filter( v -> v.getDimensionalItemObject().getUid().equals( uid ) ).findFirst().get().getValue();
+
+        for ( DimensionItemObjectValue dimensionItemObjectValue : collection )
+        {
+            final Double val = findValueByUid.apply( dimensionItemObjectValue.getDimensionalItemObject().getUid() );
+            assertEquals( val, dimensionItemObjectValue.getValue() );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/offset/PeriodOffsetUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/offset/PeriodOffsetUtilsTest.java
@@ -1,0 +1,164 @@
+package org.hisp.dhis.analytics.offset;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.ListMap;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.period.CalendarPeriodType;
+import org.hisp.dhis.period.MonthlyPeriodType;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.QuarterlyPeriodType;
+import org.hisp.dhis.period.WeeklyPeriodType;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class PeriodOffsetUtilsTest
+{
+    @Test
+    public void verifyGetPeriodTypePeriodMapExitOnNull()
+    {
+        // Given | When
+        ListMap<String, DimensionalItemObject> periodTypePeriodMap = PeriodOffsetUtils
+            .getPeriodTypePeriodMap( null );
+
+        // Then
+        assertThat( periodTypePeriodMap.size(), is( 0 ) );
+
+        // Given | When
+        PeriodOffsetUtils.getPeriodTypePeriodMap( DataQueryParams.newBuilder().build() );
+
+        // Then
+        assertThat( periodTypePeriodMap.size(), is( 0 ) );
+    }
+
+    @Test
+    public void verifyMappingIsCreatedWithNoOffset()
+    {
+        // Given
+        Period month1 = createMonthlyPeriod( 2020, 1 );
+        Period month2 = createMonthlyPeriod( 2020, 2 );
+        Period month3 = createMonthlyPeriod( 2020, 3 );
+        Period q1 = createQuarterPeriod( 2020, 1 );
+
+        DataQueryParams queryParams = DataQueryParams.newBuilder()
+            .withPeriods( Lists.newArrayList( month1, month2, month3, q1 ) )
+            .build();
+
+        // When
+        final ListMap<String, DimensionalItemObject> periodMap = PeriodOffsetUtils
+            .getPeriodTypePeriodMap( queryParams );
+
+        // Then
+        assertThat( periodMap.size(), is( 2 ) );
+        assertThat( periodMap.get( MonthlyPeriodType.NAME ), hasSize( 3 ) );
+        assertThat( periodMap.get( QuarterlyPeriodType.NAME ), hasSize( 1 ) );
+    }
+
+    @Test
+    public void verifyMappingIsCreatedWitOffset()
+    {
+        // Given
+        Period month1 = createMonthlyPeriod( 2020, 1 );
+        Period q1 = createQuarterPeriod( 2020, 1 );
+
+        DataQueryParams queryParams = DataQueryParams.newBuilder()
+            .withPeriods( Lists.newArrayList( month1, q1 ) )
+            .withDataElements( Lists.newArrayList( createDataElement( 1 ), createDataElement( 5 ) ) )
+            .build();
+
+        // When
+        final ListMap<String, DimensionalItemObject> periodMap = PeriodOffsetUtils
+            .getPeriodTypePeriodMap( queryParams );
+
+        // Then
+        assertThat( periodMap.size(), is( 2 ) );
+        assertThat( periodMap.get( MonthlyPeriodType.NAME ), hasSize( 3 ) );
+        assertIsoPeriods( periodMap.get( MonthlyPeriodType.NAME ), "202001", "202002", "202006" );
+        assertThat( periodMap.get( QuarterlyPeriodType.NAME ), hasSize( 3 ) );
+        assertIsoPeriods( periodMap.get( QuarterlyPeriodType.NAME ), "2020Q1", "2020Q2", "2021Q2" );
+    }
+
+    @Test
+    public void verifyShiftPeriod()
+    {
+        Period p1 = PeriodOffsetUtils.shiftPeriod( createMonthlyPeriod( 2020, 1 ), 12 );
+        assertThat( p1.getIsoDate(), is( "202101" ) );
+
+        Period p2 = PeriodOffsetUtils.shiftPeriod( createQuarterPeriod( 2020, 1 ), 12 );
+        assertThat( p2.getIsoDate(), is( "2023Q1" ) );
+
+        Period p3 = PeriodOffsetUtils.shiftPeriod( createWeeklyType( 2020, 5, 1 ), 2 );
+        assertThat( p3.getIsoDate(), is( "2020W20" ) );
+    }
+
+    private void assertIsoPeriods( List<DimensionalItemObject> periods, String... isoPeriod )
+    {
+        List<String> isoPeriods = periods.stream().map( dim -> (Period) dim ).map( Period::getIsoDate )
+            .collect( Collectors.toList() );
+        assertThat( isoPeriods, containsInAnyOrder( isoPeriod ) );
+    }
+
+    private Period createMonthlyPeriod( int year, int month )
+    {
+        CalendarPeriodType periodType = new MonthlyPeriodType();
+        return periodType.createPeriod( new DateTime( year, month, 1, 0, 0 ).toDate() );
+    }
+
+    private Period createQuarterPeriod( int year, int month )
+    {
+        CalendarPeriodType periodType = new QuarterlyPeriodType();
+        return periodType.createPeriod( new DateTime( year, month, 1, 0, 0 ).toDate() );
+    }
+
+    private Period createWeeklyType( int year, int month, int day )
+    {
+        CalendarPeriodType periodType = new WeeklyPeriodType();
+        return periodType.createPeriod( new DateTime( year, month, day, 0, 0 ).toDate() );
+    }
+
+    private DataElement createDataElement( int offset )
+    {
+        DataElement de = DhisConvenienceTest.createDataElement( 'A' );
+        de.setPeriodOffset( offset );
+        return de;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
@@ -33,7 +33,6 @@ import com.google.common.collect.Lists;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.ColumnDataType;
 import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.category.Category;
@@ -53,7 +52,6 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -619,5 +617,24 @@ public class AnalyticsUtilsTest
 
         assertTrue( AnalyticsUtils.isPeriodInPeriods( "202001", periods ) );
         assertFalse( AnalyticsUtils.isPeriodInPeriods( "202005", periods ) );
+    }
+    
+    @Test
+    public void testFindDimensionalItems()
+    {
+        ProgramIndicator pi1 = new ProgramIndicator();
+        pi1.setUid( CodeGenerator.generateUid() );
+        ProgramIndicator pi2 = new ProgramIndicator();
+        pi2.setUid( CodeGenerator.generateUid() );
+        ProgramIndicator pi3 = new ProgramIndicator();
+        pi3.setUid( CodeGenerator.generateUid() );
+        ProgramIndicator pi4 = new ProgramIndicator();
+        pi4.setUid( pi1.getUid() );
+
+        List<DimensionalItemObject> dimensionalItems = AnalyticsUtils.findDimensionalItems( pi1.getUid(),
+            Lists.newArrayList( pi1, pi2, pi3, pi4 ) );
+
+        assertEquals( dimensionalItems.size(), 2);
+        
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -605,5 +606,18 @@ public class AnalyticsUtilsTest
         assertEquals( 9, AnalyticsUtils.getBaseMonth( new FinancialOctoberPeriodType() ), 0 );
         assertEquals( 10, AnalyticsUtils.getBaseMonth( new FinancialNovemberPeriodType() ), 0 ) ;
         assertEquals( 0, AnalyticsUtils.getBaseMonth( new DailyPeriodType() ), 0 );
+    }
+    
+    @Test
+    public void testIsPeriodInPeriods()
+    {
+        Period p1 = PeriodType.getPeriodFromIsoString( "202001" );
+        Period p2 = PeriodType.getPeriodFromIsoString( "202002" );
+        Period p3 = PeriodType.getPeriodFromIsoString( "202003" );
+
+        List<DimensionalItemObject> periods = Lists.newArrayList( p1, p2, p3 );
+
+        assertTrue( AnalyticsUtils.isPeriodInPeriods( "202001", periods ) );
+        assertFalse( AnalyticsUtils.isPeriodInPeriods( "202005", periods ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/PeriodOffsetUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/PeriodOffsetUtilsTest.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.analytics.offset;
+package org.hisp.dhis.analytics.util;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
-import org.apache.commons.validator.Var;
 import org.hisp.dhis.category.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.UniqueArrayList;
@@ -629,7 +628,6 @@ public class DefaultDimensionService
             {
                 itemObjectMap.put( id, dimensionalItemObject );
             }
-
         }
 
         return itemObjectMap;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -38,8 +38,11 @@ import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.*;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Joiner;
+import org.apache.commons.validator.Var;
 import org.hisp.dhis.category.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.UniqueArrayList;
@@ -368,7 +371,32 @@ public class DefaultDimensionService
     @Override
     public Set<DimensionalItemObject> getDataDimensionalItemObjects( Set<DimensionalItemId> itemIds )
     {
-        return new HashSet<>( getDataDimensionalItemObjectMap( itemIds ).values() );
+        final Map<DimensionalItemId, DimensionalItemObject> map = getDataDimensionalItemObjectMap( itemIds );
+
+        Map<String, DimensionalItemObject> dios = new HashMap<>();
+        
+        Function<String[], String> makeKey = strings -> Joiner.on( "-" ).useForNull("null").join( strings );
+
+        for ( DimensionalItemId key : map.keySet() )
+        {
+            final String[] keyIds = {key.getId0(), key.getId1(), key.getId2()};
+            final DimensionalItemObject item = map.get( key );
+
+            if ( dios.containsKey( makeKey.apply( keyIds ) ) )
+            {
+                if ( dios.get( makeKey.apply( keyIds ) ).getPeriodOffset() == 0
+                    && item.getPeriodOffset() != 0 )
+                {
+                    dios.replace( item.getUid(), item );
+                }
+            }
+            else
+            {
+                dios.put( makeKey.apply( keyIds ), item );
+            }
+        }
+
+        return new HashSet<>( dios.values() );
     }
 
     @Override
@@ -523,14 +551,15 @@ public class DefaultDimensionService
             {
                 continue;
             }
-
+            BaseDimensionalItemObject dimensionalItemObject = null;
+                     
             switch ( id.getDimensionItemType() )
             {
                 case DATA_ELEMENT:
                     DataElement dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
                     if ( dataElement != null )
                     {
-                        itemObjectMap.put( id, dataElement );
+                        dimensionalItemObject = dataElement;
                     }
                     break;
 
@@ -538,7 +567,7 @@ public class DefaultDimensionService
                     Indicator indicator = (Indicator) atomicObjects.getValue( Indicator.class, id.getId0() );
                     if ( indicator != null )
                     {
-                        itemObjectMap.put( id, indicator );
+                        dimensionalItemObject =  indicator;
                     }
                     break;
 
@@ -550,8 +579,7 @@ public class DefaultDimensionService
                         ( id.getId1() != null ) == ( categoryOptionCombo != null ) &&
                         ( id.getId2() != null ) == ( attributeOptionCombo != null ) )
                     {
-                        DataElementOperand dataElementOperand = new DataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
-                        itemObjectMap.put( id, dataElementOperand );
+                        dimensionalItemObject = new DataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
                     }
                     break;
 
@@ -559,8 +587,7 @@ public class DefaultDimensionService
                     DataSet dataSet = (DataSet) atomicObjects.getValue( DataSet.class, id.getId0() );
                     if ( dataSet != null )
                     {
-                        ReportingRate reportingRate = new ReportingRate( dataSet, ReportingRateMetric.valueOf( id.getId1() ) );
-                        itemObjectMap.put( id, reportingRate );
+                        dimensionalItemObject = new ReportingRate( dataSet, ReportingRateMetric.valueOf( id.getId1() ) );
                     }
                     break;
 
@@ -569,8 +596,7 @@ public class DefaultDimensionService
                     dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId1() );
                     if ( program != null && dataElement != null )
                     {
-                        ProgramDataElementDimensionItem programDataElementDimensionItem = new ProgramDataElementDimensionItem( program, dataElement );
-                        itemObjectMap.put( id, programDataElementDimensionItem );
+                        dimensionalItemObject = new ProgramDataElementDimensionItem( program, dataElement );
                     }
                     break;
 
@@ -579,8 +605,7 @@ public class DefaultDimensionService
                     TrackedEntityAttribute attribute = (TrackedEntityAttribute) atomicObjects.getValue( TrackedEntityAttribute.class, id.getId1() );
                     if ( program != null && attribute != null )
                     {
-                        ProgramTrackedEntityAttributeDimensionItem programTrackedEntityAttributeDimensionItem = new ProgramTrackedEntityAttributeDimensionItem( program, attribute );
-                        itemObjectMap.put( id, programTrackedEntityAttributeDimensionItem );
+                        dimensionalItemObject = new ProgramTrackedEntityAttributeDimensionItem( program, attribute );
                     }
                     break;
 
@@ -588,7 +613,7 @@ public class DefaultDimensionService
                     ProgramIndicator programIndicator = (ProgramIndicator) atomicObjects.getValue( ProgramIndicator.class, id.getId0() );
                     if ( programIndicator != null )
                     {
-                        itemObjectMap.put( id, programIndicator );
+                        dimensionalItemObject = programIndicator;
                     }
                     break;
 
@@ -596,6 +621,15 @@ public class DefaultDimensionService
                     log.warn( "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getItemObjectMap" );
                     break;
             }
+            if ( dimensionalItemObject != null && id.getPeriodOffset() != 0 )
+            {
+                dimensionalItemObject.setPeriodOffset( id.getPeriodOffset() );
+            }
+            if ( dimensionalItemObject != null )
+            {
+                itemObjectMap.put( id, dimensionalItemObject );
+            }
+
         }
 
         return itemObjectMap;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -529,7 +529,10 @@ public class DefaultExpressionService
             samplePeriods, constantMap, missingValueStrategy );
 
         Map<String, Double> itemValueMap = valueMap.entrySet().stream().collect(
-            Collectors.toMap( e -> e.getKey().getDimensionItem(), Map.Entry::getValue ) );
+            Collectors.toMap(
+                e -> e.getKey().getDimensionItem()
+                    + (e.getKey().getPeriodOffset() == 0 ? "" : "." + e.getKey().getPeriodOffset()),
+                Map.Entry::getValue ) );
 
         MapMap<Period, String, Double> periodItemValueMap = new MapMap<>();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -528,22 +528,8 @@ public class DefaultExpressionService
         CommonExpressionVisitor visitor = newVisitor( parseType, ITEM_EVALUATE,
             samplePeriods, constantMap, missingValueStrategy );
 
-        Map<String, Double> itemValueMap = valueMap.entrySet().stream().collect(
-            Collectors.toMap(
-                e -> e.getKey().getDimensionItem()
-                    + (e.getKey().getPeriodOffset() == 0 ? "" : "." + e.getKey().getPeriodOffset()),
-                Map.Entry::getValue ) );
-
-        MapMap<Period, String, Double> periodItemValueMap = new MapMap<>();
-
-        for ( Period p : periodValueMap.keySet() )
-        {
-            periodItemValueMap.put( p, periodValueMap.get( p ).entrySet().stream().collect(
-                Collectors.toMap( e -> e.getKey().getDimensionItem(), Map.Entry::getValue ) ) );
-        }
-
-        visitor.setItemValueMap( itemValueMap );
-        visitor.setPeriodItemValueMap( periodItemValueMap );
+        visitor.setItemValueMap( convertToIdentifierMap( valueMap ) );
+        visitor.setPeriodItemValueMap( convertToIdentifierPeriodMap( periodValueMap ) );
         visitor.setOrgUnitCountMap( orgUnitCountMap );
 
         if ( days != null )
@@ -713,5 +699,47 @@ public class DefaultExpressionService
     private int getDaysFromPeriods( List<Period> periods )
     {
         return periods.stream().mapToInt( Period::getDaysInPeriod ).sum();
+    }
+
+    /**
+     * Converts a Map of {@see DimensionalItemObject} and values into a Map
+     * of {@see DimensionalItemObject} identifier and value.
+     * 
+     * If the {@see DimensionalItemObject} has a Period offset set, the value of the offset is added to the Map key:
+     * 
+     * [identifier.periodOffset]
+     * 
+     *  
+     * @param valueMap a Map
+     * @return a Map of DimensionalItemObject and value
+     */
+    private Map<String, Double> convertToIdentifierMap( Map<DimensionalItemObject, Double> valueMap )
+    {
+        return valueMap.entrySet().stream().collect(
+            Collectors.toMap(
+                e -> e.getKey().getDimensionItem()
+                    + (e.getKey().getPeriodOffset() == 0 ? "" : "." + e.getKey().getPeriodOffset()),
+                Map.Entry::getValue ) );
+
+    }
+
+    /**
+     * Converts a Map of Maps of {@see Period}, {@see DimensionalItemObject} and
+     * values into a Map of Maps of {@see Period}, {@see DimensionalItemObject}
+     * identifier and value
+     * 
+     * @param periodValueMap a Map of Maps
+     *
+     */
+    private MapMap<Period, String, Double> convertToIdentifierPeriodMap( MapMap<Period, DimensionalItemObject, Double> periodValueMap )
+    {
+        MapMap<Period, String, Double> periodItemValueMap = new MapMap<>();
+
+        for ( Period p : periodValueMap.keySet() )
+        {
+            periodItemValueMap.put( p, periodValueMap.get( p ).entrySet().stream().collect(
+                Collectors.toMap( e -> e.getKey().getDimensionItem(), Map.Entry::getValue ) ) );
+        }
+        return periodItemValueMap;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
@@ -28,13 +28,14 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
-import org.hisp.dhis.common.DimensionalItemId;
-
 import static org.apache.commons.lang3.ObjectUtils.anyNotNull;
 import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT_OPERAND;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
  * Expression items DataElement and DataElementOperand
@@ -45,34 +46,37 @@ public class DimItemDataElementAndOperand
     extends DimensionalItem
 {
     @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx )
+    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
+        CommonExpressionVisitor visitor )
     {
         if ( isDataElementOperandSyntax( ctx ) )
         {
             return new DimensionalItemId( DATA_ELEMENT_OPERAND,
                 ctx.uid0.getText(),
                 ctx.uid1 == null ? null : ctx.uid1.getText(),
-                ctx.uid2 == null ? null : ctx.uid2.getText() );
+                ctx.uid2 == null ? null : ctx.uid2.getText(),
+                visitor.getPeriodOffset() );
         }
         else
         {
             return new DimensionalItemId( DATA_ELEMENT,
-                ctx.uid0.getText() );
+                ctx.uid0.getText(), visitor.getPeriodOffset() );
         }
     }
 
     @Override
-    public String getId( ExprContext ctx )
+    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         if ( isDataElementOperandSyntax( ctx ) )
         {
             return ctx.uid0.getText() + "." +
-                ( ctx.uid1 == null ? "*" : ctx.uid1.getText() ) +
-                ( ctx.uid2 == null ? "" : "." + ctx.uid2.getText() );
+                (ctx.uid1 == null ? "*" : ctx.uid1.getText()) +
+                (ctx.uid2 == null ? "" : "." + ctx.uid2.getText()) +
+                (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
         }
         else // Data element:
         {
-            return ctx.uid0.getText();
+            return ctx.uid0.getText() + (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
         }
     }
 
@@ -81,8 +85,8 @@ public class DimItemDataElementAndOperand
     // -------------------------------------------------------------------------
 
     /**
-     * Does an item of the form #{...} have the syntax of a
-     * data element operand (as opposed to a data element)?
+     * Does an item of the form #{...} have the syntax of a data element operand (as
+     * opposed to a data element)?
      *
      * @param ctx the item context
      * @return true if data element operand syntax
@@ -91,7 +95,8 @@ public class DimItemDataElementAndOperand
     {
         if ( ctx.uid0 == null )
         {
-            throw new ParserExceptionWithoutContext( "Data Element or DataElementOperand must have a uid " + ctx.getText() );
+            throw new ParserExceptionWithoutContext(
+                "Data Element or DataElementOperand must have a uid " + ctx.getText() );
         }
 
         return anyNotNull( ctx.uid1, ctx.uid2 );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemIndicator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemIndicator.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.common.DimensionItemType.INDICATOR;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
  * Expression item Indicator
@@ -42,14 +43,15 @@ public class DimItemIndicator
     extends DimensionalItem
 {
     @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx )
+    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
+        CommonExpressionVisitor visitor )
     {
-        return new DimensionalItemId( INDICATOR, ctx.uid0.getText() );
+        return new DimensionalItemId( INDICATOR, ctx.uid0.getText(), visitor.getPeriodOffset() );
     }
 
     @Override
-    public String getId( ExprContext ctx )
+    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return ctx.uid0.getText();
+        return ctx.uid0.getText() + (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemProgramDataElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemProgramDataElement.java
@@ -28,10 +28,11 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.common.DimensionalItemId;
-
 import static org.hisp.dhis.common.DimensionItemType.PROGRAM_DATA_ELEMENT;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
  * Expression item ProgramDataElement
@@ -42,7 +43,8 @@ public class DimItemProgramDataElement
     extends DimensionalItem
 {
     @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx )
+    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
+        CommonExpressionVisitor visitor )
     {
         return new DimensionalItemId( PROGRAM_DATA_ELEMENT,
             ctx.uid0.getText(),
@@ -50,9 +52,10 @@ public class DimItemProgramDataElement
     }
 
     @Override
-    public String getId( ExprContext ctx )
+    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         return ctx.uid0.getText() + "." +
-            ctx.uid1.getText();
+            ctx.uid1.getText() +
+            (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemProgramIndicator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemProgramIndicator.java
@@ -28,10 +28,11 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.common.DimensionalItemId;
-
 import static org.hisp.dhis.common.DimensionItemType.PROGRAM_INDICATOR;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
  * Expression item ProgramIndicator
@@ -42,15 +43,17 @@ public class DimItemProgramIndicator
     extends DimensionalItem
 {
     @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx )
+    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
+        CommonExpressionVisitor visitor )
     {
         return new DimensionalItemId( PROGRAM_INDICATOR,
             ctx.uid0.getText() );
     }
 
     @Override
-    public String getId( ExprContext ctx )
+    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return ctx.uid0.getText();
+        return ctx.uid0.getText() +
+            (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemReportingRate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemReportingRate.java
@@ -28,10 +28,11 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.common.DimensionalItemId;
-
 import static org.hisp.dhis.common.DimensionItemType.REPORTING_RATE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
  * Expression item ReportingRate
@@ -42,7 +43,8 @@ public class DimItemReportingRate
     extends DimensionalItem
 {
     @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx )
+    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
+        CommonExpressionVisitor visitor )
     {
         return new DimensionalItemId( REPORTING_RATE,
             ctx.uid0.getText(),
@@ -50,9 +52,10 @@ public class DimItemReportingRate
     }
 
     @Override
-    public String getId( ExprContext ctx )
+    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         return ctx.uid0.getText() + "." +
-            ctx.REPORTING_RATE_TYPE().getText();
+            ctx.REPORTING_RATE_TYPE().getText() +
+            (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimensionalItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimensionalItem.java
@@ -28,14 +28,14 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.ExpressionItem;
-
-import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 /**
  * Parsed dimensional item as handled by the expression service.
@@ -48,13 +48,14 @@ public abstract class DimensionalItem
     @Override
     public final Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        DimensionalItemId itemId = getDimensionalItemId( ctx );
+        DimensionalItemId itemId = getDimensionalItemId( ctx, visitor );
 
         DimensionalItemObject item = visitor.getDimensionService().getDataDimensionalItemObject( itemId );
 
         if ( item == null )
         {
-            throw new ParserExceptionWithoutContext( "Can't find " + itemId.getDimensionItemType().name() + " for '" + itemId + "'" );
+            throw new ParserExceptionWithoutContext(
+                "Can't find " + itemId.getDimensionItemType().name() + " for '" + itemId + "'" );
         }
 
         visitor.getItemDescriptions().put( ctx.getText(), item.getDisplayName() );
@@ -65,7 +66,7 @@ public abstract class DimensionalItem
     @Override
     public final Object getItemId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getItemIds().add( getDimensionalItemId( ctx ) );
+        visitor.getItemIds().add( getDimensionalItemId( ctx, visitor ) );
 
         return DOUBLE_VALUE_IF_NULL;
     }
@@ -79,7 +80,7 @@ public abstract class DimensionalItem
     @Override
     public final Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        Double value = visitor.getItemValueMap().get( getId( ctx ) );
+        Double value = visitor.getItemValueMap().get( getId( ctx, visitor ) );
 
         return visitor.handleNulls( value );
     }
@@ -88,9 +89,11 @@ public abstract class DimensionalItem
      * Constructs the DimensionalItemId object for this item.
      *
      * @param ctx the parser item context
+     * @param visitor
      * @return the DimensionalItemId object for this item
      */
-    public abstract DimensionalItemId getDimensionalItemId( ExprContext ctx );
+    public abstract DimensionalItemId getDimensionalItemId( ExprContext ctx,
+        CommonExpressionVisitor visitor );
 
     /**
      * Returns the id for this item.
@@ -100,5 +103,5 @@ public abstract class DimensionalItem
      * @param ctx the parser item context
      * @return the id for this item
      */
-    public abstract String getId( ExprContext ctx );
+    public abstract String getId( ExprContext ctx, CommonExpressionVisitor visitor );
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -28,6 +28,19 @@ package org.hisp.dhis.parser.expression;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
+import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
+import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_REGENERATE;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.Validate;
 import org.hisp.dhis.antlr.AntlrExpressionVisitor;
@@ -51,22 +64,9 @@ import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
-import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
-import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_REGENERATE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
-
 /**
- * Common traversal of the ANTLR4 expression parse tree using the
- * visitor pattern.
+ * Common traversal of the ANTLR4 expression parse tree using the visitor
+ * pattern.
  *
  * @author Jim Grace
  */
@@ -105,6 +105,11 @@ public class CommonExpressionVisitor
      * By default, replace nulls with 0 or ''.
      */
     private boolean replaceNulls = true;
+
+    /**
+     * By default, the offset is not set.
+     */
+    private int periodOffset = 0;
 
     /**
      * Used to collect the string replacements to build a description.
@@ -147,8 +152,8 @@ public class CommonExpressionVisitor
     private Map<String, Double> itemValueMap;
 
     /**
-     * Dimensional item values by period for aggregating in evaluating
-     * an expression.
+     * Dimensional item values by period for aggregating in evaluating an
+     * expression.
      */
     private MapMap<Period, String, Double> periodItemValueMap;
 
@@ -263,8 +268,8 @@ public class CommonExpressionVisitor
     // -------------------------------------------------------------------------
 
     /**
-     * Visits a context while allowing null values (not replacing them
-     * with 0 or ''), even if we would otherwise be replacing them.
+     * Visits a context while allowing null values (not replacing them with 0 or
+     * ''), even if we would otherwise be replacing them.
      *
      * @param ctx any context
      * @return the value while allowing nulls
@@ -283,15 +288,34 @@ public class CommonExpressionVisitor
     }
 
     /**
+     * Visits a context using a period offset.
+     *
+     * @param ctx any context
+     * @return the value with the applied offset
+     */
+    public Object visitWithOffset( ParserRuleContext ctx, int offset )
+    {
+        int savedPeriodOffset = periodOffset;
+
+        periodOffset = offset;
+
+        Object result = visit( ctx );
+
+        periodOffset = savedPeriodOffset;
+
+        return result;
+    }
+
+    /**
      * Handles nulls and missing values.
      * <p/>
-     * If we should replace nulls with the default value, then do so, and
-     * remember how many items found, and how many of them had values, for
-     * subsequent MissingValueStrategy analysis.
+     * If we should replace nulls with the default value, then do so, and remember
+     * how many items found, and how many of them had values, for subsequent
+     * MissingValueStrategy analysis.
      * <p/>
-     * If we should not replace nulls with the default value, then don't,
-     * as this is likely for some function that is testing for nulls, and
-     * a missing value should not count towards the MissingValueStrategy.
+     * If we should not replace nulls with the default value, then don't, as this is
+     * likely for some function that is testing for nulls, and a missing value
+     * should not count towards the MissingValueStrategy.
      *
      * @param value the (possibly null) value
      * @return the value we should return.
@@ -318,7 +342,8 @@ public class CommonExpressionVisitor
     /**
      * Validates a program stage id / data element id pair
      *
-     * @param text expression text containing both program stage id and data element id
+     * @param text expression text containing both program stage id and data element
+     *        id
      * @param programStageId the program stage id
      * @param dataElementId the data element id
      * @return the ValueType of the data element
@@ -339,7 +364,8 @@ public class CommonExpressionVisitor
             throw new ParserExceptionWithoutContext( "Data element " + dataElementId + " not found" );
         }
 
-        String description = programStage.getDisplayName() + ProgramIndicator.SEPARATOR_ID + dataElement.getDisplayName();
+        String description = programStage.getDisplayName() + ProgramIndicator.SEPARATOR_ID
+            + dataElement.getDisplayName();
 
         itemDescriptions.put( text, description );
 
@@ -347,8 +373,8 @@ public class CommonExpressionVisitor
     }
 
     /**
-     * Regenerates an expression by visiting all the children of the
-     * expression node (including any terminal nodes).
+     * Regenerates an expression by visiting all the children of the expression node
+     * (including any terminal nodes).
      *
      * @param ctx the expression context
      * @return the regenerated expression (as a String)
@@ -470,12 +496,22 @@ public class CommonExpressionVisitor
         this.replaceNulls = replaceNulls;
     }
 
+    public int getPeriodOffset()
+    {
+        return periodOffset;
+    }
+
+    public void setPeriodOffset( int periodOffset )
+    {
+        this.periodOffset = periodOffset;
+    }
+
     public Set<DimensionalItemId> getItemIds()
     {
         return itemIds;
     }
 
-    public void setItemIds(Set<DimensionalItemId> itemIds )
+    public void setItemIds( Set<DimensionalItemId> itemIds )
     {
         this.itemIds = itemIds;
     }
@@ -485,7 +521,7 @@ public class CommonExpressionVisitor
         return sampleItemIds;
     }
 
-    public void setSampleItemIds(Set<DimensionalItemId> sampleItemIds )
+    public void setSampleItemIds( Set<DimensionalItemId> sampleItemIds )
     {
         this.sampleItemIds = sampleItemIds;
     }
@@ -668,19 +704,22 @@ public class CommonExpressionVisitor
         public CommonExpressionVisitor buildForExpressions()
         {
             Validate.notNull( this.visitor.dimensionService, "Missing required property 'dimensionService'" );
-            Validate.notNull( this.visitor.organisationUnitGroupService,"Missing required property 'organisationUnitGroupService'" );
-            Validate.notNull( this.visitor.missingValueStrategy,"Missing required property 'missingValueStrategy'" );
+            Validate.notNull( this.visitor.organisationUnitGroupService,
+                "Missing required property 'organisationUnitGroupService'" );
+            Validate.notNull( this.visitor.missingValueStrategy, "Missing required property 'missingValueStrategy'" );
 
             return validateCommonProperties();
         }
 
         public CommonExpressionVisitor buildForProgramIndicatorExpressions()
         {
-            Validate.notNull( this.visitor.programIndicatorService, "Missing required property 'programIndicatorService'" );
+            Validate.notNull( this.visitor.programIndicatorService,
+                "Missing required property 'programIndicatorService'" );
             Validate.notNull( this.visitor.programStageService, "Missing required property 'programStageService'" );
             Validate.notNull( this.visitor.dataElementService, "Missing required property 'dataElementService'" );
             Validate.notNull( this.visitor.attributeService, "Missing required property 'attributeService'" );
-            Validate.notNull( this.visitor.relationshipTypeService, "Missing required property 'relationshipTypeService'" );
+            Validate.notNull( this.visitor.relationshipTypeService,
+                "Missing required property 'relationshipTypeService'" );
             Validate.notNull( this.visitor.statementBuilder, "Missing required property 'statementBuilder'" );
             Validate.notNull( this.visitor.i18n, "Missing required property 'i18n'" );
 

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -28,8 +28,10 @@ package org.hisp.dhis.parser.expression;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
+
+import java.util.List;
+
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.dataitem.ItemConstant;
 import org.hisp.dhis.parser.expression.function.FunctionFirstNonNull;
@@ -38,13 +40,13 @@ import org.hisp.dhis.parser.expression.function.FunctionIf;
 import org.hisp.dhis.parser.expression.function.FunctionIsNotNull;
 import org.hisp.dhis.parser.expression.function.FunctionIsNull;
 import org.hisp.dhis.parser.expression.function.FunctionLeast;
+import org.hisp.dhis.parser.expression.function.PeriodOffset;
 import org.hisp.dhis.parser.expression.operator.*;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 
-import java.util.List;
-
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 
 /**
  * Utilities for ANTLR parsing
@@ -55,7 +57,8 @@ public class ParserUtils
 {
     public final static double DOUBLE_VALUE_IF_NULL = 0.0;
 
-    public final static ImmutableMap<Integer, ExpressionItem> COMMON_EXPRESSION_ITEMS = ImmutableMap.<Integer, ExpressionItem>builder()
+    public final static ImmutableMap<Integer, ExpressionItem> COMMON_EXPRESSION_ITEMS = ImmutableMap
+        .<Integer, ExpressionItem> builder()
 
         // Non-comparison operators
 
@@ -90,6 +93,7 @@ public class ParserUtils
         .put( IS_NOT_NULL, new FunctionIsNotNull() )
         .put( IS_NULL, new FunctionIsNull() )
         .put( LEAST, new FunctionLeast() )
+        .put( PERIOD_OFFSET, new PeriodOffset() )
 
         // Data items
 
@@ -110,15 +114,15 @@ public class ParserUtils
     public final static ExpressionItemMethod ITEM_REGENERATE = ExpressionItem::regenerate;
 
     /**
-     * Used for syntax checking when we don't have a list of actual
-     * periods for collecting samples.
+     * Used for syntax checking when we don't have a list of actual periods for
+     * collecting samples.
      */
-    public final static List<Period> DEFAULT_SAMPLE_PERIODS =
-        Lists.newArrayList( PeriodType.getPeriodFromIsoString( "20010101" ) );
+    public final static List<Period> DEFAULT_SAMPLE_PERIODS = Lists
+        .newArrayList( PeriodType.getPeriodFromIsoString( "20010101" ) );
 
     /**
-     * Assume that an item of the form #{...} has a syntax that could be used
-     * in a program indicator expression for #{programStageUid.dataElementUid}
+     * Assume that an item of the form #{...} has a syntax that could be used in a
+     * program indicator expression for #{programStageUid.dataElementUid}
      *
      * @param ctx the item context
      */
@@ -131,8 +135,8 @@ public class ParserUtils
     }
 
     /**
-     * Assume that an item of the form A{...} has a syntax that could be used
-     * in an expression for A{progamUid.attributeUid}
+     * Assume that an item of the form A{...} has a syntax that could be used in an
+     * expression for A{progamUid.attributeUid}
      *
      * @param ctx the item context
      */
@@ -145,8 +149,8 @@ public class ParserUtils
     }
 
     /**
-     * Assume that an item of the form A{...} has a syntax that could be used
-     * be used in an program expression for A{attributeUid}
+     * Assume that an item of the form A{...} has a syntax that could be used be
+     * used in an program expression for A{attributeUid}
      *
      * @param ctx the item context
      */

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.parser.expression.operator.*;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
@@ -117,8 +118,8 @@ public class ParserUtils
      * Used for syntax checking when we don't have a list of actual periods for
      * collecting samples.
      */
-    public final static List<Period> DEFAULT_SAMPLE_PERIODS = Lists
-        .newArrayList( PeriodType.getPeriodFromIsoString( "20010101" ) );
+    public final static List<Period> DEFAULT_SAMPLE_PERIODS = ImmutableList.of(
+        PeriodType.getPeriodFromIsoString( "20010101" ) );
 
     /**
      * Assume that an item of the form #{...} has a syntax that could be used in a

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/PeriodOffset.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/PeriodOffset.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.expression.dataitem;
+package org.hisp.dhis.parser.expression.function;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,39 +28,23 @@ package org.hisp.dhis.expression.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.common.DimensionItemType.*;
-import static org.hisp.dhis.parser.expression.ParserUtils.assumeExpressionProgramAttribute;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
-import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
- * Expression item ProgramAttribute
+ * Function least
  *
- * @author Jim Grace
+ * @author Enrico Colasante
  */
-public class DimItemProgramAttribute
-    extends DimensionalItem
+public class PeriodOffset
+    extends FunctionGreatestOrLeast
 {
     @Override
-    public DimensionalItemId getDimensionalItemId( ExprContext ctx,
-        CommonExpressionVisitor visitor )
+    public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        assumeExpressionProgramAttribute( ctx );
+        int offset = ctx.period != null ? Integer.valueOf( ctx.period.getText() ) : 0;
 
-        return new DimensionalItemId( PROGRAM_ATTRIBUTE,
-            ctx.uid0.getText(),
-            ctx.uid1.getText() );
-    }
-
-    @Override
-    public String getId( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        assumeExpressionProgramAttribute( ctx );
-
-        return ctx.uid0.getText() + "." +
-            ctx.uid1.getText() +
-            (visitor.getPeriodOffset() == 0 ? "" : "." + visitor.getPeriodOffset());
+        return visitor.visitWithOffset( ctx.expr( 0 ), offset );
     }
 }


### PR DESCRIPTION
This feature allows to "shift" by period one or more elements within an Indicator formula.

Given the following Indicator formula:

`#{gQNFkFkObU8} + #{MaXD86iob3M}`

It is now possible to add a `periodOffset()` directive, in order to calculate the value for the
query-specific period based on the declared `periodOffset`:

`(#{gQNFkFkObU8}.periodOffset(-1) + #{MaXD86iob3M}.periodOffset(-1)) - (#{gQNFkFkObU8} + #{MaXD86iob3M})`

In the above example, assuming that the Analytics query is executed for the period Feb 2020, the results will calculate the
value of `gQNFkFkObU8` + `MaXD86iob3M` for January 2020 (offset -1) and subtract the value from February 2020.

Analysis document: https://docs.google.com/document/d/17hpuy0wwkabnowsRAo_R3-m5NUMOGVipyeRwj3RjXWA/edit?usp=sharing

ref: DHIS2-8758