### PR TITLE
fix(web-apps): let v33 use master branch of usage-analytics

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -22,7 +22,7 @@
   "https://github.com/d2-ci/settings-app#v33",
   "https://github.com/d2-ci/tracker-capture-app#v33",
   "https://github.com/d2-ci/translations-app#v33",
-  "https://github.com/d2-ci/usage-analytics-app#v33",
+  "https://github.com/d2-ci/usage-analytics-app#master",
   "https://github.com/d2-ci/user-app#v33",
   "https://github.com/d2-ci/user-profile-app#v33"
 ]


### PR DESCRIPTION
This change will cause 2.33dev to use the master branch of the usage analytics app, which is how things are supposed to work.

For more context, please see the Slack conversation starting [here](https://dhis2.slack.com/archives/G01BEB0AA8G/p1600180513000100). I've also ran the proposed solution past @amcgee before preparing this PR and he agreed this was the way forward.

It seems that the `2.33` branch didn't have a README with feature-toggle table so that is not included here. I will prepare another PR against master shortly that will update that readme file.