### PR TITLE
fix: add missing set 2fa on usercredentials in me controller

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.PasswordValidationResult;
 import org.hisp.dhis.user.PasswordValidationService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
@@ -490,6 +491,12 @@ public class MeController
         currentUser.setEducation( stringWithDefault( user.getEducation(), currentUser.getEducation() ) );
         currentUser.setInterests( stringWithDefault( user.getInterests(), currentUser.getInterests() ) );
         currentUser.setLanguages( stringWithDefault( user.getLanguages(), currentUser.getLanguages() ) );
+
+        if ( user.getUserCredentials() != null && currentUser.getUserCredentials() != null )
+        {
+            UserCredentials userCredentials = user.getUserCredentials();
+            currentUser.getUserCredentials().setTwoFA( userCredentials.isTwoFA() );
+        }
     }
 
     private void updatePassword( User currentUser, String password ) throws WebMessageException


### PR DESCRIPTION
* The setting of 2fa property in the account view is not working because the /me controller is not properly setting the user credentials property when PUT is called.

Issue: [DHIS2-9392]
Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>