### PR TITLE
fix: Use orgunit name instead of UID for Report Table download

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/DimensionDescriptor.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/DimensionDescriptor.java
@@ -1,0 +1,131 @@
+package org.hisp.dhis.visualization;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.hisp.dhis.common.DimensionalObject.ATTRIBUTEOPTIONCOMBO_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.CATEGORYOPTIONCOMBO_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+
+import java.util.List;
+
+import org.hisp.dhis.common.DimensionType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This class is used to hold the association between a dimension and its type.
+ * Its main goal is to track the associations across dynamic dimensions and
+ * their actual type.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class DimensionDescriptor
+{
+    private String dimension;
+
+    private DimensionType type;
+
+    public boolean hasDimension( final String dimension )
+    {
+        return trimToEmpty( dimension ).equalsIgnoreCase( trimToEmpty( getDimension() ) );
+    }
+
+    /**
+     * Based on the given dimension and the given DimensionDescriptor list, this
+     * method will retrieve the respective dimension identifier. See the examples
+     * below.
+     *
+     * For regular dimensions: a "dimension" `dx` will have a type of
+     * {@link DimensionType#DATA_X}. Hence the dimension identifier returned will be
+     * `dx`.
+     *
+     * For dynamic dimensions: a "dimension" `mq4jAnN6fg3` (of an org unit, for
+     * example), will have a type of {@link DimensionType#ORGANISATION_UNIT}. Hence
+     * the dimension identifier returned by this method will be `ou`.
+     *
+     * @param dimensionDescriptors the list of descriptors to be compared.
+     * @param dimension the value to be retrieved from the list of
+     *        dimensionDescriptors
+     * @return the respective descriptive value
+     */
+    public static String getDimensionIdentifierFor( final String dimension,
+        final List<DimensionDescriptor> dimensionDescriptors )
+    {
+        if ( isNotEmpty( dimensionDescriptors ) )
+        {
+            // For each dimension descriptor
+            for ( final DimensionDescriptor dimensionDescriptor : dimensionDescriptors )
+            {
+                if ( dimensionDescriptor.hasDimension( dimension ) )
+                {
+                    // Returns the string/value associated with the dimension type.
+                    return dimensionDescriptor.getDimensionIdentifier();
+                }
+            }
+        }
+
+        return dimension;
+    }
+
+    /**
+     * This method will return the respective dimension identifier associated with
+     * the current dimension {@link #type}.
+     *
+     * @return the dimension identifier. See
+     *         {@link org.hisp.dhis.common.DimensionalObject} for the list of
+     *         possible dimension identifiers.
+     */
+    private String getDimensionIdentifier()
+    {
+        switch ( getType() )
+        {
+        case ATTRIBUTE_OPTION_COMBO:
+            return ATTRIBUTEOPTIONCOMBO_DIM_ID;
+        case CATEGORY_OPTION_COMBO:
+            return CATEGORYOPTIONCOMBO_DIM_ID;
+        case DATA_X:
+            return DATA_X_DIM_ID;
+        case ORGANISATION_UNIT:
+        case ORGANISATION_UNIT_GROUP_SET:
+            return ORGUNIT_DIM_ID;
+        case PERIOD:
+            return PERIOD_DIM_ID;
+        default:
+            return EMPTY;
+        }
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -34,13 +34,14 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import org.apache.commons.lang3.StringUtils;
+
 import org.hisp.dhis.analytics.NumberType;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.color.ColorSet;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.CombinationGenerator;
+import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
@@ -84,6 +85,7 @@ import static org.hisp.dhis.common.DimensionalObjectUtils.getSortedKeysMap;
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
+import static org.hisp.dhis.visualization.DimensionDescriptor.getDimensionIdentifierFor;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 
 @JacksonXmlRootElement( localName = "visualization", namespace = DXF_2_0 )
@@ -349,6 +351,8 @@ public class Visualization
     private transient List<List<DimensionalItemObject>> gridColumns = new ArrayList<>();
 
     private transient List<List<DimensionalItemObject>> gridRows = new ArrayList<>();
+
+    private transient List<DimensionDescriptor> dimensionDescriptors = new ArrayList<>();
 
     public Visualization()
     {
@@ -1049,6 +1053,30 @@ public class Visualization
         this.yearlySeries = yearlySeries;
     }
 
+    /**
+     * Returns the list of DimensionDescriptor held internally to the current Visualization object.
+     * See {@link #addDimensionDescriptor}.
+     *
+     * @return the list of DimensionDescriptor's held.
+     */
+    public List<DimensionDescriptor> getDimensionDescriptors()
+    {
+        return dimensionDescriptors;
+    }
+
+    /**
+     * This method will hold the mapping of a dimension and its respective formal
+     * type.
+     *
+     * @param dimension the dimension, which should also be found in
+     *        "{@link #columnDimensions}" and "{@link #rowDimensions}".
+     * @param dimensionType the formal dimension type. See {@link DimensionType}
+     */
+    public void addDimensionDescriptor( final String dimension, final DimensionType dimensionType )
+    {
+        this.dimensionDescriptors.add( new DimensionDescriptor( dimension, dimensionType ) );
+    }
+
     @Override
     public void init( final User user, final Date date, final OrganisationUnit organisationUnit,
         final List<OrganisationUnit> organisationUnitsAtLevel, final List<OrganisationUnit> organisationUnitsInGroups,
@@ -1412,10 +1440,11 @@ public class Visualization
         final Map<String, String> metaData = getMetaData();
         metaData.putAll( PRETTY_NAMES );
 
-        for ( String row : rowDimensions )
+        for ( String dimension : rowDimensions )
         {
-            final String name = StringUtils.defaultIfEmpty( metaData.get( row ), row );
-            final String col = StringUtils.defaultIfEmpty( COLUMN_NAMES.get( row ), row );
+            final String dimensionId = getDimensionIdentifierFor( dimension, getDimensionDescriptors() );
+            final String name = defaultIfEmpty( metaData.get( dimensionId ), dimensionId );
+            final String col = defaultIfEmpty( COLUMN_NAMES.get( dimensionId ), dimensionId );
 
             grid.addHeader( new GridHeader( name + " ID", col + "id", TEXT, String.class.getName(), true, true ) );
             grid.addHeader( new GridHeader( name, col + "name", TEXT, String.class.getName(), false, true ) );

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/DimensionDescriptorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/DimensionDescriptorTest.java
@@ -1,0 +1,117 @@
+package org.hisp.dhis.visualization;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hisp.dhis.common.DimensionType.DATA_X;
+import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.visualization.DimensionDescriptor.getDimensionIdentifierFor;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.hisp.dhis.common.DimensionType;
+import org.junit.Test;
+
+public class DimensionDescriptorTest
+{
+    @Test
+    public void testHasDimensionWithSuccess()
+    {
+        // Given
+        final String anyDimensionValue = "dx";
+        final DimensionType theDimensionType = DATA_X;
+        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, theDimensionType );
+        final String dimensionAbbreviation = "dx";
+
+        // When
+        final boolean actualResult = aDimensionDescriptor.hasDimension( dimensionAbbreviation );
+
+        // Then
+        assertThat( actualResult, is( true ) );
+    }
+
+    @Test
+    public void testHasDimensionFails()
+    {
+        // Given
+        final String anyDimensionValue = "dx";
+        final DimensionType theDimensionType = DATA_X;
+        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, theDimensionType );
+        final String nonExistingDimensionAbbreviation = "ou";
+
+        // When
+        final boolean actualResult = aDimensionDescriptor.hasDimension( nonExistingDimensionAbbreviation );
+
+        // Then
+        assertThat( actualResult, is( false ) );
+    }
+
+    @Test
+    public void testRetrieveDescriptiveValue()
+    {
+        // Given
+        final String anyDimensionDynamicValue = "ZyxerTyuP";
+        final List<DimensionDescriptor> someDimensionDescriptors = mockDimensionDescriptors( anyDimensionDynamicValue );
+        final String theDimensionToRetrieve = "dx";
+
+        // When
+        final String actualResult = getDimensionIdentifierFor( theDimensionToRetrieve, someDimensionDescriptors );
+
+        // Then
+        assertThat( actualResult, is( DATA_X_DIM_ID ) );
+    }
+
+    @Test
+    public void testRetrieveDescriptiveValueDynamicValue()
+    {
+        // Given
+        final String theDynamicDimensionToRetrieve = "ZyxerTyuP";
+        final List<DimensionDescriptor> someDimensionDescriptors = mockDimensionDescriptors(
+            theDynamicDimensionToRetrieve );
+
+        // When
+        final String actualResult = getDimensionIdentifierFor( theDynamicDimensionToRetrieve,
+            someDimensionDescriptors );
+
+        // Then
+        assertThat( actualResult, is( ORGUNIT_DIM_ID ) );
+    }
+
+    private List<DimensionDescriptor> mockDimensionDescriptors( final String orgUnitDynamicDimension )
+    {
+        final DimensionDescriptor dx = new DimensionDescriptor( "dx", DATA_X );
+        final DimensionDescriptor dynamicOu = new DimensionDescriptor( orgUnitDynamicDimension, ORGANISATION_UNIT );
+
+        return asList( dx, dynamicOu );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -1004,6 +1004,8 @@ public class DefaultAnalyticsService
         {
             for ( String dimension : columns )
             {
+                visualization.addDimensionDescriptor( dimension, params.getDimension( dimension ).getDimensionType() );
+
                 visualization.getColumnDimensions().add( dimension );
                 tableColumns.add( params.getDimensionItemsExplodeCoc( dimension ) );
             }
@@ -1013,6 +1015,8 @@ public class DefaultAnalyticsService
         {
             for ( String dimension : rows )
             {
+                visualization.addDimensionDescriptor( dimension, params.getDimension( dimension ).getDimensionType() );
+
                 visualization.getRowDimensions().add( dimension );
                 tableRows.add( params.getDimensionItemsExplodeCoc( dimension ) );
             }


### PR DESCRIPTION
This is just a backport from master. This fix was merged into master this morning.