### PR TITLE
[2.35.0] fix: prevent db deadlock during Event update (#6131)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
@@ -52,6 +52,13 @@ public interface EventStore
      */
     void saveEvents( List<ProgramStageInstance> programStageInstances );
 
+    /**
+     * Updates a List of {@see ProgramStageInstance}, including notes and Data
+     * Values.
+     *
+     * @param programStageInstances a List of {@see ProgramStageInstance}
+     *
+     */
     void updateEvents( List<ProgramStageInstance> programStageInstances );
 
     List<Event> getEvents( EventSearchParams params, List<OrganisationUnit> organisationUnits,
@@ -71,5 +78,12 @@ public interface EventStore
      */
     void delete( List<Event> events );
 
+    /**
+     * Updates the "last updated" and "last updated By" of the
+     * Tracked Entity Instances matching the provided list of UIDs
+     *
+     * @param teiUid a List of Tracked Entity Instance uid
+     * @param user the User to use for the last update by value. Can be null.
+     */
     void updateTrackedEntityInstances( List<String> teiUid, User user );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/EventPersistenceService.java
@@ -30,21 +30,38 @@ package org.hisp.dhis.dxf2.events.event.persistence;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
-import org.hisp.dhis.program.ProgramStageInstance;
 
 /**
+ * Wrapper service for Event-related operations. This service acts as a
+ * transactional wrapper for insert/update/delete operations on Events.
+ *
  * @author Luciano Fiandesio
  */
 public interface EventPersistenceService
 {
+    /**
+     * Add the list of given events.
+     *
+     * @param context a {@see WorkContext}
+     * @param events a List of {@see Event}
+     */
     void save( WorkContext context, List<Event> events );
 
+    /**
+     * Updates the list of given events.
+     *
+     * @param context a {@see WorkContext}
+     * @param events a List of {@see Event}
+     */
     void update( WorkContext context, List<Event> events );
 
-    void delete( WorkContext context, Event event );
-
+    /**
+     * Deletes the provided list of events.
+     *
+     * @param context a {@see WorkContext}
+     * @param events a List of {@see Event}
+     */
     void delete( WorkContext context, List<Event> events );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -29,22 +29,19 @@
 package org.hisp.dhis.dxf2.events.importer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.dxf2.importsummary.ImportStatus.ERROR;
 import static org.hisp.dhis.dxf2.importsummary.ImportStatus.SUCCESS;
 import static org.hisp.dhis.dxf2.importsummary.ImportSummary.error;
-import static org.hisp.dhis.importexport.ImportStrategy.CREATE;
-import static org.hisp.dhis.importexport.ImportStrategy.DELETE;
-import static org.hisp.dhis.importexport.ImportStrategy.UPDATE;
+import static org.hisp.dhis.importexport.ImportStrategy.*;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.persistence.EventPersistenceService;
@@ -59,6 +56,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableList;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
@@ -141,12 +140,9 @@ public class EventManager
         // pre-process events
         preInsertProcessorFactory.process( workContext, validEvents );
 
-        // @formatter:off
         importSummaries.addImportSummaries(
             // Run validation against the remaining "insertable" events //
-            insertValidationFactory.check( workContext, validEvents )
-        );
-        // @formatter:on
+            insertValidationFactory.check( workContext, validEvents ) );
 
         // collect the UIDs of events that did not pass validation
         final List<String> invalidEvents = importSummaries.getImportSummaries().stream()
@@ -182,7 +178,7 @@ public class EventManager
 
     public ImportSummary updateEvent( final Event event, final WorkContext workContext )
     {
-        final List<Event> singleEvent = Collections.singletonList( event );
+        final List<Event> singleEvent = singletonList( event );
 
         final ImportSummaries importSummaries = updateEvents( singleEvent, workContext );
 
@@ -203,12 +199,9 @@ public class EventManager
         // pre-process events
         preUpdateProcessorFactory.process( workContext, events );
 
-        // @formatter:off
         importSummaries.addImportSummaries(
             // Run validation against the remaining "updatable" events //
-            updateValidationFactory.check( workContext, events)
-        );
-        // @formatter:on
+            updateValidationFactory.check( workContext, events ) );
 
         // collect the UIDs of events that did not pass validation
         final List<String> eventValidationFailedUids = importSummaries.getImportSummaries().stream()
@@ -386,15 +379,15 @@ public class EventManager
             {
                 if ( UPDATE == importStrategy )
                 {
-                    eventPersistenceService.update( workContext, Collections.singletonList( event ) );
+                    eventPersistenceService.update( workContext, singletonList( event ) );
                 }
                 else if ( CREATE == importStrategy )
                 {
-                    eventPersistenceService.save( workContext, Collections.singletonList( event ) );
+                    eventPersistenceService.save( workContext, singletonList( event ) );
                 }
                 else
                 {
-                    eventPersistenceService.delete( workContext, event );
+                    eventPersistenceService.delete( workContext, singletonList( event ) );
                 }
 
             }


### PR DESCRIPTION
- Make sure that events are sorted by UID before doing a batch update.
This prevents multiple concurrent transactions to trigger a Postgres
deadlock, when the list of events is "out of order"
- Make sure that the TEI are sorted when updating TEI after an Event
update
- Added javadoc to interfaces
- Code clean-up

(cherry picked from commit 3348897beff380785f0404c57019da62ee3fba0b)