### PR TITLE
[2.34] fix: pagination for DataElementOperands uses proper count (#5852)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -244,7 +244,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             }
             else
             {
-                count = paginationCountCache.computeIfAbsent( calculatePaginationCountKey(currentUser, filters, options), () -> count( metadata, options, filters, orders ) );
+                count = paginationCountCache.computeIfAbsent(
+                    calculatePaginationCountKey( currentUser, filters, options ),
+                    () -> count( options, filters, orders ) );
             }
             
             pager = new Pager( options.getPage(), count, options.getPageSize() );
@@ -1178,7 +1180,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return entityList;
     }
 
-    private int count( WebMetadata metadata, WebOptions options, List<String> filters, List<Order> orders )
+    private int count( WebOptions options, List<String> filters, List<Order> orders )
     {
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
             options.getRootJunction() );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -31,12 +31,14 @@ package org.hisp.dhis.webapi.controller.dataelement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
@@ -47,6 +49,7 @@ import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.node.NodeUtils;
 import org.hisp.dhis.node.Preset;
+import org.hisp.dhis.node.types.CollectionNode;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.Query;
@@ -55,6 +58,8 @@ import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.descriptors.DataElementOperandSchemaDescriptor;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.LinkService;
@@ -68,6 +73,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.google.common.collect.Lists;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -84,11 +91,26 @@ public class DataElementOperandController
     private final ContextService contextService;
     private final SchemaService schemaService;
     private final CategoryService dataElementCategoryService;
-
+    private final CurrentUserService currentUserService;
+    
+    private Cache<String,Integer> paginationCountCache = new Cache2kBuilder<String, Integer>() {}
+        .expireAfterWrite( 1, TimeUnit.MINUTES )
+        .build();
+    
     public DataElementOperandController( IdentifiableObjectManager manager, QueryService queryService,
-        FieldFilterService fieldFilterService, LinkService linkService, ContextService contextService, SchemaService schemaService,
-        CategoryService dataElementCategoryService )
+        FieldFilterService fieldFilterService, LinkService linkService, ContextService contextService,
+        SchemaService schemaService,
+        CategoryService dataElementCategoryService, CurrentUserService currentUserService )
     {
+        checkNotNull( manager );
+        checkNotNull( queryService );
+        checkNotNull( fieldFilterService );
+        checkNotNull( linkService );
+        checkNotNull( contextService );
+        checkNotNull( schemaService );
+        checkNotNull( dataElementCategoryService );
+        checkNotNull( currentUserService );
+
         this.manager = manager;
         this.queryService = queryService;
         this.fieldFilterService = fieldFilterService;
@@ -96,12 +118,13 @@ public class DataElementOperandController
         this.contextService = contextService;
         this.schemaService = schemaService;
         this.dataElementCategoryService = dataElementCategoryService;
+        this.currentUserService = currentUserService;
     }
 
     @GetMapping
     @SuppressWarnings( "unchecked" )
     public @ResponseBody RootNode getObjectList( @RequestParam Map<String, String> rpParameters, OrderParams orderParams )
-        throws QueryParserException
+            throws QueryParserException
     {
         Schema schema = schemaService.getDynamicSchema( DataElementOperand.class );
 
@@ -153,16 +176,17 @@ public class DataElementOperandController
         query.setDefaultOrder();
         query.setObjects( dataElementOperands );
 
-
         dataElementOperands = (List<DataElementOperand>) queryService.query( query );
         Pager pager = metadata.getPager();
 
         if ( options.hasPaging() && pager == null )
         {
-            pager = new Pager( options.getPage(), dataElementOperands.size(), options.getPageSize() );
+            // fetch the count for the current query from a short-lived cache
+            int count = paginationCountCache.computeIfAbsent(
+                calculatePaginationCountKey( currentUserService.getCurrentUser(), filters, options ),
+                () -> queryService.count( query ) );
+            pager = new Pager( options.getPage(), count, options.getPageSize() );
             linkService.generatePagerLinks( pager, DataElementOperand.class );
-
-            dataElementOperands = PagerUtils.pageCollection( dataElementOperands, pager );
         }
 
         RootNode rootNode = NodeUtils.createMetadata();
@@ -176,5 +200,11 @@ public class DataElementOperandController
             new FieldFilterParams( dataElementOperands, fields ) ) );
 
         return rootNode;
+    }
+
+    private String calculatePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
+    {
+        return currentUser.getUsername() + "." + "DataElementOperand" + "." + String.join( "|", filters ) + "."
+            + options.getRootJunction().name() + options.get( "restrictToCaptureScope" );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -1,0 +1,271 @@
+package org.hisp.dhis.webapi.controller.dataelement;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.commons.config.JacksonObjectMapperConfig.staticJsonMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.Compression;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.fieldfilter.FieldFilterParams;
+import org.hisp.dhis.fieldfilter.FieldFilterService;
+import org.hisp.dhis.node.DefaultNodeService;
+import org.hisp.dhis.node.NodeService;
+import org.hisp.dhis.node.serializers.Jackson2JsonNodeSerializer;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.ComplexNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.query.CriteriaQueryEngine;
+import org.hisp.dhis.query.DefaultQueryParser;
+import org.hisp.dhis.query.DefaultQueryService;
+import org.hisp.dhis.query.InMemoryQueryEngine;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.query.planner.DefaultQueryPlanner;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.hisp.dhis.webapi.service.DefaultContextService;
+import org.hisp.dhis.webapi.service.LinkService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.google.common.collect.Lists;
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DataElementOperandControllerTest
+{
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private IdentifiableObjectManager manager;
+
+    @Mock
+    private FieldFilterService fieldFilterService;
+
+    @Mock
+    private LinkService linkService;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private CategoryService dataElementCategoryService;
+
+    private QueryService queryService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    private BeanRandomizer rnd;
+
+    private final static String ENDPOINT = "/dataElementOperands";
+
+    @Before
+    public void setUp()
+    {
+        MockitoAnnotations.initMocks( this );
+
+        rnd = new BeanRandomizer();
+
+        ContextService contextService = new DefaultContextService();
+
+        QueryService _queryService = new DefaultQueryService(
+            new DefaultQueryParser( schemaService, currentUserService, mock( OrganisationUnitService.class ) ),
+            new DefaultQueryPlanner( schemaService ), mock( CriteriaQueryEngine.class ),
+            new InMemoryQueryEngine<>( schemaService, mock( AclService.class ), currentUserService ) );
+        // Use "spy" on queryService, because we want a partial mock: we only want to
+        // mock the method "count"
+        queryService = spy( _queryService );
+
+        // Controller under test
+        final DataElementOperandController controller = new DataElementOperandController( manager, queryService,
+            fieldFilterService, linkService,
+            contextService, schemaService, dataElementCategoryService, currentUserService );
+
+        // Set custom Node Message converter //
+        NodeService nodeService = new DefaultNodeService();
+        Jackson2JsonNodeSerializer serializer = new Jackson2JsonNodeSerializer( staticJsonMapper() );
+        ReflectionTestUtils.setField( nodeService, "nodeSerializers", Lists.newArrayList( serializer ) );
+        ReflectionTestUtils.invokeMethod( nodeService, "init" );
+
+        JsonMessageConverter jsonMessageConverter = new JsonMessageConverter( nodeService, Compression.NONE );
+        mockMvc = MockMvcBuilders.standaloneSetup( controller )
+            .setMessageConverters( jsonMessageConverter )
+            .build();
+        // End mockmvc setup
+
+        when( schemaService.getDynamicSchema( DataElementOperand.class ) )
+            .thenReturn( new Schema( DataElementOperand.class, "", "" ) );
+
+        when( currentUserService.getCurrentUser() ).thenReturn( rnd.randomObject( User.class ) );
+    }
+
+    @Test
+    public void verifyPaginationGetFirstPage()
+        throws Exception
+    {
+        int pageSize = 15;
+        int totalSize = 150;
+
+        // Given
+        final List<DataElement> dataElements = rnd.randomObjects( DataElement.class, 1 );
+
+        when( manager.getAllSorted( DataElement.class ) ).thenReturn( dataElements );
+
+        final List<DataElementOperand> dataElementOperands = rnd.randomObjects( DataElementOperand.class, totalSize );
+        when( dataElementCategoryService.getOperands( dataElements, true ) )
+            .thenReturn( rnd.randomObjects( DataElementOperand.class, totalSize ) );
+
+        final List<DataElementOperand> first50elements = dataElementOperands.subList( 0, pageSize );
+        ArgumentCaptor<FieldFilterParams> filterParamsArgumentCaptor = ArgumentCaptor
+            .forClass( FieldFilterParams.class );
+
+        when( fieldFilterService.toCollectionNode( eq( DataElementOperand.class ),
+            filterParamsArgumentCaptor.capture() ) )
+                .thenReturn( buildResponse( first50elements ) );
+
+        doReturn( totalSize ).when( queryService ).count( any( Query.class ) );
+
+        // Then
+        ResultActions resultActions = mockMvc.perform( get( ENDPOINT )
+            .param( "totals", "true" )
+            .param( "pageSize", Integer.toString( pageSize ) ) )
+            .andExpect( status().isOk() )
+            .andExpect( content().contentType( "application/json" ) )
+            .andExpect( jsonPath( "$.pager.pageSize" ).value( Integer.toString( pageSize ) ) )
+            .andExpect( jsonPath( "$.pager.page" ).value( "1" ) )
+            .andExpect( jsonPath( "$.pager.total" ).value( Integer.toString( totalSize ) ) )
+            .andExpect( jsonPath( "$.pager.pageCount" ).value( Integer.toString( totalSize / pageSize ) ) )
+            .andExpect( jsonPath( "$.dataElementOperands", hasSize( pageSize ) ) );
+
+        final FieldFilterParams fieldFilterParams = filterParamsArgumentCaptor.getValue();
+        assertThat( fieldFilterParams.getObjects(), hasSize( pageSize ) );
+        assertThat( fieldFilterParams.getFields(), Matchers.is( Lists.newArrayList( "*" ) ) );
+
+        // Make sure that the first and last element in the page matches with the
+        // original list
+        List<Map<String, Object>> jsonDataElementOperands = convertResponse( resultActions );
+
+        assertThat( jsonDataElementOperands.get( 0 ).get( "id" ),
+            Matchers.is( dataElementOperands.get( 0 ).getDimensionItem() ) );
+        assertThat( jsonDataElementOperands.get( pageSize - 1 ).get( "id" ),
+            Matchers.is( dataElementOperands.get( pageSize - 1 ).getDimensionItem() ) );
+    }
+
+    @Test
+    public void verifyPaginationGetThirdPage()
+        throws Exception
+    {
+        int pageSize = 25;
+        int totalSize = 100;
+
+        // Given
+        final List<DataElement> dataElements = rnd.randomObjects( DataElement.class, 1 );
+
+        when( manager.getAllSorted( DataElement.class ) ).thenReturn( dataElements );
+
+        final List<DataElementOperand> dataElementOperands = rnd.randomObjects( DataElementOperand.class, totalSize );
+        when( dataElementCategoryService.getOperands( dataElements, true ) )
+            .thenReturn( rnd.randomObjects( DataElementOperand.class, totalSize ) );
+
+        final List<DataElementOperand> thirdPageElements = dataElementOperands.subList( 50, 50 + pageSize );
+        ArgumentCaptor<FieldFilterParams> filterParamsArgumentCaptor = ArgumentCaptor
+            .forClass( FieldFilterParams.class );
+
+        when( fieldFilterService.toCollectionNode( eq( DataElementOperand.class ),
+            filterParamsArgumentCaptor.capture() ) )
+                .thenReturn( buildResponse( thirdPageElements ) );
+
+        doReturn( totalSize ).when( queryService ).count( any( Query.class ) );
+
+        // Then
+        ResultActions resultActions = mockMvc.perform( get( ENDPOINT )
+            .param( "totals", "true" )
+            .param( "pageSize", Integer.toString( pageSize ) )
+            .param( "page", Integer.toString( 3 ) ) )
+            .andExpect( status().isOk() )
+            .andExpect( content().contentType( "application/json" ) )
+            .andExpect( jsonPath( "$.pager.pageSize" ).value( Integer.toString( pageSize ) ) )
+            .andExpect( jsonPath( "$.pager.page" ).value( "3" ) )
+            .andExpect( jsonPath( "$.pager.total" ).value( Integer.toString( totalSize ) ) )
+            .andExpect( jsonPath( "$.pager.pageCount" ).value( Integer.toString( totalSize / pageSize ) ) )
+            .andExpect( jsonPath( "$.dataElementOperands", hasSize( pageSize ) ) );
+
+        final FieldFilterParams fieldFilterParams = filterParamsArgumentCaptor.getValue();
+        assertThat( fieldFilterParams.getObjects(), hasSize( pageSize ) );
+        assertThat( fieldFilterParams.getFields(), Matchers.is( Lists.newArrayList( "*" ) ) );
+
+        // Make sure that the first and last element in the page matches with the
+        // original list
+        List<Map<String, Object>> jsonDataElementOperands = convertResponse( resultActions );
+
+        assertThat( jsonDataElementOperands.get( 0 ).get( "id" ),
+            Matchers.is( dataElementOperands.get( 50 ).getDimensionItem() ) );
+        assertThat( jsonDataElementOperands.get( pageSize - 1 ).get( "id" ),
+            Matchers.is( dataElementOperands.get( 74  ).getDimensionItem() ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private List<Map<String, Object>> convertResponse( ResultActions resultActions )
+        throws UnsupportedEncodingException
+    {
+        return JsonPath
+            .parse( resultActions.andReturn().getResponse().getContentAsString() )
+            .read( "$.dataElementOperands",
+                List.class );
+    }
+
+    private CollectionNode buildResponse( List<DataElementOperand> dataElementOperands )
+    {
+        CollectionNode collectionNode = new CollectionNode( "dataElementOperands" );
+        collectionNode.setWrapping( true );
+        collectionNode.setNamespace( "http://dhis2.org/schema/dxf/2.0" );
+
+        for ( DataElementOperand dataElementOperand : dataElementOperands )
+        {
+            ComplexNode complexNode = new ComplexNode( "dataElementOperand" );
+            complexNode.setNamespace( collectionNode.getNamespace() );
+            complexNode.addChild( new SimpleNode( "displayName", dataElementOperand.getDisplayName(), false ) );
+            complexNode.addChild( new SimpleNode( "id", dataElementOperand.getDimensionItem(), true ) );
+            collectionNode.addChild( complexNode );
+        }
+
+        return collectionNode;
+
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -2,7 +2,6 @@ package org.hisp.dhis.webapi.controller.dataelement;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hisp.dhis.commons.config.JacksonObjectMapperConfig.staticJsonMapper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -18,6 +17,10 @@ import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.hamcrest.Matchers;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.Compression;
@@ -32,7 +35,6 @@ import org.hisp.dhis.node.serializers.Jackson2JsonNodeSerializer;
 import org.hisp.dhis.node.types.CollectionNode;
 import org.hisp.dhis.node.types.ComplexNode;
 import org.hisp.dhis.node.types.SimpleNode;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.query.CriteriaQueryEngine;
 import org.hisp.dhis.query.DefaultQueryParser;
 import org.hisp.dhis.query.DefaultQueryService;
@@ -68,7 +70,6 @@ import com.jayway.jsonpath.JsonPath;
  */
 public class DataElementOperandControllerTest
 {
-
     private MockMvc mockMvc;
 
     @Mock
@@ -98,6 +99,7 @@ public class DataElementOperandControllerTest
     @Before
     public void setUp()
     {
+
         MockitoAnnotations.initMocks( this );
 
         rnd = new BeanRandomizer();
@@ -105,7 +107,7 @@ public class DataElementOperandControllerTest
         ContextService contextService = new DefaultContextService();
 
         QueryService _queryService = new DefaultQueryService(
-            new DefaultQueryParser( schemaService, currentUserService, mock( OrganisationUnitService.class ) ),
+            new DefaultQueryParser( schemaService ),
             new DefaultQueryPlanner( schemaService ), mock( CriteriaQueryEngine.class ),
             new InMemoryQueryEngine<>( schemaService, mock( AclService.class ), currentUserService ) );
         // Use "spy" on queryService, because we want a partial mock: we only want to
@@ -119,7 +121,7 @@ public class DataElementOperandControllerTest
 
         // Set custom Node Message converter //
         NodeService nodeService = new DefaultNodeService();
-        Jackson2JsonNodeSerializer serializer = new Jackson2JsonNodeSerializer( staticJsonMapper() );
+        Jackson2JsonNodeSerializer serializer = new Jackson2JsonNodeSerializer( );
         ReflectionTestUtils.setField( nodeService, "nodeSerializers", Lists.newArrayList( serializer ) );
         ReflectionTestUtils.invokeMethod( nodeService, "init" );
 


### PR DESCRIPTION
The `DataElementOperand` controller doesn't use the `AbstractCrudController` and has a "custom" pagination implementation.
Pagination wasn't working because the Pagination logic was not using the "total" size of elements returned by the query.

ref: DHIS2-9182

Co-authored-by: Lars Helge Øverland <lars@dhis2.org>
(cherry picked from commit 98cead69f5f38450c82df626a31997de1869246d)