### PR TITLE
fix: [DHIS2-8730] fix event data values 'like' filters when using numeric comparisons (2.35)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -809,9 +809,17 @@ public class JdbcEventStore
                             eventDataValuesWhereSql += " and ";
                         }
 
-                        eventDataValuesWhereSql += " " + queryCol + " " + filter.getSqlOperator() + " "
+                        if ( QueryOperator.LIKE.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
+                        {
+                            eventDataValuesWhereSql += " " + queryCol + " " + filter.getSqlOperator() + " "
+                            + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
+                        }
+                        else
+                        {
+                            eventDataValuesWhereSql += " " + queryCol + " " + filter.getSqlOperator() + " "
                             + StringUtils.lowerCase( StringUtils.isNumeric( encodedFilter ) ? encodedFilter :
                             filter.getSqlFilter( encodedFilter ) ) + " ";
+                        }
                     }
                     else if ( QueryOperator.IN.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
                     {


### PR DESCRIPTION
When using like comparisons in event filters, pure numeric strings where not encoded properly. Added an extra if condition to handle it. 