### PR TITLE
fix: [DHIS2-9483] Update FOP deps (2.35)

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1464,7 +1464,7 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-transcoder</artifactId>
-        <version>1.11</version>
+        <version>1.13</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -1483,13 +1483,17 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-codec</artifactId>
-        <version>1.11</version>
+        <version>1.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>fop</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
         <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
This fixes a NoSuchMethodError in the PDF generation.

Backporting from master (2.36).