### PR TITLE
perf: [DHIS-9415] avoid querying programstageinstancecomments if not necessary

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventCommentStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventCommentStore.java
@@ -28,57 +28,21 @@ package org.hisp.dhis.dxf2.events.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.dxf2.events.report.EventRow;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.user.User;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
-public interface EventStore
+public interface EventCommentStore
 {
     /**
-     * Inserts a List of {@see ProgramStageInstance}. Notes are not stored
-     * at this stage.
+     * Inserts non-empty comments from a List {@see ProgramStageInstance}
      *
      * @param programStageInstances a List of {@see ProgramStageInstance}
-     *
-     * @return a list of saved program stage instances
+     * 
      */
-    List<ProgramStageInstance> saveEvents(List<ProgramStageInstance> programStageInstances );
+    void saveAllComments( List<ProgramStageInstance> programStageInstances );
 
-    /**
-     * Updates a List of {@see ProgramStageInstance}. Notes are not stored
-     * at this stage.
-     *
-     * @param programStageInstances a List of {@see ProgramStageInstance}
-     *
-     * @return a list of saved program stage instances
-     */
-    List<ProgramStageInstance> updateEvents(List<ProgramStageInstance> programStageInstances );
-
-    List<Event> getEvents( EventSearchParams params, List<OrganisationUnit> organisationUnits,
-        Map<String, Set<String>> psdesWithSkipSyncTrue );
-
-    List<Map<String, String>> getEventsGrid( EventSearchParams params, List<OrganisationUnit> organisationUnits );
-
-    List<EventRow> getEventRows( EventSearchParams params, List<OrganisationUnit> organisationUnits );
-
-    int getEventCount( EventSearchParams params, List<OrganisationUnit> organisationUnits );
-
-    /**
-     * Delete list of given events to be removed. This operation also remove comments
-     * connected to each Event.
-     *
-     * @param events List to be removed
-     */
-    void delete( List<Event> events );
-
-    void updateTrackedEntityInstances( List<String> teiUid, User user );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStore.java
@@ -52,7 +52,7 @@ import lombok.extern.slf4j.Slf4j;
 @Repository
 @RequiredArgsConstructor
 @Slf4j
-public class JdbcEventCommentStore
+public class JdbcEventCommentStore implements EventCommentStore
 {
 
     private final JdbcTemplate jdbcTemplate;
@@ -74,11 +74,11 @@ public class JdbcEventCommentStore
      *
      * @param batch a List of {@see ProgramStageInstance}
      */
-    void saveAllComments( List<ProgramStageInstance> batch )
+    public void saveAllComments( List<ProgramStageInstance> batch )
     {
         try
         {
-            // List of PSI that has at least one non empty comment (i.e. PSO having comments
+            // List of PSI that has at least one non empty comment (i.e. PSI having comments
             // that can actually be saved)
             // In resulting PSI list, all comments without text are removed.
             List<ProgramStageInstance> programStageInstances = batch.stream()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStore.java
@@ -1,0 +1,199 @@
+package org.hisp.dhis.dxf2.events.event;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static java.util.stream.Collectors.toList;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Giuseppe Nespolino <g.nespolino@gmail.com>
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class JdbcEventCommentStore
+{
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private final String INSERT_EVENT_NOTE_SQL = "INSERT INTO TRACKEDENTITYCOMMENT (trackedentitycommentid, " + // 0
+        "uid, " + // 1
+        "commenttext, " + // 2
+        "created, " + // 3
+        "creator," + // 4
+        "lastUpdated" + // 5
+        ")  values ( nextval('hibernate_sequence'), ?, ?, ?, ?, ?)";
+
+    private final static String INSERT_EVENT_COMMENT_LINK = "INSERT INTO programstageinstancecomments (programstageinstanceid, "
+        + "sort_order, trackedentitycommentid) values (?, ?, ?)";
+
+    /**
+     * Save all the comments ({@see TrackedEntityComment} for the list of
+     * {@see ProgramStageInstance}
+     *
+     * @param batch a List of {@see ProgramStageInstance}
+     */
+    void saveAllComments( List<ProgramStageInstance> batch )
+    {
+        try
+        {
+            // List of PSI that has at least one non empty comment (i.e. PSO having comments
+            // that can actually be saved)
+            // In resulting PSI list, all comments without text are removed.
+            List<ProgramStageInstance> programStageInstances = batch.stream()
+                .map( this::withoutEmptyComments )
+                .filter( this::hasComments )
+                .collect( toList() );
+
+            for ( ProgramStageInstance psi : programStageInstances )
+            {
+                Integer sortOrder = getInitialSortOrder( psi );
+
+                for ( TrackedEntityComment comment : psi.getComments() )
+                {
+                    Long commentId = saveComment( comment );
+                    if ( commentId != null && commentId != 0 )
+                    {
+                        saveCommentToEvent( psi.getId(), commentId, sortOrder );
+                        sortOrder++;
+                    }
+                }
+            }
+        }
+        catch ( DataAccessException dae )
+        {
+            log.error( "An error occurred saving a Program Stage Instance comment", dae );
+            throw dae;
+        }
+    }
+
+    private boolean hasComments( ProgramStageInstance programStageInstance )
+    {
+        return CollectionUtils.isNotEmpty( programStageInstance.getComments() );
+    }
+
+    Integer getInitialSortOrder( ProgramStageInstance psi )
+    {
+        if ( psi.getId() > 0 )
+        {
+            // if the PSI is already in the db, fetch the latest sort order for the
+            // notes, to avoid conflicts
+            return jdbcTemplate.queryForObject(
+                "select coalesce(max(sort_order) + 1, 1) from programstageinstancecomments where programstageinstanceid = "
+                    + psi.getId(),
+                Integer.class );
+        }
+        return 1;
+    }
+
+    private ProgramStageInstance withoutEmptyComments( ProgramStageInstance programStageInstance )
+    {
+        programStageInstance.setComments( getNonEmptyComments( programStageInstance ) );
+        return programStageInstance;
+    }
+
+    private List<TrackedEntityComment> getNonEmptyComments( ProgramStageInstance programStageInstance )
+    {
+        return programStageInstance.getComments().stream()
+            .filter( this::hasCommentText )
+            .collect( toList() );
+    }
+
+    private boolean hasCommentText( TrackedEntityComment trackedEntityComment )
+    {
+        return StringUtils.isNotEmpty( trackedEntityComment.getCommentText() );
+    }
+
+    Long saveComment( TrackedEntityComment comment )
+    {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        try
+        {
+            jdbcTemplate.update( connection -> {
+                PreparedStatement ps = connection.prepareStatement( INSERT_EVENT_NOTE_SQL,
+                    new String[] { "trackedentitycommentid" } );
+
+                ps.setString( 1, comment.getUid() );
+                ps.setString( 2, comment.getCommentText() );
+                ps.setTimestamp( 3, JdbcEventSupport.toTimestamp( comment.getCreated() ) );
+                ps.setString( 4, comment.getCreator() );
+                ps.setTimestamp( 5, JdbcEventSupport.toTimestamp( comment.getLastUpdated() ) );
+
+                return ps;
+            }, keyHolder );
+        }
+        catch ( DataAccessException e )
+        {
+            log.error( "An error occurred saving a TrackedEntityComment", e );
+            return null;
+        }
+
+        return (Long) keyHolder.getKey();
+    }
+
+    void saveCommentToEvent( Long programStageInstanceId, Long commentId, int sortOrder )
+    {
+        try
+        {
+            jdbcTemplate.update( connection -> {
+                PreparedStatement ps = connection.prepareStatement( INSERT_EVENT_COMMENT_LINK );
+
+                ps.setLong( 1, programStageInstanceId );
+                ps.setInt( 2, sortOrder );
+                ps.setLong( 3, commentId );
+
+                return ps;
+            } );
+        }
+        catch ( DataAccessException e )
+        {
+            log.error(
+                "An error occurred saving a link between a TrackedEntityComment and a ProgramStageInstance with primary key: "
+                    + programStageInstanceId,
+                e );
+            throw e;
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -233,8 +233,6 @@ public class JdbcEventStore implements EventStore
 
     private final JdbcTemplate jdbcTemplate;
 
-    private final JdbcEventCommentStore jdbcEventCommentStore;
-
     private final CurrentUserService currentUserService;
 
     private final IdentifiableObjectManager manager;
@@ -248,9 +246,9 @@ public class JdbcEventStore implements EventStore
         .expireAfterWrite( 10, TimeUnit.SECONDS )
         .build();
 
-    public JdbcEventStore(StatementBuilder statementBuilder, JdbcTemplate jdbcTemplate,
-                          JdbcEventCommentStore jdbcEventCommentStore, @Qualifier("dataValueJsonMapper") ObjectMapper jsonMapper,
-                          CurrentUserService currentUserService, IdentifiableObjectManager identifiableObjectManager, Environment env)
+    public JdbcEventStore( StatementBuilder statementBuilder, JdbcTemplate jdbcTemplate,
+        @Qualifier( "dataValueJsonMapper" ) ObjectMapper jsonMapper,
+        CurrentUserService currentUserService, IdentifiableObjectManager identifiableObjectManager, Environment env )
     {
         checkNotNull( statementBuilder );
         checkNotNull( jdbcTemplate );
@@ -261,7 +259,6 @@ public class JdbcEventStore implements EventStore
 
         this.statementBuilder = statementBuilder;
         this.jdbcTemplate = jdbcTemplate;
-        this.jdbcEventCommentStore = jdbcEventCommentStore;
         this.currentUserService = currentUserService;
         this.manager = identifiableObjectManager;
         this.jsonMapper = jsonMapper;
@@ -452,11 +449,11 @@ public class JdbcEventStore implements EventStore
         return events;
     }
 
-    public void saveEvents( List<ProgramStageInstance> events )
+    public List<ProgramStageInstance> saveEvents(List<ProgramStageInstance> events )
     {
         try
         {
-            jdbcEventCommentStore.saveAllComments( saveAllEvents( events ) );
+            return saveAllEvents( events );
         }
         catch ( Exception e )
         {
@@ -466,7 +463,7 @@ public class JdbcEventStore implements EventStore
     }
 
     @Override
-    public void updateEvents( List<ProgramStageInstance> programStageInstances )
+    public List<ProgramStageInstance> updateEvents(List<ProgramStageInstance> programStageInstances )
     {
         try
         {
@@ -489,7 +486,7 @@ public class JdbcEventStore implements EventStore
             throw e;
         }
 
-        jdbcEventCommentStore.saveAllComments( programStageInstances );
+        return programStageInstances;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -119,7 +119,6 @@ import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.security.acl.AccessStringHelper;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
@@ -130,8 +129,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementCallback;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Repository;
 
@@ -191,17 +188,6 @@ public class JdbcEventStore implements EventStore
         // @formatter:on
         "values ( nextval('programstageinstance_sequence'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )";
 
-    String INSERT_EVENT_NOTE_SQL = "INSERT INTO TRACKEDENTITYCOMMENT (trackedentitycommentid, " + // 0
-        "uid, " +           // 1
-        "commenttext, " +   // 2
-        "created, " +       // 3
-        "creator," +        // 4
-        "lastUpdated" +     // 5
-        ") " + "values ( nextval('hibernate_sequence'), ?, ?, ?, ?, ?)";
-
-    private final static String INSERT_EVENT_COMMENT_LINK = "INSERT INTO programstageinstancecomments (programstageinstanceid, "
-            + "sort_order, trackedentitycommentid) values (?, ?, ?)";
-
     private final static String UPDATE_EVENT_SQL = "update programstageinstance set " +
         // @formatter:off
         "programinstanceid = ?, " +         // 1
@@ -247,6 +233,8 @@ public class JdbcEventStore implements EventStore
 
     private final JdbcTemplate jdbcTemplate;
 
+    private final JdbcEventCommentStore jdbcEventCommentStore;
+
     private final CurrentUserService currentUserService;
 
     private final IdentifiableObjectManager manager;
@@ -260,9 +248,9 @@ public class JdbcEventStore implements EventStore
         .expireAfterWrite( 10, TimeUnit.SECONDS )
         .build();
 
-    public JdbcEventStore( StatementBuilder statementBuilder, JdbcTemplate jdbcTemplate,
-        @Qualifier( "dataValueJsonMapper" ) ObjectMapper jsonMapper, CurrentUserService currentUserService,
-        IdentifiableObjectManager identifiableObjectManager, Environment env )
+    public JdbcEventStore(StatementBuilder statementBuilder, JdbcTemplate jdbcTemplate,
+                          JdbcEventCommentStore jdbcEventCommentStore, @Qualifier("dataValueJsonMapper") ObjectMapper jsonMapper,
+                          CurrentUserService currentUserService, IdentifiableObjectManager identifiableObjectManager, Environment env)
     {
         checkNotNull( statementBuilder );
         checkNotNull( jdbcTemplate );
@@ -273,6 +261,7 @@ public class JdbcEventStore implements EventStore
 
         this.statementBuilder = statementBuilder;
         this.jdbcTemplate = jdbcTemplate;
+        this.jdbcEventCommentStore = jdbcEventCommentStore;
         this.currentUserService = currentUserService;
         this.manager = identifiableObjectManager;
         this.jsonMapper = jsonMapper;
@@ -467,7 +456,7 @@ public class JdbcEventStore implements EventStore
     {
         try
         {
-            saveAllComments( saveAllEvents( events ) );
+            jdbcEventCommentStore.saveAllComments( saveAllEvents( events ) );
         }
         catch ( Exception e )
         {
@@ -500,7 +489,7 @@ public class JdbcEventStore implements EventStore
             throw e;
         }
 
-        saveAllComments( programStageInstances );
+        jdbcEventCommentStore.saveAllComments( programStageInstances );
     }
 
     @Override
@@ -1575,102 +1564,6 @@ public class JdbcEventStore implements EventStore
         }
     }
 
-    /**
-     * Save all the comments ({@see TrackedEntityComment} for the list of
-     * {@see ProgramStageInstance}
-     * 
-     * @param batch a List of {@see ProgramStageInstance}
-     */
-    private void saveAllComments( List<ProgramStageInstance> batch )
-    {
-        try
-        {
-            for ( ProgramStageInstance psi : batch )
-            {
-                int sortOrder = 1;
-                if ( psi.getId() > 0 )
-                {
-                    // if the PSI is already in the db, fetch the latest sort order for the
-                    // notes, to avoid conflicts
-                    sortOrder = jdbcTemplate.queryForObject(
-                        "select coalesce(max(sort_order) + 1, 1) from programstageinstancecomments where programstageinstanceid = "
-                            + psi.getId(),
-                        Integer.class );
-                }
-                List<TrackedEntityComment> comments = psi.getComments();
-
-                for ( TrackedEntityComment comment : comments )
-                {
-                    if ( !StringUtils.isEmpty( comment.getCommentText() ) )
-                    {
-                        Long commentId = saveComment( comment );
-                        if ( commentId != null && commentId != 0 )
-                        {
-                            saveCommentToEvent( psi.getId(), commentId, sortOrder );
-                            sortOrder++;
-                        }
-                    }
-                }
-            }
-        }
-        catch ( DataAccessException dae )
-        {
-            log.error( "An error occurred saving a Program Stage Instance comment", dae );
-            throw dae;
-        }
-    }
-
-    private Long saveComment( TrackedEntityComment comment )
-    {
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-
-        try
-        {
-            jdbcTemplate.update( connection -> {
-                PreparedStatement ps = connection.prepareStatement( INSERT_EVENT_NOTE_SQL, new String[]{"trackedentitycommentid"} );
-
-                ps.setString( 1, comment.getUid() );
-                ps.setString( 2, comment.getCommentText() );
-                ps.setTimestamp( 3, toTimestamp( comment.getCreated() ) );
-                ps.setString( 4, comment.getCreator() );
-                ps.setTimestamp( 5, toTimestamp( comment.getLastUpdated() ) );
-
-                return ps;
-            }, keyHolder );
-        }
-        catch ( DataAccessException e )
-        {
-            log.error( "An error occurred saving a TrackedEntityComment", e );
-            return null;
-        }
-
-        return (long) keyHolder.getKey();
-    }
-
-    private void saveCommentToEvent( Long programStageInstanceId, Long commentId, int sortOrder )
-    {
-        try
-        {
-            jdbcTemplate.update( connection -> {
-                PreparedStatement ps = connection.prepareStatement( INSERT_EVENT_COMMENT_LINK );
-
-                ps.setLong( 1, programStageInstanceId );
-                ps.setInt( 2, sortOrder );
-                ps.setLong( 3, commentId );
-
-                return ps;
-            } );
-        }
-        catch ( DataAccessException e )
-        {
-            log.error(
-                "An error occurred saving a link between a TrackedEntityComment and a ProgramStageInstance with primary key: "
-                    + programStageInstanceId,
-                e );
-            throw e;
-        }
-    }
-
     public void updateTrackedEntityInstances( List<String> teiUids, User user )
     {
         if ( teiUids.isEmpty() )
@@ -1698,7 +1591,7 @@ public class JdbcEventStore implements EventStore
 
                 jdbcTemplate.execute( getUpdateTeiSql(), (PreparedStatementCallback<Boolean>) psc -> {
                     psc.setString( 1, result );
-                    psc.setTimestamp( 2, toTimestamp( new Date() ) );
+                    psc.setTimestamp( 2, JdbcEventSupport.toTimestamp( new Date() ) );
                     if ( user != null )
                     {
                         psc.setLong( 3, user.getId() );
@@ -1738,21 +1631,21 @@ public class JdbcEventStore implements EventStore
         // @formatter:off
         ps.setLong(         1, event.getProgramInstance().getId() );
         ps.setLong(         2, event.getProgramStage().getId() );
-        ps.setTimestamp(    3, toTimestamp( event.getDueDate() ) );
-        ps.setTimestamp(    4, toTimestamp( event.getExecutionDate() ) );
+        ps.setTimestamp(    3, JdbcEventSupport.toTimestamp( event.getDueDate() ) );
+        ps.setTimestamp(    4, JdbcEventSupport.toTimestamp( event.getExecutionDate() ) );
         ps.setLong(         5, event.getOrganisationUnit().getId() );
         ps.setString(       6, event.getStatus().toString() );
-        ps.setTimestamp(    7, toTimestamp( event.getCompletedDate() ) );
+        ps.setTimestamp(    7, JdbcEventSupport.toTimestamp( event.getCompletedDate() ) );
         ps.setString(       8, event.getUid() );
-        ps.setTimestamp(    9, toTimestamp( new Date() ) );
-        ps.setTimestamp(    10, toTimestamp( new Date() ) );
+        ps.setTimestamp(    9, JdbcEventSupport.toTimestamp( new Date() ) );
+        ps.setTimestamp(    10, JdbcEventSupport.toTimestamp( new Date() ) );
         ps.setLong(         11, event.getAttributeOptionCombo().getId() );
         ps.setString(       12, event.getStoredBy() );
         ps.setString(       13, event.getCompletedBy() );
         ps.setBoolean(      14, false );
         ps.setString(       15, event.getCode() );
-        ps.setTimestamp(    16, toTimestamp( event.getCreatedAtClient() ) );
-        ps.setTimestamp(    17, toTimestamp( event.getLastUpdatedAtClient() ) );
+        ps.setTimestamp(    16, JdbcEventSupport.toTimestamp( event.getCreatedAtClient() ) );
+        ps.setTimestamp(    17, JdbcEventSupport.toTimestamp( event.getLastUpdatedAtClient() ) );
         ps.setObject(       18, toGeometry( event.getGeometry() )  );
         if ( event.getAssignedUser() != null )
         {
@@ -1774,15 +1667,15 @@ public class JdbcEventStore implements EventStore
         ps.setTimestamp( 4, new Timestamp( programStageInstance.getExecutionDate().getTime() ) );
         ps.setLong( 5, programStageInstance.getOrganisationUnit().getId() );
         ps.setString( 6, programStageInstance.getStatus().toString() );
-        ps.setTimestamp( 7, toTimestamp( programStageInstance.getCompletedDate() ) );
-        ps.setTimestamp( 8, toTimestamp( new Date() ) );
+        ps.setTimestamp( 7, JdbcEventSupport.toTimestamp( programStageInstance.getCompletedDate() ) );
+        ps.setTimestamp( 8, JdbcEventSupport.toTimestamp( new Date() ) );
         ps.setLong( 9, programStageInstance.getAttributeOptionCombo().getId() );
         ps.setString( 10, programStageInstance.getStoredBy() );
         ps.setString( 11, programStageInstance.getCompletedBy() );
         ps.setBoolean( 12, programStageInstance.isDeleted() );
         ps.setString( 13, programStageInstance.getCode() );
-        ps.setTimestamp( 14, toTimestamp( programStageInstance.getCreatedAtClient() ) );
-        ps.setTimestamp( 15, toTimestamp( programStageInstance.getLastUpdatedAtClient() ) );
+        ps.setTimestamp( 14, JdbcEventSupport.toTimestamp( programStageInstance.getCreatedAtClient() ) );
+        ps.setTimestamp( 15, JdbcEventSupport.toTimestamp( programStageInstance.getLastUpdatedAtClient() ) );
         ps.setObject( 16, toGeometry( programStageInstance.getGeometry()  )  );
 
         if ( programStageInstance.getAssignedUser() != null )
@@ -1923,11 +1816,6 @@ public class JdbcEventStore implements EventStore
             params.setAccessibleProgramStages( manager.getDataReadAll( ProgramStage.class ).stream()
                     .map( ProgramStage::getUid ).collect( Collectors.toSet() ) );
         }
-    }
-
-    private Timestamp toTimestamp( Date date )
-    {
-        return date != null ? new Timestamp( date.getTime() ) : null;
     }
 
     private PGgeometry toGeometry( Geometry geometry )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventSupport.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventSupport.java
@@ -1,0 +1,16 @@
+package org.hisp.dhis.dxf2.events.event;
+
+import lombok.experimental.UtilityClass;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+@UtilityClass
+class JdbcEventSupport
+{
+    // Any chances we are duplicating this elsewhere ?
+    Timestamp toTimestamp( Date date )
+    {
+        return date != null ? new Timestamp( date.getTime() ) : null;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
@@ -1,0 +1,106 @@
+package org.hisp.dhis.dxf2.events.event;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Giuseppe Nespolino <g.nespolino@gmail.com>
+ */
+public class JdbcEventCommentStoreTest
+{
+
+    private JdbcEventCommentStore jdbcEventCommentStore;
+
+    @Before
+    public void setUp()
+    {
+        JdbcTemplate jdbcTemplate = mock( JdbcTemplate.class );
+        JdbcEventCommentStore jdbcEventCommentStore = new JdbcEventCommentStore( jdbcTemplate );
+        this.jdbcEventCommentStore = Mockito.spy( jdbcEventCommentStore );
+        doReturn( 1L ).when( this.jdbcEventCommentStore ).saveComment( any() );
+        doNothing().when( this.jdbcEventCommentStore ).saveCommentToEvent( anyLong(), anyLong(), anyInt() );
+    }
+
+    @Test
+    public void verifyPSITableIsNotQueriedWhenNoComments()
+    {
+        List<ProgramStageInstance> programStageInstanceList = getProgramStageList( false );
+        jdbcEventCommentStore.saveAllComments( programStageInstanceList );
+        verify( jdbcEventCommentStore, never() ).getInitialSortOrder( any() );
+    }
+
+    @Test
+    public void verifyPSITableIsNotQueriedWhenCommentsTextEmpty()
+    {
+        List<ProgramStageInstance> programStageInstanceList = getProgramStageList( true, true );
+        jdbcEventCommentStore.saveAllComments( programStageInstanceList );
+        verify( jdbcEventCommentStore, never() ).getInitialSortOrder( any() );
+    }
+
+    @Test
+    public void verifyPSITableIsQueriedWhenComments()
+    {
+        List<ProgramStageInstance> programStageInstanceList = getProgramStageList( true );
+        jdbcEventCommentStore.saveAllComments( programStageInstanceList );
+        verify( jdbcEventCommentStore ).getInitialSortOrder( any() );
+    }
+
+    private List<ProgramStageInstance> getProgramStageList( boolean withComments )
+    {
+        return getProgramStageList( withComments, false );
+    }
+
+    private List<ProgramStageInstance> getProgramStageList( boolean withComments, boolean emptyComment )
+    {
+        ProgramStageInstance programStageInstance = new ProgramStageInstance();
+        if ( withComments )
+        {
+            programStageInstance.setComments( ImmutableList.of( getComment( emptyComment ? "" : "Some comment" ) ) );
+        }
+        return ImmutableList.of( programStageInstance );
+    }
+
+    private TrackedEntityComment getComment( String commentText )
+    {
+        return new TrackedEntityComment( commentText, "Some author" );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -60,9 +60,6 @@ public class JdbcEventStoreTest
     private JdbcEventStore subject;
 
     @Mock
-    private JdbcEventCommentStore jdbcEventCommentStore;
-
-    @Mock
     private JdbcTemplate jdbcTemplate;
     
     @Mock
@@ -88,7 +85,7 @@ public class JdbcEventStoreTest
         when( jdbcTemplate.getDataSource() ).thenReturn( mock( DataSource.class ) );
 
         ObjectMapper objectMapper = new ObjectMapper();
-        subject = new JdbcEventStore( new PostgreSQLStatementBuilder(), jdbcTemplate, jdbcEventCommentStore, objectMapper, currentUserService,
+        subject = new JdbcEventStore( new PostgreSQLStatementBuilder(), jdbcTemplate, objectMapper, currentUserService,
             manager, env );
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -60,6 +60,9 @@ public class JdbcEventStoreTest
     private JdbcEventStore subject;
 
     @Mock
+    private JdbcEventCommentStore jdbcEventCommentStore;
+
+    @Mock
     private JdbcTemplate jdbcTemplate;
     
     @Mock
@@ -85,7 +88,7 @@ public class JdbcEventStoreTest
         when( jdbcTemplate.getDataSource() ).thenReturn( mock( DataSource.class ) );
 
         ObjectMapper objectMapper = new ObjectMapper();
-        subject = new JdbcEventStore( new PostgreSQLStatementBuilder(), jdbcTemplate, objectMapper, currentUserService,
+        subject = new JdbcEventStore( new PostgreSQLStatementBuilder(), jdbcTemplate, jdbcEventCommentStore, objectMapper, currentUserService,
             manager, env );
     }
 


### PR DESCRIPTION
This PR includes some minor refactoring to help writing a cleaner test.
- Comments related methods extracted from JdbcEventStore into JdbcEventCommentStore
- Table programstageinstancecomments is only queried if there's at least one comment to store.