### PR TITLE
[2.35] fix: remove static get for `ExternalAccessVoter` (#5999)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -114,6 +114,9 @@ public class DhisWebCommonsWebSecurityConfig
         @Autowired
         private DhisConfigurationProvider configurationProvider;
 
+        @Autowired
+        private ExternalAccessVoter externalAccessVoter;
+
         @Override
         public void configure( WebSecurity web )
             throws Exception
@@ -316,7 +319,7 @@ public class DhisWebCommonsWebSecurityConfig
                 new UnanimousBased( ImmutableList.of( new SimpleAccessVoter( "ALL" ) ) ),
                 new UnanimousBased( ImmutableList.of( actionAccessVoter(), moduleAccessVoter() ) ),
                 new UnanimousBased( ImmutableList.of( webExpressionVoter() ) ),
-                new UnanimousBased( ImmutableList.of( ExternalAccessVoter.get() ) ),
+                new UnanimousBased( ImmutableList.of( externalAccessVoter ) ),
                 new UnanimousBased( ImmutableList.of( new AuthenticatedVoter() ) )
             );
             return new LogicalOrAccessDecisionManager( decisionVoters );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/vote/ExternalAccessVoter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/vote/ExternalAccessVoter.java
@@ -28,7 +28,10 @@ package org.hisp.dhis.security.vote;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -38,7 +41,6 @@ import org.hisp.dhis.eventreport.EventReport;
 import org.hisp.dhis.report.Report;
 import org.hisp.dhis.sqlview.SqlView;
 import org.hisp.dhis.visualization.Visualization;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.ConfigAttribute;
@@ -47,9 +49,7 @@ import org.springframework.security.web.FilterInvocation;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Allows certain type/uid combinations to be externally accessed (no login required).
@@ -58,22 +58,8 @@ import java.util.Map;
  */
 @Slf4j
 @Component
-public class ExternalAccessVoter implements AccessDecisionVoter<FilterInvocation>, InitializingBean
+public class ExternalAccessVoter implements AccessDecisionVoter<FilterInvocation>
 {
-    private static ExternalAccessVoter instance;
-
-    @Override
-    public void afterPropertiesSet()
-        throws Exception
-    {
-        instance = this;
-    }
-
-    public static ExternalAccessVoter get()
-    {
-        return instance;
-    }
-
     // this should probably be moved somewhere else, but leaving it here for now
     private static final Map<String, Class<? extends IdentifiableObject>> externalClasses = new HashMap<>();
 

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/vote/LogicalOrAccessDecisionManager.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/vote/LogicalOrAccessDecisionManager.java
@@ -28,17 +28,19 @@ package org.hisp.dhis.security.vote;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * AccessDecisionManager which delegates to other AccessDecisionManagers in a
@@ -51,20 +53,19 @@ import java.util.List;
  * @version $Id: LogicalOrAccessDecisionManager.java 6335 2008-11-20 11:11:26Z larshelg $
  */
 @Primary
+@Component
 @Slf4j
-public class LogicalOrAccessDecisionManager
-    implements AccessDecisionManager
+public class LogicalOrAccessDecisionManager implements AccessDecisionManager
 {
-    private List<AccessDecisionManager> accessDecisionManagers = Collections.emptyList();
+    private List<AccessDecisionManager> accessDecisionManagers;
 
     public LogicalOrAccessDecisionManager(
         List<AccessDecisionManager> accessDecisionManagers )
     {
-        this.accessDecisionManagers = accessDecisionManagers;
-    }
-
-    public void setAccessDecisionManagers( List<AccessDecisionManager> accessDecisionManagers )
-    {
+        if ( accessDecisionManagers == null )
+        {
+            accessDecisionManagers = Collections.emptyList();
+        }
         this.accessDecisionManagers = accessDecisionManagers;
     }
 


### PR DESCRIPTION
(cherry picked from commit a8c567ccb12b8d3a0df2b30b9b7145f5a0e82977)