### PR TITLE
fix: Use Org Unit uid on Events/Enrollment table creation

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
@@ -485,4 +485,12 @@ public interface Grid
      * @param maxLimit the max number of records to return, use {@code -1} for no limit.
      */
     Grid addRows( SqlRowSet rs, int maxLimit );
+
+    /**
+     * Replaces the content of the Grid with the provided List of rows
+     * 
+     * @param rows a List of List, representing the Grid's rows
+     * 
+     */
+    Grid replaceAllValues( List<List<Object>> rows );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitStore.java
@@ -107,7 +107,16 @@ public interface OrganisationUnitStore
      *
      * @return a map of sets.
      */
-    Map<String, Set<String>> getOrganisationUnitDataSetAssocationMap( Collection<OrganisationUnit> organisationUnits, Collection<DataSet> dataSets );
+    Map<String, Set<String>> getOrganisationUnitDataSetAssociationMap( Collection<OrganisationUnit> organisationUnits,
+        Collection<DataSet> dataSets );
+
+    /**
+     * Creates a mapping between the provided organisation unit UIDs and their names
+     * 
+     * @param organisationUnitUids a List of organisation unit UIDs
+     * @return a Map, where the key is the OU UID and the value is the OU Name
+     */
+    Map<String, String> getOrganisationUnitUidNameMap( Collection<String> organisationUnitUids );
 
     /**
      * Retrieves the objects where its coordinate is within the 4 area points.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Lists;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
+import org.hisp.dhis.analytics.event.data.grid.postprocessor.GridPostprocessor;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.common.*;
@@ -64,13 +65,17 @@ public abstract class AbstractAnalyticsService
 
     final EventQueryValidator queryValidator;
 
-    public AbstractAnalyticsService( AnalyticsSecurityManager securityManager, EventQueryValidator queryValidator )
+    private final GridPostprocessor gridPostprocessor;
+
+    public AbstractAnalyticsService( AnalyticsSecurityManager securityManager, EventQueryValidator queryValidator, GridPostprocessor gridPostprocessor )
     {
         checkNotNull( securityManager );
         checkNotNull( queryValidator );
+        checkNotNull( gridPostprocessor );
 
         this.securityManager = securityManager;
         this.queryValidator = queryValidator;
+        this.gridPostprocessor = gridPostprocessor;
     }
 
     protected Grid getGrid( EventQueryParams params )
@@ -137,7 +142,7 @@ public abstract class AbstractAnalyticsService
             grid.getMetaData().put( PAGER.getKey(), pager );
         }
 
-        return grid;
+        return gridPostprocessor.postProcess( grid );
     }
 
     protected abstract Grid createGridWithHeaders( EventQueryParams params );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
@@ -34,6 +34,7 @@ import java.util.Date;
 
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.event.*;
+import org.hisp.dhis.analytics.event.data.grid.postprocessor.GridPostprocessor;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.ValueType;
@@ -66,9 +67,10 @@ public class DefaultEnrollmentAnalyticsService
     private final EventQueryPlanner queryPlanner;
 
     public DefaultEnrollmentAnalyticsService( EnrollmentAnalyticsManager enrollmentAnalyticsManager,
-        AnalyticsSecurityManager securityManager, EventQueryPlanner queryPlanner, EventQueryValidator queryValidator )
+        AnalyticsSecurityManager securityManager, EventQueryPlanner queryPlanner, EventQueryValidator queryValidator,
+        GridPostprocessor gridPostprocessor )
     {
-        super( securityManager, queryValidator );
+        super( securityManager, queryValidator, gridPostprocessor );
 
         checkNotNull( enrollmentAnalyticsManager );
         checkNotNull( queryPlanner );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.analytics.event.EventDataQueryService;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryPlanner;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
+import org.hisp.dhis.analytics.event.data.grid.postprocessor.GridPostprocessor;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -149,9 +150,9 @@ public class DefaultEventAnalyticsService
         TrackedEntityAttributeService trackedEntityAttributeService, EventAnalyticsManager eventAnalyticsManager,
         EventDataQueryService eventDataQueryService, AnalyticsSecurityManager securityManager,
         EventQueryPlanner queryPlanner, EventQueryValidator queryValidator, DatabaseInfo databaseInfo,
-        AnalyticsCache analyticsCache, EnrollmentAnalyticsManager enrollmentAnalyticsManager )
+        AnalyticsCache analyticsCache, EnrollmentAnalyticsManager enrollmentAnalyticsManager, GridPostprocessor gridPostprocessor )
     {
-        super( securityManager, queryValidator );
+        super( securityManager, queryValidator, gridPostprocessor );
 
         checkNotNull( dataElementService );
         checkNotNull( trackedEntityAttributeService );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/ColumnProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/ColumnProcessor.java
@@ -1,5 +1,33 @@
 package org.hisp.dhis.analytics.event.data.grid.postprocessor;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import java.util.List;
 
 import org.hisp.dhis.common.GridHeader;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/ColumnProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/ColumnProcessor.java
@@ -1,0 +1,19 @@
+package org.hisp.dhis.analytics.event.data.grid.postprocessor;
+
+import java.util.List;
+
+import org.hisp.dhis.common.GridHeader;
+
+/**
+ * A ColumnProcessor is responsible for modifying the data of the column of a
+ * {@see Grid} object.
+ * 
+ * Instances of this interface are invoked by a {@GridPostprocessor} in order to
+ * post-process a Grid values.
+ * 
+ * @author Luciano Fiandesio
+ */
+public interface ColumnProcessor
+{
+    List<List<Object>> process( List<GridHeader> headers, List<List<Object>> rows );
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/DefaultGridPostprocessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/DefaultGridPostprocessor.java
@@ -1,5 +1,33 @@
 package org.hisp.dhis.analytics.event.data.grid.postprocessor;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import org.hisp.dhis.common.Grid;
 import org.springframework.stereotype.Component;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/DefaultGridPostprocessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/DefaultGridPostprocessor.java
@@ -1,0 +1,32 @@
+package org.hisp.dhis.analytics.event.data.grid.postprocessor;
+
+import org.hisp.dhis.common.Grid;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Component
+public class DefaultGridPostprocessor implements GridPostprocessor
+{
+    private final List<ColumnProcessor> processors;
+
+    public DefaultGridPostprocessor( List<ColumnProcessor> processors )
+    {
+        this.processors = processors;
+    }
+
+    @Override
+    public Grid postProcess( Grid grid )
+    {
+        for ( ColumnProcessor processor : processors )
+        {
+            grid = grid.replaceAllValues( processor.process( grid.getHeaders(), grid.getRows() ) );
+
+        }
+
+        return grid;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/GridPostprocessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/GridPostprocessor.java
@@ -1,5 +1,33 @@
 package org.hisp.dhis.analytics.event.data.grid.postprocessor;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import org.hisp.dhis.common.Grid;
 
 /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/GridPostprocessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/GridPostprocessor.java
@@ -1,0 +1,25 @@
+package org.hisp.dhis.analytics.event.data.grid.postprocessor;
+
+import org.hisp.dhis.common.Grid;
+
+/**
+ * Process a {@see Grid} through Grid post-processors in order to replace or
+ * correct data, for instance replacing a UID with a name. The GridPostprocessor
+ * is designed to be invoked at the very end of the Grid population process
+ * (that is, when all data has been aggregated and the Grid is ready to be
+ * returned).
+ * 
+ * @author Luciano Fiandesio
+ */
+public interface GridPostprocessor
+{
+    /**
+     * Post-process the provided Grid by passing it to a list of
+     * {@see ColumnProcessor}. Each processor is responsible for modifying the values of one column of the
+     * Grid.
+     * 
+     * @param grid a {@see Grid}
+     * @return a {@see Grid
+     */
+    Grid postProcess( Grid grid );
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessor.java
@@ -1,0 +1,139 @@
+package org.hisp.dhis.analytics.event.data.grid.postprocessor;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.organisationunit.OrganisationUnitStore;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Component
+public class OrgUnitColumnProcessor implements ColumnProcessor
+{
+    private final OrganisationUnitStore organisationUnitStore;
+
+    public OrgUnitColumnProcessor( OrganisationUnitStore organisationUnitStore )
+    {
+        checkNotNull( organisationUnitStore );
+
+        this.organisationUnitStore = organisationUnitStore;
+    }
+
+    @Override
+    public List<List<Object>> process( List<GridHeader> headers, List<List<Object>> rows )
+    {
+        // based on the Grid headers, fetch the Grid's indexes for the ORGANISATION_UNIT type
+        int[] indexes = getGridIndexesByType( headers, ValueType.ORGANISATION_UNIT );
+
+        if ( indexes.length > 0 )
+        {
+            // Collect all the Org Units UIDs.
+            Map<Integer, Map<Integer, String>> orgUnitUid = collectUids( indexes, rows );
+
+            if ( !orgUnitUid.isEmpty() )
+            {
+                // Map the Org Units UID to the Org Unit names
+                Map<String, String> orgUnitUidNameMap = organisationUnitStore.getOrganisationUnitUidNameMap(
+                    orgUnitUid.values().stream().flatMap( m -> m.values().stream() ).collect( Collectors.toSet() ) );
+
+                // Only loop on the rows which contain Org Unit Uids
+                for ( Integer index : orgUnitUid.keySet() )
+                {
+                    final List<Object> row = rows.get( index );
+                    // Get the UIDs
+                    final Map<Integer, String> orgUnitUids = orgUnitUid.get( index );
+                    for ( Integer rowIndex : orgUnitUids.keySet() )
+                    {
+                        row.set( rowIndex, orgUnitUidNameMap.get( row.get( rowIndex ) ) );
+                    }
+                }
+            }
+        }
+
+        return rows;
+    }
+
+    /**
+     * Get the Org Unit UID for each row of the grid
+     * 
+     * The returned Map has:
+     * 
+     * - the row number as key
+     * 
+     * - a Map where the key is the row index and the value is the actual UID
+     */
+    private Map<Integer, Map<Integer, String>> collectUids( int[] indexes, List<List<Object>> rows )
+    {
+        Map<Integer, Map<Integer, String>> orgUnitUid = new HashMap<>();
+        for ( int i = 0; i < rows.size(); i++ )
+        {
+            Map<Integer, String> uids = getUidFromRow( indexes, rows.get( i ) );
+            if ( !uids.isEmpty() )
+            {
+                orgUnitUid.put( i, uids );
+            }
+
+        }
+        return orgUnitUid;
+    }
+
+    /**
+     *
+     */
+    private Map<Integer, String> getUidFromRow( int[] indexes, List<Object> row )
+    {
+        Map<Integer, String> indexToUidMap = new HashMap<>( indexes.length );
+        for ( int index : indexes )
+        {
+            // TODO check if it's a String to avoid classcastexc?
+            final String orgUnitUid = (String) row.get( index );
+            if ( StringUtils.isNotEmpty( orgUnitUid ) )
+            {
+                indexToUidMap.put( index, orgUnitUid );
+            }
+        }
+        return indexToUidMap;
+    }
+
+    private int[] removeElements( int[] arr, int key )
+    {
+        // Move all other elements to beginning
+        int index = 0;
+        for ( int i = 0; i < arr.length; i++ )
+            if ( arr[i] != key )
+                arr[index++] = arr[i];
+
+        // Create a copy of arr[]
+        return Arrays.copyOf( arr, index );
+    }
+
+    private int[] getGridIndexesByType( List<GridHeader> headers, ValueType valueType )
+    {
+        int[] indexes = new int[headers.size()];
+
+        // Get index by type
+        for ( int i = 0; i < headers.size(); i++ )
+        {
+            if ( headers.get( i ).getValueType().equals( valueType ) )
+            {
+                indexes[i] = i;
+            }
+            else
+            {
+                indexes[i] = -1;
+            }
+        }
+
+        return removeElements( indexes, -1 );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessor.java
@@ -1,5 +1,33 @@
 package org.hisp.dhis.analytics.event.data.grid.postprocessor;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Arrays;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -128,7 +128,7 @@ public abstract class AbstractEventJdbcTableManager
         }
         else if ( valueType.isOrganisationUnit() )
         {
-            return "ou.name from organisationunit ou where ou.uid = (select " + columnName ;
+            return "ou.uid from organisationunit ou where ou.uid = (select " + columnName ;
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessorTest.java
@@ -1,0 +1,232 @@
+package org.hisp.dhis.analytics.event.data.grid.postprocessor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.organisationunit.OrganisationUnitStore;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class OrgUnitColumnProcessorTest
+{
+    private OrgUnitColumnProcessor processor;
+
+    @Mock
+    private OrganisationUnitStore organisationUnitStore;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp()
+    {
+
+        processor = new OrgUnitColumnProcessor( organisationUnitStore );
+    }
+
+    @Test
+    public void verifyOrgUnitUidIsReplacedWithName()
+    {
+        // Given
+        List<GridHeader> headers = createGridHeaders( ValueType.INTEGER, ValueType.DATETIME, ValueType.BOOLEAN,
+            ValueType.NUMBER, ValueType.ORGANISATION_UNIT );
+        List<List<Object>> grid = generateRandomGridValues( headers, 10 );
+
+        // When
+        List<String> orgUnitUids = grid.stream().map( l -> (String) l.get( 4 ) ).collect( Collectors.toList() );
+
+        final Map<String, String> uidToNameMap = generateUidOrgUnitNameMap( orgUnitUids );
+        when( organisationUnitStore.getOrganisationUnitUidNameMap( argThat( t -> t.containsAll( orgUnitUids ) ) ) )
+            .thenReturn( uidToNameMap );
+
+        final List<List<Object>> aGrid = processor.process( headers, grid );
+
+        // Then
+        for ( int i = 0; i < aGrid.size(); i++ )
+        {
+            assertThat( aGrid.get( i ).get( 4 ), is( uidToNameMap.get( orgUnitUids.get( i ) ) ) );
+        }
+    }
+
+    @Test
+    public void verifyMultipleOrgUnitUidIsReplacedWithName()
+    {
+        // Given
+        List<GridHeader> headers = createGridHeaders( ValueType.ORGANISATION_UNIT, ValueType.DATETIME,
+            ValueType.BOOLEAN, ValueType.NUMBER, ValueType.ORGANISATION_UNIT, ValueType.INTEGER );
+
+        List<List<Object>> grid = generateRandomGridValues( headers, 10 );
+
+        // When
+        List<String> orgUnitUids1 = grid.stream().map( l -> (String) l.get( 0 ) ).collect( Collectors.toList() );
+        List<String> orgUnitUids2 = grid.stream().map( l -> (String) l.get( 4 ) ).collect( Collectors.toList() );
+        List<String> merged = Lists.newArrayList( Iterables.concat( orgUnitUids1, orgUnitUids2 ) );
+        final Map<String, String> uidToNameMap = generateUidOrgUnitNameMap( merged );
+
+        when( organisationUnitStore.getOrganisationUnitUidNameMap( argThat( t -> t.containsAll( merged ) ) ) )
+            .thenReturn( uidToNameMap );
+
+        final List<List<Object>> aGrid = processor.process( headers, grid );
+
+        // Then
+        for ( int i = 0; i < aGrid.size(); i++ )
+        {
+            assertThat( aGrid.get( i ).get( 0 ), is( uidToNameMap.get( orgUnitUids1.get( i ) ) ) );
+            assertThat( aGrid.get( i ).get( 4 ), is( uidToNameMap.get( orgUnitUids2.get( i ) ) ) );
+        }
+    }
+
+    @Test
+    public void verifyMultipleOrgUnitUidWithNullValuesIsReplacedWithName()
+    {
+        // Given
+        List<GridHeader> headers = createGridHeaders( ValueType.ORGANISATION_UNIT, ValueType.DATETIME,
+            ValueType.BOOLEAN, ValueType.NUMBER, ValueType.ORGANISATION_UNIT, ValueType.INTEGER );
+
+        List<List<Object>> grid = generateRandomGridValues( headers, 10 );
+
+        // make sure some values are null
+        // set the index 0 to null every two rows
+        for ( int i = 0; i < grid.size(); i += 2 )
+        {
+            grid.get( i ).set( 0, null );
+        }
+
+        // When
+        List<String> orgUnitUids1 = grid.stream().map( l -> (String) l.get( 0 ) ).filter( Objects::nonNull )
+            .collect( Collectors.toList() );
+        List<String> orgUnitUids2 = grid.stream().map( l -> (String) l.get( 4 ) ).filter( Objects::nonNull )
+            .collect( Collectors.toList() );
+        List<String> merged = Lists.newArrayList( Iterables.concat( orgUnitUids1, orgUnitUids2 ) );
+        final Map<String, String> uidToNameMap = generateUidOrgUnitNameMap( merged );
+
+        when( organisationUnitStore.getOrganisationUnitUidNameMap( argThat( t -> t.containsAll( merged ) ) ) )
+            .thenReturn( uidToNameMap );
+
+        final List<List<Object>> aGrid = processor.process( headers, grid );
+
+        // Then
+        for ( int i = 0; i < aGrid.size(); i++ )
+        {
+
+            if ( i % 2 != 0 )
+            {
+                assertTrue( aGrid.get( i ).get( 0 ).toString().startsWith( "NAME_" ) );
+            }
+            else
+            {
+                assertThat( aGrid.get( i ).get( 0 ), is( nullValue() ) );
+            }
+            assertThat( aGrid.get( i ).get( 4 ), is( uidToNameMap.get( orgUnitUids2.get( i ) ) ) );
+        }
+    }
+
+    @Test
+    public void verifyGridDoesNotContainOrgUnitType()
+    {
+        // Given
+        List<GridHeader> headers = createGridHeaders( ValueType.INTEGER, ValueType.DATETIME, ValueType.BOOLEAN,
+            ValueType.NUMBER, ValueType.NUMBER );
+        List<List<Object>> grid = generateRandomGridValues( headers, 10 );
+
+        // When
+        processor.process( headers, grid );
+
+        verifyNoMoreInteractions( organisationUnitStore );
+    }
+
+    private GridHeader createGridHeader( ValueType valueType )
+    {
+        return new GridHeader( randomAlphabetic( 5 ), randomAlphabetic( 5 ), valueType, randomAlphabetic( 5 ),
+            false,
+            false );
+    }
+
+    private List<GridHeader> createGridHeaders( ValueType... valueTypes )
+    {
+        return Lists.newArrayList( valueTypes ).stream().map( this::createGridHeader ).collect( Collectors.toList() );
+    }
+
+    private List<List<Object>> generateRandomGridValues( List<GridHeader> headers, int size )
+    {
+        List<List<Object>> grid = new ArrayList<>();
+
+        for ( int i = 0; i < size; i++ )
+        {
+            List<Object> row = new ArrayList<>( headers.size() );
+
+            for ( GridHeader header : headers )
+            {
+                switch ( header.getValueType() )
+                {
+                case INTEGER:
+                    row.add( RandomUtils.nextInt() );
+                    break;
+                case BOOLEAN:
+                    row.add( true );
+                    break;
+                case NUMBER:
+                    row.add( RandomUtils.nextDouble() );
+                    break;
+                case DATETIME:
+                    row.add( randomTimestamp() );
+                    break;
+                case ORGANISATION_UNIT:
+                    row.add( CodeGenerator.generateUid() );
+                    break;
+                }
+
+            }
+            grid.add( row );
+
+        }
+
+        return grid;
+    }
+
+    private long randomTimestamp()
+    {
+        long offset = Timestamp.valueOf( "2012-01-01 00:00:00" ).getTime();
+        long end = Timestamp.valueOf( "2020-12-31 00:00:00" ).getTime();
+        long diff = end - offset + 1;
+        return (offset + (long) (Math.random() * diff));
+    }
+
+    private Map<String, String> generateUidOrgUnitNameMap( List<String> uids )
+    {
+        return uids.stream()
+            .collect(
+                Collectors.toMap( Function.identity(),
+                    s -> "NAME_" + RandomStringUtils.randomAlphanumeric( 10 ) ) );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/grid/postprocessor/OrgUnitColumnProcessorTest.java
@@ -1,5 +1,33 @@
 package org.hisp.dhis.analytics.event.data.grid.postprocessor;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -117,7 +117,7 @@ public class JdbcEnrollmentAnalyticsTableManagerTest
 
         verify( jdbcTemplate ).execute( sql.capture() );
 
-        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = " +
+        String ouQuery = "(select ou.uid from organisationunit ou where ou.uid = " +
             "(select value from trackedentityattributevalue where trackedentityinstanceid=pi.trackedentityinstanceid and " +
             "trackedentityattributeid=9999)) as \"" + tea.getUid() + "\"";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -258,7 +258,7 @@ public class JdbcEventAnalyticsTableManagerTest
         String aliasD4 = "(select cast(eventdatavalues #>> '{%s, value}' as timestamp) " + FROM_CLAUSE
             + "  and eventdatavalues #>> '{%s,value}' " + statementBuilder.getRegexpMatch()
             + " '^\\d{4}-\\d{2}-\\d{2}(\\s|T)?((\\d{2}:)(\\d{2}:)?(\\d{2}))?$') as \"%s\"";
-        String aliasD5 = "(select ou.name from organisationunit ou where ou.uid = " + "(select eventdatavalues #>> '{"
+        String aliasD5 = "(select ou.uid from organisationunit ou where ou.uid = " + "(select eventdatavalues #>> '{"
             + d5.getUid() + ", value}' " + FROM_CLAUSE + " )) as \"" + d5.getUid() + "\"";
         String aliasD6 = "(select cast(eventdatavalues #>> '{%s, value}' as bigint) " + FROM_CLAUSE
             + "  and eventdatavalues #>> '{%s,value}' " + statementBuilder.getRegexpMatch()
@@ -336,7 +336,7 @@ public class JdbcEventAnalyticsTableManagerTest
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() ).withTableType( AnalyticsTableType.EVENT )
             .withColumnSize( 42 ).addColumns( periodColumns )
             .addColumn( d1.getUid(), TEXT, toAlias( aliasD1, d1.getUid() ) ) // ValueType.TEXT
-            .addColumn( tea1.getUid(), TEXT, String.format( aliasTea1, "ou.name", tea1.getId(), tea1.getUid() ) ) // ValueType.ORGANISATION_UNIT
+            .addColumn( tea1.getUid(), TEXT, String.format( aliasTea1, "ou.uid", tea1.getId(), tea1.getUid() ) ) // ValueType.ORGANISATION_UNIT
             // Second Geometry column created from the OU column above
             .addColumn( tea1.getUid() + "_geom", GEOMETRY,
                 String.format( aliasTea1, "ou.geometry", tea1.getId(), tea1.getUid() ), "gist" )
@@ -369,7 +369,7 @@ public class JdbcEventAnalyticsTableManagerTest
             PartitionUtils.getTablePartitions( subject.getAnalyticsTables( params ) ).get( 0 ) );
 
         verify( jdbcTemplate ).execute( sql.capture() );
-        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = " + "(select eventdatavalues #>> '{"
+        String ouQuery = "(select ou.uid from organisationunit ou where ou.uid = " + "(select eventdatavalues #>> '{"
             + d5.getUid() + ", value}' from programstageinstance where "
             + "programstageinstanceid=psi.programstageinstanceid )) as \"" + d5.getUid() + "\"";
 
@@ -405,7 +405,7 @@ public class JdbcEventAnalyticsTableManagerTest
 
         verify( jdbcTemplate ).execute( sql.capture() );
 
-        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = "
+        String ouQuery = "(select ou.uid from organisationunit ou where ou.uid = "
             + "(select value from trackedentityattributevalue where trackedentityinstanceid=pi.trackedentityinstanceid and "
             + "trackedentityattributeid=9999)) as \"" + tea.getUid() + "\"";
 
@@ -563,7 +563,7 @@ public class JdbcEventAnalyticsTableManagerTest
 
         verify( jdbcTemplate ).execute( sql.capture() );
 
-        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = "
+        String ouQuery = "(select ou.uid from organisationunit ou where ou.uid = "
             + "(select value from trackedentityattributevalue where trackedentityinstanceid=pi.trackedentityinstanceid and "
             + "trackedentityattributeid=9999)) as \"" + tea.getUid() + "\"";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -420,7 +420,7 @@ public class DefaultOrganisationUnitService
         List<DataSet> dataSets = (user != null && user.isSuper()) ? null : dataSetService.getUserDataWrite( user );
 
         Map<String, Set<String>> associationSet = organisationUnitStore
-            .getOrganisationUnitDataSetAssocationMap( organisationUnits, dataSets );
+            .getOrganisationUnitDataSetAssociationMap( organisationUnits, dataSets );
 
         OrganisationUnitDataSetAssociationSet set = new OrganisationUnitDataSetAssociationSet();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.organisationunit;
 
 import com.google.common.collect.Sets;
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.dataset.DataSet;
@@ -38,7 +39,10 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 /**
@@ -404,5 +408,26 @@ public class OrganisationUnitStoreTest
         orgUnitStore.save( ouG );
         
         assertEquals( 3, orgUnitStore.getMaxLevel() );
-    }        
+    }
+
+    @Test
+    public void testGetOrganisationUnitUidNameMap()
+    {
+        orgUnitStore.save( ouA );
+        orgUnitStore.save( ouB );
+        orgUnitStore.save( ouC );
+        orgUnitStore.save( ouD );
+        orgUnitStore.save( ouE );
+
+        List<OrganisationUnit> orgUnits = orgUnitStore.getAll();
+
+        final Map<String, String> organisationUnitUidNameMap = orgUnitStore.getOrganisationUnitUidNameMap(
+            orgUnits.stream().map( BaseIdentifiableObject::getUid ).collect( Collectors.toList() ) );
+
+        assertThat( organisationUnitUidNameMap.get( ouA.getUid() ), is( ouA.getName() ) );
+        assertThat( organisationUnitUidNameMap.get( ouB.getUid() ), is( ouB.getName() ) );
+        assertThat( organisationUnitUidNameMap.get( ouC.getUid() ), is( ouC.getName() ) );
+        assertThat( organisationUnitUidNameMap.get( ouD.getUid() ), is( ouD.getName() ) );
+        assertThat( organisationUnitUidNameMap.get( ouE.getUid() ), is( ouE.getName() ) );
+    }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -1052,6 +1052,13 @@ public class ListGrid
     }
 
     @Override
+    public Grid replaceAllValues( List<List<Object>> rows )
+    {
+        this.grid = rows;
+        return this;
+    }
+
+    @Override
     public Grid addRows( SqlRowSet rs )
     {
         return addRows( rs, -1 );


### PR DESCRIPTION
When a Program has a Data Element or TEA of type Organisation Unit, the system was persisting the OU name in the `analytics_event_*` and `analytics_enrollment_*` tables.

This was done to fix another issue with Event/Enrollment Line List view, which was showing the Org Unit UID rather than name.
Persisting the name, rather than the UID, was causing a bug becuase the join with the Org Unit table was broken, if a user selects "Org Unit Field" in the Event table layout (Pivot App).

This fix:
- reverts the change to the JdbcTableManager, so that the Org Unit UID is used in analytics tables
- introduces a Grid Postprocessor to resolve Grid data that have to be displayed with a name, instead of UID.
The Postprocessor has been designed to run the Grid through a number of Processors: at the moment there is only one processors in use.

ref: DHIS2-9096