### PR TITLE
fix: fix User Access SQL query for programs

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
@@ -129,11 +129,11 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
     private final static String PROGRAM_STAGE_ID = "programstageid";
     private final static String TRACKED_ENTITY_TYPE_ID = "trackedentitytypeid";
 
-    // @formatter:off
-    private final static String USER_ACCESS_SQL = "select eua.${column_name}, eua.useraccessid, ua.useraccessid, ua.access, ua.userid, ui.uid " +
+    private final static String USER_ACCESS_SQL = "select eua.${column_name}, eua.useraccessid, ua.useraccessid, " +
+        "ua.access, ua.userid, ui.uid, ui.firstname, ui.surname " +
         "from ${table_name} eua " +
         "join useraccess ua on eua.useraccessid = ua.useraccessid " +
-        "join userinfo ui on ui.userinfoid = ua.useraccessid " +
+        "join userinfo ui on ui.userinfoid = ua.userid " +
         "order by eua.${column_name}";
 
     private final static String USER_GROUP_ACCESS_SQL = "select ega.${column_name}, ega.usergroupaccessid, u.access, u.usergroupid, ug.uid " +
@@ -160,8 +160,6 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
                 return loadUserGroups( userGroupId );
             }
         } ).build() ;
-
-    // @formatter:on
 
     public ProgramSupplier( NamedParameterJdbcTemplate jdbcTemplate, ObjectMapper jsonMapper, Environment env )
     {
@@ -579,6 +577,8 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
         User user = new User();
         user.setId( rs.getLong( "userid" ) );
         user.setUid( rs.getString( "uid" ) );
+        user.setFirstName( rs.getString( "firstname" ) );
+        user.setSurname( rs.getString( "surname" ) );
         userAccess.setUser( user );
         return userAccess;
     }


### PR DESCRIPTION
During event import, the query that fetches user access for programs was using an incorrect join, which
was causing no rows to return.

(cherry picked from commit 1eaad52e08503ba82b067a2b7ba02bf7e9fec6ad)