### PR TITLE
fix: Add MapView noDataColor property [DHIS2-9047]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Property;
+import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
 
@@ -135,6 +136,12 @@ public class MapView
     private String colorScale;
 
     private LegendSet legendSet;
+
+    /**
+     * Color in hex format to use for features with no corresponding
+     * data. Must be exactly 7 characters.
+     */
+    private String noDataColor;
 
     private Integer radiusLow;
 
@@ -523,6 +530,20 @@ public class MapView
     public void setLegendSet( LegendSet legendSet )
     {
         this.legendSet = legendSet;
+    }
+
+    @JsonProperty
+    @JsonSerialize( as = BaseIdentifiableObject.class )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @PropertyRange( min = 7, max = 7 )
+    public String getNoDataColor()
+    {
+        return noDataColor;
+    }
+
+    public void setNoDataColor( String noDataColor )
+    {
+        this.noDataColor = noDataColor;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
@@ -176,6 +176,8 @@
 
     <many-to-one name="legendSet" class="org.hisp.dhis.legend.LegendSet" column="legendsetid"
       foreign-key="fk_mapview_maplegendsetid" />
+      
+    <property name="noDataColor" length="7" />
 
     <property name="radiusLow" />
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/AnalyticalObjectStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/AnalyticalObjectStoreTest.java
@@ -130,7 +130,8 @@ public class AnalyticalObjectStoreTest
         assertTrue( actual.contains( mvB ) );
     }
 
-    public void testAssertEnumProperties()
+    @Test
+    public void testAssertProperties()
     {
         MapView mapView = mapViewStore.getByUid( mvA.getUid() );
 
@@ -140,5 +141,6 @@ public class AnalyticalObjectStoreTest
         assertEquals( OrganisationUnitSelectionMode.DESCENDANTS, mapView.getOrganisationUnitSelectionMode() );
         assertEquals( MapViewRenderingStrategy.SINGLE, mapView.getRenderingStrategy() );
         assertEquals( UserOrgUnitType.DATA_CAPTURE, mapView.getUserOrgUnitType() );
+        assertEquals( "#ddeeff", mapView.getNoDataColor() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapping/MappingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapping/MappingServiceTest.java
@@ -174,6 +174,7 @@ public class MappingServiceTest
 
         MapView mapView = map.getMapViews().get( 0 );
         assertNotNull( mapView );
+        assertEquals( "#ddeeff", mapView.getNoDataColor() );
         assertEquals( ThematicMapType.CHOROPLETH, mapView.getThematicMapType() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/create_map.json
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/create_map.json
@@ -63,6 +63,7 @@
             }
           ],
           "startDate": "2018-09-01",
+          "noDataColor": "#ddeeff",
           "thematicMapType": "CHOROPLETH"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/update_map.json
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/resources/update_map.json
@@ -43,7 +43,8 @@
               ]
             }
           ],
-          "startDate": "2018-09-01",          
+          "startDate": "2018-09-01",
+          "noDataColor": "#ddeeff",     
           "thematicMapType": "CHOROPLETH"
         }
       ],

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1347,6 +1347,7 @@ public abstract class DhisConvenienceTest
         mapView.setOrganisationUnitSelectionMode( OrganisationUnitSelectionMode.DESCENDANTS );
         mapView.setRenderingStrategy( MapViewRenderingStrategy.SINGLE );
         mapView.setUserOrgUnitType( UserOrgUnitType.DATA_CAPTURE );
+        mapView.setNoDataColor( "#ddeeff" );
 
         return mapView;
     }


### PR DESCRIPTION
Adds property `noDataColor` to entity `MapView`. The purpose of this property is to store the color to use for map features which have no corresponding data. The color format is in 7 character hex format.