### PR TITLE
fix: Fixing pagination for RTable and Chart (Favourites) [DHIS2-9139]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -92,6 +92,7 @@ import org.hisp.dhis.patch.Patch;
 import org.hisp.dhis.patch.PatchParams;
 import org.hisp.dhis.patch.PatchService;
 import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Pagination;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryService;
@@ -1084,7 +1085,7 @@ public abstract class ChartFacadeController {
     {
         List<Visualization> entityList;
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders,
-            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
+                new Pagination(), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -89,6 +89,7 @@ import org.hisp.dhis.patch.Patch;
 import org.hisp.dhis.patch.PatchParams;
 import org.hisp.dhis.patch.PatchService;
 import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Pagination;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryService;
@@ -1083,7 +1084,7 @@ public abstract class ReportTableFacadeController {
     {
         List<Visualization> entityList;
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders,
-            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
+                new Pagination(), options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 


### PR DESCRIPTION
This is a small fix for the pagination issue/missing data for the ReportTables and Charts (Favourites) API's.