### PR TITLE
fix: [DHIS2-9295] Events missing/hidden from response due to incorrect security filter sql (2.32)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1160,7 +1160,7 @@ public class JdbcEventStore
         sql += "select categoryoptioncomboid, count(categoryoptioncomboid) as option_size from categoryoptioncombos_categoryoptions group by categoryoptioncomboid) "
             + "as cocount on coc.categoryoptioncomboid = cocount.categoryoptioncomboid "
             + "left join ("
-            + "select deco.categoryoptionid as deco_id, deco.uid as deco_uid, deco.publicaccess AS deco_publicaccess, "
+            + "select distinct on (deco.categoryoptionid) deco.categoryoptionid as deco_id, deco.uid as deco_uid, deco.publicaccess AS deco_publicaccess, "
             + "couga.usergroupaccessid as uga_id, coua.useraccessid as ua_id, uga.access as uga_access, uga.usergroupid AS usrgrp_id, "
             + "ua.access as ua_access, ua.userid as usr_id from dataelementcategoryoption deco "
             + "left join dataelementcategoryoptionusergroupaccesses couga on deco.categoryoptionid = couga.categoryoptionid "


### PR DESCRIPTION
Added a **distinct** on the dataelementcategoryoption table. Without the distinct, a "certain production database" is getting duplicated records, which in turn duplicates the rows because of the left join. Eventually there are as many "duplicate events",
If the page size is 15, we get 15 duplicated records of the same event. The implementation recognizes the duplicate event uid, and ultimately just one event is sent back to the client with incorrect pager objects. Parallely investigating if its a data issue.