### PR TITLE
fix: Analytics error on period as filter

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
@@ -189,5 +189,9 @@ public class IdentifiableObjectUtilsTest
             IdentifiableObjectUtils.getPeriodByPeriodType( PeriodType.getPeriodFromIsoString( "2016Q4" ), yearly, calendar ) );
         assertEquals( PeriodType.getPeriodFromIsoString( "2017" ),
             IdentifiableObjectUtils.getPeriodByPeriodType( PeriodType.getPeriodFromIsoString( "2017Q1" ), yearly, calendar ) );
+
+        assertNull( PeriodType.getPeriodFromIsoString( "u3847847" ));
+
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -2583,6 +2583,12 @@ public class DataQueryParams
             return this;
         }
 
+        public Builder withPeriods( String periodName, List<? extends DimensionalItemObject> periods )
+        {
+            this.params.setDimensionOptions( PERIOD_DIM_ID, DimensionType.PERIOD, periodName, asList( periods ) );
+            return this;
+        }
+
         public Builder withPeriods( List<? extends DimensionalItemObject> periods, String periodType )
         {
             this.params.setDimensionOptions( PERIOD_DIM_ID, DimensionType.PERIOD, periodType.toLowerCase(), asList( periods ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -253,11 +253,11 @@ public class DefaultAnalyticsService
 
         queryValidator.validate( params );
 
-//        if ( analyticsCache.isEnabled() )
-//        {
-//            final DataQueryParams immutableParams = DataQueryParams.newBuilder( params ).build();
-//            return analyticsCache.getOrFetch( params, p -> getAggregatedDataValueGridInternal( immutableParams ) );
-//        }
+        if ( analyticsCache.isEnabled() )
+        {
+            final DataQueryParams immutableParams = DataQueryParams.newBuilder( params ).build();
+            return analyticsCache.getOrFetch( params, p -> getAggregatedDataValueGridInternal( immutableParams ) );
+        }
 
         return getAggregatedDataValueGridInternal( params );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -1400,7 +1400,7 @@ public class DefaultAnalyticsService
             // Check if the current row's Period belongs to the list of periods from the
             // original Analytics request
             // The row may not have a Period if Period is used as filter
-            if ( hasPeriod( row, periodIndex ) && isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
+            if ( AnalyticsUtils.hasPeriod( row, periodIndex ) && isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
             {
                 if ( dimensionalItems.size() == 1 )
                 {
@@ -1442,12 +1442,6 @@ public class DefaultAnalyticsService
         }
 
         return result;
-    }
-
-    private boolean hasPeriod( List<Object> row, int periodIndex )
-    {
-        return periodIndex <= row.size() && row.get( periodIndex ) instanceof String
-            && PeriodType.getPeriodFromIsoString( (String) row.get( periodIndex ) ) != null;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -1348,11 +1348,12 @@ public class DefaultAnalyticsService
      * @param indicators the list of indicators.
      * @return a dimensional items to aggregate values map.
      */
-    private MultiValuedMap<String, DimensionItemObjectValue> getAggregatedDataValueMap(DataQueryParams params,
-                                                                                       List<Indicator> indicators )
+    private MultiValuedMap<String, DimensionItemObjectValue> getAggregatedDataValueMap( DataQueryParams params,
+        List<Indicator> indicators )
     {
         List<DimensionalItemObject> items = Lists
-                .newArrayList( expressionService.getIndicatorDimensionalItemObjects( resolveIndicatorExpressions( indicators ) ) );
+            .newArrayList(
+                expressionService.getIndicatorDimensionalItemObjects( resolveIndicatorExpressions( indicators ) ) );
 
         if ( items.isEmpty() )
         {
@@ -1361,7 +1362,8 @@ public class DefaultAnalyticsService
 
         items = DimensionalObjectUtils.replaceOperandTotalsWithDataElements( items );
 
-        DimensionalObject dimension = new BaseDimensionalObject( DimensionalObject.DATA_X_DIM_ID, DimensionType.DATA_X, null, DISPLAY_NAME_DATA_X, items );
+        DimensionalObject dimension = new BaseDimensionalObject( DimensionalObject.DATA_X_DIM_ID, DimensionType.DATA_X,
+            null, DISPLAY_NAME_DATA_X, items );
 
         DataQueryParams dataSourceParams = DataQueryParams
             .newBuilder( params )
@@ -1381,8 +1383,8 @@ public class DefaultAnalyticsService
             return result;
         }
 
-        BiFunction<Integer, Integer, Integer> replaceIndexIfMissing = (Integer index, Integer defaultIndex )
-                -> index == -1 ? defaultIndex : index;
+        BiFunction<Integer, Integer, Integer> replaceIndexIfMissing = ( Integer index,
+            Integer defaultIndex ) -> index == -1 ? defaultIndex : index;
 
         final int dataIndex = replaceIndexIfMissing.apply( grid.getIndexOfHeader( DATA_X_DIM_ID ), 0 );
         final int periodIndex = replaceIndexIfMissing.apply( grid.getIndexOfHeader( PERIOD_DIM_ID ), 1 );
@@ -1395,7 +1397,8 @@ public class DefaultAnalyticsService
             final List<DimensionalItemObject> dimensionalItems = AnalyticsUtils
                 .findDimensionalItems( (String) row.get( dataIndex ), items );
 
-            // Check if the current row's Period belongs to the list of periods from the original Analytics request
+            // Check if the current row's Period belongs to the list of periods from the
+            // original Analytics request
             // The row may not have a Period if Period is used as filter
             if ( hasPeriod( row, periodIndex ) && isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -253,11 +253,11 @@ public class DefaultAnalyticsService
 
         queryValidator.validate( params );
 
-        if ( analyticsCache.isEnabled() )
-        {
-            final DataQueryParams immutableParams = DataQueryParams.newBuilder( params ).build();
-            return analyticsCache.getOrFetch( params, p -> getAggregatedDataValueGridInternal( immutableParams ) );
-        }
+//        if ( analyticsCache.isEnabled() )
+//        {
+//            final DataQueryParams immutableParams = DataQueryParams.newBuilder( params ).build();
+//            return analyticsCache.getOrFetch( params, p -> getAggregatedDataValueGridInternal( immutableParams ) );
+//        }
 
         return getAggregatedDataValueGridInternal( params );
     }
@@ -1393,7 +1393,7 @@ public class DefaultAnalyticsService
         for ( List<Object> row : grid.getRows() )
         {
             // Check if the current row period belongs to the list of periods from the original request
-            if ( isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
+            if ( hasPeriod( row, periodIndex) &&  isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
             {
                 // Key is composed of [uid-period]
                 final String key = StringUtils.join(
@@ -1421,9 +1421,22 @@ public class DefaultAnalyticsService
                 result.put( key,
                     new DimensionItemObjectValue( clone, (Double) row.get( valueIndex ) ) );
             }
+            else
+            {
+                final DimensionalItemObject dimensionalItemObject = AnalyticsUtils
+                    .findDimensionalItems( (String) row.get( dataIndex ), items ).get( 0 );
+                result.put( dimensionalItemObject.getUid(),
+                    new DimensionItemObjectValue( dimensionalItemObject, (Double) row.get( valueIndex ) ) );
+            }
         }
 
         return result;
+    }
+
+    private boolean hasPeriod( List<Object> row, int periodIndex )
+    {
+        return periodIndex <= row.size() && row.get( periodIndex ) instanceof String
+            && PeriodType.getPeriodFromIsoString( (String) row.get( periodIndex ) ) != null;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -87,6 +87,7 @@ import org.hisp.dhis.period.FinancialPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.util.MathUtils;
@@ -890,18 +891,19 @@ public class AnalyticsUtils
     }
 
     /**
-     * Filters a List by Dimensional Item Object UID and returns one ore more
-     * {@see DimensionalItemObject} matching the given UID
+     * Filters a List by Dimensional Item Object identifier and returns one ore more
+     * {@see DimensionalItemObject} matching the given identifier
      *
-     * @param uid a uid to filter {@see DimensionalItemObject} on
+     * @param dimensionIdentifier a uid to filter {@see DimensionalItemObject} on
      * @param items the filtered List
      * @return a List only containing the {@see DimensionalItemObject} matching the
      *         uid
      */
-    public static List<DimensionalItemObject> findDimensionalItems( String uid, List<DimensionalItemObject> items )
+    public static List<DimensionalItemObject> findDimensionalItems( String dimensionIdentifier,
+        List<DimensionalItemObject> items )
     {
         return items.stream()
-            .filter( dio -> dio.getUid() != null && dio.getUid().equals( uid ) )
+            .filter( dio -> dio.getDimensionItem() != null && dio.getDimensionItem().equals( dimensionIdentifier ) )
             .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -906,4 +906,18 @@ public class AnalyticsUtils
             .filter( dio -> dio.getDimensionItem() != null && dio.getDimensionItem().equals( dimensionIdentifier ) )
             .collect( Collectors.toList() );
     }
+
+    /**
+     * Check if the given Grid's row contains a valid period iso string
+     * 
+     * @param row the row as List of Object
+     * @param periodIndex the index in which the period is located
+     * @return true, if the rows contains a valid period iso string at the given
+     *         index
+     */
+    public static boolean hasPeriod( List<Object> row, int periodIndex )
+    {
+        return periodIndex < row.size() && row.get( periodIndex ) instanceof String
+            && PeriodType.getPeriodFromIsoString( (String) row.get( periodIndex ) ) != null;
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
@@ -164,7 +164,7 @@ public class PeriodOffsetUtils
                 .collect( Collectors.toList() );
 
             return DataQueryParams.newBuilder( params )
-                .withPeriods( nonShiftedPeriods )
+                .withPeriods( params.getDimension( PERIOD_DIM_ID ).getDimensionName(), nonShiftedPeriods )
                 .build();
         }
         return params;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -635,6 +636,33 @@ public class AnalyticsUtilsTest
             Lists.newArrayList( pi1, pi2, pi3, pi4 ) );
 
         assertEquals( dimensionalItems.size(), 2);
-        
+    }
+
+    @Test
+    public void testHasPeriod()
+    {
+        List<Object> row = new ArrayList<>();
+
+        row.add( "someUid" );
+        row.add( "202010" );
+        row.add( 100D );
+        // pass - index 1 is a valid iso period
+        assertTrue( AnalyticsUtils.hasPeriod( row, 1 ) );
+        // fail - index 3 is too high
+        assertFalse( AnalyticsUtils.hasPeriod( row, 3 ) );
+        // fail - index 4 is too high
+        assertFalse( AnalyticsUtils.hasPeriod( row, 4 ) );
+        // fail - index 2 is a Double
+        assertFalse( AnalyticsUtils.hasPeriod( row, 2 ) );
+
+        row = new ArrayList<>();
+
+        row.add( "someUid" );
+        row.add( "2020A" );
+        row.add( 100D );
+        // pass - index 1 is not a valid period iso string
+        assertFalse( AnalyticsUtils.hasPeriod( row, 1 ) );
+
+
     }
 }


### PR DESCRIPTION
- Fix exception thrown when a `pe` dimension is used as filter; fixed by skipping the new Period Offset logic when the Analytics results Grid does not contain a Period column
- Add a new `.withPeriods` method to `DataQueryParams` builder that preserves dimension name
- Fix logic to extract data from the Grid prior to passing the data to the Expression engine

ref: DHIS2-9152