### PR TITLE
fix: match bundled filter to prop name

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -202,7 +202,7 @@ public class DefaultAppManager
         {
             apps.retainAll( getAppsByShortName( value, apps, operator ) );
         }
-        else if ( "isBundled".equalsIgnoreCase( key ) )
+        else if ( "bundled".equalsIgnoreCase( key ) )
         {
             boolean isBundled = "true".equalsIgnoreCase( value );
             apps.retainAll( getAppsByIsBundled( isBundled, apps ) );


### PR DESCRIPTION
The prop in the json output of `/api/apps` is `bundled`.  This change changes the `?filter` query to match this, from `?filter=isBundled:eq:true` to `?filter=bundled:eq:true`

This filter parameter is not currently used by any frontend apps, so this is not a breaking change.  It's important to get into 2.35.0 if possible so that we don't introduce a new API inconsistency that we have to "break" later.