### PR TITLE
fix: Use orgunit name instead of UID for Report Table download

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/DimensionDescriptor.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/DimensionDescriptor.java
@@ -1,0 +1,131 @@
+package org.hisp.dhis.visualization;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.hisp.dhis.common.DimensionalObject.ATTRIBUTEOPTIONCOMBO_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.CATEGORYOPTIONCOMBO_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+
+import java.util.List;
+
+import org.hisp.dhis.common.DimensionType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This class is used to hold the association between a dimension and its type.
+ * Its main goal is to track the associations across dynamic dimensions and
+ * their actual type.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class DimensionDescriptor
+{
+    private String dimension;
+
+    private DimensionType type;
+
+    public boolean hasDimension( final String dimension )
+    {
+        return trimToEmpty( dimension ).equalsIgnoreCase( trimToEmpty( getDimension() ) );
+    }
+
+    /**
+     * Based on the given dimension and the given DimensionDescriptor list, this
+     * method will retrieve the respective dimension identifier. See the examples
+     * below.
+     *
+     * For regular dimensions: a "dimension" `dx` will have a type of
+     * {@link DimensionType#DATA_X}. Hence the dimension identifier returned will be
+     * `dx`.
+     *
+     * For dynamic dimensions: a "dimension" `mq4jAnN6fg3` (of an org unit, for
+     * example), will have a type of {@link DimensionType#ORGANISATION_UNIT}. Hence
+     * the dimension identifier returned by this method will be `ou`.
+     *
+     * @param dimensionDescriptors the list of descriptors to be compared.
+     * @param dimension the value to be retrieved from the list of
+     *        dimensionDescriptors
+     * @return the respective descriptive value
+     */
+    public static String getDimensionIdentifierFor( final String dimension,
+        final List<DimensionDescriptor> dimensionDescriptors )
+    {
+        if ( isNotEmpty( dimensionDescriptors ) )
+        {
+            // For each dimension descriptor
+            for ( final DimensionDescriptor dimensionDescriptor : dimensionDescriptors )
+            {
+                if ( dimensionDescriptor.hasDimension( dimension ) )
+                {
+                    // Returns the string/value associated with the dimension type.
+                    return dimensionDescriptor.getDimensionIdentifier();
+                }
+            }
+        }
+
+        return dimension;
+    }
+
+    /**
+     * This method will return the respective dimension identifier associated with
+     * the current dimension {@link #type}.
+     *
+     * @return the dimension identifier. See
+     *         {@link org.hisp.dhis.common.DimensionalObject} for the list of
+     *         possible dimension identifiers.
+     */
+    private String getDimensionIdentifier()
+    {
+        switch ( getType() )
+        {
+        case ATTRIBUTE_OPTION_COMBO:
+            return ATTRIBUTEOPTIONCOMBO_DIM_ID;
+        case CATEGORY_OPTION_COMBO:
+            return CATEGORYOPTIONCOMBO_DIM_ID;
+        case DATA_X:
+            return DATA_X_DIM_ID;
+        case ORGANISATION_UNIT:
+        case ORGANISATION_UNIT_GROUP_SET:
+            return ORGUNIT_DIM_ID;
+        case PERIOD:
+            return PERIOD_DIM_ID;
+        default:
+            return EMPTY;
+        }
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/DimensionDescriptorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/DimensionDescriptorTest.java
@@ -1,0 +1,118 @@
+package org.hisp.dhis.visualization;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hisp.dhis.common.DimensionType.DATA_X;
+import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.visualization.DimensionDescriptor.getDimensionIdentifierFor;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.hisp.dhis.common.DimensionType;
+import org.junit.Test;
+
+public class DimensionDescriptorTest
+{
+    @Test
+    public void testHasDimensionWithSuccess()
+    {
+        // Given
+        final String anyDimensionValue = "dx";
+        final DimensionType theDimensionType = DATA_X;
+        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, theDimensionType );
+        final String dimensionAbbreviation = "dx";
+
+        // When
+        final boolean actualResult = aDimensionDescriptor.hasDimension( dimensionAbbreviation );
+
+        // Then
+        assertThat( actualResult, is( true ) );
+    }
+
+    @Test
+    public void testHasDimensionFails()
+    {
+        // Given
+        final String anyDimensionValue = "dx";
+        final DimensionType theDimensionType = DATA_X;
+        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, theDimensionType );
+        final String nonExistingDimensionAbbreviation = "ou";
+
+        // When
+        final boolean actualResult = aDimensionDescriptor.hasDimension( nonExistingDimensionAbbreviation );
+
+        // Then
+        assertThat( actualResult, is( false ) );
+    }
+
+    @Test
+    public void testRetrieveDescriptiveValue()
+    {
+        // Given
+        final String anyDimensionDynamicValue = "ZyxerTyuP";
+        final List<DimensionDescriptor> someDimensionDescriptors = mockDimensionDescriptors( anyDimensionDynamicValue );
+        final String theDimensionToRetrieve = "dx";
+
+        // When
+        final String actualResult = getDimensionIdentifierFor( theDimensionToRetrieve,
+                someDimensionDescriptors );
+
+        // Then
+        assertThat( actualResult, is( DATA_X_DIM_ID ) );
+    }
+
+    @Test
+    public void testRetrieveDescriptiveValueDynamicValue()
+    {
+        // Given
+        final String theDynamicDimensionToRetrieve = "ZyxerTyuP";
+        final List<DimensionDescriptor> someDimensionDescriptors = mockDimensionDescriptors(
+                theDynamicDimensionToRetrieve );
+
+        // When
+        final String actualResult = getDimensionIdentifierFor( theDynamicDimensionToRetrieve,
+                someDimensionDescriptors );
+
+        // Then
+        assertThat( actualResult, is( ORGUNIT_DIM_ID ) );
+    }
+
+    private List<DimensionDescriptor> mockDimensionDescriptors( final String orgUnitDynamicDimension )
+    {
+        final DimensionDescriptor dx = new DimensionDescriptor( "dx", DATA_X );
+        final DimensionDescriptor dynamicOu = new DimensionDescriptor( orgUnitDynamicDimension, ORGANISATION_UNIT );
+
+        return asList( dx, dynamicOu );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -231,6 +231,8 @@ public class DefaultAnalyticsService
         {
             for ( String dimension : columns )
             {
+                visualization.addDimensionDescriptor( dimension, params.getDimension( dimension ).getDimensionType() );
+
                 visualization.getColumnDimensions().add( dimension );
                 tableColumns.add( params.getDimensionItemsExplodeCoc( dimension ) );
             }
@@ -240,6 +242,8 @@ public class DefaultAnalyticsService
         {
             for ( String dimension : rows )
             {
+                visualization.addDimensionDescriptor( dimension, params.getDimension( dimension ).getDimensionType() );
+
                 visualization.getRowDimensions().add( dimension );
                 tableRows.add( params.getDimensionItemsExplodeCoc( dimension ) );
             }


### PR DESCRIPTION
This is just a backport from master. This fix was merged into master this morning.