### PR TITLE
fix: Add thematic map type to map view [DHIS2-9046]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
@@ -168,6 +168,8 @@ public class MapView
 
     private MapViewRenderingStrategy renderingStrategy;
 
+    private ThematicMapType thematicMapType;
+
     /**
      * General configuration property for JSON values used to store information
      * for layers with arbitrary configuration needs.
@@ -714,6 +716,18 @@ public class MapView
     public void setRenderingStrategy( MapViewRenderingStrategy renderingStrategy )
     {
         this.renderingStrategy = renderingStrategy;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public ThematicMapType getThematicMapType()
+    {
+        return thematicMapType;
+    }
+
+    public void setThematicMapType( ThematicMapType thematicMapType )
+    {
+        this.thematicMapType = thematicMapType;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
@@ -194,7 +194,6 @@ public class MapView
 
     public MapView()
     {
-        this.thematicMapType = ThematicMapType.CHOROPLETH;
         this.renderingStrategy = MapViewRenderingStrategy.SINGLE;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
@@ -194,6 +194,7 @@ public class MapView
 
     public MapView()
     {
+        this.thematicMapType = ThematicMapType.CHOROPLETH;
         this.renderingStrategy = MapViewRenderingStrategy.SINGLE;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/ThematicMapType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/ThematicMapType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.mapping;
+
+/**
+ * Represents the type of thematic map visualisation.
+ *
+ * @author Lars Helge Overland
+ */
+public enum ThematicMapType
+{
+    CHOROPLETH,
+    BUBBLE;
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
@@ -208,7 +208,7 @@
 
     <property name="eventPointRadius" />
     
-    <property name="thematicMapType" length="50" column="thematicmaptype" not-null="true">
+    <property name="thematicMapType" length="50" column="thematicmaptype">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.mapping.ThematicMapType</param>
         <param name="useNamed">true</param>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
@@ -208,6 +208,14 @@
 
     <property name="eventPointRadius" />
     
+    <property name="thematicMapType" length="50" column="thematicmaptype" not-null="true">
+      <type name="org.hibernate.type.EnumType">
+        <param name="enumClass">org.hisp.dhis.mapping.ThematicMapType</param>
+        <param name="useNamed">true</param>
+        <param name="type">12</param>
+      </type>
+    </property>
+    
     <property name="renderingStrategy" length="50" column="renderingstrategy" not-null="true">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.mapping.MapViewRenderingStrategy</param>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/AnalyticalObjectStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/AnalyticalObjectStoreTest.java
@@ -29,11 +29,16 @@ package org.hisp.dhis.common;
  */
 
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.UserOrgUnitType;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.mapping.MapView;
+import org.hisp.dhis.mapping.MapViewRenderingStrategy;
 import org.hisp.dhis.mapping.MapViewStore;
+import org.hisp.dhis.mapping.ThematicMapType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.ProgramStatus;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -87,9 +92,9 @@ public class AnalyticalObjectStoreTest
         idObjectManager.save( ouA );
         idObjectManager.save( ouB );
 
-        mvA = new MapView( MapView.LAYER_THEMATIC1 );
-        mvB = new MapView( MapView.LAYER_THEMATIC1 );
-        mvC = new MapView( MapView.LAYER_THEMATIC1 );
+        mvA = createMapView( MapView.LAYER_THEMATIC1 );
+        mvB = createMapView( MapView.LAYER_THEMATIC2 );
+        mvC = createMapView( MapView.LAYER_THEMATIC3 );
 
         mvA.addDataDimensionItem( inA );
         mvA.getOrganisationUnits().add( ouA );
@@ -123,5 +128,17 @@ public class AnalyticalObjectStoreTest
 
         assertTrue( actual.contains( mvA ) );
         assertTrue( actual.contains( mvB ) );
+    }
+
+    public void testAssertEnumProperties()
+    {
+        MapView mapView = mapViewStore.getByUid( mvA.getUid() );
+
+        assertEquals( AggregationType.SUM, mapView.getAggregationType() );
+        assertEquals( ThematicMapType.CHOROPLETH, mapView.getThematicMapType() );
+        assertEquals( ProgramStatus.COMPLETED, mapView.getProgramStatus() );
+        assertEquals( OrganisationUnitSelectionMode.DESCENDANTS, mapView.getOrganisationUnitSelectionMode() );
+        assertEquals( MapViewRenderingStrategy.SINGLE, mapView.getRenderingStrategy() );
+        assertEquals( UserOrgUnitType.DATA_CAPTURE, mapView.getUserOrgUnitType() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapping/MappingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapping/MappingServiceTest.java
@@ -142,7 +142,7 @@ public class MappingServiceTest
     @Test
     public void testImportMapCreateAndUpdate() throws IOException {
         java.util.Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
-                new ClassPathResource("create_map.json").getInputStream(), RenderFormat.JSON );
+            new ClassPathResource( "create_map.json" ).getInputStream(), RenderFormat.JSON );
 
         MetadataImportParams params = new MetadataImportParams();
         params.setImportMode( ObjectBundleMode.COMMIT );
@@ -158,7 +158,7 @@ public class MappingServiceTest
         assertEquals( 1, maps.get(0).getMapViews().size() );
 
         metadata = renderService.fromMetadata(
-                new ClassPathResource("update_map.json").getInputStream(), RenderFormat.JSON );
+            new ClassPathResource( "update_map.json" ).getInputStream(), RenderFormat.JSON );
 
         params = new MetadataImportParams();
         params.setImportMode( ObjectBundleMode.COMMIT );
@@ -171,5 +171,9 @@ public class MappingServiceTest
         Map map = mappingService.getMap( "LTNgXfzTFTv" );
         assertNotNull( map );
         assertEquals( 1, map.getMapViews().size() );
+
+        MapView mapView = map.getMapViews().get( 0 );
+        assertNotNull( mapView );
+        assertEquals( ThematicMapType.CHOROPLETH, mapView.getThematicMapType() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/create_map.json
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/create_map.json
@@ -63,7 +63,7 @@
             }
           ],
           "startDate": "2018-09-01",
-          "valueType": "de"
+          "thematicMapType": "CHOROPLETH"
         }
       ],
       "name": "test1",

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/update_map.json
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/update_map.json
@@ -43,8 +43,8 @@
               ]
             }
           ],
-          "startDate": "2018-09-01",
-          "valueType": "de"
+          "startDate": "2018-09-01",          
+          "thematicMapType": "CHOROPLETH"
         }
       ],
       "name": "test1",

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_8__Add_mapview_thematicmaptype.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_8__Add_mapview_thematicmaptype.sql
@@ -1,0 +1,6 @@
+
+-- Add column 'thematicmaptype' to 'mapview', set to default value and set not null
+
+alter table mapview add column if not exists "thematicmaptype" varchar(50);
+update mapview set "thematicmaptype" = 'CHOROPLETH' where "thematicmaptype" is null;
+alter table mapview alter column "thematicmaptype" set not null;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_8__Add_mapview_thematicmaptype.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_8__Add_mapview_thematicmaptype.sql
@@ -1,5 +1,8 @@
 
--- Add column 'thematicmaptype' to 'mapview', set to default value and set not null
+-- Add column 'thematicmaptype' to 'mapview'
 
 alter table mapview add column if not exists "thematicmaptype" varchar(50);
+
+-- Upgrade existing thematic map views to 'CHOROPLETH'
+
 update mapview set "thematicmaptype" = 'CHOROPLETH' where "thematicmaptype" is null and "layer" like 'thematic%';

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_8__Add_mapview_thematicmaptype.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_8__Add_mapview_thematicmaptype.sql
@@ -2,5 +2,4 @@
 -- Add column 'thematicmaptype' to 'mapview', set to default value and set not null
 
 alter table mapview add column if not exists "thematicmaptype" varchar(50);
-update mapview set "thematicmaptype" = 'CHOROPLETH' where "thematicmaptype" is null;
-alter table mapview alter column "thematicmaptype" set not null;
+update mapview set "thematicmaptype" = 'CHOROPLETH' where "thematicmaptype" is null and "layer" like 'thematic%';

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -36,6 +36,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.UserOrgUnitType;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.category.Category;
@@ -53,6 +54,7 @@ import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.constant.Constant;
@@ -79,6 +81,9 @@ import org.hisp.dhis.indicator.IndicatorGroupSet;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.legend.LegendSet;
+import org.hisp.dhis.mapping.MapView;
+import org.hisp.dhis.mapping.MapViewRenderingStrategy;
+import org.hisp.dhis.mapping.ThematicMapType;
 import org.hisp.dhis.notification.SendStrategy;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
@@ -100,6 +105,7 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageSection;
+import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeGroup;
 import org.hisp.dhis.program.ProgramType;
@@ -1327,6 +1333,22 @@ public abstract class DhisConvenienceTest
         user.setAutoFields();
 
         return user;
+    }
+
+    public static MapView createMapView( String layer )
+    {
+        MapView mapView = new MapView();
+        mapView.setAutoFields();
+
+        mapView.setLayer( layer );
+        mapView.setAggregationType( AggregationType.SUM );
+        mapView.setThematicMapType( ThematicMapType.CHOROPLETH );
+        mapView.setProgramStatus( ProgramStatus.COMPLETED );
+        mapView.setOrganisationUnitSelectionMode( OrganisationUnitSelectionMode.DESCENDANTS );
+        mapView.setRenderingStrategy( MapViewRenderingStrategy.SINGLE );
+        mapView.setUserOrgUnitType( UserOrgUnitType.DATA_CAPTURE );
+
+        return mapView;
     }
 
     public static UserCredentials createUserCredentials( char uniqueCharacter, User user )


### PR DESCRIPTION
Adds enum `ThematicMapType` and association from `MapView`. Purpose of this enum/field is to distinguish between various thematic map visualization types like choropleth and bubble maps.