### PR TITLE
feat: Update rule engine for completed_date variable support [DHIS2-9223]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -338,7 +338,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
                 .map( dv -> RuleDataValue.create( ObjectUtils.defaultIfNull( psi.getExecutionDate(), psi.getDueDate() ),
                     psi.getProgramStage().getUid(), dv.getDataElement(), getEventDataValue( dv ) ) )
                 .collect( Collectors.toList() ),
-            psi.getProgramStage().getName() );
+            psi.getProgramStage().getName(), ObjectUtils.defaultIfNull( psi.getCompletedDate(), null ) );
     }
 
     // ---------------------------------------------------------------------

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -618,7 +618,7 @@
       <dependency>
         <groupId>org.hisp.dhis.rules</groupId>
         <artifactId>rule-engine</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.8-SNAPSHOT</version>
       </dependency>
 
       <!-- Spring -->


### PR DESCRIPTION
This PR will add support for `completed_date` program environment variable support. Unlike ProgramIndicators this completion date will always be taken as event completed date.