### PR TITLE
[2.35] fix: DB pool saturation under heavy concurrency

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceAuditStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceAuditStore.java
@@ -47,7 +47,14 @@ public interface TrackedEntityInstanceAuditStore
      * @param trackedEntityInstanceAudit the audit to add
      */
     void addTrackedEntityInstanceAudit( TrackedEntityInstanceAudit trackedEntityInstanceAudit );
-    
+
+    /**
+     * Adds multiple {@see TrackedEntityInstanceAudit} instances to the database
+     *
+     * @param trackedEntityInstanceAudit the audit to add
+     */
+    void addTrackedEntityInstanceAudit( List<TrackedEntityInstanceAudit> trackedEntityInstanceAudit );
+
     /**
      * Deletes tracked entity instance audit for the given tracked entity instance
      * 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceAuditService.java
@@ -84,6 +84,14 @@ public class DefaultTrackedEntityInstanceAuditService
     }
 
     @Override
+    @Async
+    @Transactional
+    public void addTrackedEntityInstanceAudit( List<TrackedEntityInstanceAudit> trackedEntityInstanceAudits )
+    {
+        trackedEntityInstanceAuditStore.addTrackedEntityInstanceAudit( trackedEntityInstanceAudits );
+    }
+
+    @Override
     @Transactional
     public void deleteTrackedEntityInstanceAudit( TrackedEntityInstance trackedEntityInstance )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -210,6 +210,7 @@ public class DefaultTrackedEntityInstanceService
         }
 
         decideAccess( params );
+
         //AccessValidation should be skipped only and only if it is internal service that runs the task (for example sync job)
         if ( !skipAccessValidation )
         {
@@ -227,9 +228,7 @@ public class DefaultTrackedEntityInstanceService
 
         params.handleCurrentUserSelectionMode();
 
-        List<Long> trackedEntityInstances = trackedEntityInstanceStore.getTrackedEntityInstanceIds( params );
-
-        return trackedEntityInstances;
+        return trackedEntityInstanceStore.getTrackedEntityInstanceIds( params );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -321,11 +321,11 @@ public class HibernateTrackedEntityInstanceStore
         // If sync job, fetch only TEAVs that are supposed to be synchronized
 
         hql += addConditionally( params.isSynchronizationQuery(),
-                () -> "left join tei.trackedEntityAttributeValues teav1 " +
-                "left join teav1.attribute as attr" + hlp.whereAnd() + " attr.skipSynchronization = false" );
+            () -> "left join tei.trackedEntityAttributeValues teav1 " +
+            "left join teav1.attribute as attr" + hlp.whereAnd() + " attr.skipSynchronization = false" );
 
         hql += addWhereConditionally( hlp, params.hasTrackedEntityType(), () ->
-                "tei.trackedEntityType.uid='" + params.getTrackedEntityType().getUid() + "'" );
+            "tei.trackedEntityType.uid='" + params.getTrackedEntityType().getUid() + "'" );
 
         if ( params.hasLastUpdatedDuration() )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/AbstractAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/AbstractAggregate.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.dxf2.events.aggregates;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -41,30 +42,31 @@ import com.google.common.collect.Multimap;
  */
 public abstract class AbstractAggregate
 {
-
     /**
-     * Executes the Supplier asynchronously
+     * Executes the Supplier asynchronously using the thread pool from the provided {@see Executor}
      *
-     * @param condition A condition that, if true, executes the Suppier, if false, returns an empty Multimap
+     * @param condition A condition that, if true, executes the Supplier, if false, returns an empty Multimap
      * @param supplier The Supplier to execute
+     * @param executor an Executor instance
+     *                 
      * @return A CompletableFuture with the result of the Supplier
      */
     <T> CompletableFuture<Multimap<String, T>> conditionalAsyncFetch( boolean condition,
-        Supplier<Multimap<String, T>> supplier )
+        Supplier<Multimap<String, T>> supplier, Executor executor )
     {
-        return (condition ? supplyAsync( supplier ) : supplyAsync( ArrayListMultimap::create ));
+        return (condition ? supplyAsync( supplier, executor ) : supplyAsync( ArrayListMultimap::create, executor ));
     }
 
     /**
-     * Executes the Supplier asynchronously
+     * Executes the Supplier asynchronously using the thread pool from the provided {@see Executor}
      *
      * @param supplier The Supplier to execute
      *
      * @return A CompletableFuture with the result of the Supplier
      */
-    <T> CompletableFuture<Multimap<String, T>> asyncFetch( Supplier<Multimap<String, T>> supplier )
+    <T> CompletableFuture<Multimap<String, T>> asyncFetch( Supplier<Multimap<String, T>> supplier, Executor executor )
     {
-        return supplyAsync( supplier );
+        return supplyAsync( supplier, executor );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/ThreadPoolManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/ThreadPoolManager.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.trackedentity;
+package org.hisp.dhis.dxf2.events.aggregates;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,53 +28,34 @@ package org.hisp.dhis.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.audit.payloads.TrackedEntityInstanceAudit;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
-import java.util.List;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
- * @author Abyot Asalefew Gizaw abyota@gmail.com
+ * Exposes a static method to fetch an Executor for the Aggregates operations
  *
+ * @author Luciano Fiandesio
  */
-public interface TrackedEntityInstanceAuditService
+public class ThreadPoolManager
 {
-    
-    String ID = TrackedEntityInstanceAuditService.class.getName();
-    
-    /**
-     * Adds tracked entity instance audit
-     * 
-     * @param trackedEntityInstanceAudit the audit to add
-     */
-    void addTrackedEntityInstanceAudit( TrackedEntityInstanceAudit trackedEntityInstanceAudit );
+    // Thread factory that sets a user-defined thread name (useful for debugging purposes)
+
+    private final static ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat( "TRACKER-TEI-FETCH-%d" )
+        .setDaemon( true )
+        .build();
 
     /**
-     * Adds multipe tracked entity instance audit
-     *
+     * Cached thread pool: not bound to a size, but can reuse existing threads.
      */
-    void addTrackedEntityInstanceAudit( List<TrackedEntityInstanceAudit> trackedEntityInstanceAudits );
+    private final static Executor AGGREGATE_THREAD_POOL = Executors.newCachedThreadPool( threadFactory );
 
-    /**
-     * Deletes tracked entity instance audit for the given tracked entity instance
-     * 
-     * @param trackedEntityInstance the tracked entity instance
-     */
-    void deleteTrackedEntityInstanceAudit( TrackedEntityInstance trackedEntityInstance );    
-    
-    /**
-     * Returns tracked entity instance audits matching query params
-     * 
-     * @param params tracked entity instance audit query params 
-     * @return matching TrackedEntityInstanceAudits
-     */
-    List<TrackedEntityInstanceAudit> getTrackedEntityInstanceAudits( TrackedEntityInstanceAuditQueryParams params );
-    
-    /**
-     * Returns count of tracked entity instance audits matching query params
-     * 
-     * @param params tracked entity instance audit query params
-     * @return count of TrackedEntityInstanceAudits
-     */
-    int getTrackedEntityInstanceAuditsCount( TrackedEntityInstanceAuditQueryParams params );
+    static Executor getPool()
+    {
+        return AGGREGATE_THREAD_POOL;
+    }
 
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
@@ -28,6 +28,11 @@ package org.hisp.dhis.dxf2.events.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
+
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
@@ -35,11 +40,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.user.User;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Date;
-import java.util.List;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -59,6 +59,19 @@ public interface TrackedEntityInstanceService
     List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityInstanceParams params, boolean skipAccessValidation );
 
+    /**
+     * Fetches a List of {@see TrackedEntityInstance} based on the specified
+     * parameters. This methods beh
+     * 
+     * @param queryParams a {@see TrackedEntityInstanceQueryParams} instance with
+     *        the query parameters
+     * @param params a {@see TrackedEntityInstanceParams} instance containing the
+     *        directives for how much data should be fetched (e.g. Enrollments,
+     *        Events, Relationships)
+     * @param skipAccessValidation whether access validation should be ignored
+     *
+     * @return a List of {@see TrackedEntityInstance}
+     */
     List<TrackedEntityInstance> getTrackedEntityInstances2( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityInstanceParams params, boolean skipAccessValidation );
 


### PR DESCRIPTION
Removes the `@Transactional` annotation from the newly added `getTrackedEntityInstances2 (courtesy of @enricocolasante ).
The annotation was causing the C3P0 pool to saturate with 200+ concurrent users. The first 80 threads were keeping the Transactionopen (80 is the default pool size) while executing the TEI fetching
logic. The other 120 threads were also trying to access the DB, but
could not get a connection from the pool.

This PR also:

- Makes the TEI fetching use a dedicated Executor to avoid using the default JVM ThreadPool
- Adds 3 local caches for TEI Attribute Type, TEI Attribute by Program and security context
- Adds a method to persist TEI Audit in batch, rather than executing an `INSERT` statement for each TEI to audit
- Minor code cleanup