### PR TITLE
chore: fix http basic auth to redirect to form login on 401

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.security;
  */
 
 import com.google.common.base.MoreObjects;
+import com.google.common.net.HttpHeaders;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
@@ -67,9 +68,9 @@ public class DHIS2BasicAuthenticationEntryPoint extends LoginUrlAuthenticationEn
         AuthenticationException authException )
         throws IOException, ServletException
     {
-        String acceptHeader = MoreObjects.firstNonNull( request.getHeader( "Accept" ), "" );
-        String requestWithHeader = MoreObjects.firstNonNull( request.getHeader( "X-Requested-With" ), "" );
-        String authorizationHeader = MoreObjects.firstNonNull( request.getHeader( "Authorization" ), "" );
+        String acceptHeader = MoreObjects.firstNonNull( request.getHeader( HttpHeaders.ACCEPT ), "" );
+        String requestWithHeader = MoreObjects.firstNonNull( request.getHeader( HttpHeaders.X_REQUESTED_WITH ), "" );
+        String authorizationHeader = MoreObjects.firstNonNull( request.getHeader( HttpHeaders.AUTHORIZATION ), "" );
 
         if ( "XMLHttpRequest".equals( requestWithHeader ) || authorizationHeader.contains( "Basic" ) )
         {

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.webapi.security;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.base.MoreObjects;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
@@ -35,36 +36,66 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
+ * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class DHIS2BasicAuthenticationEntryPoint implements AuthenticationEntryPoint
+public class DHIS2BasicAuthenticationEntryPoint extends LoginUrlAuthenticationEntryPoint
 {
     @Autowired
     private RenderService renderService;
 
-    @Override
-    public void commence( HttpServletRequest request, HttpServletResponse response, AuthenticationException authException ) throws IOException
+    /**
+     * @param loginFormUrl URL where the login page can be found. Should either be
+     *                     relative to the web-app context path (include a leading {@code /}) or an absolute
+     *                     URL.
+     */
+    public DHIS2BasicAuthenticationEntryPoint( String loginFormUrl )
     {
-        String message;
+        super( loginFormUrl );
+    }
 
-        if ( ExceptionUtils.indexOfThrowable( authException, LockedException.class ) != -1 )
+    @Override
+    public void commence( HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException )
+        throws IOException, ServletException
+    {
+        String acceptHeader = MoreObjects.firstNonNull( request.getHeader( "Accept" ), "" );
+        String requestWithHeader = MoreObjects.firstNonNull( request.getHeader( "X-Requested-With" ), "" );
+        String authorizationHeader = MoreObjects.firstNonNull( request.getHeader( "Authorization" ), "" );
+
+        if ( "XMLHttpRequest".equals( requestWithHeader ) || authorizationHeader.contains( "Basic" ) )
         {
-            message = "Account locked" ;
-        }
-        else
-        {
-            message = "Unauthorized";
+            String message = "Unauthorized";
+
+            if ( ExceptionUtils.indexOfThrowable( authException, LockedException.class ) != -1 )
+            {
+                message = "Account locked";
+            }
+
+            response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
+
+            if ( acceptHeader.contains( MediaType.APPLICATION_XML_VALUE ) )
+            {
+                response.setContentType( MediaType.APPLICATION_XML_VALUE );
+                renderService.toXml( response.getOutputStream(), WebMessageUtils.unathorized( message ) );
+            }
+            else
+            {
+                response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+                renderService.toJson( response.getOutputStream(), WebMessageUtils.unathorized( message ) );
+            }
+
+            return;
         }
 
-        response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
-        renderService.toJson( response.getOutputStream(), WebMessageUtils.unathorized( message ) );
+        super.commence( request, response, authException );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -289,7 +289,6 @@ public class DhisWebApiWebSecurityConfig
             OAuth2AuthenticationProcessingFilter resourcesServerFilter = new OAuth2AuthenticationProcessingFilter();
             resourcesServerFilter.setAuthenticationEntryPoint( authenticationEntryPoint );
             resourcesServerFilter.setAuthenticationManager( oauthAuthenticationManager );
-
             resourcesServerFilter.setStateless( false );
 
             http
@@ -312,15 +311,15 @@ public class DhisWebApiWebSecurityConfig
                 )
                 .httpBasic()
                 .authenticationEntryPoint( basicAuthenticationEntryPoint() )
-                .and().csrf().disable()
+                .and()
+                .exceptionHandling()
+                .accessDeniedHandler( accessDeniedHandler )
+                .and()
+                .csrf().disable()
 
                 .addFilterBefore( CorsFilter.get(), BasicAuthenticationFilter.class )
                 .addFilterBefore( CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class )
-
-                .addFilterAfter( resourcesServerFilter, BasicAuthenticationFilter.class )
-                .exceptionHandling()
-                .accessDeniedHandler( accessDeniedHandler )
-                .authenticationEntryPoint( authenticationEntryPoint );
+                .addFilterAfter( resourcesServerFilter, BasicAuthenticationFilter.class );
 
             setHttpHeaders( http );
         }
@@ -328,7 +327,7 @@ public class DhisWebApiWebSecurityConfig
         @Bean
         public DHIS2BasicAuthenticationEntryPoint basicAuthenticationEntryPoint()
         {
-            return new DHIS2BasicAuthenticationEntryPoint();
+            return new DHIS2BasicAuthenticationEntryPoint("/dhis-web-commons/security/login.action");
         }
     }
 


### PR DESCRIPTION
* Make sure 2.35 behaves in the same way as before xml to java config refactor.
On <=2.34 the user would be redirected to the form login if user is not authorized.

Issue: [DHIS2-9469]

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>