### PR TITLE
ci: moves fetch-depth to correct action stage

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -22,11 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        fetch-depth: 0 
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
**Sonarcloud team is looking into why the check on this PR failed.** 