### PR TITLE
fix: changes number return type to big decimal

### DIFF
--- a/dhis-2/dhis-e2e-test/pom.xml
+++ b/dhis-2/dhis-e2e-test/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.0.0</version>
+      <version>4.3.1</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.5</version>
+      <version>2.8.6</version>
     </dependency>
 
     <dependency>

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/schemas/SchemaProperty.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/schemas/SchemaProperty.java
@@ -46,9 +46,9 @@ public class SchemaProperty
 
     private String relativeApiEndpoint;
 
-    private double min;
+    public Double min;
 
-    private double max;
+    public Double max;
 
     private long length;
 
@@ -94,14 +94,15 @@ public class SchemaProperty
         this.relativeApiEndpoint = relativeApiEndpoint;
     }
 
-    public double getMin()
+    public Double getMin()
     {
         return min;
     }
 
-    public void setMin( double min )
+    public void setMin( Double o )
     {
-        this.min = min;
+
+        this.min = o;
     }
 
     public PropertyType getPropertyType()
@@ -114,12 +115,12 @@ public class SchemaProperty
         this.propertyType = propertyType;
     }
 
-    public double getMax()
+    public Double getMax()
     {
         return max;
     }
 
-    public void setMax( double max )
+    public void setMax( Double max )
     {
         this.max = max;
     }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -58,7 +58,7 @@ public class DataGenerator
         return RandomStringUtils.randomAlphabetic( 6 );
     }
 
-    public static String randomString( int count ) 
+    public static String randomString( int count )
     {
         return RandomStringUtils.randomAlphabetic( count );
     }
@@ -81,7 +81,7 @@ public class DataGenerator
         {
         case STRING:
             jsonElement = new JsonPrimitive(
-                generateStringByFieldName( property.getName(), (int) property.getMin(), (int) property.getMax() ) );
+                generateStringByFieldName( property.getName(), property.getMin().intValue(), property.getMax().intValue() ) );
             break;
 
         case DATE:
@@ -105,7 +105,8 @@ public class DataGenerator
             break;
 
         case NUMBER:
-            jsonElement = new JsonPrimitive( faker.number().numberBetween( (int) property.getMin(), (int) property.getMax() ) );
+            jsonElement = new JsonPrimitive(
+                faker.number().numberBetween( property.getMin().intValue(), property.getMax().intValue() ) );
             break;
 
         default:

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/ConfigurationExtension.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/ConfigurationExtension.java
@@ -57,7 +57,6 @@ public class ConfigurationExtension
         RestAssured.config = RestAssuredConfig.config()
             .jsonConfig( new JsonConfig().numberReturnType( JsonPathConfig.NumberReturnType.BIG_DECIMAL ) );
 
-        //RestAssured.config().getJsonConfig().numberReturnType( JsonPathConfig.NumberReturnType.BIG_DECIMAL );
         RestAssured.defaultParser = Parser.JSON;
         RestAssured.requestSpecification = defaultRequestSpecification();
     }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/ConfigurationExtension.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/ConfigurationExtension.java
@@ -30,10 +30,13 @@ package org.hisp.dhis.helpers.extensions;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.JsonConfig;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.filter.cookie.CookieFilter;
 import io.restassured.filter.session.SessionFilter;
 import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
+import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.specification.RequestSpecification;
 import org.hisp.dhis.helpers.config.TestConfiguration;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -50,6 +53,11 @@ public class ConfigurationExtension
     {
         RestAssured.baseURI = TestConfiguration.get().baseUrl();
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+        RestAssured.config = RestAssuredConfig.config()
+            .jsonConfig( new JsonConfig().numberReturnType( JsonPathConfig.NumberReturnType.BIG_DECIMAL ) );
+
+        //RestAssured.config().getJsonConfig().numberReturnType( JsonPathConfig.NumberReturnType.BIG_DECIMAL );
         RestAssured.defaultParser = Parser.JSON;
         RestAssured.requestSpecification = defaultRequestSpecification();
     }


### PR DESCRIPTION
After changing Double.MIN_VALUE to -Double.MAX_VALUE, the API tests started failing with  `Number -Infinity can't be serialized as JSON: infinite are not allowed in JSON.` exception. This change should fix it. 