### PR TITLE
fix: [DHIS2-9286] add exception handling globally to catch any unhandled ones and notify job correctly

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -158,9 +158,6 @@ public class DefaultTrackerImportService
                 notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Failed with exception: " + e.getMessage(), true );
                 notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
             }
-            
-            //TODO: Should this be rethrown in case of sync? Or is the error report added to the import report in the above lines enough?
-            throw e;
 
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -149,7 +149,7 @@ public class DefaultTrackerImportService
                 tvr = new TrackerValidationReport();
             }
             
-            tvr.getErrorReports().add( new TrackerErrorReport( null, "Exception:"+e.getMessage(), TrackerErrorCode.E9999, 0, null, null, null, null ) );
+            tvr.getErrorReports().add( new TrackerErrorReport( "Exception:" + e.getMessage(), TrackerErrorCode.E9999 ) );
             importReport.setTrackerValidationReport( tvr );
             importReport.setStatus( TrackerStatus.ERROR );
             

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -149,7 +149,7 @@ public class DefaultTrackerImportService
                 tvr = new TrackerValidationReport();
             }
             
-            tvr.getErrorReports().add(new TrackerErrorReport( null, "Exception:"+e.getMessage(), TrackerErrorCode.E9999, 0, null, null, null, null ));
+            tvr.getErrorReports().add( new TrackerErrorReport( null, "Exception:"+e.getMessage(), TrackerErrorCode.E9999, 0, null, null, null, null ) );
             importReport.setTrackerValidationReport( tvr );
             importReport.setStatus( TrackerStatus.ERROR );
             

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -137,14 +137,7 @@ public class DefaultTrackerImportService
         }
         catch ( Exception e )
         {
-
-            if ( params.hasJobConfiguration() )
-            {
-                notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Failed with exception: " + e.getMessage(), true );
-                notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
-            }
-            importReport.setStatus( TrackerStatus.ERROR );
-           
+            
             TrackerValidationReport tvr = importReport.getTrackerValidationReport();
             
             if ( tvr == null )
@@ -154,8 +147,15 @@ public class DefaultTrackerImportService
             
             tvr.getErrorReports().add(new TrackerErrorReport( null, "Exception:"+e.getMessage(), TrackerErrorCode.E9999, 0, null, null, null, null ));
             importReport.setTrackerValidationReport( tvr );
+            importReport.setStatus( TrackerStatus.ERROR );
             
-            //TODO: Should this be rethrown in case of sync? Or is the error report added to the import report in the line above enough?
+            if ( params.hasJobConfiguration() )
+            {
+                notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Failed with exception: " + e.getMessage(), true );
+                notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
+            }
+            
+            //TODO: Should this be rethrown in case of sync? Or is the error report added to the import report in the above lines enough?
             throw e;
 
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -43,6 +43,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundleMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundleParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundleService;
 import org.hisp.dhis.tracker.preprocess.TrackerPreprocessService;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
@@ -139,9 +141,20 @@ public class DefaultTrackerImportService
             if ( params.hasJobConfiguration() )
             {
                 notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Failed with exception: " + e.getMessage(), true );
-                importReport.setStatus( TrackerStatus.ERROR );
                 notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
             }
+            importReport.setStatus( TrackerStatus.ERROR );
+           
+            TrackerValidationReport tvr = importReport.getTrackerValidationReport();
+            
+            if ( tvr == null )
+            {
+                tvr = new TrackerValidationReport();
+            }
+            
+            tvr.getErrorReports().add(new TrackerErrorReport( null, "Exception:"+e.getMessage(), TrackerErrorCode.E9999, 0, null, null, null, null ));
+         
+            //TODO: Should this be rethrown in case of sync? Or is the error report added to the import report in the line above enough?
             throw e;
 
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -102,32 +102,50 @@ public class DefaultTrackerImportService
         {
             notifier.notify( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Start" );
         }
-
-        List<TrackerBundle> trackerBundles = preheatBundle( params, importReport );
-
-        trackerBundles = preProcessBundle( trackerBundles, importReport );
-
-        TrackerValidationReport validationReport = validateBundle( params, importReport, trackerBundles );
-
-        if ( validationReport.hasErrors() && params.getAtomicMode() == AtomicMode.ALL )
+        
+        try
         {
-            importReport.setStatus( TrackerStatus.ERROR );
-        }
-        else
-        {
-            if ( TrackerImportStrategy.DELETE == params.getImportStrategy() )
+
+            List<TrackerBundle> trackerBundles = preheatBundle( params, importReport );
+
+            trackerBundles = preProcessBundle( trackerBundles, importReport );
+
+            TrackerValidationReport validationReport = validateBundle( params, importReport, trackerBundles );
+
+            if ( validationReport.hasErrors() && params.getAtomicMode() == AtomicMode.ALL )
             {
-                deleteBundle( params, importReport, trackerBundles );
+                importReport.setStatus( TrackerStatus.ERROR );
             }
             else
             {
-                commitBundle( params, importReport, trackerBundles );
+                if ( TrackerImportStrategy.DELETE == params.getImportStrategy() )
+                {
+                    deleteBundle( params, importReport, trackerBundles );
+                }
+                else
+                {
+                    commitBundle( params, importReport, trackerBundles );
+                }
             }
+
+            importReport.getTimings().setTotalImport( requestTimer.toString() );
+
+            TrackerBundleReportModeUtils.filter( importReport, params.getReportMode() );
+
+        }
+        catch ( Exception e )
+        {
+
+            if ( params.hasJobConfiguration() )
+            {
+                notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Failed with exception: " + e.getMessage(), true );
+                importReport.setStatus( TrackerStatus.ERROR );
+                notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
+            }
+            throw e;
+
         }
 
-        importReport.getTimings().setTotalImport( requestTimer.toString() );
-
-        TrackerBundleReportModeUtils.filter( importReport, params.getReportMode() );
 
         if ( params.hasJobConfiguration() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -153,7 +153,8 @@ public class DefaultTrackerImportService
             }
             
             tvr.getErrorReports().add(new TrackerErrorReport( null, "Exception:"+e.getMessage(), TrackerErrorCode.E9999, 0, null, null, null, null ));
-         
+            importReport.setTrackerValidationReport( tvr );
+            
             //TODO: Should this be rethrown in case of sync? Or is the error report added to the import report in the line above enough?
             throw e;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -56,10 +56,13 @@ import org.springframework.util.StringUtils;
 
 import com.google.common.base.Enums;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Service
+@Slf4j
 public class DefaultTrackerImportService
     implements TrackerImportService
 {
@@ -137,6 +140,7 @@ public class DefaultTrackerImportService
         }
         catch ( Exception e )
         {
+            log.error( "Exception thrown during import.",e );
             
             TrackerValidationReport tvr = importReport.getTrackerValidationReport();
             

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -95,6 +95,16 @@ public class TrackerErrorReport
         this.value = value;
 
     }
+    
+    public TrackerErrorReport( String errorMessage, TrackerErrorCode errorCode )
+    {
+        this.errorMessage = errorMessage;
+        this.errorCode = errorCode;
+        this.mainKlass = null;
+        this.lineNumber = 0;
+        this.errorProperties = null;
+        
+    }
 
     @JsonProperty
     public TrackerErrorCode getErrorCode()

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -135,8 +135,9 @@ public class ContextUtilsTest
         assertEquals( "max-age=1209600, public", response.getHeader( "Cache-Control" ) );
 
         response.reset();
+        long secondsTo6Tomorrow = CACHE_6AM_TOMORROW.toSeconds();
         contextUtils.configureResponse( response, null, CACHE_6AM_TOMORROW, null, false );
-        assertEquals( "max-age=" + CACHE_6AM_TOMORROW.toSeconds() + ", public", response.getHeader( "Cache-Control" ) );
+        assertEquals( "max-age=" + secondsTo6Tomorrow + ", public", response.getHeader( "Cache-Control" ) );
 
         response.reset();
         systemSettingManager.saveSystemSetting( CACHE_STRATEGY, getAsRealClass( CACHE_STRATEGY.getName(), CACHE_1_HOUR.toString() ) );

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -135,9 +135,8 @@ public class ContextUtilsTest
         assertEquals( "max-age=1209600, public", response.getHeader( "Cache-Control" ) );
 
         response.reset();
-        long secondsTo6Tomorrow = CACHE_6AM_TOMORROW.toSeconds();
         contextUtils.configureResponse( response, null, CACHE_6AM_TOMORROW, null, false );
-        assertEquals( "max-age=" + secondsTo6Tomorrow + ", public", response.getHeader( "Cache-Control" ) );
+        assertEquals( "max-age=" + CACHE_6AM_TOMORROW.toSeconds() + ", public", response.getHeader( "Cache-Control" ) );
 
         response.reset();
         systemSettingManager.saveSystemSetting( CACHE_STRATEGY, getAsRealClass( CACHE_STRATEGY.getName(), CACHE_1_HOUR.toString() ) );


### PR DESCRIPTION
Added an try catch block around the new tracker import service flow, to catch any unhandled exceptions. 
In case of exceptions, the import report and job summary in notifier will reflect the same with exception error message in it. 