### PR TITLE
[2.33] fix: Ensure unique column names for Resource Tables (#5409)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryResourceTable.java
@@ -63,20 +63,21 @@ public class CategoryResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
+        UniqueNameVerifier uniqueNameVerifier = new UniqueNameVerifier();
+
         String statement = "create table " + getTempTableName() + " (" +
             "categoryoptioncomboid bigint not null, " +
             "categoryoptioncomboname varchar(255), ";
 
         for ( Category category : objects )
         {
-            quote( category.getName() );
-            statement += quote( category.getShortName() ) + " varchar(230), ";
+            statement += uniqueNameVerifier.ensureUniqueShortName( category ) + " varchar(230), ";
             statement += quote( category.getUid() ) + " character(11), ";
         }
-
+        
         for ( CategoryOptionGroupSet groupSet : groupSets )
         {
-            statement += quote( groupSet.getShortName() ) + " varchar(230), ";
+            statement += uniqueNameVerifier.ensureUniqueShortName( groupSet ) + " varchar(230), ";
             statement += quote( groupSet.getUid() ) + " character(11), ";
         }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementGroupSetResourceTable.java
@@ -60,13 +60,15 @@ public class DataElementGroupSetResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
+        UniqueNameVerifier uniqueNameVerifier = new UniqueNameVerifier();
+
         String statement = "create table " + getTempTableName() + " (" +
             "dataelementid bigint not null, " +
             "dataelementname varchar(230), ";
 
         for ( DataElementGroupSet groupSet : objects )
         {
-            statement += quote( groupSet.getShortName() ) + " varchar(230), ";
+            statement += uniqueNameVerifier.ensureUniqueShortName( groupSet ) + " varchar(230), ";
             statement += quote( groupSet.getUid() ) + " character(11), ";
         }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/IndicatorGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/IndicatorGroupSetResourceTable.java
@@ -60,13 +60,15 @@ public class IndicatorGroupSetResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
+        UniqueNameVerifier uniqueNameVerifier = new UniqueNameVerifier();
+
         String statement = "create table " + getTempTableName() + " (" +
             "indicatorid bigint not null, " +
             "indicatorname varchar(230), ";
 
         for ( IndicatorGroupSet groupSet : objects )
         {
-            statement += quote( groupSet.getName() ) + " varchar(230), ";
+            statement += uniqueNameVerifier.ensureUniqueName( groupSet.getName() ) + " varchar(230), ";
             statement += quote( groupSet.getUid() ) + " character(11), ";
         }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitGroupSetResourceTable.java
@@ -68,6 +68,8 @@ public class OrganisationUnitGroupSetResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
+        UniqueNameVerifier uniqueNameVerifier = new UniqueNameVerifier();
+
         String statement = "create table " + getTempTableName() + " (" +
             "organisationunitid bigint not null, " +
             "organisationunitname varchar(230), " +
@@ -75,7 +77,7 @@ public class OrganisationUnitGroupSetResourceTable
 
         for ( OrganisationUnitGroupSet groupSet : objects )
         {
-            statement += quote( groupSet.getShortName() ) + " varchar(230), ";
+            statement += uniqueNameVerifier.ensureUniqueShortName( groupSet ) + " varchar(230), ";
             statement += quote( groupSet.getUid() ) + " character(11), ";
         }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/UniqueNameVerifier.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/UniqueNameVerifier.java
@@ -1,0 +1,78 @@
+package org.hisp.dhis.resourcetable.table;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.common.BaseDimensionalObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hisp.dhis.system.util.SqlUtils.quote;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class UniqueNameVerifier {
+
+    protected List<String> columnNames = new ArrayList<>();
+
+    /**
+     * Returns the short name in quotes for the given {@see BaseDimensionalObject}, ensuring
+     * that the short name is unique across the list of BaseDimensionalObject this
+     * class operates on
+     *
+     * @param baseDimensionalObject a {@see BaseDimensionalObject}
+     * @return a unique, quoted short name
+     */
+    protected String ensureUniqueShortName( BaseDimensionalObject baseDimensionalObject )
+    {
+        String columnName = quote( baseDimensionalObject.getShortName()
+                + (columnNames.contains( baseDimensionalObject.getShortName() ) ? columnNames.size() : "") );
+
+        this.columnNames.add( baseDimensionalObject.getShortName() );
+
+        return columnName;
+    }
+
+    /**
+     * Returns the name in quotes, ensuring
+     * that the name is unique across the list of objects this class operates on
+     *
+     * @param name a String
+     * @return a unique, quoted name
+     */
+    protected String ensureUniqueName( String name )
+    {
+        String columnName = quote( name + (columnNames.contains( name ) ? columnNames.size() : "") );
+
+        this.columnNames.add( name );
+
+        return columnName;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/resourcetable/table/UniqueNameVerifierTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/resourcetable/table/UniqueNameVerifierTest.java
@@ -1,0 +1,100 @@
+package org.hisp.dhis.resourcetable.table;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.apache.commons.lang.StringUtils.countMatches;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOptionGroupSet;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.indicator.IndicatorGroupSet;
+import org.junit.Test;
+
+public class UniqueNameVerifierTest
+{
+    @Test
+    public void verifyResourceTableColumnNameAreUniqueWhenComputingShortName()
+    {
+        // Category short name will be shorten to 49 chars, and create 3 identical
+        // short-names
+        String categoryName = RandomStringUtils.randomAlphabetic( 50 );
+
+        String cogsName = RandomStringUtils.randomAlphabetic( 49 );
+
+        final List<Category> categories = IntStream.of( 1, 2, 3 )
+            .mapToObj( i -> new Category( categoryName + i, DataDimensionType.ATTRIBUTE ) )
+            .peek( c -> c.setUid( CodeGenerator.generateUid() ) ).collect( Collectors.toList() );
+
+        final List<CategoryOptionGroupSet> categoryOptionGroupSets = IntStream.of( 1, 2, 3 )
+            .mapToObj( i -> new CategoryOptionGroupSet( cogsName + i ) )
+            .peek( c -> c.setUid( CodeGenerator.generateUid() ) ).collect( Collectors.toList() );
+
+        CategoryResourceTable categoryResourceTable = new CategoryResourceTable( categories, categoryOptionGroupSets );
+
+        final String sql = categoryResourceTable.getCreateTempTableStatement();
+
+        assertEquals( countMatches( sql, "\"" + categories.get( 0 ).getShortName() + "\"" ), 1 );
+        assertEquals( countMatches( sql, "\"" + categories.get( 0 ).getShortName() + "1\"" ), 1 );
+        assertEquals( countMatches( sql, "\"" + categories.get( 0 ).getShortName() + "2\"" ), 1 );
+
+        assertEquals( countMatches( sql, "\"" + cogsName + "1\"" ), 1 );
+        assertEquals( countMatches( sql, "\"" + cogsName + "2\"" ), 1 );
+        assertEquals( countMatches( sql, "\"" + cogsName + "3\"" ), 1 );
+
+    }
+
+    @Test
+    public void verifyResourceTableColumnNameAreUniqueWhenComputingShortName2()
+    {
+        // Category short name will be shorten to 49 chars, and create 3 identical
+        // short-names
+        String indicatorGroupSetName = RandomStringUtils.randomAlphabetic( 50 );
+
+        final List<IndicatorGroupSet> indicatorGroupSets = IntStream.of( 1, 2, 3 )
+            .mapToObj( i -> new IndicatorGroupSet( indicatorGroupSetName + 1 ) )
+            .peek( c -> c.setUid( CodeGenerator.generateUid() ) ).collect( Collectors.toList() );
+
+        IndicatorGroupSetResourceTable indicatorGroupSetResourceTable = new IndicatorGroupSetResourceTable(
+            indicatorGroupSets );
+
+        final String sql = indicatorGroupSetResourceTable.getCreateTempTableStatement();
+
+        assertEquals( countMatches( sql, "\"" + indicatorGroupSets.get( 0 ).getName() + "\"" ), 1 );
+        assertEquals( countMatches( sql, "\"" + indicatorGroupSets.get( 0 ).getName() + "1\"" ), 1 );
+        assertEquals( countMatches( sql, "\"" + indicatorGroupSets.get( 0 ).getName() + "2\"" ), 1 );
+
+    }
+}


### PR DESCRIPTION
* fix: ensure unique column names for Resource Table

- DHIS2-8684
- This fix makes sure that during Resource Table generation process, the column names are always unique.

* chore: add missing class header

* Replace Abstract class with class encapsulating logic to ensure short
names do not collide.

* chore: renamed variable

(cherry picked from commit 7e8667f33c993c831f47aa1948d65e1901105ebb)