### PR TITLE
[2.35.0] fix: allow updating an Event with File data type

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -115,6 +115,10 @@
       <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exparity</groupId>
+      <artifactId>hamcrest-date</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1733,12 +1733,21 @@ public class JdbcEventStore implements EventStore
         // @formatter:on
     }
 
-    private void bindEventParamsForUpdate( PreparedStatement ps, ProgramStageInstance programStageInstance  ) throws SQLException, JsonProcessingException {
-
+    private void bindEventParamsForUpdate( PreparedStatement ps, ProgramStageInstance programStageInstance )
+        throws SQLException,
+        JsonProcessingException
+    {
         ps.setLong( 1, programStageInstance.getProgramInstance().getId() );
         ps.setLong( 2, programStageInstance.getProgramStage().getId() );
         ps.setTimestamp( 3, new Timestamp( programStageInstance.getDueDate().getTime() ) );
-        ps.setTimestamp( 4, new Timestamp( programStageInstance.getExecutionDate().getTime() ) );
+        if ( programStageInstance.getExecutionDate() != null )
+        {
+            ps.setTimestamp( 4, new Timestamp( programStageInstance.getExecutionDate().getTime() ) );
+        }
+        else
+        {
+            ps.setObject( 4, null );
+        }
         ps.setLong( 5, programStageInstance.getOrganisationUnit().getId() );
         ps.setString( 6, programStageInstance.getStatus().toString() );
         ps.setTimestamp( 7, toTimestamp( programStageInstance.getCompletedDate() ) );
@@ -1750,7 +1759,7 @@ public class JdbcEventStore implements EventStore
         ps.setString( 13, programStageInstance.getCode() );
         ps.setTimestamp( 14, toTimestamp( programStageInstance.getCreatedAtClient() ) );
         ps.setTimestamp( 15, toTimestamp( programStageInstance.getLastUpdatedAtClient() ) );
-        ps.setObject( 16, toGeometry( programStageInstance.getGeometry()  )  );
+        ps.setObject( 16, toGeometry( programStageInstance.getGeometry() ) );
 
         if ( programStageInstance.getAssignedUser() != null )
         {
@@ -1763,7 +1772,6 @@ public class JdbcEventStore implements EventStore
 
         ps.setObject( 18, eventDataValuesToJson( programStageInstance.getEventDataValues(), this.jsonMapper ) );
         ps.setString( 19, programStageInstance.getUid() );
-
     }
 
     private boolean userHasAccess( SqlRowSet rowSet )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
@@ -66,34 +66,34 @@ public class AttributeOptionComboLoader
     private final static String KEY_SEPARATOR = "-";
 
     public final static String SQL_GET_CATEGORYOPTIONCOMBO = "select coc.categoryoptioncomboid, "
-            + "coc.uid, coc.code, coc.ignoreapproval, coc.name, c.uid as cc_uid, c.name as cc_name, "
-            + "string_agg(dec.categoryid::text, ',') as cat_ids from categoryoptioncombo coc "
-            + "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid "
-            + "join categorycombo c on co.categorycomboid = c.categorycomboid "
-            + "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid "
-            + "join dataelementcategory dec on cc.categoryid = dec.categoryid where coc."
-            + "${resolvedScheme} "
-            + "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name";
+        + "coc.uid, coc.code, coc.ignoreapproval, coc.name, c.uid as cc_uid, c.name as cc_name, "
+        + "string_agg(dec.categoryid::text, ',') as cat_ids from categoryoptioncombo coc "
+        + "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid "
+        + "join categorycombo c on co.categorycomboid = c.categorycomboid "
+        + "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid "
+        + "join dataelementcategory dec on cc.categoryid = dec.categoryid where coc."
+        + "${resolvedScheme} "
+        + "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name";
 
     public final static String SQL_GET_CATEGORYOPTIONCOMBO_BY_CATEGORYIDS = "select * from ( " +
-            "select coc.categoryoptioncomboid, " +
-            "coc.uid, " +
-            "coc.code, " +
-            "coc.ignoreapproval, " +
-            "coc.name, " +
-            "c.uid as cc_uid, " +
-            "c.name as cc_name," +
-            "string_agg( dec.categoryid::text, ',') as cat_ids " +
-            "from categoryoptioncombo coc " +
-            "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid " +
-            "join categorycombo c on co.categorycomboid = c.categorycomboid " +
-            "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid " +
-            "join dataelementcategory dec on cc.categoryid = dec.categoryid " +
-            "where c.${resolvedScheme} " +
-            "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name " +
-            ") as catoptcombo where " +
-            "array_length(regexp_split_to_array(cat_ids, ','),1) = array_length(ARRAY[${option_ids}],1) AND " +
-            "regexp_split_to_array(cat_ids, ',') @> ARRAY[${option_ids}]";
+        "select coc.categoryoptioncomboid, " +
+        "coc.uid, " +
+        "coc.code, " +
+        "coc.ignoreapproval, " +
+        "coc.name, " +
+        "c.uid as cc_uid, " +
+        "c.name as cc_name," +
+        "string_agg( dec.categoryid::text, ',') as cat_ids " +
+        "from categoryoptioncombo coc " +
+        "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid " +
+        "join categorycombo c on co.categorycomboid = c.categorycomboid " +
+        "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid " +
+        "join dataelementcategory dec on cc.categoryid = dec.categoryid " +
+        "where c.${resolvedScheme} " +
+        "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name " +
+        ") as catoptcombo where " +
+        "array_length(regexp_split_to_array(cat_ids, ','),1) = array_length(ARRAY[${option_ids}],1) AND " +
+        "regexp_split_to_array(cat_ids, ',') @> ARRAY[${option_ids}]";
 
     public AttributeOptionComboLoader( @Qualifier( "readOnlyJdbcTemplate" ) JdbcTemplate jdbcTemplate )
     {
@@ -249,13 +249,11 @@ public class AttributeOptionComboLoader
             .map( s -> "'" + s + "'" )
             .collect( Collectors.joining( "," ) );
 
-        // @formatter:off
-        StrSubstitutor sub = new StrSubstitutor( ImmutableMap.<String, String>builder()
-                .put( "resolvedScheme", Objects.requireNonNull( categoryComboKey ) )
-                .put( "option_ids", optionsId )
-                .build() );
-        // @formatter:on
-        
+        StrSubstitutor sub = new StrSubstitutor( ImmutableMap.<String, String> builder()
+            .put( "resolvedScheme", Objects.requireNonNull( categoryComboKey ) )
+            .put( "option_ids", optionsId )
+            .build() );
+
         // TODO use cache
         List<CategoryOptionCombo> categoryOptionCombos = jdbcTemplate
             .query( sub.replace( SQL_GET_CATEGORYOPTIONCOMBO_BY_CATEGORYIDS ), ( rs, i ) -> bind( key, rs ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContext.java
@@ -177,4 +177,9 @@ public class WorkContext
     {
         return Optional.ofNullable( this.getProgramStageInstanceMap().get( event ) );
     }
+
+    public Optional<ProgramInstance> getProgramInstance( String event )
+    {
+        return Optional.ofNullable( this.getProgramInstanceMap().get( event ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
@@ -81,11 +81,7 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         // Org Unit
         getOrganisationUnit( event ).ifPresent( psi::setOrganisationUnit );
 
-        // Status
-        if ( event.getStatus() != null && !psi.getStatus().equals( event.getStatus() ) )
-        {
-            psi.setStatus( event.getStatus() );
-        }
+        // Status and completed date are set in the Update Preprocessor //
 
         // Attribute Option Combo
         psi.setAttributeOptionCombo( this.workContext.getCategoryOptionComboMap().get( event.getUid() ) );
@@ -102,9 +98,12 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         // Data Values
         psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ) );
 
-        setDueDate( event, psi );
+        if ( event.getDueDate() != null )
+        {
+            psi.setDueDate( parseDate( event.getDueDate() ) );
+        }
+
         setExecutionDate( event, psi );
-        setCompletedDate( event, psi );
 
         if ( psi.getProgramStage() != null && psi.getProgramStage().isEnableUserAssignment() )
         {
@@ -161,7 +160,14 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         // Data Values
         psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ) );
 
-        setDueDate( event, psi );
+        Date dueDate = new Date();
+
+        if ( event.getDueDate() != null )
+        {
+            dueDate = parseDate( event.getDueDate() );
+        }
+
+        psi.setDueDate( dueDate );
         setCompletedDate( event, psi );
         // Note that execution date can be null
         setExecutionDate( event, psi );
@@ -203,14 +209,6 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         return Optional.ofNullable( this.workContext.getOrganisationUnitMap().get( event.getUid() ) );
     }
 
-    private void setDueDate( Event event, ProgramStageInstance psi )
-    {
-        if ( event.getDueDate() != null )
-        {
-            psi.setDueDate( parseDate( event.getDueDate() ) );
-        }
-    }
-
     private void setExecutionDate( Event event, ProgramStageInstance psi )
     {
         if ( event.getEventDate() != null )
@@ -221,8 +219,8 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
     
     private void setCompletedDate( Event event, ProgramStageInstance psi )
     {
-        // Completed Date
-        if ( psi.isCompleted() && event.getStatus() != COMPLETED )
+        // Completed Date // FIXME this logic should be moved to a preprocessor
+        if ( psi.isCompleted() )
         {
             Date completedDate = new Date();
             if ( event.getCompletedDate() != null )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
@@ -33,15 +33,19 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.IdScheme.CODE;
 import static org.hisp.dhis.common.IdScheme.UID;
+import static org.hisp.dhis.event.EventStatus.COMPLETED;
 import static org.hisp.dhis.event.EventStatus.fromInt;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 
@@ -61,89 +65,119 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
     @Override
     public ProgramStageInstance map( Event event )
     {
-        ImportOptions importOptions = workContext.getImportOptions();
+        ProgramStageInstance psi = workContext.getProgramStageInstanceMap().get( event.getUid() );
         
-        ProgramStageInstance psi = new ProgramStageInstance();
-        
-        ProgramStageInstance programStageInstance = this.workContext.getProgramStageInstanceMap().get( event.getUid() );
-        if ( programStageInstance != null )
+        return psi == null ? mapForInsert( event ) : mapForUpdate( event, psi );
+    }
+
+    private ProgramStageInstance mapForUpdate( Event event, ProgramStageInstance psi )
+    {
+        // Program Instance
+        workContext.getProgramInstance( event.getUid() ).ifPresent( psi::setProgramInstance );
+
+        // Program Stage
+        getProgramStage( event ).ifPresent( psi::setProgramStage );
+
+        // Org Unit
+        getOrganisationUnit( event ).ifPresent( psi::setOrganisationUnit );
+
+        // Status
+        if ( event.getStatus() != null && !psi.getStatus().equals( event.getStatus() ) )
         {
-            psi.setId( programStageInstance.getId() );
+            psi.setStatus( event.getStatus() );
         }
 
-        if ( importOptions.getIdSchemes().getProgramStageInstanceIdScheme().equals( CODE ) )
-        {
-            // TODO: Is this really correct?
-            psi.setCode( event.getUid() );
-        }
-        else if ( importOptions.getIdSchemes().getProgramStageIdScheme().equals( UID ) )
-        {
-            psi.setUid( event.getUid() );
-        }
-
-        // FKs
-        psi.setProgramInstance( this.workContext.getProgramInstanceMap().get( event.getUid() ) );
-        psi.setProgramStage( this.workContext.getProgramStage( importOptions.getIdSchemes().getProgramStageIdScheme(),
-            event.getProgramStage() ) );
-        psi.setOrganisationUnit( this.workContext.getOrganisationUnitMap().get( event.getUid() ) );
-
-        // EXECUTION + DUE DATE
-        Date executionDate = null;
-
-        if ( event.getEventDate() != null )
-        {
-            executionDate = parseDate( event.getEventDate() );
-        }
-
-        Date dueDate = new Date();
-
-        if ( event.getDueDate() != null )
-        {
-            dueDate = parseDate( event.getDueDate() );
-        }
-
-        psi.setDueDate( dueDate );
-        // Note that execution date can be null
-        psi.setExecutionDate( executionDate );
-
-        psi.setStoredBy( event.getStoredBy() );
-        psi.setCompletedBy( event.getCompletedBy() );
-        
-        // STATUS
-        psi.setStatus( fromInt( event.getStatus().getValue() ) );
-
-        if ( psi.isCompleted() )
-        {
-            Date completedDate = new Date();
-            if ( event.getCompletedDate() != null )
-            {
-                completedDate = parseDate( event.getCompletedDate() );
-            }
-            psi.setCompletedDate( completedDate );
-        }
-
-        // ATTRIBUTE OPTION COMBO
-
+        // Attribute Option Combo
         psi.setAttributeOptionCombo( this.workContext.getCategoryOptionComboMap().get( event.getUid() ) );
 
-        // GEOMETRY
-
+        // Geometry
         psi.setGeometry( event.getGeometry() );
 
-        // CREATED AT CLIENT + UPDATED AT CLIENT
+        // Notes
+        if ( !event.getNotes().isEmpty() )
+        {
+            psi.setComments( convertNotes( event, this.workContext ) );
+        }
 
-        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
-        psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
+        // Data Values
+        psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ) );
+
+        setDueDate( event, psi );
+        setExecutionDate( event, psi );
+        setCompletedDate( event, psi );
 
         if ( psi.getProgramStage() != null && psi.getProgramStage().isEnableUserAssignment() )
         {
             psi.setAssignedUser( this.workContext.getAssignedUserMap().get( event.getUid() ) );
         }
 
-        // COMMENTS
+        // CREATED AT CLIENT + UPDATED AT CLIENT
+        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
+        psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
+
+        psi.setStoredBy( event.getStoredBy() );
+        psi.setCompletedBy( event.getCompletedBy() );
+
+        return psi;
+    }
+
+    private ProgramStageInstance mapForInsert( Event event )
+    {
+        ImportOptions importOptions = workContext.getImportOptions();
+
+        ProgramStageInstance psi = new ProgramStageInstance();
+
+        if ( importOptions.getIdSchemes().getProgramStageInstanceIdScheme().equals( CODE ) )
+        {
+            psi.setCode( event.getEvent() );
+        }
+        else if ( importOptions.getIdSchemes().getProgramStageIdScheme().equals( UID ) )
+        {
+            psi.setUid( event.getUid() );
+        }
+
+        // Program Instance
+        psi.setProgramInstance( this.workContext.getProgramInstanceMap().get( event.getUid() ) );
+
+        // Program Stage
+        psi.setProgramStage( this.workContext.getProgramStage( importOptions.getIdSchemes().getProgramStageIdScheme(),
+            event.getProgramStage() ) );
+
+        // Org Unit
+        psi.setOrganisationUnit( this.workContext.getOrganisationUnitMap().get( event.getUid() ) );
+
+        // Status
+        psi.setStatus( fromInt( event.getStatus().getValue() ) );
+
+        // Attribute Option Combo
+        psi.setAttributeOptionCombo( this.workContext.getCategoryOptionComboMap().get( event.getUid() ) );
+
+        // Geometry
+        psi.setGeometry( event.getGeometry() );
+
+        // Notes
         psi.setComments( convertNotes( event, this.workContext ) );
 
-        psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ));
+        // Data Values
+        psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ) );
+
+        setDueDate( event, psi );
+        setCompletedDate( event, psi );
+        // Note that execution date can be null
+        setExecutionDate( event, psi );
+
+        if ( psi.getProgramStage() != null && psi.getProgramStage().isEnableUserAssignment() )
+        {
+            psi.setAssignedUser( this.workContext.getAssignedUserMap().get( event.getUid() ) );
+        }
+
+        // CREATED AT CLIENT + UPDATED AT CLIENT
+        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
+        psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
+
+        psi.setStoredBy( event.getStoredBy() );
+        psi.setCompletedBy( event.getCompletedBy() );
+
         return psi;
     }
 
@@ -156,5 +190,46 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         }
 
         return emptyList();
+    }
+
+    private Optional<ProgramStage> getProgramStage( Event event )
+    {
+        return Optional.ofNullable( this.workContext.getProgramStage(
+            this.workContext.getImportOptions().getIdSchemes().getProgramStageIdScheme(), event.getProgramStage() ) );
+    }
+
+    private Optional<OrganisationUnit> getOrganisationUnit( Event event )
+    {
+        return Optional.ofNullable( this.workContext.getOrganisationUnitMap().get( event.getUid() ) );
+    }
+
+    private void setDueDate( Event event, ProgramStageInstance psi )
+    {
+        if ( event.getDueDate() != null )
+        {
+            psi.setDueDate( parseDate( event.getDueDate() ) );
+        }
+    }
+
+    private void setExecutionDate( Event event, ProgramStageInstance psi )
+    {
+        if ( event.getEventDate() != null )
+        {
+            psi.setExecutionDate( parseDate( event.getEventDate() ) );
+        }
+    }
+    
+    private void setCompletedDate( Event event, ProgramStageInstance psi )
+    {
+        // Completed Date
+        if ( psi.isCompleted() && event.getStatus() != COMPLETED )
+        {
+            Date completedDate = new Date();
+            if ( event.getCompletedDate() != null )
+            {
+                completedDate = parseDate( event.getCompletedDate() );
+            }
+            psi.setCompletedDate( completedDate );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/preprocess/ProgramStageInstanceUpdatePreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/preprocess/ProgramStageInstanceUpdatePreProcessor.java
@@ -83,7 +83,10 @@ public class ProgramStageInstanceUpdatePreProcessor implements Processor
 
             programStageInstance.setStoredBy( storedBy );
             programStageInstance.setDueDate( dueDate );
-            programStageInstance.setOrganisationUnit( organisationUnit );
+            if ( organisationUnit != null )
+            {
+                programStageInstance.setOrganisationUnit( organisationUnit );
+            }
             programStageInstance.setGeometry( event.getGeometry() );
 
             if ( programStageInstance.getProgramStage() != null

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -508,11 +508,11 @@ public class EventImportTest
 
     @Test
     public void testVerifyEventCanBeUpdatedUsingProgramOnly2()
-            throws IOException
+        throws IOException
     {
         // CREATE A NEW EVENT
         InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
-                organisationUnitB.getUid(), null, dataElementB, "10" );
+            organisationUnitB.getUid(), null, dataElementB, "10" );
 
         ImportSummaries importSummaries = eventService.addEventsJson( is, null );
         String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
@@ -579,50 +579,6 @@ public class EventImportTest
 
     @Test
     public void testVerifyEventUncompleteSetsCompletedDateToNull()
-            throws IOException
-    {
-        // CREATE A NEW EVENT
-        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
-                organisationUnitB.getUid(), null, dataElementB, "10" );
-
-        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
-        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
-        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
-
-        // FETCH NEWLY CREATED EVENT
-        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
-
-        // UPDATE EVENT (no actual changes, except for empty data value and status change)
-        // USE ONLY PROGRAM
-        Event event = new Event();
-        event.setEvent( uid );
-        event.setProgram( programB.getUid() );
-        event.setStatus( EventStatus.ACTIVE );
-
-        assertEquals( ImportStatus.SUCCESS,
-                eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
-
-        cleanSession();
-
-        ProgramStageInstance psi2 = programStageInstanceService.getProgramStageInstance( uid );
-
-        assertThat( psi.getLastUpdated(), DateMatchers.before( psi2.getLastUpdated() ) );
-        assertThat( psi.getCreated(), is( psi2.getCreated() ) );
-        assertThat( psi.getProgramInstance().getUid(), is( psi2.getProgramInstance().getUid() ) );
-        assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
-        assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
-        assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
-        assertThat( psi2.getStatus(), is( EventStatus.ACTIVE ) );
-        assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
-        assertThat( psi.getCompletedDate(), is( nullValue() ) );
-        assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
-        assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
-        assertThat( psi.getEventDataValues().size(), is( 1 ) );
-        assertThat( psi2.getEventDataValues().size(), is( 0 ) );
-    }
-
-    @Test
-    public void testVerifyEventUpdateCoc()
         throws IOException
     {
         // CREATE A NEW EVENT
@@ -638,12 +594,10 @@ public class EventImportTest
 
         // UPDATE EVENT (no actual changes, except for empty data value and status
         // change)
-        // USE ONLY PROGRAM
         Event event = new Event();
         event.setEvent( uid );
         event.setProgram( programB.getUid() );
-        event.setStatus( EventStatus.COMPLETED );
-        event.setAttributeOptionCombo( "123456" );
+        event.setStatus( EventStatus.ACTIVE );
 
         assertEquals( ImportStatus.SUCCESS,
             eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
@@ -658,9 +612,9 @@ public class EventImportTest
         assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
         assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
         assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
-        assertThat( psi2.getStatus(), is( EventStatus.COMPLETED ) );
+        assertThat( psi2.getStatus(), is( EventStatus.ACTIVE ) );
         assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
-        assertThat( psi.getCompletedDate(), is( nullValue() ) );
+        assertThat( psi2.getCompletedDate(), is( nullValue() ) );
         assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
         assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
         assertThat( psi.getEventDataValues().size(), is( 1 ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.dxf2.events;
  */
 
 import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -42,7 +44,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
+import org.exparity.hamcrest.date.DateMatchers;
 import org.hamcrest.CoreMatchers;
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
@@ -120,6 +124,9 @@ public class EventImportTest
 
     @Autowired
     private UserService _userService;
+
+    @Autowired
+    private SessionFactory sessionFactory;
 
     private TrackedEntityInstance trackedEntityInstanceMaleA;
 
@@ -493,6 +500,177 @@ public class EventImportTest
             organisationUnitB.getUid(), null, dataElementB, "10" );
         ImportSummaries importSummaries = eventService.addEventsJson( is, null );
         assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+    }
+
+    //
+    // UPDATE EVENT TESTS
+    //
+
+    @Test
+    public void testVerifyEventCanBeUpdatedUsingProgramOnly2()
+            throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+                organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT - Program is not specified
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setStatus( EventStatus.COMPLETED );
+
+        final ImportSummary summary = eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(),
+            false );
+        assertThat( summary.getStatus(), is( ImportStatus.ERROR ) );
+        assertThat( summary.getDescription(), is( "Event.program does not point to a valid program: null" ) );
+        assertThat( summary.getReference(), is( uid ) );
+    }
+
+    @Test
+    public void testVerifyEventCanBeUpdatedUsingProgramOnly()
+        throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+            organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT (no actual changes, except for empty data value)
+        // USE ONLY PROGRAM
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setProgram( programB.getUid() );
+        event.setStatus( EventStatus.COMPLETED );
+
+        assertEquals( ImportStatus.SUCCESS,
+            eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
+
+        cleanSession();
+
+        ProgramStageInstance psi2 = programStageInstanceService.getProgramStageInstance( uid );
+
+        assertThat( psi.getLastUpdated(), DateMatchers.before( psi2.getLastUpdated() ) );
+        assertThat( psi.getCreated(), is( psi2.getCreated() ) );
+        assertThat( psi.getProgramInstance().getUid(), is( psi2.getProgramInstance().getUid() ) );
+        assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
+        assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
+        assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
+        assertThat( psi.getStatus().getValue(), is( psi2.getStatus().getValue() ) );
+        assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
+        assertThat( psi.getCompletedDate(), is( psi2.getCompletedDate() ) );
+        assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
+        assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
+        assertThat( psi.getEventDataValues().size(), is( 1 ) );
+        assertThat( psi2.getEventDataValues().size(), is( 0 ) );
+    }
+
+    @Test
+    public void testVerifyEventUncompleteSetsCompletedDateToNull()
+            throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+                organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT (no actual changes, except for empty data value and status change)
+        // USE ONLY PROGRAM
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setProgram( programB.getUid() );
+        event.setStatus( EventStatus.ACTIVE );
+
+        assertEquals( ImportStatus.SUCCESS,
+                eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
+
+        cleanSession();
+
+        ProgramStageInstance psi2 = programStageInstanceService.getProgramStageInstance( uid );
+
+        assertThat( psi.getLastUpdated(), DateMatchers.before( psi2.getLastUpdated() ) );
+        assertThat( psi.getCreated(), is( psi2.getCreated() ) );
+        assertThat( psi.getProgramInstance().getUid(), is( psi2.getProgramInstance().getUid() ) );
+        assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
+        assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
+        assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
+        assertThat( psi2.getStatus(), is( EventStatus.ACTIVE ) );
+        assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
+        assertThat( psi.getCompletedDate(), is( nullValue() ) );
+        assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
+        assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
+        assertThat( psi.getEventDataValues().size(), is( 1 ) );
+        assertThat( psi2.getEventDataValues().size(), is( 0 ) );
+    }
+
+    @Test
+    public void testVerifyEventUpdateCoc()
+        throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+            organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT (no actual changes, except for empty data value and status
+        // change)
+        // USE ONLY PROGRAM
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setProgram( programB.getUid() );
+        event.setStatus( EventStatus.COMPLETED );
+        event.setAttributeOptionCombo( "123456" );
+
+        assertEquals( ImportStatus.SUCCESS,
+            eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
+
+        cleanSession();
+
+        ProgramStageInstance psi2 = programStageInstanceService.getProgramStageInstance( uid );
+
+        assertThat( psi.getLastUpdated(), DateMatchers.before( psi2.getLastUpdated() ) );
+        assertThat( psi.getCreated(), is( psi2.getCreated() ) );
+        assertThat( psi.getProgramInstance().getUid(), is( psi2.getProgramInstance().getUid() ) );
+        assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
+        assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
+        assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
+        assertThat( psi2.getStatus(), is( EventStatus.COMPLETED ) );
+        assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
+        assertThat( psi.getCompletedDate(), is( nullValue() ) );
+        assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
+        assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
+        assertThat( psi.getEventDataValues().size(), is( 1 ) );
+        assertThat( psi2.getEventDataValues().size(), is( 0 ) );
+    }
+
+    private void cleanSession()
+    {
+        sessionFactory.getCurrentSession().flush();
+        sessionFactory.getCurrentSession().clear();
     }
 
     @SuppressWarnings( "unchecked" )

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1926,6 +1926,12 @@
         <version>1.3</version>
       </dependency>
       <dependency>
+        <groupId>org.exparity</groupId>
+        <artifactId>hamcrest-date</artifactId>
+        <version>2.0.7</version>
+      </dependency>
+
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>


### PR DESCRIPTION
Data Value of type File Type were making the update process to fail.
Introduced a more solid handling of mandatory data (e.g. Program Instance, Org Unit) since we can't always assume that the client will send all the required data.
Added some tests.
Added new test library to assert dates.

ref: DHIS2-9559
(cherry picked from commit 408c1e286509c0b49736791d1a1e2d86e15c2eac)