### PR TITLE
fix [2.33]: Prevent NullPointer exception when empty jsonbjobparams are loaded

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v33/V2_33_5__Update_job_parameters_with_system_setting_values.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v33/V2_33_5__Update_job_parameters_with_system_setting_values.java
@@ -120,11 +120,15 @@ public class V2_33_5__Update_job_parameters_with_system_setting_values extends B
                         JobType.TRACKER_PROGRAMS_DATA_SYNC.name() + "';" );
                     while ( rs.next())
                     {
-                        TrackerProgramsDataSynchronizationJobParameters jobparams = reader
-                            .readValue( rs.getString( "jsonbjobparameters" ) );
-                        jobparams.setPageSize( trackerPageSize );
+                        String jsonbJobParams = rs.getString( "jsonbjobparameters" );
+                        if ( jsonbJobParams != null )
+                        {
+                            TrackerProgramsDataSynchronizationJobParameters jobparams = reader
+                                    .readValue( jsonbJobParams );
+                            jobparams.setPageSize( trackerPageSize );
 
-                        updatedJobParameters.put( rs.getInt( "jobconfigurationid" ), jobparams );
+                            updatedJobParameters.put( rs.getInt( "jobconfigurationid" ), jobparams );
+                        }
                     }
                 }
             }
@@ -137,11 +141,15 @@ public class V2_33_5__Update_job_parameters_with_system_setting_values extends B
                         JobType.EVENT_PROGRAMS_DATA_SYNC.name() + "';" );
                     while ( rs.next())
                     {
-                        EventProgramsDataSynchronizationJobParameters jobparams = reader
-                            .readValue( rs.getString( "jsonbjobparameters" ) );
-                        jobparams.setPageSize( eventPageSize );
+                        String jsonbJobParams = rs.getString( "jsonbjobparameters" );
+                        if ( jsonbJobParams != null )
+                        {
+                            EventProgramsDataSynchronizationJobParameters jobparams = reader.readValue( jsonbJobParams );
+                            jobparams.setPageSize( eventPageSize );
 
-                        updatedJobParameters.put( rs.getInt( "jobconfigurationid" ), jobparams );
+                            updatedJobParameters.put( rs.getInt( "jobconfigurationid" ), jobparams );
+                        }
+
                     }
                 }
             }
@@ -152,25 +160,29 @@ public class V2_33_5__Update_job_parameters_with_system_setting_values extends B
                     JobType.META_DATA_SYNC.name() + "';" );
                 while ( rs.next())
                 {
-                    MetadataSyncJobParameters jobparams = reader
-                        .readValue( rs.getString( "jsonbjobparameters" ) );
-
-                    if ( trackerPageSize > 0 )
+                    String jsonbJobParams = rs.getString( "jsonbjobparameters" );
+                    if ( jsonbJobParams != null )
                     {
-                        jobparams.setTrackerProgramPageSize( trackerPageSize );
-                    }
+                        MetadataSyncJobParameters jobparams = reader
+                                .readValue( jsonbJobParams );
 
-                    if ( eventPageSize > 0 )
-                    {
-                        jobparams.setEventProgramPageSize( eventPageSize );
-                    }
+                        if ( trackerPageSize > 0 )
+                        {
+                            jobparams.setTrackerProgramPageSize( trackerPageSize );
+                        }
 
-                    if ( dataValuesPageSize > 0 )
-                    {
-                        jobparams.setDataValuesPageSize( dataValuesPageSize );
-                    }
+                        if ( eventPageSize > 0 )
+                        {
+                            jobparams.setEventProgramPageSize( eventPageSize );
+                        }
 
-                    updatedJobParameters.put( rs.getInt( "jobconfigurationid" ), jobparams );
+                        if ( dataValuesPageSize > 0 )
+                        {
+                            jobparams.setDataValuesPageSize( dataValuesPageSize );
+                        }
+
+                        updatedJobParameters.put( rs.getInt( "jobconfigurationid" ), jobparams );
+                    }
                 }
             }
 


### PR DESCRIPTION
**Description**

NullPointer Exception is thrown while upgrading an existing database that has empty `jsonbjobparams`. This fix seeks to address that.