### PR TITLE
chore: remove explicit wiring of an AuthenticationManager

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
@@ -153,10 +153,6 @@ public class AuthoritiesProviderConfig
     @Autowired
     public TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
 
-    @Autowired
-    @Qualifier( "formLoginAuthenticationManager" )
-    public AuthenticationManager formLoginAuthenticationManager;
-
     @Bean( "org.hisp.dhis.security.intercept.XWorkSecurityInterceptor" )
     public XWorkSecurityInterceptor xWorkSecurityInterceptor()
         throws Exception
@@ -172,7 +168,6 @@ public class AuthoritiesProviderConfig
 
         XWorkSecurityInterceptor interceptor = new XWorkSecurityInterceptor();
         interceptor.setAccessDecisionManager( accessDecisionManager );
-        interceptor.setAuthenticationManager( formLoginAuthenticationManager );
         interceptor.setValidateConfigAttributes( false );
         interceptor.setRequiredAuthoritiesProvider( provider );
         interceptor.setActionAccessResolver( resolver );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -332,12 +332,5 @@ public class DhisWebCommonsWebSecurityConfig
             );
             return new LogicalOrAccessDecisionManager( decisionVoters );
         }
-
-        @Bean( "formLoginAuthenticationManager" )
-        public AuthenticationManager formLoginAuthenticationManager()
-            throws Exception
-        {
-            return authenticationManager();
-        }
     }
 }


### PR DESCRIPTION
* Remove explicit wiring of an AuthenticationManager into XWorkSecurityInterceptor, this seems to fix an issue of Spring failing to startup because dep. wiring instability.

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>