### PR TITLE
fix: invoke super.equals() on BaseDimensionalItemObject

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -184,16 +184,6 @@ public class BaseDimensionalItemObject
     @Override
     public boolean equals( Object o )
     {
-        if ( this == o )
-        {
-            return true;
-        }
-
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-
         if ( !super.equals( o ) )
         {
             return false;


### PR DESCRIPTION
The `equals` function on `BaseDimensionaltemObject` was using the default equals comparison: `if ( o == null || getClass() != o.getClass() )` which, in case of Hibernate proxied objects, will not work.
This fix removes that checks and calls the `equals` on the super class (`BaseNameableObject` which uses `isAssignableFrom` to handle proxy classes.