### PR TITLE
fix: [DHIS2-9410] include tei parameter when searching for existing psi (2.35)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
@@ -54,7 +54,12 @@ public class ProgramInstanceRepeatableStageCheck implements Checker
         ProgramStage programStage = ctx.getProgramStage( scheme, event.getProgramStage() );
         ProgramInstance programInstance = ctx.getProgramInstanceMap().get( event.getUid() );
         Program program = ctx.getProgramsMap().get( event.getProgram() );
-        TrackedEntityInstance tei = ctx.getTrackedEntityInstanceMap().get( event.getUid() ).getLeft();
+        TrackedEntityInstance tei = null;
+        
+        if ( program.isRegistration() )
+        {
+            tei = ctx.getTrackedEntityInstanceMap().get( event.getUid() ).getLeft();
+        }
 
         /*
          * ProgramInstance should never be null. If it's null, the ProgramInstanceCheck

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
@@ -53,6 +54,7 @@ public class ProgramInstanceRepeatableStageCheck implements Checker
         ProgramStage programStage = ctx.getProgramStage( scheme, event.getProgramStage() );
         ProgramInstance programInstance = ctx.getProgramInstanceMap().get( event.getUid() );
         Program program = ctx.getProgramsMap().get( event.getProgram() );
+        TrackedEntityInstance tei = ctx.getTrackedEntityInstanceMap().get( event.getTrackedEntityInstance() ).getLeft();
 
         /*
          * ProgramInstance should never be null. If it's null, the ProgramInstanceCheck
@@ -62,7 +64,7 @@ public class ProgramInstanceRepeatableStageCheck implements Checker
         if ( programInstance != null && 
              program.isRegistration() && 
              !programStage.getRepeatable() && 
-             hasProgramStageInstance( ctx.getServiceDelegator().getJdbcTemplate(), programStage.getUid() ) )
+             hasProgramStageInstance( ctx.getServiceDelegator().getJdbcTemplate(), programStage.getId(), tei.getId() ) )
         {
             return new ImportSummary( ImportStatus.ERROR,
                 "Program stage is not repeatable and an event already exists" ).setReference( event.getEvent() )
@@ -73,20 +75,20 @@ public class ProgramInstanceRepeatableStageCheck implements Checker
         return success();
     }
 
-    private boolean hasProgramStageInstance( JdbcTemplate jdbcTemplate, String programStageUid )
+    private boolean hasProgramStageInstance( JdbcTemplate jdbcTemplate, long programStageId, long trackedEntityInstanceId )
     {
         // @formatter:off
         final String sql = "select exists( " +
                 "select * " +
                 "from programstageinstance psi " +
                 "  join programinstance pi on psi.programinstanceid = pi.programinstanceid " +
-                "  join programstage ps on psi.programstageid = ps.programstageid " +
-                "where ps.uid = ? " +
+                "where psi.programstageid = ? " +
                 "  and psi.deleted = false " +
+                "  and pi.trackedentityinstanceid = ? " +
                 "  and psi.status != 'SKIPPED'" +
                 ")";
         // @formatter:on
 
-        return jdbcTemplate.queryForObject( sql, Boolean.class, programStageUid );
+        return jdbcTemplate.queryForObject( sql, Boolean.class, programStageId, trackedEntityInstanceId );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
@@ -54,7 +54,7 @@ public class ProgramInstanceRepeatableStageCheck implements Checker
         ProgramStage programStage = ctx.getProgramStage( scheme, event.getProgramStage() );
         ProgramInstance programInstance = ctx.getProgramInstanceMap().get( event.getUid() );
         Program program = ctx.getProgramsMap().get( event.getProgram() );
-        TrackedEntityInstance tei = ctx.getTrackedEntityInstanceMap().get( event.getTrackedEntityInstance() ).getLeft();
+        TrackedEntityInstance tei = ctx.getTrackedEntityInstanceMap().get( event.getUid() ).getLeft();
 
         /*
          * ProgramInstance should never be null. If it's null, the ProgramInstanceCheck

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/ProgramInstanceRepeatableStageCheck.java
@@ -67,6 +67,7 @@ public class ProgramInstanceRepeatableStageCheck implements Checker
          */
         // @formatter:off
         if ( programInstance != null && 
+             tei != null &&
              program.isRegistration() && 
              !programStage.getRepeatable() && 
              hasProgramStageInstance( ctx.getServiceDelegator().getJdbcTemplate(), programStage.getId(), tei.getId() ) )


### PR DESCRIPTION
1. Added tei id into where clause when checking for existing programstageinstace
2. Removed an extra join , and used "id" columns instead of "uid"