### PR TITLE
fix: prevent db deadlock during Event update

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
@@ -54,8 +54,8 @@ public interface EventStore
     List<ProgramStageInstance> saveEvents(List<ProgramStageInstance> programStageInstances );
 
     /**
-     * Updates a List of {@see ProgramStageInstance}. Notes are not stored
-     * at this stage.
+     * Updates a List of {@see ProgramStageInstance}.
+     * Notes are not stored at this stage.
      *
      * @param programStageInstances a List of {@see ProgramStageInstance}
      *
@@ -80,5 +80,12 @@ public interface EventStore
      */
     void delete( List<Event> events );
 
+    /**
+     * Updates the "last updated" and "last updated By" of the
+     * Tracked Entity Instances matching the provided list of UIDs
+     *
+     * @param teiUid a List of Tracked Entity Instance uid
+     * @param user the User to use for the last update by value. Can be null.
+     */
     void updateTrackedEntityInstances( List<String> teiUid, User user );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -69,26 +69,16 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.google.common.collect.ImmutableMap;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.cache2k.Cache;
-import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
@@ -123,7 +113,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
-import org.postgis.PGgeometry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
 import org.springframework.dao.DataAccessException;
@@ -133,8 +122,16 @@ import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -217,9 +214,8 @@ public class JdbcEventStore implements EventStore
      * statement. This prevents deadlocks when Postgres tries to update the same
      * TEI.
      */
-    String UPDATE_TEI_SQL = "SELECT * FROM trackedentityinstance where uid in (?) FOR UPDATE %s;" +
-            "update trackedentityinstance set lastupdated = ?, lastupdatedby = ? where uid in (?)";
-
+    private final static String UPDATE_TEI_SQL = "SELECT * FROM trackedentityinstance where uid in (?) FOR UPDATE %s;" +
+        "update trackedentityinstance set lastupdated = ?, lastupdatedby = ? where uid in (?)";
 
     // -------------------------------------------------------------------------
     // Dependencies
@@ -240,11 +236,6 @@ public class JdbcEventStore implements EventStore
     private final ObjectMapper jsonMapper;
 
     private final Environment env;
-
-    private final Cache<String, String> teiUpdateCache = new Cache2kBuilder<String, String>() {}
-        .name( "teiUpdateCache" + RandomStringUtils.randomAlphabetic(5) )
-        .expireAfterWrite( 10, TimeUnit.SECONDS )
-        .build();
 
     public JdbcEventStore( StatementBuilder statementBuilder, JdbcTemplate jdbcTemplate,
         @Qualifier( "dataValueJsonMapper" ) ObjectMapper jsonMapper,
@@ -467,7 +458,7 @@ public class JdbcEventStore implements EventStore
     {
         try
         {
-            jdbcTemplate.batchUpdate( UPDATE_EVENT_SQL, programStageInstances, programStageInstances.size(),
+            jdbcTemplate.batchUpdate( UPDATE_EVENT_SQL, sort( programStageInstances) , programStageInstances.size(),
                 ( ps, programStageInstance ) -> {
                     try
                     {
@@ -1497,7 +1488,7 @@ public class JdbcEventStore implements EventStore
     private List<ProgramStageInstance> saveAllEvents( List<ProgramStageInstance> batch )
     {
         JdbcUtils.batchUpdateWithKeyHolder( jdbcTemplate, INSERT_EVENT_SQL,
-                new BatchPreparedStatementSetterWithKeyHolder<ProgramStageInstance>( batch )
+                new BatchPreparedStatementSetterWithKeyHolder<ProgramStageInstance>( sort (batch) )
             {
                 @Override
                 protected void setValues( PreparedStatement ps, ProgramStageInstance event )
@@ -1569,38 +1560,26 @@ public class JdbcEventStore implements EventStore
         }
         try
         {
-            List<String> updatableTeiUid = new ArrayList<>();
-            for ( String uid : teiUids )
-            {
-                if ( !teiUpdateCache.containsKey( uid ) )
+            final String result = teiUids.stream()
+                .sorted() // make sure the list is sorted, to prevent deadlocks
+                .map( s -> "'" + s + "'" )
+                .collect( Collectors.joining( ", " ) );
+
+            jdbcTemplate.execute( getUpdateTeiSql(), (PreparedStatementCallback<Boolean>) psc -> {
+                psc.setString( 1, result );
+                psc.setTimestamp( 2, JdbcEventSupport.toTimestamp( new Date() ) );
+                if ( user != null )
                 {
-                    updatableTeiUid.add( uid );
-                    teiUpdateCache.put( uid, uid );
+                    psc.setLong( 3, user.getId() );
                 }
-            }
-            
+                else
+                {
+                    psc.setNull( 3, Types.INTEGER );
+                }
+                psc.setString( 4, result );
+                return psc.execute();
+            } );
 
-            if ( !updatableTeiUid.isEmpty() )
-            {
-                final String result = updatableTeiUid.stream()
-                    .map( s -> "'" + s + "'" )
-                    .collect( Collectors.joining( ", " ) );
-
-                jdbcTemplate.execute( getUpdateTeiSql(), (PreparedStatementCallback<Boolean>) psc -> {
-                    psc.setString( 1, result );
-                    psc.setTimestamp( 2, JdbcEventSupport.toTimestamp( new Date() ) );
-                    if ( user != null )
-                    {
-                        psc.setLong( 3, user.getId() );
-                    }
-                    else
-                    {
-                        psc.setNull( 3, Types.INTEGER );
-                    }
-                    psc.setString( 4, result );
-                    return psc.execute();
-                } );
-            }
         }
         catch ( DataAccessException e )
         {
@@ -1643,7 +1622,7 @@ public class JdbcEventStore implements EventStore
         ps.setString(       15, event.getCode() );
         ps.setTimestamp(    16, JdbcEventSupport.toTimestamp( event.getCreatedAtClient() ) );
         ps.setTimestamp(    17, JdbcEventSupport.toTimestamp( event.getLastUpdatedAtClient() ) );
-        ps.setObject(       18, toGeometry( event.getGeometry() )  );
+        ps.setObject(       18, JdbcEventSupport.toGeometry( event.getGeometry() )  );
         if ( event.getAssignedUser() != null )
         {
             ps.setLong(     19, event.getAssignedUser().getId() );
@@ -1673,7 +1652,7 @@ public class JdbcEventStore implements EventStore
         ps.setString( 13, programStageInstance.getCode() );
         ps.setTimestamp( 14, JdbcEventSupport.toTimestamp( programStageInstance.getCreatedAtClient() ) );
         ps.setTimestamp( 15, JdbcEventSupport.toTimestamp( programStageInstance.getLastUpdatedAtClient() ) );
-        ps.setObject( 16, toGeometry( programStageInstance.getGeometry()  )  );
+        ps.setObject( 16, JdbcEventSupport.toGeometry( programStageInstance.getGeometry()  )  );
 
         if ( programStageInstance.getAssignedUser() != null )
         {
@@ -1815,10 +1794,12 @@ public class JdbcEventStore implements EventStore
         }
     }
 
-    private PGgeometry toGeometry( Geometry geometry )
-            throws SQLException
+    /**
+     * Sort the list of {@see ProgramStageInstance} by UID
+     */
+    private List<ProgramStageInstance> sort( List<ProgramStageInstance> batch )
     {
-        return geometry != null ? new PGgeometry( geometry.toText() ) : null;
+        return batch.stream().sorted( Comparator.comparing( ProgramStageInstance::getUid ) ).collect( toList() );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventSupport.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventSupport.java
@@ -1,9 +1,14 @@
 package org.hisp.dhis.dxf2.events.event;
 
-import lombok.experimental.UtilityClass;
-
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Date;
+
+import org.postgis.PGgeometry;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 class JdbcEventSupport
@@ -12,5 +17,10 @@ class JdbcEventSupport
     Timestamp toTimestamp( Date date )
     {
         return date != null ? new Timestamp( date.getTime() ) : null;
+    }
+
+    PGgeometry toGeometry( Geometry geometry ) throws SQLException
+    {
+        return geometry != null ? new PGgeometry( geometry.toText() ) : null;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/EventPersistenceService.java
@@ -44,7 +44,5 @@ public interface EventPersistenceService
 
     void update( WorkContext context, List<Event> events );
 
-    void delete( WorkContext context, Event event );
-
     void delete( WorkContext context, List<Event> events );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -34,9 +34,7 @@ import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.dxf2.importsummary.ImportStatus.ERROR;
 import static org.hisp.dhis.dxf2.importsummary.ImportStatus.SUCCESS;
 import static org.hisp.dhis.dxf2.importsummary.ImportSummary.error;
-import static org.hisp.dhis.importexport.ImportStrategy.CREATE;
-import static org.hisp.dhis.importexport.ImportStrategy.DELETE;
-import static org.hisp.dhis.importexport.ImportStrategy.UPDATE;
+import static org.hisp.dhis.importexport.ImportStrategy.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +42,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.persistence.EventPersistenceService;
@@ -59,6 +56,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableList;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
@@ -141,12 +140,9 @@ public class EventManager
         // pre-process events
         preInsertProcessorFactory.process( workContext, validEvents );
 
-        // @formatter:off
         importSummaries.addImportSummaries(
             // Run validation against the remaining "insertable" events //
-            insertValidationFactory.check( workContext, validEvents )
-        );
-        // @formatter:on
+            insertValidationFactory.check( workContext, validEvents ) );
 
         // collect the UIDs of events that did not pass validation
         final List<String> invalidEvents = importSummaries.getImportSummaries().stream()
@@ -203,12 +199,9 @@ public class EventManager
         // pre-process events
         preUpdateProcessorFactory.process( workContext, events );
 
-        // @formatter:off
         importSummaries.addImportSummaries(
             // Run validation against the remaining "updatable" events //
-            updateValidationFactory.check( workContext, events)
-        );
-        // @formatter:on
+            updateValidationFactory.check( workContext, events ) );
 
         // collect the UIDs of events that did not pass validation
         final List<String> eventValidationFailedUids = importSummaries.getImportSummaries().stream()
@@ -249,12 +242,9 @@ public class EventManager
     {
         final ImportSummaries importSummaries = new ImportSummaries();
 
-        // @formatter:off
         importSummaries.addImportSummaries(
             // Run validation against the remaining "insertable" events //
-            deleteValidationFactory.check( workContext, events )
-        );
-        // @formatter:on
+            deleteValidationFactory.check( workContext, events ) );
 
         // collect the UIDs of events that did not pass validation
         final List<String> eventValidationFailedUids = importSummaries.getImportSummaries().stream()
@@ -394,7 +384,7 @@ public class EventManager
                 }
                 else
                 {
-                    eventPersistenceService.delete( workContext, event );
+                    eventPersistenceService.delete( workContext, Collections.singletonList( event ) );
                 }
 
             }


### PR DESCRIPTION
- Make sure that events are sorted by UID before doing a batch update.
This prevents multiple concurrent transactions to trigger a Postgres
deadlock, when the list of events is "out of order"
- fix: prevent db deadlock during Event update
- Make sure that the TEI are sorted when updating TEI after an Event
update
- Added missing javadoc to Event-related interface methods
- Minor code cleanup

ref: DHIS2-9383
(cherry picked from commit 3348897)]

**PLEASE NOTE THAT THIS PR HAS BEEN ALREADY APPROVED AND MERGED FOR 2.35**