### PR TITLE
feat: support external access voter for eventReports, eventCharts

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/vote/ExternalAccessVoter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/vote/ExternalAccessVoter.java
@@ -34,10 +34,11 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.document.Document;
+import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.eventreport.EventReport;
 import org.hisp.dhis.report.Report;
 import org.hisp.dhis.reporttable.ReportTable;
 import org.hisp.dhis.sqlview.SqlView;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.core.Authentication;
@@ -67,14 +68,20 @@ public class ExternalAccessVoter implements AccessDecisionVoter<FilterInvocation
         externalClasses.put( "reports", Report.class );
         externalClasses.put( "documents", Document.class );
         externalClasses.put( "sqlViews", SqlView.class );
+        externalClasses.put( "eventReports", EventReport.class );
+        externalClasses.put( "eventCharts", EventChart.class );
     }
 
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @Autowired
-    private IdentifiableObjectManager manager;
+    private final IdentifiableObjectManager manager;
+
+    public ExternalAccessVoter( IdentifiableObjectManager manager )
+    {
+        this.manager = manager;
+    }
 
     // -------------------------------------------------------------------------
     // AccessDecisionVoter Implementation


### PR DESCRIPTION
We have had externalAccess property enabled in hibernate for EventReport and EventChart for a long time, but they have now been properly added to the ExternalAccessVoter, this PR fixes that.

[DHIS2-9121](https://jira.dhis2.org/browse/DHIS2-9121)