### PR TITLE
feat(apps to bundle): add cache cleaner to bundled apps v35

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/README.md
+++ b/dhis-2/dhis-web/dhis-web-apps/README.md
@@ -2,10 +2,10 @@
 
 The following shows the mapping of app repos to the DHIS2 versions that use the `master` branch of the app (feature toggling)
 
-|app repository|2.29|2.30|2.31|2.32|2.33|2.34|
-|---|---|---|---|---|---|---|
-|git@github.com:dhis2/cache-cleaner-app.git|n/a|n/a|2.31|2.32|2.33|2.34|
-|git@github.com:dhis2/core-resource-app.git|master|master|2.31|2.32|master|DELETED|
-|git@github.com:dhis2/messaging-app.git|master|master|master|master|master|master|
-|git@github.com:dhis2/reports-app.git|n/a|n/a|n/a|n/a|master|master|
-|git@github.com:dhis2/usage-analytics-app.git|2.29|2.30|2.31|master|2.33|master|
+|app repository|2.29|2.30|2.31|2.32|2.33|2.34|2.35|
+|---|---|---|---|---|---|---|---|
+|git@github.com:dhis2/cache-cleaner-app.git|n/a|n/a|2.31|2.32|2.33|2.34|master|
+|git@github.com:dhis2/core-resource-app.git|master|master|2.31|2.32|master|DELETED|DELETED|
+|git@github.com:dhis2/messaging-app.git|master|master|master|master|master|master|master|
+|git@github.com:dhis2/reports-app.git|n/a|n/a|n/a|n/a|master|master|master|
+|git@github.com:dhis2/usage-analytics-app.git|2.29|2.30|2.31|master|2.33|master|master|

--- a/dhis-2/dhis-web/dhis-web-apps/README.md
+++ b/dhis-2/dhis-web/dhis-web-apps/README.md
@@ -4,6 +4,7 @@ The following shows the mapping of app repos to the DHIS2 versions that use the 
 
 |app repository|2.29|2.30|2.31|2.32|2.33|2.34|
 |---|---|---|---|---|---|---|
+|git@github.com:dhis2/cache-cleaner-app.git|n/a|n/a|2.31|2.32|2.33|2.34|
 |git@github.com:dhis2/core-resource-app.git|master|master|2.31|2.32|master|DELETED|
 |git@github.com:dhis2/messaging-app.git|master|master|master|master|master|master|
 |git@github.com:dhis2/reports-app.git|n/a|n/a|n/a|n/a|master|master|

--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -1,7 +1,7 @@
 [
     "https://github.com/d2-ci/app-management-app#v35",
     "https://github.com/d2-ci/cache-cleaner-app#v35",
-    "https://github.com/d2-ci/capture-app#v35",
+    "https://github.com/d2-ci/capture-app#master",
     "https://github.com/d2-ci/dashboards-app#v35",
     "https://github.com/d2-ci/data-administration-app#v35",
     "https://github.com/d2-ci/data-visualizer-app#35.x",


### PR DESCRIPTION
The app has been re-written and is now supports feature toggling (although there are no features to toggle as there are no api requests).

This PR
- [x] uses the cache-cleaner app's `master` branch
- [x] a row for the app to the README with the feature toggle apps
- [x] a column for v 2.35 to the README
  * If this is wrong, it's a separate commit I could just drop and the force-push the branch again

(please disregard the branch name)