### PR TITLE
chore: add missing permitall to urls

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
@@ -28,16 +28,14 @@ package org.hisp.dhis.security;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.base.Charsets;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
 import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.util.ClassUtils;
-
-import com.google.common.base.Charsets;
-import com.google.common.hash.HashCode;
-import com.google.common.hash.Hashing;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -58,7 +56,8 @@ public class AuthenticationLoggerListener
 
             Object details = event.getAuthentication().getDetails();
 
-            if ( ForwardedIpAwareWebAuthenticationDetails.class.isAssignableFrom( details.getClass() ) )
+            if ( details != null &&
+                ForwardedIpAwareWebAuthenticationDetails.class.isAssignableFrom( details.getClass() ) )
             {
                 ForwardedIpAwareWebAuthenticationDetails authDetails = (ForwardedIpAwareWebAuthenticationDetails) details;
                 String ip = authDetails.getIp();

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
@@ -189,7 +189,9 @@ public class AuthoritiesProviderConfig
         DefaultOrganisationUnitSelectionManager selectionManager = new DefaultOrganisationUnitSelectionManager();
         selectionManager.setOrganisationUnitService( organisationUnitService );
         unitsAction.setSelectionManager( selectionManager );
-        unitsAction.setSelectionTreeManager( new DefaultSelectionTreeManager() );
+        DefaultSelectionTreeManager selectionTreeManager = new DefaultSelectionTreeManager();
+        selectionTreeManager.setOrganisationUnitService( organisationUnitService );
+        unitsAction.setSelectionTreeManager( selectionTreeManager );
 
         LoginInterceptor interceptor = new LoginInterceptor();
         interceptor.setActions( ImmutableList.of( unitsAction ) );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -153,6 +153,9 @@ public class DhisWebCommonsWebSecurityConfig
                 .requestMatchers( analyticsPluginResources() ).permitAll()
 
                 .antMatchers( "/dhis-web-commons/security/login.action" ).permitAll()
+                .antMatchers( "/dhis-web-commons/security/logo_front.png" ).permitAll()
+                .antMatchers( "/dhis-web-commons/security/recovery.action" ).permitAll()
+                .antMatchers( "/dhis-web-commons/security/account.action" ).permitAll()
                 .antMatchers( "/oauth2/**" ).permitAll()
                 .antMatchers( "/dhis-web-dashboard/**" ).hasAnyAuthority( "ALL", "M_dhis-web-dashboard" )
                 .antMatchers( "/dhis-web-pivot/**" ).hasAnyAuthority( "ALL", "M_dhis-web-pivot" )


### PR DESCRIPTION
* Adds permit all rule to urls that are outside (before) authentication
* Add missing service to DefaultSelectionTreeManager
* Add null check for user details on AuthenticationLoggerListener.java (happens when you register user and login automatically, and then try to log out)

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>