### PR TITLE
fix: handle Period as filter in analytics Indicator queries

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
@@ -966,11 +966,8 @@ public class DataHandler
             }
             else
             {
-                if ( dimensionalItems.size() == 1 )
-                {
-                    result.put( dimensionalItems.get( 0 ).getDimensionItem(),
-                        new DimensionItemObjectValue( dimensionalItems.get( 0 ), (Double) row.get( valueIndex ) ) );
-                }
+                result.put( join( remove( row.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP ),
+                    new DimensionItemObjectValue( dimensionalItems.get( 0 ), (Double) row.get( valueIndex ) ) );
             }
         }
 


### PR DESCRIPTION
Fix an issue during the aggregation of the Grid data in Indicator queries: if the Period is used as filter and no
Period Offset is used in the Indicator, the code generates an invalid Map key.
Fix the problem by using all the dimension item UID as key components.

// Example

Given an analytics query:

`api/32/analytics.json?dimension=dx:Uvn6LCg7dVU&dimension=ou:ImspTQPwCqd&filter=pe:LAST_12_MONTHS`

There are 2 dimensions (`dx` and `ou`) and one filter (`pe`).
If the `dx` is an Indicator, the resulting Grid will contain multiple rows (one for each Indicator item), with 3 columns

1) indicator item uiid
2) ou uid
3) value

The aggregated Map, that is returned and used by the Expression engine, should  have the following key:

`<indicator item uid>-<ou uid>`