### PR TITLE
fix: [DHIS2-9411] assigned user related filters in hql formation (2.35)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -821,10 +821,10 @@ public class HibernateTrackedEntityInstanceStore
             () -> "(au.uid in (" + getQuotedCommaDelimitedString( params.getAssignedUsers() ) + ")) and" );
 
         hql += addConditionally( params.isIncludeOnlyUnassignedEvents(),
-            () -> "(psi.assigneduserid is null) and" );
+            () -> "(psi.assignedUser is null) and" );
 
         hql += addConditionally( params.isIncludeOnlyAssignedEvents(),
-            () -> "(psi.assigneduserid is not null) and" );
+            () -> "(psi.assignedUser is not null) and" );
 
         hql += " psi.deleted=false ";
 


### PR DESCRIPTION
Corrected hql snippet to use the correct object structure instead of sql