### PR TITLE
fix: Casting to Number to avoid class cast exception [DHIS2-8631]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
@@ -96,7 +96,10 @@ public class IdentifiableObjectUtils
      */
     public static <T extends IdentifiableObject> List<String> getUids( Collection<T> objects )
     {
-        return objects != null ? objects.stream().map( o -> o.getUid() ).collect( Collectors.toList() ) : null;
+        return objects != null ? objects.stream()
+                .filter( o -> o != null )
+                .map( o -> o.getUid() )
+                .collect( Collectors.toList() ) : null;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -80,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -89,6 +90,7 @@ import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.AnalyticsManager;
 import org.hisp.dhis.analytics.AnalyticsMetaDataKey;
@@ -1428,7 +1430,7 @@ public class DefaultAnalyticsService
                     }
 
                     result.put( key,
-                        new DimensionItemObjectValue( clone, (Double) row.get( valueIndex ) ) );
+                        new DimensionItemObjectValue( clone, ((Number) row.get( valueIndex )).doubleValue() ) );
                 }
             }
             else

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -199,14 +199,22 @@ public abstract class AbstractAnalyticsService
             metadataItemMap.put( value.getUid(), new MetadataItem( value.getDisplayProperty( params.getDisplayProperty() ), includeDetails ? value.getUid() : null, value.getCode() ) );
         }
 
-        params.getItemLegends().forEach( legend -> metadataItemMap.put( legend.getUid(),
-            new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null, legend.getCode() ) ) );
+        params.getItemLegends().stream()
+            .filter( legend -> legend != null )
+            .forEach( legend -> metadataItemMap.put( legend.getUid(),
+                new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null,
+                    legend.getCode() ) ) );
 
-        params.getItemOptions().forEach( option -> metadataItemMap.put( option.getUid(),
-            new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null, option.getCode() ) ) );
+        params.getItemOptions().stream()
+            .filter( option -> option != null )
+            .forEach( option -> metadataItemMap.put( option.getUid(),
+                new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
+                    option.getCode() ) ) );
 
-        params.getItemsAndItemFilters().forEach( item -> metadataItemMap.put( item.getItemId(),
-            new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
+        params.getItemsAndItemFilters().stream()
+            .filter( item -> item != null )
+            .forEach( item -> metadataItemMap.put( item.getItemId(),
+                new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
 
         return metadataItemMap;
     }


### PR DESCRIPTION
Sometimes `row.get( valueIndex )` returns `long`, so we cannot cast to `Double`. This fix will cast to `Number` and convert to `double` in order to avoid the error.

I also added some null checks, as during my tests I accidentally got an NPE when iterating through some lists. I believe they are related to the known issue related to Hibernate and null elements in Lists.
