### PR TITLE
feat: add support for application overloads (DHIS2-9092)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -28,16 +28,16 @@ package org.hisp.dhis.appmanager;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.hisp.dhis.common.DxfNamespaces;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * @author Saptarshi
@@ -52,6 +52,8 @@ public class App
     private static final long serialVersionUID = -6638197841892194228L;
 
     public static final String SEE_APP_AUTHORITY_PREFIX = "M_";
+
+    public static final String INSTALLED_APP_PATH = "api/apps/";
 
     /**
      * Required.
@@ -75,6 +77,8 @@ public class App
     /**
      * Optional.
      */
+    private String shortName;
+
     private String description;
 
     private AppIcons icons;
@@ -93,6 +97,8 @@ public class App
 
     private AppStatus appState = AppStatus.OK;
 
+    private boolean isBundledApp = false;
+
     // -------------------------------------------------------------------------
     // Logic
     // -------------------------------------------------------------------------
@@ -104,11 +110,15 @@ public class App
      */
     public void init( String contextPath )
     {
-        this.baseUrl = contextPath + "/api/apps";
+        isBundledApp = AppManager.BUNDLED_APPS.contains( getShortName() );
+
+        String appPathPrefix = isBundledApp ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
+
+        this.baseUrl = String.join( "/", contextPath, appPathPrefix ) + getUrlFriendlyName();
 
         if ( contextPath != null && name != null && launchPath != null )
         {
-            launchUrl = baseUrl + ("/" + getUrlFriendlyName() + "/" + launchPath).replaceAll( "//", "/" );
+            launchUrl = String.join( "/", baseUrl, launchPath.replaceFirst( "^/+", "" ) );
         }
     }
 
@@ -119,6 +129,12 @@ public class App
     public String getKey()
     {
         return getUrlFriendlyName();
+    }
+
+    @JsonProperty
+    public boolean getIsBundledApp()
+    {
+        return isBundledApp;
     }
 
     // -------------------------------------------------------------------------
@@ -135,6 +151,22 @@ public class App
     public void setVersion( String version )
     {
         this.version = version;
+    }
+
+    @JsonProperty( "short_name" )
+    @JacksonXmlProperty( localName = "short_name", namespace = DxfNamespaces.DXF_2_0 )
+    public String getShortName()
+    {
+        if ( shortName == null )
+        {
+            return name;
+        }
+        return shortName;
+    }
+
+    public void setShortName( String shortName )
+    {
+        this.shortName = shortName;
     }
 
     @JsonProperty
@@ -280,7 +312,8 @@ public class App
         this.launchUrl = launchUrl;
     }
 
-    @JsonIgnore
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getBaseUrl()
     {
         return baseUrl;
@@ -324,7 +357,7 @@ public class App
 
     public void setAppState( AppStatus appState )
     {
-         this.appState = appState;
+        this.appState = appState;
     }
 
     // -------------------------------------------------------------------------
@@ -335,7 +368,7 @@ public class App
     public int hashCode()
     {
         int hash = 7;
-        hash = 79 * hash + (this.name != null ? this.name.hashCode() : 0);
+        hash = 79 * hash + (this.getShortName() != null ? this.getShortName().hashCode() : 0);
         return hash;
     }
 
@@ -359,12 +392,8 @@ public class App
 
         final App other = (App) obj;
 
-        if ( (this.name == null) ? (other.name != null) : !this.name.equals( other.name ) )
-        {
-            return false;
-        }
-
-        return true;
+        return this.getShortName() == null ? other.getShortName() == null
+            : this.getShortName().equals( other.getShortName() );
     }
 
     @Override
@@ -373,16 +402,18 @@ public class App
         return "{" +
             "\"version:\"" + version + "\", " +
             "\"name:\"" + name + "\", " +
+            "\"shortName:\"" + getShortName() + "\", " +
             "\"appType:\"" + appType + "\", " +
+            "\"baseUrl:\"" + baseUrl + "\", " +
             "\"launchPath:\"" + launchPath + "\" " +
             "}";
     }
 
     public String getUrlFriendlyName()
     {
-        if ( name != null )
+        if ( getShortName() != null )
         {
-            return name
+            return getShortName()
                 .trim()
                 .replaceAll( "[^A-Za-z0-9\\s-]", "" )
                 .replaceAll( " ", "-" );
@@ -393,6 +424,6 @@ public class App
 
     public String getSeeAppAuthority()
     {
-        return SEE_APP_AUTHORITY_PREFIX + name.trim().replaceAll( "[^a-zA-Z0-9\\s]","" ).replaceAll( " ", "_" );
+        return SEE_APP_AUTHORITY_PREFIX + getUrlFriendlyName();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -416,7 +416,7 @@ public class App
             return getShortName()
                 .trim()
                 .replaceAll( "[^A-Za-z0-9\\s-]", "" )
-                .replaceAll( " ", "-" );
+                .replaceAll( "\\s+", "-" );
         }
 
         return null;
@@ -424,6 +424,7 @@ public class App
 
     public String getSeeAppAuthority()
     {
-        return SEE_APP_AUTHORITY_PREFIX + getUrlFriendlyName();
+        return SEE_APP_AUTHORITY_PREFIX
+            + getShortName().trim().replaceAll( "[^a-zA-Z0-9\\s]", "" ).replaceAll( "\\s+", "_" );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -28,13 +28,15 @@ package org.hisp.dhis.appmanager;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.user.User;
-import org.springframework.core.io.Resource;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+
+import org.hisp.dhis.user.User;
+import org.springframework.core.io.Resource;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Saptarshi Purkayastha
@@ -42,6 +44,41 @@ import java.util.List;
 public interface AppManager
 {
     String ID = AppManager.class.getName();
+
+    String BUNDLED_APP_PREFIX = "dhis-web-";
+
+    ImmutableSet<String> BUNDLED_APPS = ImmutableSet.of(
+        // Javascript apps
+        "app-management",
+        "cache-cleaner",
+        "capture",
+        "dashboard",
+        "data-administration",
+        "data-visualizer",
+        "data-quality",
+        "datastore",
+        "event-reports",
+        "event-visualizer",
+        "import-export",
+        "interpretation",
+        "maintenance",
+        "maps",
+        "menu-management",
+        "messaging",
+        "pivot",
+        "reports",
+        "scheduler",
+        "settings",
+        "tracker-capture",
+        "translations",
+        "usage-analytics",
+        "user",
+        "user-profile",
+
+        // Struts apps
+        "approval",
+        "dataentry",
+        "maintenance-mobile" );
 
     /**
      * Returns a list of all installed apps.
@@ -70,16 +107,32 @@ public interface AppManager
     List<App> getAppsByType( AppType appType, Collection<App> apps );
 
     /**
-     * Returns a list of all installed apps with name equal the given name
-     * and operator. Currently supports eq and ilike.
+     * Returns a list of all installed apps with name equal the given name and
+     * operator. Currently supports eq and ilike.
      *
      * @return list of installed apps with given name
      */
     List<App> getAppsByName( String name, Collection<App> apps, String operator );
 
     /**
-     * Return a list of all installed apps with given filter list
-     * Currently support filtering by AppType and name
+     * Returns a list of all installed apps with shortName equal the given name and
+     * operator. Currently supports eq and ilike.
+     *
+     * @return list of installed apps with given name
+     */
+    List<App> getAppsByShortName( String shortName, Collection<App> apps, String operator );
+
+    /**
+     * Returns a list of all installed apps which are either bundled or not bundled
+     * operator. Currently supports eq.
+     *
+     * @return list of installed apps with given isBundled property
+     */
+    List<App> getAppsByIsBundled( boolean isBundled, Collection<App> apps );
+
+    /**
+     * Return a list of all installed apps with given filter list Currently support
+     * filtering by AppType and name
      *
      * @param filter
      * @return Return a list of all installed apps with given filter list
@@ -89,7 +142,7 @@ public interface AppManager
     /**
      * Returns the app with the given key (folder name).
      *
-     * @param key         the app key.
+     * @param key the app key.
      * @param contextPath the context path of this instance.
      * @return the app with the given key.
      */
@@ -106,7 +159,7 @@ public interface AppManager
     /**
      * Installs the app.
      *
-     * @param file     the app file.
+     * @param file the app file.
      * @param fileName the name of the app file.
      * @throws IOException if the app manifest file could not be read.
      */
@@ -123,8 +176,9 @@ public interface AppManager
     /**
      * Deletes the given app.
      *
-     * @param app           the app to delete.
-     * @param deleteAppData decide if associated data in dataStore should be deleted or not.
+     * @param app the app to delete.
+     * @param deleteAppData decide if associated data in dataStore should be deleted
+     *        or not.
      */
     void deleteApp( App app, boolean deleteAppData );
 
@@ -158,7 +212,8 @@ public interface AppManager
     boolean isAccessible( App app, User user );
 
     /**
-     * Returns the app associated with the namespace, or null if no app is associated.
+     * Returns the app associated with the namespace, or null if no app is
+     * associated.
      *
      * @param namespace the namespace to check
      * @return App or null
@@ -166,7 +221,9 @@ public interface AppManager
     App getAppByNamespace( String namespace );
 
     /**
-     * Looks up and returns the file associated with the app and pageName, if it exists
+     * Looks up and returns the file associated with the app and pageName, if it
+     * exists
+     *
      * @param app the app to look up files for
      * @param pageName the page requested
      * @return the Resource representing the file, or null if no file was found
@@ -176,6 +233,7 @@ public interface AppManager
 
     /**
      * Sets the app status to DELETION_IN_PROGRESS.
+     *
      * @param app The app that has to be marked as deleted.
      * @return true if the status was changed in this method.
      */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
@@ -27,16 +27,38 @@ package org.hisp.dhis.appmanager;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.blobstore.options.ListContainerOptions.Builder.prefix;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.external.location.LocationManager;
+import org.hisp.dhis.external.location.LocationManagerException;
 import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobRequestSigner;
 import org.jclouds.blobstore.BlobStore;
@@ -60,27 +82,9 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.blobstore.options.ListContainerOptions.Builder.prefix;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Stian Sandvold
@@ -90,7 +94,8 @@ import static org.jclouds.blobstore.options.ListContainerOptions.Builder.prefix;
 public class JCloudsAppStorageService
     implements AppStorageService
 {
-    private static final Pattern CONTAINER_NAME_PATTERN = Pattern.compile( "^(?![.-])(?=.{1,63}$)([.-]?[a-zA-Z0-9]+)+$" );
+    private static final Pattern CONTAINER_NAME_PATTERN = Pattern
+        .compile( "^(?![.-])(?=.{1,63})([.-]?[a-zA-Z0-9]+)+$" );
 
     private static final long FIVE_MINUTES_IN_SECONDS = Minutes.minutes( 5 ).toStandardDuration().getStandardSeconds();
 
@@ -112,8 +117,8 @@ public class JCloudsAppStorageService
 
     private static final String JCLOUDS_PROVIDER_KEY_TRANSIENT = "transient";
 
-    private static final List<String> SUPPORTED_PROVIDERS =
-        Arrays.asList( JCLOUDS_PROVIDER_KEY_FILESYSTEM, JCLOUDS_PROVIDER_KEY_AWS_S3, JCLOUDS_PROVIDER_KEY_TRANSIENT );
+    private static final List<String> SUPPORTED_PROVIDERS = Arrays.asList( JCLOUDS_PROVIDER_KEY_FILESYSTEM,
+        JCLOUDS_PROVIDER_KEY_AWS_S3, JCLOUDS_PROVIDER_KEY_TRANSIENT );
 
     // -------------------------------------------------------------------------
     // Dependencies
@@ -149,14 +154,12 @@ public class JCloudsAppStorageService
         config = new BlobStoreProperties(
             configurationProvider.getProperty( ConfigurationKey.FILESTORE_PROVIDER ),
             configurationProvider.getProperty( ConfigurationKey.FILESTORE_LOCATION ),
-            configurationProvider.getProperty( ConfigurationKey.FILESTORE_CONTAINER )
-        );
+            configurationProvider.getProperty( ConfigurationKey.FILESTORE_CONTAINER ) );
 
         Pair<Credentials, Properties> providerConfig = configureForProvider(
             config.provider,
             configurationProvider.getProperty( ConfigurationKey.FILESTORE_IDENTITY ),
-            configurationProvider.getProperty( ConfigurationKey.FILESTORE_SECRET )
-        );
+            configurationProvider.getProperty( ConfigurationKey.FILESTORE_SECRET ) );
 
         // ---------------------------------------------------------------------
         // Set up JClouds context
@@ -253,8 +256,7 @@ public class JCloudsAppStorageService
                 appMap.put( app.getUrlFriendlyName(), app );
 
                 log.info( "Discovered app '" + app.getName() + "' from JClouds storage " );
-            }
-        );
+            } );
 
         if ( appList.isEmpty() )
         {
@@ -275,7 +277,7 @@ public class JCloudsAppStorageService
         App app = new App();
         log.info( "Installing new app: " + filename );
 
-        try ( ZipFile zip = new ZipFile( file ) )
+        try (ZipFile zip = new ZipFile( file ))
         {
             // -----------------------------------------------------------------
             // Parse ZIP file and it's manifest.webapp file.
@@ -359,9 +361,9 @@ public class JCloudsAppStorageService
             } );
 
             log.info( String.format( ""
-                    + "New app '%s' installed"
-                    + "\n\tInstall path: %s"
-                    + (namespace != null && !namespace.isEmpty() ? "\n\tNamespace reserved: %s" : ""),
+                + "New app '%s' installed"
+                + "\n\tInstall path: %s"
+                + (namespace != null && !namespace.isEmpty() ? "\n\tNamespace reserved: %s" : ""),
                 app.getName(), dest, namespace ) );
 
             // -----------------------------------------------------------------
@@ -429,9 +431,24 @@ public class JCloudsAppStorageService
 
             String filepath = configurationProvider.getProperty( ConfigurationKey.FILESTORE_CONTAINER ) + "/" + key;
             filepath = filepath.replaceAll( "//", "/" );
-            File res = locationManager.getFileForReading( filepath );
+            File res;
 
-            if ( res.exists() )
+            try
+            {
+                res = locationManager.getFileForReading( filepath );
+            }
+            catch ( LocationManagerException e )
+            {
+                return null;
+            }
+
+            if ( res.isDirectory() )
+            {
+                String indexPath = pageName.replaceAll( "/+$", "" ) + "/index.html";
+                log.info( "Resource " + pageName + " (" + filepath + " is a directory, serving " + indexPath );
+                return getAppResource( app, indexPath );
+            }
+            else if ( res.exists() )
             {
                 return new FileSystemResource( res );
             }
@@ -446,13 +463,12 @@ public class JCloudsAppStorageService
 
     private static Location createRegionLocation( BlobStoreProperties config, Location provider )
     {
-        return config.location != null ?
-            new LocationBuilder()
-                .scope( LocationScope.REGION )
-                .id( config.location )
-                .description( config.location )
-                .parent( provider )
-                .build() : null;
+        return config.location != null ? new LocationBuilder()
+            .scope( LocationScope.REGION )
+            .id( config.location )
+            .description( config.location )
+            .parent( provider )
+            .build() : null;
     }
 
     private Pair<Credentials, Properties> configureForProvider( String provider, String identity, String secret )
@@ -507,8 +523,8 @@ public class JCloudsAppStorageService
                 if ( container != null )
                 {
                     log.warn( String.format( "Container name '%s' is illegal. " +
-                            "Standard domain name naming conventions apply (no underscores allowed). " +
-                            "Using default container name ' %s'", container,
+                        "Standard domain name naming conventions apply (no underscores allowed). " +
+                        "Using default container name ' %s'", container,
                         ConfigurationKey.FILESTORE_CONTAINER.getDefaultValue() ) );
                 }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -135,6 +135,13 @@ public class AppController
         renderService.toJson( response.getOutputStream(), apps );
     }
 
+    @RequestMapping( value= "/bundledAppNames", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    public void getBundledAppNames( HttpServletRequest request, HttpServletResponse response )
+        throws IOException
+    {
+        renderService.toJson( response.getOutputStream(), AppManager.BUNDLED_APPS );
+    }
+
     @RequestMapping( method = RequestMethod.POST )
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
@@ -168,10 +175,23 @@ public class AppController
         throws IOException, WebMessageException
     {
         App application = appManager.getApp( app );
+        
+        // Get page requested
+        String pageName = getUrl( request.getPathInfo(), app );
 
         if ( application == null )
         {
             throw new WebMessageException( WebMessageUtils.notFound( "App '" + app + "' not found." ) );
+        }
+
+        if ( application.getIsBundledApp() )
+        {
+            String redirectPath = application.getBaseUrl() + "/" + pageName;
+            
+            log.info( String.format( "Redirecting to bundled app: %s", redirectPath ) );
+
+            response.sendRedirect( redirectPath );
+            return;
         }
 
         if ( !appManager.isAccessible( application ) )
@@ -184,16 +204,13 @@ public class AppController
             throw new WebMessageException( WebMessageUtils.conflict( "App '" + app + "' deletion is still in progress." ) );
         }
 
-        // Get page requested
-        String pageName = getUrl( request.getPathInfo(), app );
-
         log.debug( String.format( "App page name: '%s'", pageName ) );
 
         // Handling of 'manifest.webapp'
         if ( "manifest.webapp".equals( pageName ) )
         {
             // If request was for manifest.webapp, check for * and replace with host
-            if ( "*".equals( application.getActivities().getDhis().getHref() ) )
+            if ( application.getActivities() != null && application.getActivities().getDhis() != null && "*".equals( application.getActivities().getDhis().getHref() ) )
             {
                 String contextPath = ContextUtils.getContextPath( request );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -135,13 +135,6 @@ public class AppController
         renderService.toJson( response.getOutputStream(), apps );
     }
 
-    @RequestMapping( value= "/bundledAppNames", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
-    public void getBundledAppNames( HttpServletRequest request, HttpServletResponse response )
-        throws IOException
-    {
-        renderService.toJson( response.getOutputStream(), AppManager.BUNDLED_APPS );
-    }
-
     @RequestMapping( method = RequestMethod.POST )
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -100,6 +100,9 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer
         context.addFilter( "RequestIdentifierFilter", new DelegatingFilterProxy( "requestIdentifierFilter" ) )
             .addMappingForUrlPatterns( null, true, "/*" );
 
+        context.addFilter( "AppOverrideFilter", new DelegatingFilterProxy( "appOverrideFilter" ) )
+            .addMappingForUrlPatterns( null, true, "/*" );
+
         context.addListener( new StartupListener() );
     }
 

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
@@ -75,7 +75,7 @@ public class RedirectAction
 
                 for ( App app : apps )
                 {
-                    if ( app.getName().equals( startModule.substring( "app:".length() ) ) )
+                    if ( app.getShortName().equals( startModule.substring( "app:".length() ) ) )
                     {
                         redirectUrl = app.getLaunchUrl();
                         return SUCCESS;

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
@@ -54,7 +54,7 @@ public class AppsSystemAuthoritiesProvider implements SystemAuthoritiesProvider
         Set<String> authorities = new HashSet<>();
 
         appManager.getApps( null ).stream()
-            .filter( app -> !StringUtils.isEmpty( app.getName() ) )
+            .filter( app -> !StringUtils.isEmpty( app.getShortName() ) && !app.getIsBundledApp() )
             .forEach( app -> {
                 authorities.add( app.getSeeAppAuthority() );
                 authorities.addAll( app.getAuthorities() );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.appmanager.AppStatus;
+import org.hisp.dhis.webapi.utils.ContextUtils;
 
 /**
  * @author Austin McGee <austin@dhis2.org>
@@ -95,7 +96,7 @@ public class AppOverrideFilter
             // If request was for manifest.webapp, check for * and replace with host
             if ( app.getActivities() != null && app.getActivities().getDhis() != null && "*".equals( app.getActivities().getDhis().getHref() ) )
             {
-                String contextPath = "../";
+                String contextPath = ContextUtils.getContextPath( request );
                 log.debug( String.format( "Manifest context path: '%s'", contextPath ) );
                 app.getActivities().getDhis().setHref( contextPath );
             }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -1,0 +1,173 @@
+package org.hisp.dhis.servlet.filter;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import org.hisp.dhis.util.DateUtils;
+import org.hisp.dhis.appmanager.App;
+import org.hisp.dhis.appmanager.AppManager;
+import org.hisp.dhis.appmanager.AppStatus;
+
+/**
+ * @author Austin McGee <austin@dhis2.org>
+ */
+ @Slf4j
+ @Component
+public class AppOverrideFilter
+    extends OncePerRequestFilter
+{
+    @Autowired
+    private AppManager appManager;
+
+    @Autowired
+    private ObjectMapper jsonMapper;
+
+    public static final String APP_PATH_PATTERN = "^/" + AppManager.BUNDLED_APP_PREFIX + "(" + String.join("|", AppManager.BUNDLED_APPS) + ")/(.*)";
+    // public static final String REDIRECT_APP_PATH_PATTERN = "^/" + AppController.RESOURCE_PATH + "-(" + String.join("|", AppManager.BUNDLED_APPS) + ")/(.*)"
+
+    // -------------------------------------------------------------------------
+    // Filter implementation
+    // -------------------------------------------------------------------------
+
+    // From AppController.java (some duplication)
+    private void serveInstalledAppResource( App app, String resourcePath, HttpServletRequest request, HttpServletResponse response )
+        throws IOException
+    {
+        // Get page requested
+
+        log.debug( String.format( "Serving app resource: '%s'", resourcePath ) );
+
+        // Handling of 'manifest.webapp'
+        if ( "manifest.webapp".equals( resourcePath ) )
+        {
+            // If request was for manifest.webapp, check for * and replace with host
+            if ( app.getActivities() != null && app.getActivities().getDhis() != null && "*".equals( app.getActivities().getDhis().getHref() ) )
+            {
+                String contextPath = "../";
+                log.debug( String.format( "Manifest context path: '%s'", contextPath ) );
+                app.getActivities().getDhis().setHref( contextPath );
+            }
+
+            jsonMapper.writeValue( response.getOutputStream(), app );
+        }
+        // Any other resource
+        else
+        {
+            // Retrieve file
+            Resource resource = appManager.getAppResource( app, resourcePath );
+
+            if ( resource == null )
+            {
+                response.sendError( HttpServletResponse.SC_NOT_FOUND );
+                return;
+            }
+
+            String filename = resource.getFilename();
+            log.debug( String.format( "App filename: '%s'", filename ) );
+
+            if ( new ServletWebRequest( request, response ).checkNotModified( resource.lastModified() ) )
+            {
+                response.setStatus( HttpServletResponse.SC_NOT_MODIFIED );
+                return;
+            }
+
+            String mimeType = request.getSession().getServletContext().getMimeType( filename );
+
+            if ( mimeType != null )
+            {
+                response.setContentType( mimeType );
+            }
+
+            response.setContentLength( (int) resource.contentLength() );
+            response.setHeader( "Last-Modified", DateUtils.getHttpDateString( new Date( resource.lastModified() ) ) );
+            StreamUtils.copy( resource.getInputStream(), response.getOutputStream() );
+        }
+    }
+
+    @Override
+    protected void doFilterInternal( HttpServletRequest req, HttpServletResponse res, FilterChain chain )
+        throws IOException, ServletException
+    {
+        String requestURI = req.getRequestURI();
+
+        Pattern p = Pattern.compile( APP_PATH_PATTERN );
+        Matcher m = p.matcher( requestURI );
+
+        if ( m.find() )
+        {
+            String namespace = m.group( 0 );
+            String appName = m.group( 1 );
+            String resourcePath = m.group( 2 );
+
+            log.info( "AppOverrideFilter :: Matched for URI " + requestURI );
+
+            App app = appManager.getApp( appName );
+
+            if ( app != null && app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
+            {
+                log.info( "AppOverrideFilter :: Overridden app " + appName + " found, serving override" );
+                serveInstalledAppResource( app, resourcePath, req, res );
+
+                return;
+            }
+            else
+            {
+                log.info( "AppOverrideFilter :: App " + appName + " not found, falling back to bundled app" );
+            }
+        }
+
+        chain.doFilter( req, res );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -102,6 +102,10 @@ public class AppOverrideFilter
 
             jsonMapper.writeValue( response.getOutputStream(), app );
         }
+        else if ( "index.action".equals( resourcePath ) )
+        {
+            response.sendRedirect( app.getLaunchUrl() );
+        }
         // Any other resource
         else
         {

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/DefaultModuleManager.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/DefaultModuleManager.java
@@ -157,7 +157,7 @@ public class DefaultModuleManager
         List<App> apps = appManager
             .getAccessibleApps( contextPath )
             .stream()
-            .filter( app -> app.getAppType() == AppType.APP )
+            .filter( app -> app.getAppType() == AppType.APP && !app.getIsBundledApp() )
             .collect( Collectors.toList() );
 
         modules.addAll( apps.stream().map( Module::getModule ).collect( Collectors.toList() ) );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/Module.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/Module.java
@@ -91,9 +91,10 @@ public class Module
 
         String description = TextUtils.subString( app.getDescription(), 0, 80 );
         
-        Module module = new Module( app.getName(), app.getName(), defaultAction );
+        Module module = new Module( app.getShortName(), app.getShortName(), defaultAction );
         module.setIcon( icon );
         module.setDescription( description );
+        module.setDisplayName(app.getName());
         
         return module;
     }


### PR DESCRIPTION
This PR adds a filter to the `dhis-web-portal` project which implements overloading of bundled core apps (`/dhis-web-xyz`) with an installed app of the same name (`/api/apps/xyz`)

To simplify this change and prevent issues with server discovery we are NOT changing app paths here.  The core apps are still served at the same paths (`/dhis-web-dashboard` etc.) but under the hood they will serve an installed `dashboard` app if it exists.  The path consolidation should be targeted for 2.36

TODO (in this PR):
- [x] If they exist, serve installed apps with names matching core apps from `/dhis-web-<name>`
- [x] 302 redirect `/api/apps/<name>` to `/dhis-web-<name>` for core apps
- [x] Confirm caching behavior
- [x] Hide override apps from modules list (apps menu)
- [x] Fix raw URL handling for overridden apps (i.e. `/dhis-web-scheduler` should redirect to `/dhis-web-scheduler/index.html`, does in bundled app but not when overridden) - also applies to any requested directory
- [x] Fix override name matching (uses label)
- [x] Expose `isBundledApp` property in `/api/apps` response
- [x] Expose correct `baseUrl` and `launchUrl` for bundled apps in API response
- [x] ~Expose list of bundled / overridable apps at `/api/apps/bundledAppNames`~ (removed)
- [x] Support filtering by `isBundledApp` in `/api/apps`

TODO (after this PR):
- Check performance - can/should we restrict the filter to a subset of routes in `web.xml` instead of `/*`?
- **security** Consider namespacing core apps or creating a new app type to prevent accidental overrides
- **security** Consider validating developer org of core apps for override?
- Deprecate `getModules.action` in favor of `/api/apps`
- Add support for "emergency" deletion of installed apps (maybe in the `/dhis-web-apps` project, or just through documentation) This is critical if AppManagement app is broken by a continuous release, which would be really nasty
- Look into excluding `manifest.webapp` from app cache.
- **In App Management App**
  - Support easy updating (maybe with an alert banner) of the App Management app itself, so we can defer these changes
  - Show bundled / core apps in their own section, warn of overrides
  - Fix App Icon in App Management app for overrides
  - Fix link to overridden apps in App Management

**NB** Includes some unrelated build automation additions, will remove those and put them in a separate PR

## Cache Behavior

`index.html` (including when served from `/`) appears to always avoid the cache, which was the existing behavior and works well here.  All other app files ARE cached, but since the vast majority include a hash in the filename (referenced from `index.html`) this should be fine.  The notable exception is `manifest.webapp` which could be stale - we should look into possibly excluding this from the cache as well**.  More testing is needed, but for the moment the app behavior after an app install / uninstall appears functional and consistent.

## Demo

A demo of this behavior (with an installed override of the Scheduler app) can be found at http://d2.winged.tech:8080 (admin:district)

## Incidental bugs fixed

Additional existing bugs in all Installed Apps fixed by this change:
- (in JCloudsAppStorageService.java) requests for non-existent files previously throw a 500 error instead of a 404
- (in JCloudsAppStorageService.java) requests pointing to directories (including the app route) would throw an error rather than serving `index.html` from that directory
