### PR TITLE
[2.35] fix: SQL query to fetch category option combo

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
@@ -83,12 +83,12 @@ public class AttributeOptionComboLoader
         "coc.name, " +
         "c.uid as cc_uid, " +
         "c.name as cc_name," +
-        "string_agg( dec.categoryid::text, ',') as cat_ids " +
+        "string_agg( coco.categoryoptionid::text, ',') as cat_ids " +
         "from categoryoptioncombo coc " +
         "join categorycombos_optioncombos co on coc.categoryoptioncomboid = co.categoryoptioncomboid " +
         "join categorycombo c on co.categorycomboid = c.categorycomboid " +
         "join categorycombos_categories cc on c.categorycomboid = cc.categorycomboid " +
-        "join dataelementcategory dec on cc.categoryid = dec.categoryid " +
+        "join categoryoptioncombos_categoryoptions coco on coc.categoryoptioncomboid = coco.categoryoptioncomboid " +
         "where c.${resolvedScheme} " +
         "group by coc.categoryoptioncomboid, coc.uid, coc.code, coc.ignoreapproval, coc.name, cc_uid, cc_name " +
         ") as catoptcombo where " +
@@ -255,7 +255,7 @@ public class AttributeOptionComboLoader
         
         // TODO use cache
         List<CategoryOptionCombo> categoryOptionCombos = jdbcTemplate
-            .query( sub.replace( SQL_GET_CATEGORYOPTIONCOMBO_BY_CATEGORYIDS ), ( rs, i ) -> bind( key, rs ) );
+            .query( sub.replace( SQL_GET_CATEGORYOPTIONCOMBO_BY_CATEGORYIDS ), ( rs, i ) -> bind( "categoryoptioncomboid", rs ) );
 
         if ( categoryOptionCombos.size() == 1 )
         {
@@ -281,12 +281,12 @@ public class AttributeOptionComboLoader
     private CategoryOptionCombo loadCategoryOptionCombo( IdScheme idScheme, String id )
     {
         String key = "categoryoptioncomboid";
-        // @formatter:off
+
         StrSubstitutor sub = new StrSubstitutor( ImmutableMap.<String, String>builder()
             .put( "key", key )
             .put( "resolvedScheme", Objects.requireNonNull( resolveId( idScheme, key, id ) ) )
             .build() );
-        // @formatter:on
+
         try
         {
             return jdbcTemplate.queryForObject( sub.replace( SQL_GET_CATEGORYOPTIONCOMBO ),


### PR DESCRIPTION
During Event Import, the system tries to fetch a Category Option Combo by Category Combo ID
and category options, based on the input.
The SQL query for fetching the Category Option Combo was using an incorrect `join`, which in certain cases, was not returning any result.

ref: DHIS2-9565
(cherry picked from commit cf7cadc05f06671c5b8a244b9d51abcf33e7adcb)

Note: this PR was already approved and merged in 2.35.0