### PR TITLE
fix: save Period in stateless session

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
@@ -206,6 +206,8 @@ public interface PeriodStore
     // RelativePeriods
     // -------------------------------------------------------------------------
 
+    Period insertIsoPeriodInStatelessSession( Period period );
+
     /**
      * Deletes a RelativePeriods instance.
      * 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/aggregate/DataImportTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/aggregate/DataImportTest.java
@@ -55,7 +55,6 @@ import static org.hamcrest.Matchers.*;
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-@Disabled
 public class DataImportTest
     extends ApiTest
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -42,16 +42,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.StatelessSession;
-import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.dbms.DbmsUtils;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -322,26 +316,9 @@ public class DefaultPeriodService
             return reloadedPeriod;
         }
 
-        StatelessSession session = sessionFactory.openStatelessSession();
-        session.beginTransaction();
-        try
-        {
-            period.setPeriodType( reloadPeriodType( period.getPeriodType() ) );
+        period.setPeriodType( reloadPeriodType( period.getPeriodType() ) );
 
-            session.insert( period );
-
-            return period;
-        }
-        catch ( Exception exception )
-        {
-            log.error( DebugUtils.getStackTrace( exception ) );
-        }
-        finally
-        {
-            DbmsUtils.closeStatelessSession( session );
-        }
-
-        return null;
+        return periodStore.insertIsoPeriodInStatelessSession( period );
     }
     
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodServiceTest.java
@@ -28,19 +28,19 @@ package org.hisp.dhis.period;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.dbms.DbmsUtils;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-import org.hisp.dhis.DhisSpringTest;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static org.junit.Assert.*;
 
 /**
  * @author Kristian Nordal
@@ -51,7 +51,17 @@ public class PeriodServiceTest
 {
     @Autowired
     private PeriodService periodService;
-    
+
+    @Autowired
+    private SessionFactory sessionFactory;
+
+    @Override
+    protected void setUpTest()
+        throws Exception
+    {
+        populatePeriodType();
+    }
+
     // -------------------------------------------------------------------------
     // Period
     // -------------------------------------------------------------------------
@@ -572,5 +582,68 @@ public class PeriodServiceTest
         assertNotNull( periodService.getPeriodType( periodTypeB.getId() ) );
         assertNotNull( periodService.getPeriodType( periodTypeC.getId() ) );
         assertNotNull( periodService.getPeriodType( periodTypeD.getId() ) );
+    }
+
+    @Test
+    public void testReloadPeriodInStatelessSession()
+    {
+        Period period = periodService.reloadIsoPeriodInStatelessSession( "202510" );
+
+        assertNotNull( period );
+
+        removeTestPeriod( "202510" );
+    }
+
+    private void removeTestPeriod( String period )
+    {
+        StatelessSession session = sessionFactory.openStatelessSession();
+        session.beginTransaction();
+        try
+        {
+            session.delete( periodService.getPeriod( period ) );
+            session.getTransaction().commit();
+        }
+        catch ( Exception ex )
+        {
+            session.getTransaction().rollback();
+        }
+        finally
+        {
+            session.close();
+        }
+    }
+    /**
+     * This is to fix the issue of PeriodType hasn't been inserted to H2 database
+     * but only available in Hibernate session
+     * so periodService.reloadIsoPeriodInStatelessSession() will fail
+     */
+    private void populatePeriodType()
+    {
+        List<PeriodType> periodTypes = periodService.getAllPeriodTypes();
+        StatelessSession session = sessionFactory.openStatelessSession();
+        session.beginTransaction();
+        try
+        {
+            periodTypes.forEach( pt -> {
+                Object periodType = session.get( PeriodType.class, pt.getId() );
+                if ( periodType == null )
+                {
+                    if ( sessionFactory.getCurrentSession().contains( pt ) )
+                    {
+                        sessionFactory.getCurrentSession().delete( pt );
+                    }
+
+                    session.insert( pt );
+                }
+            } );
+        }
+        catch ( Exception exception )
+        {
+            exception.printStackTrace();
+        }
+        finally
+        {
+            DbmsUtils.closeStatelessSession( session );
+        }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/DbmsUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/DbmsUtils.java
@@ -64,6 +64,7 @@ public class DbmsUtils
         }
         catch ( Exception exception )
         {
+            session.getTransaction().rollback();
             DebugUtils.getStackTrace( exception );
         }
         finally


### PR DESCRIPTION

https://jira.dhis2.org/browse/DHIS2-7539
This is a fix for PR https://github.com/dhis2/dhis2-core/pull/5897

- Move the code for opening stateless session  from PeriodService to HibernatePeriodStore
- Update the PERIOD_CACHE after saving period in stateless session
- Add unit test and a tweak to make PeriodType works with stateless session and h2 database in PeriodServiceTest