### PR TITLE
fix: Error importing data values in first time

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.period;
  */
 
 import org.hisp.dhis.i18n.I18nFormat;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.Date;
@@ -238,6 +239,8 @@ public interface PeriodService
      * @return a Period.
      */
     Period reloadPeriod( Period period );
+
+    Period reloadIsoPeriodInStatelessSession( String isoPeriod );
 
     /**
      * Retrieves the period with the given ISO period identifier. Reloads the 

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -40,6 +40,7 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.expression.Operator;
@@ -94,11 +95,15 @@ public class ValidationNotificationServiceTest
     @Mock
     private PeriodStore periodStore;
 
+    @Mock
+    private SessionFactory sessionFactory;
+
     private DefaultPeriodService periodService;
 
     private DefaultValidationNotificationService subject;
 
     private List<MockMessage> sentMessages;
+
 
     // -------------------------------------------------------------------------
     // Test fixtures
@@ -134,7 +139,7 @@ public class ValidationNotificationServiceTest
 
         subject = new DefaultValidationNotificationService(renderer, messageService, validationResultService);
 
-        this.periodService = new DefaultPeriodService(periodStore);
+        this.periodService = new DefaultPeriodService(periodStore, sessionFactory);
 
         sentMessages = new ArrayList<>();
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/DbmsUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/DbmsUtils.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.dbms;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hisp.dhis.commons.util.DebugUtils;
 import org.springframework.orm.hibernate5.SessionFactoryUtils;
 import org.springframework.orm.hibernate5.SessionHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -52,5 +54,21 @@ public class DbmsUtils
         SessionHolder sessionHolder = (SessionHolder) TransactionSynchronizationManager.unbindResource( sessionFactory );
 
         SessionFactoryUtils.closeSession( sessionHolder.getSession() );
+    }
+
+    public static void closeStatelessSession( StatelessSession session )
+    {
+        try
+        {
+            session.getTransaction().commit();
+        }
+        catch ( Exception exception )
+        {
+            DebugUtils.getStackTrace( exception );
+        }
+        finally
+        {
+            session.close();
+        }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/callable/PeriodCallable.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/callable/PeriodCallable.java
@@ -52,7 +52,7 @@ public class PeriodCallable
     public Period call()
         throws ExecutionException
     {
-        return periodService.reloadIsoPeriod( id );
+        return periodService.reloadIsoPeriodInStatelessSession( id );
     }
 
     @Override


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7539

Issue in in dataValueSet api.
- If the payload includes a period that doesn't exist in DB, then we have the function `reloadAndForceAddPeriod` to handle it.
- However the newly added Period is flushed to DB *after* the `dataValuesBatchHandler.flush()` Which leads to a foreign key constraint error 

=> This  fix will create a StatelessSession for adding the new Period and sync it with DB immediately. Instead of using the current session.
