### PR TITLE
feat: require bundled app overrides to be configured with the coreApp flag in the manifest

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -113,7 +113,7 @@ public class App
      */
     public void init( String contextPath )
     {
-        String appPathPrefix = getIsBundledApp() ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
+        String appPathPrefix = isBundled() ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
 
         this.baseUrl = String.join( "/", contextPath, appPathPrefix ) + getUrlFriendlyName();
 
@@ -136,7 +136,7 @@ public class App
      * Determine if this app will overload a bundled app
      */
     @JsonProperty
-    public boolean getIsBundledApp()
+    public boolean isBundled()
     {
         return AppManager.BUNDLED_APPS.contains( getShortName() );
     }
@@ -147,12 +147,12 @@ public class App
      */
     @JsonProperty( "core_app" )
     @JacksonXmlProperty( localName = "core_app", namespace = DxfNamespaces.DXF_2_0 )
-    public boolean getIsCoreApp()
+    public boolean isCoreApp()
     {
         return coreApp;
     }
 
-    public void setIsCoreApp( boolean coreApp )
+    public void setCoreApp( boolean coreApp )
     {
         this.coreApp = coreApp;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -95,9 +95,12 @@ public class App
 
     private Set<String> authorities = new HashSet<>();
 
-    private AppStatus appState = AppStatus.OK;
+    private boolean coreApp = false;
 
-    private boolean isBundledApp = false;
+    /**
+     * Generated.
+     */
+    private AppStatus appState = AppStatus.OK;
 
     // -------------------------------------------------------------------------
     // Logic
@@ -110,9 +113,7 @@ public class App
      */
     public void init( String contextPath )
     {
-        isBundledApp = AppManager.BUNDLED_APPS.contains( getShortName() );
-
-        String appPathPrefix = isBundledApp ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
+        String appPathPrefix = getIsBundledApp() ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
 
         this.baseUrl = String.join( "/", contextPath, appPathPrefix ) + getUrlFriendlyName();
 
@@ -131,10 +132,25 @@ public class App
         return getUrlFriendlyName();
     }
 
+    /**
+     * Determine whether this app will overload a bundled app
+     */
     @JsonProperty
     public boolean getIsBundledApp()
     {
-        return isBundledApp;
+        return AppManager.BUNDLED_APPS.contains( getShortName() );
+    }
+
+    @JsonProperty( "core_app" )
+    @JacksonXmlProperty( localName = "core_app", namespace = DxfNamespaces.DXF_2_0 )
+    public boolean getIsCoreApp()
+    {
+        return coreApp;
+    }
+
+    public void setIsCoreApp( boolean coreApp )
+    {
+        this.coreApp = coreApp;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -133,7 +133,7 @@ public class App
     }
 
     /**
-     * Determine whether this app will overload a bundled app
+     * Determine if this app will overload a bundled app
      */
     @JsonProperty
     public boolean getIsBundledApp()
@@ -141,6 +141,10 @@ public class App
         return AppManager.BUNDLED_APPS.contains( getShortName() );
     }
 
+    /**
+     * Determine if the app is configured as a coreApp (to be served at the root
+     * namespace)
+     */
     @JsonProperty( "core_app" )
     @JacksonXmlProperty( localName = "core_app", namespace = DxfNamespaces.DXF_2_0 )
     public boolean getIsCoreApp()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppStatus.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppStatus.java
@@ -30,21 +30,23 @@ package org.hisp.dhis.appmanager;
 
 public enum AppStatus
 {
-    OK( "ok" ), 
-    NAMESPACE_TAKEN( "namespace_defined_in_manifest_is_in_use" ), 
+    OK( "ok" ),
+    INVALID_BUNDLED_APP_OVERRIDE( "invalid_bundled_app_override" ),
+    INVALID_CORE_APP( "invalid_core_app" ),
+    NAMESPACE_TAKEN( "namespace_defined_in_manifest_is_in_use" ),
     INVALID_ZIP_FORMAT( "zip_file_could_not_be_read" ),
-    MISSING_MANIFEST( "missing_manifest"),
-    INVALID_MANIFEST_JSON( "invalid_json_in_app_manifest_file" ), 
+    MISSING_MANIFEST( "missing_manifest" ),
+    INVALID_MANIFEST_JSON( "invalid_json_in_app_manifest_file" ),
     INSTALLATION_FAILED( "app_could_not_be_installed_on_file_system" ),
     NOT_FOUND( "app_could_not_be_found" ),
     MISSING_SYSTEM_BASE_URL( "system_base_url_is_not_defined" ),
     APPROVED( "approved" ),
     PENDING( "pending" ),
     NOT_APPROVED( "not_approved" ),
-    DELETION_IN_PROGRESS("deletion_in_progress");
-    
+    DELETION_IN_PROGRESS( "deletion_in_progress" );
+
     private String message;
-    
+
     AppStatus( String message )
     {
         this.message = message;
@@ -54,7 +56,7 @@ public enum AppStatus
     {
         return this == OK;
     }
-    
+
     public String getMessage()
     {
         return message;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -183,7 +183,7 @@ public class DefaultAppManager
     {
         return apps
             .stream()
-            .filter( app -> app.getIsBundledApp() == isBundled )
+            .filter( app -> app.isBundled() == isBundled )
             .collect( Collectors.toList() );
     }
 
@@ -202,7 +202,7 @@ public class DefaultAppManager
         {
             apps.retainAll( getAppsByShortName( value, apps, operator ) );
         }
-        else if ( "isBundledApp".equalsIgnoreCase( key ) )
+        else if ( "isBundled".equalsIgnoreCase( key ) )
         {
             boolean isBundled = "true".equalsIgnoreCase( value );
             apps.retainAll( getAppsByIsBundled( isBundled, apps ) );
@@ -230,7 +230,7 @@ public class DefaultAppManager
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );
             }
 
-            if ( "isBundledApp".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
+            if ( "isBundled".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
                 && !"false".equalsIgnoreCase( split[2] ) )
             {
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
@@ -304,9 +304,9 @@ public class JCloudsAppStorageService
         // Check that, iff this is a bundled app, it is configured as a core app
         // -----------------------------------------------------------------
 
-        if ( app.getIsBundledApp() != app.getIsCoreApp() )
+        if ( app.isBundled() != app.isCoreApp() )
         {
-            if ( app.getIsBundledApp() )
+            if ( app.isBundled() )
             {
                 log.error(
                     String.format(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
@@ -331,6 +331,33 @@ public class JCloudsAppStorageService
             }
 
             // -----------------------------------------------------------------
+            // Check that, iff this is a bundled app, it is configured as a core app
+            // -----------------------------------------------------------------
+
+            if ( app.getIsBundledApp() != app.getIsCoreApp() )
+            {
+                if ( app.getIsBundledApp() )
+                {
+                    log.error(
+                        String.format(
+                            "Failed to install app '%s': bundled app overrides muse be declared with core_app=true",
+                            app.getShortName() ) );
+                    app.setAppState( AppStatus.INVALID_BUNDLED_APP_OVERRIDE );
+                }
+                else
+                {
+                    log.error(
+                        String.format(
+                            "Failed to install app '%s': apps declared with core_app=true must override a bundled app",
+                            app.getShortName() ) );
+                    app.setAppState( AppStatus.INVALID_CORE_APP );
+                }
+
+                zip.close();
+                return app;
+            }
+
+            // -----------------------------------------------------------------
             // Unzip the app
             // -----------------------------------------------------------------
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
@@ -271,6 +271,63 @@ public class JCloudsAppStorageService
         return reservedNamespaces;
     }
 
+    private boolean validateApp( App app, Cache<App> appCache )
+    {
+        // -----------------------------------------------------------------
+        // Check if app with same key is currently being deleted (deletion_in_progress)
+        // -----------------------------------------------------------------
+        Optional<App> existingApp = appCache.getIfPresent( app.getKey() );
+        if ( existingApp.isPresent() && existingApp.get().getAppState() == AppStatus.DELETION_IN_PROGRESS )
+        {
+            log.error( "Failed to install app: App with same name is currently being deleted" );
+
+            app.setAppState( AppStatus.DELETION_IN_PROGRESS );
+            return false;
+        }
+
+        // -----------------------------------------------------------------
+        // Check for namespace and if it's already taken by another app
+        // -----------------------------------------------------------------
+
+        String namespace = app.getActivities().getDhis().getNamespace();
+
+        if ( namespace != null && !namespace.isEmpty() && app.equals( reservedNamespaces.get( namespace ) ) )
+        {
+            log.error( String.format( "Failed to install app '%s': Namespace '%s' already taken.",
+                app.getName(), namespace ) );
+
+            app.setAppState( AppStatus.NAMESPACE_TAKEN );
+            return false;
+        }
+
+        // -----------------------------------------------------------------
+        // Check that, iff this is a bundled app, it is configured as a core app
+        // -----------------------------------------------------------------
+
+        if ( app.getIsBundledApp() != app.getIsCoreApp() )
+        {
+            if ( app.getIsBundledApp() )
+            {
+                log.error(
+                    String.format(
+                        "Failed to install app '%s': bundled app overrides muse be declared with core_app=true",
+                        app.getShortName() ) );
+                app.setAppState( AppStatus.INVALID_BUNDLED_APP_OVERRIDE );
+            }
+            else
+            {
+                log.error(
+                    String.format(
+                        "Failed to install app '%s': apps declared with core_app=true must override a bundled app",
+                        app.getShortName() ) );
+                app.setAppState( AppStatus.INVALID_CORE_APP );
+            }
+
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public App installApp( File file, String filename, Cache<App> appCache )
     {
@@ -301,61 +358,13 @@ public class JCloudsAppStorageService
             app.setFolderName( APPS_DIR + File.separator + filename.substring( 0, filename.lastIndexOf( '.' ) ) );
             app.setAppStorageSource( AppStorageSource.JCLOUDS );
 
-            // -----------------------------------------------------------------
-            // Check if app with same key is currently being deleted (deletion_in_progress)
-            // -----------------------------------------------------------------
-            Optional<App> existingApp = appCache.getIfPresent( app.getKey() );
-            if ( existingApp.isPresent() && existingApp.get().getAppState() == AppStatus.DELETION_IN_PROGRESS )
+            if ( !this.validateApp( app, appCache ) )
             {
-                log.error( "Failed to install app: App with same name is currently being deleted" );
-
                 zip.close();
-                app.setAppState( AppStatus.DELETION_IN_PROGRESS );
                 return app;
             }
-
-            // -----------------------------------------------------------------
-            // Check for namespace and if it's already taken by another app
-            // -----------------------------------------------------------------
 
             String namespace = app.getActivities().getDhis().getNamespace();
-
-            if ( namespace != null && !namespace.isEmpty() && app.equals( reservedNamespaces.get( namespace ) ) )
-            {
-                log.error( String.format( "Failed to install app '%s': Namespace '%s' already taken.",
-                    app.getName(), namespace ) );
-
-                zip.close();
-                app.setAppState( AppStatus.NAMESPACE_TAKEN );
-                return app;
-            }
-
-            // -----------------------------------------------------------------
-            // Check that, iff this is a bundled app, it is configured as a core app
-            // -----------------------------------------------------------------
-
-            if ( app.getIsBundledApp() != app.getIsCoreApp() )
-            {
-                if ( app.getIsBundledApp() )
-                {
-                    log.error(
-                        String.format(
-                            "Failed to install app '%s': bundled app overrides muse be declared with core_app=true",
-                            app.getShortName() ) );
-                    app.setAppState( AppStatus.INVALID_BUNDLED_APP_OVERRIDE );
-                }
-                else
-                {
-                    log.error(
-                        String.format(
-                            "Failed to install app '%s': apps declared with core_app=true must override a bundled app",
-                            app.getShortName() ) );
-                    app.setAppState( AppStatus.INVALID_CORE_APP );
-                }
-
-                zip.close();
-                return app;
-            }
 
             // -----------------------------------------------------------------
             // Unzip the app

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -1635,6 +1635,8 @@ app_search_placeholder=Search apps
 
 #-- App manager----------------------------------------------------------------#
 
+invalid_bundled_app_override=Bundled apps must be declared as core apps
+invalid_core_app=Only bundled apps may be declared as core apps
 namespace_defined_in_manifest_is_in_use=Namespace defined in manifest is already in use
 zip_file_could_not_be_read=Zip file could not be read
 invalid_json_in_app_manifest_file=Invalid JSON in app manifest file

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -177,7 +177,7 @@ public class AppController
             throw new WebMessageException( WebMessageUtils.notFound( "App '" + app + "' not found." ) );
         }
 
-        if ( application.getIsBundledApp() )
+        if ( application.isBundled() )
         {
             String redirectPath = application.getBaseUrl() + "/" + pageName;
 

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/bundle-apps.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/bundle-apps.js
@@ -7,7 +7,7 @@ const path = require('path')
 const access = promisify(require('fs').access)
 const mkdir = promisify(require('fs').mkdir)
 
-const { clone_app, show_sha } = require('./git.js')
+const { clone_app, get_sha } = require('./git.js')
 const generate_index = require('./write-index-html.js')
 const generate_struts = require('./write-struts-xml.js')
 const generate_bundle = require('./write-bundle-json.js')
@@ -72,7 +72,7 @@ async function main(opts = {}) {
     const final = await Promise.all(new_apps)
     console.dir(final)
 
-    const core_sha = await show_sha(root)
+    const core_sha = await get_sha(root)
 
     await generate_index(final, core_sha, html_template_path, html_index_path)
     await generate_struts(final, xml_template_path, xml_struts_path)

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
@@ -91,7 +91,7 @@ async function clone (name, url, clone_path, treeish) {
 async function get_sha (repo_path) {
     let refspec
     try {
-        const { stderr, stdout } = await exec(`git rev-parse --verify HEAD`, { cwd: repo_path})
+        const { stdout } = await exec(`git rev-parse --verify HEAD`, { cwd: repo_path})
         refspec = stdout.trim()
     } catch (err) {
         console.error(`[get_sha] could not fetch refspec for ${repo_path}, using fallback`, err)
@@ -103,7 +103,7 @@ async function get_sha (repo_path) {
 async function get_commit_date (repo_path, sha) {
     let date
     try {
-        const { stderr, stdout } = await exec(`git show --no-patch --no-notes --pretty='%cd' ${sha}`, { cwd: repo_path})
+        const { stdout } = await exec(`git show --no-patch --no-notes --pretty='%cd' ${sha}`, { cwd: repo_path})
         date = stdout.trim()
     } catch (err) {
         console.error(`[get_commit_date] could not fetch commit date for ${repo_path}, using fallback`, err)

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
@@ -5,6 +5,7 @@ const rename = promisify(require('fs').rename)
 const path = require('path')
 
 const {
+    scrub,
     sanitize_app_name,
     split_repo_path,
     ex_clone_path
@@ -112,12 +113,14 @@ async function clone_app (repo, target, default_branch) {
         const sha = await show_sha(clone_path)
 
         const pkg_name = require(path.join(clone_path, 'package.json')).name
+        const name = scrub(pkg_name)
         const web_name = await rename_app(pkg_name, clone_path, target)
 
         return {
             ref,
             sha,
             pkg_name,
+            name,
             web_name,
             url,
             path: path.join(target, web_name),

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/git.js
@@ -88,16 +88,28 @@ async function clone (name, url, clone_path, treeish) {
     }
 }
 
-async function show_sha (repo_path) {
+async function get_sha (repo_path) {
     let refspec
     try {
         const { stderr, stdout } = await exec(`git rev-parse --verify HEAD`, { cwd: repo_path})
         refspec = stdout.trim()
     } catch (err) {
-        console.error(`[show_sha] could not fetch refspec for ${repo_path}, using fallback`, err)
+        console.error(`[get_sha] could not fetch refspec for ${repo_path}, using fallback`, err)
         refspec = 'n/a'
     }
     return refspec
+}
+
+async function get_commit_date (repo_path, sha) {
+    let date
+    try {
+        const { stderr, stdout } = await exec(`git show --no-patch --no-notes --pretty='%cd' ${sha}`, { cwd: repo_path})
+        date = stdout.trim()
+    } catch (err) {
+        console.error(`[get_commit_date] could not fetch commit date for ${repo_path}, using fallback`, err)
+        refspec = 'n/a'
+    }
+    return date
 }
 
 async function clone_app (repo, target, default_branch) {
@@ -110,16 +122,20 @@ async function clone_app (repo, target, default_branch) {
     try {
         await clone(repo_name, url, clone_path, treeish)
         const ref = await checkout(repo_name, clone_path, treeish)
-        const sha = await show_sha(clone_path)
+        const sha = await get_sha(clone_path)
+        const build_date = await get_commit_date(clone_path, sha)
 
-        const pkg_name = require(path.join(clone_path, 'package.json')).name
+        const pkg = require(path.join(clone_path, 'package.json'))
+        const pkg_name = pkg.name
         const name = scrub(pkg_name)
         const web_name = await rename_app(pkg_name, clone_path, target)
 
         return {
             ref,
             sha,
+            build_date,
             pkg_name,
+            version: pkg.version,
             name,
             web_name,
             url,
@@ -130,4 +146,4 @@ async function clone_app (repo, target, default_branch) {
     }
 }
 
-module.exports = { clone_app, show_sha }
+module.exports = { clone_app, get_sha }

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/lib/sanitize.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/lib/sanitize.js
@@ -61,6 +61,7 @@ function ex_clone_path (url) {
 }
 
 module.exports = {
+    scrub,
     sanitize_app_name,
     split_repo_path,
     ex_clone_path

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/write-bundle-json.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/write-bundle-json.js
@@ -5,10 +5,18 @@ const write_file = promisify(require('fs').writeFile)
 const mkdir = promisify(require('fs').mkdir)
                  
 module.exports = async function generate_bundle (apps, jsonPath) {
-    let map = {}
+    let list = []
     for (const app of apps) {
         const lock = `${app.url}#${app.sha}`
-        map[app.name] = lock
+        list.push({
+            name: app.name,
+            webName: app.web_name,
+            version: app.version,
+            buildDate: app.build_date,
+            sourceRepo: app.url,
+            sourceRef: app.ref,
+            source: lock
+        })
     }
 
     try {
@@ -24,7 +32,7 @@ module.exports = async function generate_bundle (apps, jsonPath) {
             }
         }
 
-        const json = JSON.stringify(map, null, 4)
+        const json = JSON.stringify(list, null, 4)
         await write_file(jsonPath, json, { encoding: 'utf8' })
         console.log(`[bundle] apps-bundle.json written`)
     } catch (err) {

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/write-bundle-json.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/write-bundle-json.js
@@ -5,10 +5,10 @@ const write_file = promisify(require('fs').writeFile)
 const mkdir = promisify(require('fs').mkdir)
                  
 module.exports = async function generate_bundle (apps, jsonPath) {
-    let list = []
+    let map = {}
     for (const app of apps) {
         const lock = `${app.url}#${app.sha}`
-        list.push(lock)
+        map[app.name] = lock
     }
 
     try {
@@ -24,7 +24,7 @@ module.exports = async function generate_bundle (apps, jsonPath) {
             }
         }
 
-        const json = JSON.stringify(list, null, 4)
+        const json = JSON.stringify(map, null, 4)
         await write_file(jsonPath, json, { encoding: 'utf8' })
         console.log(`[bundle] apps-bundle.json written`)
     } catch (err) {

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/write-index-html.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/write-index-html.js
@@ -5,13 +5,18 @@ const read_file = promisify(require('fs').readFile)
 const write_file = promisify(require('fs').writeFile)
 const mkdir = promisify(require('fs').mkdir)
 
-function list_item (name, webName) {
+function list_item ({ name, web_name, version, build_date }) {
     return `
-        <li>
-            <a href="../${webName}">
-                ${name}
-            </a>
-        </li>`
+        <tr>
+            <td>${name}</td>
+            <td>
+                <a href="../${web_name}">
+                    ${web_name}
+                </a>
+            </td>
+            <td>${version}</td>
+            <td>${build_date}</td>
+        </tr>`
 }
 
 function buildInfo (sha = 'n/a') {
@@ -26,7 +31,7 @@ function buildInfo (sha = 'n/a') {
 module.exports = async function generate_index (apps, core_sha, templatePath, indexPath) {
     let list = []
     for (const app of apps) {
-        list.push(list_item(app.name, app.web_name))
+        list.push(list_item(app))
     }
 
     try {

--- a/dhis-2/dhis-web/dhis-web-apps/scripts/write-index-html.js
+++ b/dhis-2/dhis-web/dhis-web-apps/scripts/write-index-html.js
@@ -5,10 +5,10 @@ const read_file = promisify(require('fs').readFile)
 const write_file = promisify(require('fs').writeFile)
 const mkdir = promisify(require('fs').mkdir)
 
-function list_item (name) {
+function list_item (name, webName) {
     return `
         <li>
-            <a href="../${name}">
+            <a href="../${webName}">
                 ${name}
             </a>
         </li>`
@@ -26,7 +26,7 @@ function buildInfo (sha = 'n/a') {
 module.exports = async function generate_index (apps, core_sha, templatePath, indexPath) {
     let list = []
     for (const app of apps) {
-        list.push(list_item(app.web_name))
+        list.push(list_item(app.name, app.web_name))
     }
 
     try {

--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-apps/template.html
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-apps/template.html
@@ -2,10 +2,22 @@
 <html>
 <body>
 	<h3>Bundled Apps</h3>
-    <ul>
-        <!-- INJECT HTML HERE -->
-    </ul>
+    <table>
+        <thead>
+            <tr>
+                <td><strong>Name</strong></td>
+                <td><strong>Path</strong></td>
+                <td><strong>Version</strong></td>
+                <td><strong>Build Date</strong></td>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- INJECT HTML HERE -->
+        </tbody>
+    </table>
     <!-- INJECT BUILD INFO HERE -->
-    <a href="./apps-bundle.json">Apps Bundle JSON</a>
+    <p>
+        <a href="./apps-bundle.json">Apps Bundle JSON</a>
+    </p>
 </body>
 </html>

--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-apps/template.html
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-apps/template.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
 <body>
-	<h3>Apps</h3>
+	<h3>Bundled Apps</h3>
     <ul>
         <!-- INJECT HTML HERE -->
     </ul>
     <!-- INJECT BUILD INFO HERE -->
+    <a href="./apps-bundle.json">Apps Bundle JSON</a>
 </body>
 </html>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
@@ -54,7 +54,7 @@ public class AppsSystemAuthoritiesProvider implements SystemAuthoritiesProvider
         Set<String> authorities = new HashSet<>();
 
         appManager.getApps( null ).stream()
-            .filter( app -> !StringUtils.isEmpty( app.getShortName() ) && !app.getIsBundledApp() )
+            .filter( app -> !StringUtils.isEmpty( app.getShortName() ) && !app.isBundled() )
             .forEach( app -> {
                 authorities.add( app.getSeeAppAuthority() );
                 authorities.addAll( app.getAuthorities() );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/DefaultModuleManager.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/DefaultModuleManager.java
@@ -157,7 +157,7 @@ public class DefaultModuleManager
         List<App> apps = appManager
             .getAccessibleApps( contextPath )
             .stream()
-            .filter( app -> app.getAppType() == AppType.APP && !app.getIsBundledApp() )
+            .filter( app -> app.getAppType() == AppType.APP && !app.isBundled() )
             .collect( Collectors.toList() );
 
         modules.addAll( apps.stream().map( Module::getModule ).collect( Collectors.toList() ) );


### PR DESCRIPTION
This does two things:

1. (important!) this adds a check on application install to ensure that any app which will override a bundled app has the new `core_app=true` flag set in its manifest.  This ensures that override apps are explicitly built to be served from the `/dhis-web-xyz` namespace rather than the `/api/apps/xyz` namespace, and should help prevent unintentional bundled app overrides.

2. (minor) This adds a little more information to `/dhis-web-apps/index.html` and `/dhis-web-apps/apps-bundle.json`, specifying the name of the application (which can then be used for overrides)