### PR TITLE
fix: DHIS2-9268 AssignedUser in Event (New Tracker Importer)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -37,6 +37,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.BaseLinkableObject;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.user.User;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -121,6 +122,9 @@ public class Event
 
     @JsonProperty
     private Geometry geometry;
+
+    @JsonProperty
+    private User assignedUser;
 
     @JsonProperty
     @Builder.Default

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.domain;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.vividsolutions.jts.geom.Geometry;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,6 +37,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.BaseLinkableObject;
+import org.hisp.dhis.common.adapter.UidJsonSerializer;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.user.User;
 
@@ -124,6 +126,7 @@ public class Event
     private Geometry geometry;
 
     @JsonProperty
+    @JsonSerialize( using = UidJsonSerializer.class )
     private User assignedUser;
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -136,6 +136,13 @@ public class TrackerPreheat
     private Map<String, List<ProgramInstance>> programInstances = new HashMap<>();
 
     /**
+     * A map of user uid and preheated {@see User}. The value is a User object.
+     * These users are primarily used to represent the "assignedUser" of events, used in validation and persisting
+     * events.
+     */
+    private Map<String, User> users = new HashMap<>();
+
+    /**
      * Identifier map
      */
     private TrackerIdentifierParams identifiers = new TrackerIdentifierParams();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -108,6 +108,7 @@ public enum TrackerErrorCode
     E1082( "Event: `{0}`, is already deleted." ),
     E1113( "Enrollment: `{0}`, is already deleted." ),
     E1114( "TrackedEntity: `{0}`, is already deleted." ),
+    E1118( "Assigned user `{0}` is not a valid uid."),
 
     //TODO: See TODO on error usage
     E1017( "Attribute: `{0}`, does not exist." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationConfig.java
@@ -78,7 +78,9 @@ public class TrackerImportValidationConfig
         RelationshipsValidationHook.class,
 
         EnrollmentRuleValidationHook.class,
-        EventRuleValidationHook.class
+        EventRuleValidationHook.class,
+
+        AssignedUserValidationHook.class
     );
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -1,4 +1,6 @@
-package org.hisp.dhis.tracker.validation.hooks;/*
+package org.hisp.dhis.tracker.validation.hooks;
+
+/*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
  *

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -29,7 +29,10 @@ package org.hisp.dhis.tracker.validation.hooks;/*
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.user.User;
@@ -66,5 +69,20 @@ public class AssignedUserValidationHook
                 reporter.addError( report );
             }
         }
+    }
+
+    @Override
+    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    {
+    }
+
+    @Override
+    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    {
+    }
+
+    @Override
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity tei )
+    {
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -1,0 +1,70 @@
+package org.hisp.dhis.tracker.validation.hooks;/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.user.User;
+import org.springframework.stereotype.Component;
+
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1118;
+
+@Component
+public class AssignedUserValidationHook
+    extends AbstractTrackerDtoValidationHook
+{
+    public AssignedUserValidationHook( TrackedEntityAttributeService teAttrService )
+    {
+        super( teAttrService );
+    }
+
+    @Override
+    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    {
+        if ( event.getAssignedUser() != null )
+        {
+            String uid = event.getAssignedUser().getUid();
+
+            if ( !CodeGenerator.isValidUid( event.getAssignedUser().getUid() )
+                ||
+                reporter.getValidationContext().getBundle().getPreheat().get( TrackerIdScheme.UID, User.class, uid ) ==
+                    null )
+            {
+                TrackerErrorReport.TrackerErrorReportBuilder report = TrackerErrorReport.builder()
+                .errorCode( E1118 )
+                .errorKlass( Event.class )
+                .addArg( uid );
+
+                reporter.addError( report );
+            }
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/AssignedUserValidationHookTest.java
@@ -1,4 +1,6 @@
-package org.hisp.dhis.tracker.validation;/*
+package org.hisp.dhis.tracker.validation;
+
+/*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
  *

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/AssignedUserValidationHookTest.java
@@ -1,0 +1,237 @@
+package org.hisp.dhis.tracker.validation;/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.AtomicMode;
+import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.TrackerImportService;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserCredentials;
+import org.hisp.dhis.user.UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AssignedUserValidationHookTest
+    extends AbstractImportValidationTest
+{
+    @Autowired
+    private UserService _userService;
+
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    @Autowired
+    private TrackerImportService trackerImportService;
+
+    private TrackedEntityType teta;
+
+    private OrganisationUnit organisationUnitA;
+
+    private Program programA;
+
+    private ProgramStage programStageA;
+
+    private User user;
+
+    private ProgramInstance pi;
+
+    @Before
+    public void setup()
+    {
+        organisationUnitA = createOrganisationUnit( 'A' );
+        manager.save( organisationUnitA );
+
+        user = new User();
+        UserCredentials userCredentials = new UserCredentials();
+
+        user.setAutoFields();
+        user.setUserCredentials( userCredentials );
+        user.setSurname( "Nordmann" );
+        user.setFirstName( "Ola" );
+        user.setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
+
+        userCredentials.setAutoFields();
+        userCredentials.setUserInfo( user );
+
+        _userService.addUser( user );
+
+        teta = createTrackedEntityType( 'A' );
+        manager.save( teta );
+
+        programA = createProgram( 'A' );
+        programA.setProgramType( ProgramType.WITHOUT_REGISTRATION );
+        programA.setTrackedEntityType( teta );
+        programA.addOrganisationUnit( organisationUnitA );
+        manager.save( programA );
+        programA.setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
+        manager.update( programA );
+
+        programStageA = createProgramStage( 'A', programA );
+        programStageA.setEnableUserAssignment( true );
+        programStageA.setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
+        manager.save( programStageA );
+
+        pi = new ProgramInstance();
+        pi.setProgram( programA );
+        pi.setOrganisationUnit( organisationUnitA );
+        pi.setEnrollmentDate( new Date() );
+
+        manager.save( pi );
+
+    }
+
+    @Test
+    public void testAssignedUserInvalidUid()
+    {
+
+        Event event = new Event();
+
+        User testUser = new User();
+        testUser.setUid( "123" );
+
+        event.setAssignedUser( testUser );
+        event.setProgram( programA.getUid() );
+        event.setProgramStage( programStageA.getUid() );
+        event.setOrgUnit( organisationUnitA.getUid() );
+        event.setEnrollment( pi.getUid() );
+        event.setOccurredAt( "1990-10-22" );
+
+        TrackerImportParams params = TrackerImportParams.builder()
+            .atomicMode( AtomicMode.ALL )
+            .events( Lists.newArrayList( event ) )
+            .importStrategy( TrackerImportStrategy.CREATE_AND_UPDATE )
+            .user( user )
+            .build();
+
+        TrackerImportReport report = trackerImportService.importTracker( params );
+
+        assertTrue( report.getTrackerValidationReport().getErrorReports().size() == 1);
+        assertEquals( "Assigned user `123` is not a valid uid.", report.getTrackerValidationReport().getErrorReports().get( 0 ).getMessage() );
+        assertEquals( TrackerErrorCode.E1118, report.getTrackerValidationReport().getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void testAssignedUserDoesNotExist()
+    {
+
+        Event event = new Event();
+
+        User testUser = new User();
+        testUser.setUid( "A01234567890" );
+
+        event.setAssignedUser( testUser );
+        event.setProgram( programA.getUid() );
+        event.setProgramStage( programStageA.getUid() );
+        event.setOrgUnit( organisationUnitA.getUid() );
+        event.setEnrollment( pi.getUid() );
+        event.setOccurredAt( "1990-10-22" );
+
+        TrackerImportParams params = TrackerImportParams.builder()
+            .atomicMode( AtomicMode.ALL )
+            .events( Lists.newArrayList( event ) )
+            .importStrategy( TrackerImportStrategy.CREATE_AND_UPDATE )
+            .user( user )
+            .build();
+
+        TrackerImportReport report = trackerImportService.importTracker( params );
+
+        assertTrue( report.getTrackerValidationReport().getErrorReports().size() == 1);
+        assertEquals( "Assigned user `A01234567890` is not a valid uid.", report.getTrackerValidationReport().getErrorReports().get( 0 ).getMessage() );
+        assertEquals( TrackerErrorCode.E1118, report.getTrackerValidationReport().getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void testAssignedUserExists()
+    {
+
+        Event event = new Event();
+
+        event.setAssignedUser( user );
+        event.setProgram( programA.getUid() );
+        event.setProgramStage( programStageA.getUid() );
+        event.setOrgUnit( organisationUnitA.getUid() );
+        event.setEnrollment( pi.getUid() );
+        event.setOccurredAt( "1990-10-22" );
+
+        TrackerImportParams params = TrackerImportParams.builder()
+            .atomicMode( AtomicMode.ALL )
+            .events( Lists.newArrayList( event ) )
+            .importStrategy( TrackerImportStrategy.CREATE_AND_UPDATE )
+            .user( user )
+            .build();
+
+        TrackerImportReport report = trackerImportService.importTracker( params );
+
+        assertTrue( report.getTrackerValidationReport().getErrorReports().isEmpty() );
+    }
+
+    @Test
+    public void testAssignedUserIsNull()
+    {
+
+        Event event = new Event();
+
+        event.setAssignedUser( null );
+        event.setProgram( programA.getUid() );
+        event.setProgramStage( programStageA.getUid() );
+        event.setOrgUnit( organisationUnitA.getUid() );
+        event.setEnrollment( pi.getUid() );
+        event.setOccurredAt( "1990-10-22" );
+
+        TrackerImportParams params = TrackerImportParams.builder()
+            .atomicMode( AtomicMode.ALL )
+            .events( Lists.newArrayList( event ) )
+            .importStrategy( TrackerImportStrategy.CREATE_AND_UPDATE )
+            .user( user )
+            .build();
+
+        TrackerImportReport report = trackerImportService.importTracker( params );
+
+        assertTrue( report.getTrackerValidationReport().getErrorReports().isEmpty() );
+    }
+
+}


### PR DESCRIPTION
Adds support for the assignedUser property in the new tracker importer.

Any valid uids are filtered, then we attempt to fetch related users in the preloader. In the validation we report any invalid uids or valid uids without a valid user.