### PR TITLE
fix: allow updating an Event with File data type

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -115,6 +115,10 @@
       <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exparity</groupId>
+      <artifactId>hamcrest-date</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1640,7 +1640,14 @@ public class JdbcEventStore implements EventStore
         ps.setLong( 1, programStageInstance.getProgramInstance().getId() );
         ps.setLong( 2, programStageInstance.getProgramStage().getId() );
         ps.setTimestamp( 3, new Timestamp( programStageInstance.getDueDate().getTime() ) );
-        ps.setTimestamp( 4, new Timestamp( programStageInstance.getExecutionDate().getTime() ) );
+        if ( programStageInstance.getExecutionDate() != null )
+        {
+            ps.setTimestamp( 4, new Timestamp( programStageInstance.getExecutionDate().getTime() ) );
+        }
+        else
+        {
+            ps.setObject( 4, null );
+        }
         ps.setLong( 5, programStageInstance.getOrganisationUnit().getId() );
         ps.setString( 6, programStageInstance.getStatus().toString() );
         ps.setTimestamp( 7, JdbcEventSupport.toTimestamp( programStageInstance.getCompletedDate() ) );
@@ -1652,7 +1659,7 @@ public class JdbcEventStore implements EventStore
         ps.setString( 13, programStageInstance.getCode() );
         ps.setTimestamp( 14, JdbcEventSupport.toTimestamp( programStageInstance.getCreatedAtClient() ) );
         ps.setTimestamp( 15, JdbcEventSupport.toTimestamp( programStageInstance.getLastUpdatedAtClient() ) );
-        ps.setObject( 16, JdbcEventSupport.toGeometry( programStageInstance.getGeometry()  )  );
+        ps.setObject( 16, JdbcEventSupport.toGeometry( programStageInstance.getGeometry() ) );
 
         if ( programStageInstance.getAssignedUser() != null )
         {
@@ -1665,7 +1672,6 @@ public class JdbcEventStore implements EventStore
 
         ps.setObject( 18, eventDataValuesToJson( programStageInstance.getEventDataValues(), this.jsonMapper ) );
         ps.setString( 19, programStageInstance.getUid() );
-
     }
 
     private boolean userHasAccess( SqlRowSet rowSet )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
@@ -66,34 +66,34 @@ public class AttributeOptionComboLoader
     private final static String KEY_SEPARATOR = "-";
 
     public final static String SQL_GET_CATEGORYOPTIONCOMBO = "select coc.categoryoptioncomboid, "
-            + "coc.uid, coc.code, coc.ignoreapproval, coc.name, c.uid as cc_uid, c.name as cc_name, "
-            + "string_agg(dec.categoryid::text, ',') as cat_ids from categoryoptioncombo coc "
-            + "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid "
-            + "join categorycombo c on co.categorycomboid = c.categorycomboid "
-            + "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid "
-            + "join dataelementcategory dec on cc.categoryid = dec.categoryid where coc."
-            + "${resolvedScheme} "
-            + "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name";
+        + "coc.uid, coc.code, coc.ignoreapproval, coc.name, c.uid as cc_uid, c.name as cc_name, "
+        + "string_agg(dec.categoryid::text, ',') as cat_ids from categoryoptioncombo coc "
+        + "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid "
+        + "join categorycombo c on co.categorycomboid = c.categorycomboid "
+        + "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid "
+        + "join dataelementcategory dec on cc.categoryid = dec.categoryid where coc."
+        + "${resolvedScheme} "
+        + "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name";
 
     public final static String SQL_GET_CATEGORYOPTIONCOMBO_BY_CATEGORYIDS = "select * from ( " +
-            "select coc.categoryoptioncomboid, " +
-            "coc.uid, " +
-            "coc.code, " +
-            "coc.ignoreapproval, " +
-            "coc.name, " +
-            "c.uid as cc_uid, " +
-            "c.name as cc_name," +
-            "string_agg( dec.categoryid::text, ',') as cat_ids " +
-            "from categoryoptioncombo coc " +
-            "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid " +
-            "join categorycombo c on co.categorycomboid = c.categorycomboid " +
-            "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid " +
-            "join dataelementcategory dec on cc.categoryid = dec.categoryid " +
-            "where c.${resolvedScheme} " +
-            "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name " +
-            ") as catoptcombo where " +
-            "array_length(regexp_split_to_array(cat_ids, ','),1) = array_length(ARRAY[${option_ids}],1) AND " +
-            "regexp_split_to_array(cat_ids, ',') @> ARRAY[${option_ids}]";
+        "select coc.categoryoptioncomboid, " +
+        "coc.uid, " +
+        "coc.code, " +
+        "coc.ignoreapproval, " +
+        "coc.name, " +
+        "c.uid as cc_uid, " +
+        "c.name as cc_name," +
+        "string_agg( dec.categoryid::text, ',') as cat_ids " +
+        "from categoryoptioncombo coc " +
+        "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid " +
+        "join categorycombo c on co.categorycomboid = c.categorycomboid " +
+        "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid " +
+        "join dataelementcategory dec on cc.categoryid = dec.categoryid " +
+        "where c.${resolvedScheme} " +
+        "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name " +
+        ") as catoptcombo where " +
+        "array_length(regexp_split_to_array(cat_ids, ','),1) = array_length(ARRAY[${option_ids}],1) AND " +
+        "regexp_split_to_array(cat_ids, ',') @> ARRAY[${option_ids}]";
 
     public AttributeOptionComboLoader( @Qualifier( "readOnlyJdbcTemplate" ) JdbcTemplate jdbcTemplate )
     {
@@ -120,7 +120,6 @@ public class AttributeOptionComboLoader
      *
      * @param categoryCombo a {@see CategoryCombo}
      * @param categoryOptions a semicolon delimited list of Category Options uid
-     * @param attributeOptionCombo
      * @param idScheme the {@see IdScheme} to use to fetch the entity
      * @return a {@see CategoryOptionCombo}
      */
@@ -249,12 +248,10 @@ public class AttributeOptionComboLoader
             .map( s -> "'" + s + "'" )
             .collect( Collectors.joining( "," ) );
 
-        // @formatter:off
-        StrSubstitutor sub = new StrSubstitutor( ImmutableMap.<String, String>builder()
-                .put( "resolvedScheme", Objects.requireNonNull( categoryComboKey ) )
-                .put( "option_ids", optionsId )
-                .build() );
-        // @formatter:on
+        StrSubstitutor sub = new StrSubstitutor( ImmutableMap.<String, String> builder()
+            .put( "resolvedScheme", Objects.requireNonNull( categoryComboKey ) )
+            .put( "option_ids", optionsId )
+            .build() );
         
         // TODO use cache
         List<CategoryOptionCombo> categoryOptionCombos = jdbcTemplate

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramStageInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramStageInstanceSupplier.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.dxf2.events.importer.context;
 
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,10 +40,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.EventUtils;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
@@ -89,8 +93,15 @@ public class ProgramStageInstanceSupplier extends AbstractSupplier<Map<String, P
             return new HashMap<>();
         }
 
-        final String sql = "select psi.programinstanceid, psi.programstageid, psi.programstageinstanceid, psi.uid, psi.status, psi.deleted, "
-            + "psi.eventdatavalues from programstageinstance psi where psi.uid in (:ids)";
+        final String sql = "select psi.programinstanceid, psi.programstageid, psi.programstageinstanceid, " +
+            "psi.uid, psi.status, psi.deleted, psi.eventdatavalues, psi.duedate, psi.executiondate, " +
+            "psi.completeddate, psi.attributeoptioncomboid, psi.geometry, " +
+            "ou.organisationunitid, ou.uid, ou.code, ou.name, psi.attributeoptioncomboid,  c.uid as coc_uid  " +
+            "from programstageinstance psi join organisationunit ou on psi.organisationunitid = ou.organisationunitid "
+            +
+            "join categoryoptioncombo c on psi.attributeoptioncomboid = c.categoryoptioncomboid " +
+            "where psi.uid in (:ids)";
+
         MapSqlParameterSource parameters = new MapSqlParameterSource();
         parameters.addValue( "ids", psiUid );
 
@@ -106,6 +117,11 @@ public class ProgramStageInstanceSupplier extends AbstractSupplier<Map<String, P
                 psi.setStatus( EventStatus.valueOf( rs.getString( "status" ) ) );
                 psi.setDeleted( rs.getBoolean( "deleted" ) );
                 psi.setProgramStage( getProgramStage( importOptions, rs.getLong( "programstageid" ) ) );
+                psi.setOrganisationUnit( getOu( rs ) );
+                psi.setDueDate( rs.getDate( "duedate" ) );
+                psi.setExecutionDate( rs.getDate( "executiondate" ) );
+                psi.setCompletedDate( rs.getDate( "completeddate" ) );
+                psi.setAttributeOptionCombo( getCatOptionCombo ( rs ));
                 try
                 {
                     psi.setEventDataValues( EventUtils.jsonToEventDataValues( jsonMapper, rs.getObject(
@@ -118,10 +134,31 @@ public class ProgramStageInstanceSupplier extends AbstractSupplier<Map<String, P
                         e );
                 }
                 results.put( psi.getUid(), psi );
-
             }
             return results;
         } );
+    }
+
+    private CategoryOptionCombo getCatOptionCombo( ResultSet rs )
+        throws SQLException
+    {
+        CategoryOptionCombo coc = new CategoryOptionCombo();
+
+        coc.setUid( rs.getString( "coc_uid" ) );
+
+        return coc;
+    }
+
+    private OrganisationUnit getOu( ResultSet rs )
+        throws SQLException
+    {
+        OrganisationUnit ou = new OrganisationUnit();
+        ou.setId( rs.getLong( "organisationunitid" ) );
+        ou.setUid( rs.getString( "uid" ) );
+        ou.setCode( rs.getString( "code" ) );
+        ou.setName( rs.getString( "name" ) );
+
+        return ou;
     }
     
     private ProgramStage getProgramStage( ImportOptions importOptions, Long programStageId )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContext.java
@@ -177,4 +177,9 @@ public class WorkContext
     {
         return Optional.ofNullable( this.getProgramStageInstanceMap().get( event ) );
     }
+
+    public Optional<ProgramInstance> getProgramInstance( String event )
+    {
+        return Optional.ofNullable( this.getProgramInstanceMap().get( event ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
@@ -38,10 +38,13 @@ import static org.hisp.dhis.util.DateUtils.parseDate;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 
@@ -57,43 +60,104 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         super( ctx );
         noteMapper = new ProgramStageInstanceNoteMapper( ctx );
     }
-
+    
     @Override
     public ProgramStageInstance map( Event event )
     {
-        ImportOptions importOptions = workContext.getImportOptions();
-        
-        ProgramStageInstance psi = new ProgramStageInstance();
-        
-        ProgramStageInstance programStageInstance = this.workContext.getProgramStageInstanceMap().get( event.getUid() );
-        if ( programStageInstance != null )
+        ProgramStageInstance psi = workContext.getProgramStageInstanceMap().get( event.getUid() );
+
+        return psi == null ? mapForInsert( event ) : mapForUpdate( event, psi );
+    }
+
+    private ProgramStageInstance mapForUpdate( Event event, ProgramStageInstance psi )
+    {
+        // Program Instance
+        workContext.getProgramInstance( event.getUid() ).ifPresent( psi::setProgramInstance );
+
+        // Program Stage
+        getProgramStage( event ).ifPresent( psi::setProgramStage );
+
+        // Org Unit
+        getOrganisationUnit( event ).ifPresent( psi::setOrganisationUnit );
+
+        // Status and completed date are set in the Update Preprocessor //
+
+        // Attribute Option Combo
+        psi.setAttributeOptionCombo( this.workContext.getCategoryOptionComboMap().get( event.getUid() ) );
+
+        // Geometry
+        psi.setGeometry( event.getGeometry() );
+
+        // Notes
+        if ( !event.getNotes().isEmpty() )
         {
-            psi.setId( programStageInstance.getId() );
+            psi.setComments( convertNotes( event, this.workContext ) );
         }
+
+        // Data Values
+        psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ) );
+
+        if ( event.getDueDate() != null )
+        {
+            psi.setDueDate( parseDate( event.getDueDate() ) );
+        }
+
+        setExecutionDate( event, psi );
+
+        if ( psi.getProgramStage() != null && psi.getProgramStage().isEnableUserAssignment() )
+        {
+            psi.setAssignedUser( this.workContext.getAssignedUserMap().get( event.getUid() ) );
+        }
+
+        // CREATED AT CLIENT + UPDATED AT CLIENT
+        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
+        psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
+
+        psi.setStoredBy( event.getStoredBy() );
+        psi.setCompletedBy( event.getCompletedBy() );
+
+        return psi;
+    }
+
+    public ProgramStageInstance mapForInsert( Event event )
+    {
+        ImportOptions importOptions = workContext.getImportOptions();
+
+        ProgramStageInstance psi = new ProgramStageInstance();
 
         if ( importOptions.getIdSchemes().getProgramStageInstanceIdScheme().equals( CODE ) )
         {
-            // TODO: Is this really correct?
-            psi.setCode( event.getUid() );
+            psi.setCode( event.getEvent() );
         }
         else if ( importOptions.getIdSchemes().getProgramStageIdScheme().equals( UID ) )
         {
             psi.setUid( event.getUid() );
         }
 
-        // FKs
+        // Program Instance
         psi.setProgramInstance( this.workContext.getProgramInstanceMap().get( event.getUid() ) );
+
+        // Program Stage
         psi.setProgramStage( this.workContext.getProgramStage( importOptions.getIdSchemes().getProgramStageIdScheme(),
-            event.getProgramStage() ) );
+                event.getProgramStage() ) );
+
+        // Org Unit
         psi.setOrganisationUnit( this.workContext.getOrganisationUnitMap().get( event.getUid() ) );
 
-        // EXECUTION + DUE DATE
-        Date executionDate = null;
+        // Status
+        psi.setStatus( fromInt( event.getStatus().getValue() ) );
 
-        if ( event.getEventDate() != null )
-        {
-            executionDate = parseDate( event.getEventDate() );
-        }
+        // Attribute Option Combo
+        psi.setAttributeOptionCombo( this.workContext.getCategoryOptionComboMap().get( event.getUid() ) );
+
+        // Geometry
+        psi.setGeometry( event.getGeometry() );
+
+        // Notes
+        psi.setComments( convertNotes( event, this.workContext ) );
+
+        // Data Values
+        psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ) );
 
         Date dueDate = new Date();
 
@@ -103,47 +167,22 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         }
 
         psi.setDueDate( dueDate );
+        setCompletedDate( event, psi );
         // Note that execution date can be null
-        psi.setExecutionDate( executionDate );
-
-        psi.setStoredBy( event.getStoredBy() );
-        psi.setCompletedBy( event.getCompletedBy() );
-        
-        // STATUS
-        psi.setStatus( fromInt( event.getStatus().getValue() ) );
-
-        if ( psi.isCompleted() )
-        {
-            Date completedDate = new Date();
-            if ( event.getCompletedDate() != null )
-            {
-                completedDate = parseDate( event.getCompletedDate() );
-            }
-            psi.setCompletedDate( completedDate );
-        }
-
-        // ATTRIBUTE OPTION COMBO
-
-        psi.setAttributeOptionCombo( this.workContext.getCategoryOptionComboMap().get( event.getUid() ) );
-
-        // GEOMETRY
-
-        psi.setGeometry( event.getGeometry() );
-
-        // CREATED AT CLIENT + UPDATED AT CLIENT
-
-        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
-        psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
+        setExecutionDate( event, psi );
 
         if ( psi.getProgramStage() != null && psi.getProgramStage().isEnableUserAssignment() )
         {
             psi.setAssignedUser( this.workContext.getAssignedUserMap().get( event.getUid() ) );
         }
 
-        // COMMENTS
-        psi.setComments( convertNotes( event, this.workContext ) );
+        // CREATED AT CLIENT + UPDATED AT CLIENT
+        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
+        psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
 
-        psi.setEventDataValues( workContext.getEventDataValueMap().get( event.getUid() ));
+        psi.setStoredBy( event.getStoredBy() );
+        psi.setCompletedBy( event.getCompletedBy() );
+
         return psi;
     }
 
@@ -156,5 +195,38 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
         }
 
         return emptyList();
+    }
+
+    private Optional<ProgramStage> getProgramStage( Event event )
+    {
+        return Optional.ofNullable( this.workContext.getProgramStage(
+            this.workContext.getImportOptions().getIdSchemes().getProgramStageIdScheme(), event.getProgramStage() ) );
+    }
+
+    private Optional<OrganisationUnit> getOrganisationUnit( Event event )
+    {
+        return Optional.ofNullable( this.workContext.getOrganisationUnitMap().get( event.getUid() ) );
+    }
+
+    private void setExecutionDate( Event event, ProgramStageInstance psi )
+    {
+        if ( event.getEventDate() != null )
+        {
+            psi.setExecutionDate( parseDate( event.getEventDate() ) );
+        }
+    }
+
+    private void setCompletedDate( Event event, ProgramStageInstance psi )
+    {
+        // Completed Date // FIXME this logic should be moved to a preprocessor
+        if ( psi.isCompleted() )
+        {
+            Date completedDate = new Date();
+            if ( event.getCompletedDate() != null )
+            {
+                completedDate = parseDate( event.getCompletedDate() );
+            }
+            psi.setCompletedDate( completedDate );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/preprocess/ProgramStageInstanceUpdatePreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/preprocess/ProgramStageInstanceUpdatePreProcessor.java
@@ -83,7 +83,10 @@ public class ProgramStageInstanceUpdatePreProcessor implements Processor
 
             programStageInstance.setStoredBy( storedBy );
             programStageInstance.setDueDate( dueDate );
-            programStageInstance.setOrganisationUnit( organisationUnit );
+            if ( organisationUnit != null )
+            {
+                programStageInstance.setOrganisationUnit( organisationUnit );
+            }
             programStageInstance.setGeometry( event.getGeometry() );
 
             if ( programStageInstance.getProgramStage() != null

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,7 +44,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
+import org.exparity.hamcrest.date.DateMatchers;
 import org.hamcrest.CoreMatchers;
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
@@ -120,6 +124,9 @@ public class EventImportTest
 
     @Autowired
     private UserService _userService;
+
+    @Autowired
+    private SessionFactory sessionFactory;
 
     private TrackedEntityInstance trackedEntityInstanceMaleA;
 
@@ -493,6 +500,131 @@ public class EventImportTest
             organisationUnitB.getUid(), null, dataElementB, "10" );
         ImportSummaries importSummaries = eventService.addEventsJson( is, null );
         assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+    }
+
+    //
+    // UPDATE EVENT TESTS
+    //
+
+    @Test
+    public void testVerifyEventCanBeUpdatedUsingProgramOnly2()
+            throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+                organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT - Program is not specified
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setStatus( EventStatus.COMPLETED );
+
+        final ImportSummary summary = eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(),
+                false );
+        assertThat( summary.getStatus(), is( ImportStatus.ERROR ) );
+        assertThat( summary.getDescription(), is( "Event.program does not point to a valid program: null" ) );
+        assertThat( summary.getReference(), is( uid ) );
+    }
+
+    @Test
+    public void testVerifyEventCanBeUpdatedUsingProgramOnly()
+            throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+                organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT (no actual changes, except for empty data value)
+        // USE ONLY PROGRAM
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setProgram( programB.getUid() );
+        event.setStatus( EventStatus.COMPLETED );
+
+        assertEquals( ImportStatus.SUCCESS,
+                eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
+
+        cleanSession();
+
+        ProgramStageInstance psi2 = programStageInstanceService.getProgramStageInstance( uid );
+
+        assertThat( psi.getLastUpdated(), DateMatchers.before( psi2.getLastUpdated() ) );
+        assertThat( psi.getCreated(), is( psi2.getCreated() ) );
+        assertThat( psi.getProgramInstance().getUid(), is( psi2.getProgramInstance().getUid() ) );
+        assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
+        assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
+        assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
+        assertThat( psi.getStatus().getValue(), is( psi2.getStatus().getValue() ) );
+        assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
+        assertThat( psi.getCompletedDate(), is( psi2.getCompletedDate() ) );
+        assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
+        assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
+        assertThat( psi.getEventDataValues().size(), is( 1 ) );
+        assertThat( psi2.getEventDataValues().size(), is( 0 ) );
+    }
+
+    @Test
+    public void testVerifyEventUncompleteSetsCompletedDateToNull()
+            throws IOException
+    {
+        // CREATE A NEW EVENT
+        InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
+                organisationUnitB.getUid(), null, dataElementB, "10" );
+
+        ImportSummaries importSummaries = eventService.addEventsJson( is, null );
+        String uid = importSummaries.getImportSummaries().get( 0 ).getReference();
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+
+        // FETCH NEWLY CREATED EVENT
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( uid );
+
+        // UPDATE EVENT (no actual changes, except for empty data value and status
+        // change)
+        Event event = new Event();
+        event.setEvent( uid );
+        event.setProgram( programB.getUid() );
+        event.setStatus( EventStatus.ACTIVE );
+
+        assertEquals( ImportStatus.SUCCESS,
+                eventService.updateEvent( event, false, ImportOptions.getDefaultImportOptions(), false ).getStatus() );
+
+        cleanSession();
+
+        ProgramStageInstance psi2 = programStageInstanceService.getProgramStageInstance( uid );
+
+        assertThat( psi.getLastUpdated(), DateMatchers.before( psi2.getLastUpdated() ) );
+        assertThat( psi.getCreated(), is( psi2.getCreated() ) );
+        assertThat( psi.getProgramInstance().getUid(), is( psi2.getProgramInstance().getUid() ) );
+        assertThat( psi.getProgramStage().getUid(), is( psi2.getProgramStage().getUid() ) );
+        assertThat( psi.getOrganisationUnit().getUid(), is( psi2.getOrganisationUnit().getUid() ) );
+        assertThat( psi.getAttributeOptionCombo().getUid(), is( psi2.getAttributeOptionCombo().getUid() ) );
+        assertThat( psi2.getStatus(), is( EventStatus.ACTIVE ) );
+        assertThat( psi.getExecutionDate(), is( psi2.getExecutionDate() ) );
+        assertThat( psi2.getCompletedDate(), is( nullValue() ) );
+        assertThat( psi.getCompletedBy(), is( psi2.getCompletedBy() ) );
+        assertThat( psi.isDeleted(), is( psi2.isDeleted() ) );
+        assertThat( psi.getEventDataValues().size(), is( 1 ) );
+        assertThat( psi2.getEventDataValues().size(), is( 0 ) );
+    }
+
+    private void cleanSession()
+    {
+        sessionFactory.getCurrentSession().flush();
+        sessionFactory.getCurrentSession().clear();
     }
 
     @SuppressWarnings( "unchecked" )

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1925,6 +1925,11 @@
         <version>1.3</version>
       </dependency>
       <dependency>
+        <groupId>org.exparity</groupId>
+        <artifactId>hamcrest-date</artifactId>
+        <version>2.0.7</version>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <version>1.3</version>


### PR DESCRIPTION
Data Value of type File Type were making the update process to fail.
Introduced a more solid handling of mandatory data (e.g. Program Instance, Org Unit) since we can't always assume that the client will send all the required data.
Added some tests.
Added new test library to assert dates.

**NOTE**: this is a forward-port from a PR alreade merged for 2.35.0 (3520e1abc8768281a8747b0b03f2a5b0027bfe6c)

ref: DHIS2-9559
(cherry picked from commit: e522e985d6d4fcd5bc5d6546b9337d6ab07dcfe7)