### PR TITLE
fix: userCredentials API endpoint not returning results [DHIS2-9024]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserCredentialsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserCredentialsStore.java
@@ -30,7 +30,9 @@ package org.hisp.dhis.user.hibernate;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
-import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserCredentialsStore;
 import org.springframework.context.ApplicationEventPublisher;
@@ -42,12 +44,13 @@ import org.springframework.stereotype.Repository;
  */
 @Repository( "org.hisp.dhis.user.UserCredentialsStore" )
 public class HibernateUserCredentialsStore
-    extends HibernateGenericStore<UserCredentials>
+    extends HibernateIdentifiableObjectStore<UserCredentials>
     implements UserCredentialsStore
 {
-    public HibernateUserCredentialsStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate, ApplicationEventPublisher publisher )
+    public HibernateUserCredentialsStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
+        ApplicationEventPublisher publisher, CurrentUserService currentUserService, AclService aclService )
     {
-        super( sessionFactory, jdbcTemplate, publisher, UserCredentials.class, true );
+        super( sessionFactory, jdbcTemplate, publisher, UserCredentials.class, currentUserService, aclService, true );
     }
 
     @Override


### PR DESCRIPTION
This issue happens because `getIdentifiableObjectStore` method in `DefaultIdentifiableObjectManager` returns `null` for  `UserCredentials` class. This because the `identifiableObjectStores` used in creating the `DefaultIdentifiableObjectManager` does not contain the `HibernateUserCredentialsStore`. 

The fix is to make `HibernateUserCredentialsStore` as sub-class of `HibernateIdentifiableObjectStore`.