### PR TITLE
[2.32] fix: Invalid weekly period year reference (#5745)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
@@ -38,10 +38,12 @@ import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.WeeklyAbstractPeriodType;
 import org.hisp.dhis.resourcetable.ResourceTable;
 import org.hisp.dhis.resourcetable.ResourceTableType;
 
 import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
 
 import static org.hisp.dhis.system.util.SqlUtils.quote;
 
@@ -99,7 +101,7 @@ public class PeriodResourceTable
             if ( period != null && period.isValid() )
             {
                 final String isoDate = period.getIsoDate();
-                final int year = PeriodType.getCalendar().fromIso( period.getStartDate() ).getYear();
+                final int year = resolveYearFromPeriod( period );
 
                 if ( !uniqueIsoDates.add( isoDate ) )
                 {
@@ -137,5 +139,21 @@ public class PeriodResourceTable
         String sql = "create unique index " + name + " on " + getTempTableName() + "(iso)";
 
         return Lists.newArrayList( sql );
+    }
+    
+    private int resolveYearFromPeriod( Period period )
+    {
+        // Weekly type has to be treated separately from other Period types.
+        // In order to handle all weekly types uniformly, 3 days are added to the week start day and
+        // the year of the modified start date is used as reference year for the Period
+
+        if ( WeeklyAbstractPeriodType.class.isAssignableFrom( period.getPeriodType().getClass() ) )
+        {
+            return new DateTime( period.getStartDate().getTime() ).plusDays( 3 ).getYear();
+        }
+        else
+        {
+            return PeriodType.getCalendar().fromIso( period.getStartDate() ).getYear();
+        }
     }
 }


### PR DESCRIPTION
* fix: Invalid weekly period year reference

This fix corrects an error during the `_periodstructure` generation process. The process assigns the wrong year to a week Period.

Example: `2019-12-31`
The week of `2019-12-31`, according to the ISO calendar system, belongs to 2020, since 4 or more days of that week fall in 2020.

In order to handle all Weekly Period types uniformly, 3 days are added to a Weekly Period type start date.

Example:

| Weekly Type     | Example Date | Date -> Start Date -> + 3             |
|-----------------|--------------|---------------------------------------|
| Standard        | 2019-12-31   | -> 2019-12-31 +3 = 2020-01-03 = 2020  |
| Weekly Saturday | 2019-12-31   | -> 2019-12-28 + 3 = 2019-12-31 = 2019 |
| Weekly Sunday   | 2019-12-31   | -> 2019-12-29 + 3 = 2020-01-01 = 2020 |
| Weekly Thursday | 2019-12-31   | -> 2019-12-26 + 3 = 2019-12-29 = 2019 |
| Weekly Wed      | 2019-12-31   | -> 2019-12-25 + 3 = 2019-12-28 = 2019 |

ref: DHIS2-5990

* chore: address sonar issue

(cherry picked from commit aa75a25b530d5013d0b309ac8f492828cad456e0)