### PR TITLE
fix: use correct error codes for coordinates query

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -328,7 +328,7 @@ public class DefaultEventDataQueryService
         {
             if ( ValueType.COORDINATE != dataElement.getValueType() )
             {
-                throwIllegalQueryEx( ErrorCode.E7129, coordinateField );
+                throwIllegalQueryEx( ErrorCode.E7219, coordinateField );
             }
 
             return dataElement.getUid();
@@ -340,7 +340,7 @@ public class DefaultEventDataQueryService
         {
             if ( ValueType.COORDINATE != attribute.getValueType() )
             {
-                throwIllegalQueryEx( ErrorCode.E7130, coordinateField );
+                throwIllegalQueryEx( ErrorCode.E7220, coordinateField );
             }
 
             return attribute.getUid();


### PR DESCRIPTION
An invalid error code was returned when calling the `/events/query` endpoint and try to retrieve a geo coordinate for a non coordinate field.