### PR TITLE
perf: use static cache in AbstractCrudController

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -140,7 +140,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
     protected static final String DEFAULTS = "INCLUDE";
 
-    private Cache<String, Integer> paginationCountCache = new Cache2kBuilder<String, Integer>()
+    private static Cache<String, Integer> paginationCountCache = new Cache2kBuilder<String, Integer>()
     {
     }
         .expireAfterWrite( 1, TimeUnit.MINUTES )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -92,7 +92,7 @@ public class DataElementOperandController
     private final CategoryService dataElementCategoryService;
     private final CurrentUserService currentUserService;
 
-    private Cache<String,Integer> paginationCountCache = new Cache2kBuilder<String, Integer>() {}
+    private static Cache<String,Integer> paginationCountCache = new Cache2kBuilder<String, Integer>() {}
         .expireAfterWrite( 1, TimeUnit.MINUTES )
         .build();
 


### PR DESCRIPTION
Spring will create many instances of `AbstractCrudController`, since each Metadata controller is extending that abstract class.
Since the cache2k cache in `AbstractCrudController` is not declared as static, we end up with many caches which are completely wasteful.
By adding the `static` keyword we make sure that one cache is shared among controllers.