### PR TITLE
fix: (2.33) Encryption issue of TEI AttributeValue

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
@@ -227,6 +227,12 @@ public class DefaultTrackedEntityAttributeValueService
                 throw new IllegalQueryException( "Value is not valid:  " + result );
             }
 
+            if ( attributeValue.getAttribute().isConfidentialBool() &&
+                !dhisConfigurationProvider.getEncryptionStatus().isOk() )
+            {
+                throw new IllegalStateException( "Unable to encrypt data, encryption is not correctly configured" );
+            }
+
             TrackedEntityAttributeValueAudit trackedEntityAttributeValueAudit = new TrackedEntityAttributeValueAudit(
                 attributeValue,
                 attributeValue.getAuditValue(), User.username( user ), AuditType.UPDATE );

--- a/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+    </dependency>
     
   </dependencies>
   <properties>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
@@ -32,12 +32,15 @@ import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.Location;
 import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.hisp.dhis.db.migration.helper.NoOpFlyway;
+import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 import javax.sql.DataSource;
+
+import java.util.HashMap;
 
 import static org.hisp.dhis.external.conf.ConfigurationKey.FLYWAY_OUT_OF_ORDER_MIGRATION;
 
@@ -64,6 +67,13 @@ public class FlywayConfig
         classicConfiguration.setIgnoreFutureMigrations( false );
         classicConfiguration.setGroup( false );
         classicConfiguration.setLocations( new Location( FLYWAY_MIGRATION_FOLDER ) );
+
+        /*
+         * This placeHolder is to be used by V2_33_26__Fix_encryption_issue_for_TEI_attributeValues
+         */
+        HashMap<String, String> placeHolders = new HashMap<>();
+        placeHolders.put( "encryption.password", configurationProvider.getProperty( ConfigurationKey.ENCRYPTION_PASSWORD ) );
+        classicConfiguration.setPlaceholders( placeHolders );
 
         return new Flyway( classicConfiguration );
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v33/V2_33_26__Fix_encryption_issue_for_TEI_attributeValues.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v33/V2_33_26__Fix_encryption_issue_for_TEI_attributeValues.java
@@ -1,0 +1,155 @@
+package org.hisp.dhis.db.migration.v33;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
+import org.jasypt.salt.RandomSaltGenerator;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * This class is to fix the jira issue DHIS2-7442. The steps are:
+ * 1) Look for TrackedEntityInstance's AttributeValues that are encrypted.
+ * 2) Check if encrypted value can be decrypted using the user defined password in dhis.conf file.
+ * 3) If (2) failed then try to decrypt value using the default password that was added in 2.33.0
+ * 4) If (3) success then encrypt value again using the correct password from dhis.conf file.
+ */
+public class V2_33_26__Fix_encryption_issue_for_TEI_attributeValues
+    extends BaseJavaMigration
+{
+    private static final Log log = LogFactory.getLog( V2_33_26__Fix_encryption_issue_for_TEI_attributeValues.class );
+
+    @Override
+    public void migrate( Context context ) throws Exception
+    {
+        String userDefinedPassword = context.getConfiguration().getPlaceholders().get( "encryption.password" );
+
+        if ( StringUtils.isEmpty( userDefinedPassword ) )
+        {
+            return;
+        }
+
+        StandardPBEStringEncryptor encryptor = initEncryptor();
+        encryptor.setPassword( userDefinedPassword );
+
+        StandardPBEStringEncryptor encryptorWithDefaultPassword = initEncryptor();
+        encryptorWithDefaultPassword.setPassword( "J7GhAs287hsSQlKd9g5" );
+
+        String selectEncryptedValueQuery = "select trackedentityinstanceid, trackedentityattributeid, encryptedvalue from trackedentityattributevalue where encryptedvalue is not null;";
+        String updateEncryptedValueQuery = "update trackedentityattributevalue set encryptedvalue=? where trackedentityinstanceid=? and trackedentityattributeid=?;";
+
+        try ( Statement statement = context.getConnection().createStatement() )
+        {
+            try ( ResultSet resultSet = statement.executeQuery( selectEncryptedValueQuery ) )
+            {
+                try ( PreparedStatement preparedStatement = context.getConnection().prepareStatement( updateEncryptedValueQuery ) )
+                {
+                    while ( resultSet.next() )
+                    {
+                        long teiId = resultSet.getLong( 1 );
+                        long attributeId = resultSet.getLong( 2 );
+                        String value = resultSet.getString( 3 );
+
+                        /*
+                         * Try to decrypt value using user defined password in dhis.conf
+                         */
+                        boolean canDecrypt = true;
+                        try
+                        {
+                            encryptor.decrypt( value );
+                        }
+                        catch ( EncryptionOperationNotPossibleException ex )
+                        {
+                            canDecrypt = false;
+                        }
+
+                        if ( canDecrypt )
+                        {
+                            continue;
+                        }
+
+                        /*
+                         * Couldn't decrypt value using user defined password,
+                         * try to decrypt it using the default password added in 2.33.0
+                         */
+                        String decryptedValue;
+                        try
+                        {
+                            decryptedValue = encryptorWithDefaultPassword.decrypt( value );
+                        }
+                        catch ( EncryptionOperationNotPossibleException ex )
+                        {
+                            log.error(
+                                "Flyway java migration error: Failed to decrypt TrackedEntityInstance AttributeValue.",
+                                ex );
+                            throw new FlywayException( "Failed to decrypt TrackedEntityInstance AttributeValue." );
+                        }
+
+                        /*
+                         * Encrypt value again using the correct password
+                         */
+                        try
+                        {
+                            preparedStatement.setString( 1, encryptor.encrypt( decryptedValue ) );
+                            preparedStatement.setLong( 2, teiId );
+                            preparedStatement.setLong( 3, attributeId );
+                            preparedStatement.addBatch();
+                        }
+                        catch ( EncryptionOperationNotPossibleException ex )
+                        {
+                            log.error(
+                                "Flyway java migration error: Failed to encrypt TrackedEntityInstance AttributeValue.",
+                                ex );
+                            throw new FlywayException( "Failed to encrypt TrackedEntityInstance AttributeValue." );
+                        }
+                    }
+
+                    preparedStatement.executeBatch();
+                }
+            }
+        }
+    }
+
+    private StandardPBEStringEncryptor initEncryptor()
+    {
+        StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
+        encryptor.setAlgorithm( "PBEWITHSHA256AND128BITAES-CBC-BC" );
+        encryptor.setSaltGenerator( new RandomSaltGenerator() );
+        return encryptor;
+    }
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7442
Issue : 
1) The encryption.password that user defined in dhis.conf was not taken by the configuration service. 
2) A default password was defined in the EncryptionConfig class and was used to encrypt TEI attribute values if no password provided.
So in 2.33.4 I have applied a fix so the encryption.password property was taken correctly from dhis.conf

However, for TEI attribute values registered from 2.33.0 to 2.33.3, they are still encrypted using that default password. Hence, the encryption service failed to decrypt those values and those TEI can't be opened on Tracker Capture app.

Fix:  Add a flyway script to reset correct password for those values.