### PR TITLE
fix: throw Exception on multiple AoC during context loading

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
@@ -63,8 +63,6 @@ public class AttributeOptionComboLoader
 {
     private final JdbcTemplate jdbcTemplate;
 
-    private final static String KEY_SEPARATOR = "-";
-
     public final static String SQL_GET_CATEGORYOPTIONCOMBO = "select coc.categoryoptioncomboid, "
             + "coc.uid, coc.code, coc.ignoreapproval, coc.name, c.uid as cc_uid, c.name as cc_name, "
             + "string_agg(dec.categoryid::text, ',') as cat_ids from categoryoptioncombo coc "
@@ -120,7 +118,6 @@ public class AttributeOptionComboLoader
      *
      * @param categoryCombo a {@see CategoryCombo}
      * @param categoryOptions a semicolon delimited list of Category Options uid
-     * @param attributeOptionCombo
      * @param idScheme the {@see IdScheme} to use to fetch the entity
      * @return a {@see CategoryOptionCombo}
      */
@@ -266,7 +263,7 @@ public class AttributeOptionComboLoader
         }
         else
         {
-            // TODO throw an error??
+            // FIXME luciano: throw an error??
             return null;
         }
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
@@ -263,8 +263,8 @@ public class AttributeOptionComboLoader
         }
         else
         {
-            // FIXME luciano: throw an error??
-            return null;
+            throw new WorkContextLoaderException( "Expecting one Category Option Combo for option ids: [" + optionsId
+                + "], got " + categoryOptionCombos.size() );
         }
     }
 
@@ -280,7 +280,7 @@ public class AttributeOptionComboLoader
      */
     private CategoryOptionCombo loadCategoryOptionCombo( IdScheme idScheme, String id )
     {
-        String key = "categoryoptioncomboid";
+        final String key = "categoryoptioncomboid";
         // @formatter:off
         StrSubstitutor sub = new StrSubstitutor( ImmutableMap.<String, String>builder()
             .put( "key", key )
@@ -324,7 +324,6 @@ public class AttributeOptionComboLoader
         categoryCombo.setName( rs.getString( "cc_name" ) );
         categoryOptionCombo.setCategoryCombo( categoryCombo );
         return categoryOptionCombo;
-
     }
 
     private CategoryOption loadCategoryOption( IdScheme idScheme, String id )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplier.java
@@ -94,10 +94,6 @@ public class CategoryOptionComboSupplier extends AbstractSupplier<Map<String, Ca
             if ( isNotEmpty( aoc ) )
             {
                 categoryOptionCombo = attributeOptionComboLoader.getCategoryOptionCombo( idScheme, aoc );
-                if ( categoryOptionCombo == null )
-                {
-                    categoryOptionCombo = attributeOptionComboLoader.getDefault();
-                }
             }
             else if ( programCatCombo != null && isNotEmpty( attributeCatOptions ) )
             {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplier.java
@@ -101,7 +101,7 @@ public class CategoryOptionComboSupplier extends AbstractSupplier<Map<String, Ca
                     attributeCatOptions, aoc, idScheme );
             }
 
-            if (categoryOptionCombo == null) {
+            if ( categoryOptionCombo == null ) {
 
                 categoryOptionCombo = attributeOptionComboLoader.getDefault();
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplier.java
@@ -89,7 +89,7 @@ public class CategoryOptionComboSupplier extends AbstractSupplier<Map<String, Ca
             final String aoc = event.getAttributeOptionCombo();
             final String attributeCatOptions = event.getAttributeCategoryOptions();
 
-            CategoryOptionCombo categoryOptionCombo;
+            CategoryOptionCombo categoryOptionCombo = null;
 
             if ( isNotEmpty( aoc ) )
             {
@@ -100,11 +100,12 @@ public class CategoryOptionComboSupplier extends AbstractSupplier<Map<String, Ca
                 categoryOptionCombo = attributeOptionComboLoader.getAttributeOptionCombo( programCatCombo,
                     attributeCatOptions, aoc, idScheme );
             }
-            else
-            {
+
+            if (categoryOptionCombo == null) {
+
                 categoryOptionCombo = attributeOptionComboLoader.getDefault();
             }
-
+            
             if ( categoryOptionCombo != null )
             {
                 eventToCocMap.put( event.getUid(), categoryOptionCombo );
@@ -113,5 +114,4 @@ public class CategoryOptionComboSupplier extends AbstractSupplier<Map<String, Ca
 
         return eventToCocMap;
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoaderException.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoaderException.java
@@ -1,0 +1,25 @@
+package org.hisp.dhis.dxf2.events.importer.context;
+
+/**
+ * Signal an irrecoverable exception during the WorkContext creation
+ *
+ * @author Luciano Fiandesio
+ */
+public class WorkContextLoaderException extends RuntimeException
+{
+    public WorkContextLoaderException() {
+        super();
+    }
+
+    public WorkContextLoaderException(String message) {
+        super(message);
+    }
+
+    public WorkContextLoaderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WorkContextLoaderException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoaderException.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoaderException.java
@@ -12,14 +12,14 @@ public class WorkContextLoaderException extends RuntimeException
     }
 
     public WorkContextLoaderException(String message) {
-        super(message);
+        super( message );
     }
 
     public WorkContextLoaderException(String message, Throwable cause) {
-        super(message, cause);
+        super( message, cause );
     }
 
     public WorkContextLoaderException(Throwable cause) {
-        super(cause);
+        super( cause );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoaderException.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoaderException.java
@@ -11,15 +11,15 @@ public class WorkContextLoaderException extends RuntimeException
         super();
     }
 
-    public WorkContextLoaderException(String message) {
+    public WorkContextLoaderException( String message ) {
         super( message );
     }
 
-    public WorkContextLoaderException(String message, Throwable cause) {
+    public WorkContextLoaderException( String message, Throwable cause ) {
         super( message, cause );
     }
 
-    public WorkContextLoaderException(Throwable cause) {
+    public WorkContextLoaderException( Throwable cause ) {
         super( cause );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/AttributeOptionComboAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/validation/AttributeOptionComboAclCheck.java
@@ -49,7 +49,7 @@ public class AttributeOptionComboAclCheck
     Checker
 {
     @Override
-    public ImportSummary check(ImmutableEvent event, WorkContext ctx )
+    public ImportSummary check( ImmutableEvent event, WorkContext ctx )
     {
         ImportSummary importSummary = new ImportSummary();
         TrackerAccessManager trackerAccessManager = ctx.getServiceDelegator().getTrackerAccessManager();


### PR DESCRIPTION
This PR makes sure that, when the query to fetch Attribute Option Combos during the event import pre-heat, returns multiple AoC, an exception is thrown.

Additionally, the CoC flow has been slightly modified to be in line with @abyot  flow diagram:  https://drive.google.com/file/d/1qO6mesQKKG1LcpEhW5YFRJnoxewwxHvI/view

ref: DHIS2-9419