### PR TITLE
fix: fix Indicator Grid results index resolution

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -256,11 +256,11 @@ public class DefaultAnalyticsService
 
         queryValidator.validate( params );
 
-//        if ( analyticsCache.isEnabled() )
-//        {
-//            final DataQueryParams immutableParams = DataQueryParams.newBuilder( params ).build();
-//            return analyticsCache.getOrFetch( params, p -> getAggregatedDataValueGridInternal( immutableParams ) );
-//        }
+        if ( analyticsCache.isEnabled() )
+        {
+            final DataQueryParams immutableParams = DataQueryParams.newBuilder( params ).build();
+            return analyticsCache.getOrFetch( params, p -> getAggregatedDataValueGridInternal( immutableParams ) );
+        }
 
         return getAggregatedDataValueGridInternal( params );
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -39,6 +39,7 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.velocity.VelocityContext;
+import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
@@ -68,6 +69,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
 import static org.hisp.dhis.system.util.PDFUtils.*;
@@ -455,6 +457,32 @@ public class GridUtils
                 grid.addValue( rs.getObject( i ) );
             }
         }
+    }
+
+    /**
+     * Derives the positional index of a Grid's row, based on the {@see DimensionalItemObject} identifiers
+     *
+     * @param row a Grid's row
+     * @param items a List of {@see DimensionalItemObject}
+     * @param defaultIndex the default positional index to return
+     * @return the positional index matching one of the DimensionalItemObject identifiers
+     */
+    public static int getGridIndexByDimensionItem( List<Object> row, List<DimensionalItemObject> items, int defaultIndex )
+    {
+        // accumulate the DimensionalItemObject identifiers into a List
+        List<String> valid = items.stream().map( DimensionalItemObject::getDimensionItem )
+            .collect( Collectors.toList() );
+
+        // skip the last index, since it is always the row value
+        for ( int i = 0; i < row.size() -1 ; i++ )
+        {
+            final String value = (String) row.get( i );
+            if ( valid.contains( value ) )
+            {
+                return i;
+            }
+        }
+        return defaultIndex;
     }
 
     /**

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
@@ -30,10 +30,16 @@ package org.hisp.dhis.system.grid;
 
 import java.nio.charset.StandardCharsets;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 
@@ -56,4 +62,35 @@ public class GridUtilsTest
         assertEquals( 6, grids.size() );
         assertEquals( "TitleA", grids.get( 0 ).getTitle() );
     }
+
+    @Test
+    public void testGetGridIndexByDimensionItem()
+    {
+        Period period1 = PeriodType.getPeriodFromIsoString( "202010" );
+        period1.setUid( CodeGenerator.generateUid() );
+
+        Period period2 = PeriodType.getPeriodFromIsoString( "202011" );
+        period2.setUid( CodeGenerator.generateUid() );
+
+        Period period3 = PeriodType.getPeriodFromIsoString( "202012" );
+        period3.setUid( CodeGenerator.generateUid() );
+
+        List<DimensionalItemObject> periods = Lists.newArrayList( period1, period2, period3);
+
+        List<Object> row = new ArrayList<>( 3 );
+        row.add( CodeGenerator.generateUid() ); // dimension
+        row.add( period2.getIsoDate()); // period
+        row.add( 10.22D ); // value
+        assertEquals( 1, GridUtils.getGridIndexByDimensionItem( row, periods, 2 ) );
+
+        List<Object> row2 = new ArrayList<>( 3 );
+        row2.add( CodeGenerator.generateUid() ); // dimension
+        row2.add( "201901" ); // period
+        row2.add( 10.22D ); // value
+        assertEquals( 2, GridUtils.getGridIndexByDimensionItem( row2, periods, 2 ) );
+
+
+    }
+
+
 }


### PR DESCRIPTION
After the introduction of Period Offset (DHIS2-8758), the Indicator data aggregation logic needs to resolve the period
index withing the aggregated Grid. In case of a query that uses ORG UNIT GROUP SET, the resulting Grid contains multiple
dimension items for each row and the period index can shift to 2 or 3 position.
With this fix, a more robust method to identify data and period index is introduced during Indicator grid handling.

ref: DHIS2-9214