### PR TITLE
fix: [DHIS2-8872] Fix import summary count for events in enrollment

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -390,6 +390,7 @@ public abstract class AbstractEnrollmentService
 
                 if ( importSummary.isStatus( ImportStatus.SUCCESS ) )
                 {
+                    events.forEach( e -> e.setEnrollment( enrollment.getEnrollment() ) );
                     events.addAll( enrollment.getEvents() );
                 }
             }
@@ -714,6 +715,7 @@ public abstract class AbstractEnrollmentService
 
                 if ( importSummary.isStatus( ImportStatus.SUCCESS ) )
                 {
+                    events.forEach( e -> e.setEnrollment( enrollment.getEnrollment() ) );
                     events.addAll( enrollment.getEvents() );
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -309,17 +309,6 @@ public class EventManager
 
                 importSummaries.addImportSummary( is );
             }
-            else
-            {
-                final Optional<ImportSummary> isOptional = importSummaries.getByReference( event.getUid() );
-
-                if ( isOptional.isPresent() )
-                {
-                    final ImportSummary is = isOptional.get();
-                    is.setStatus( ERROR );
-                    is.incrementIgnored();
-                }
-            }
         }
     }
 


### PR DESCRIPTION
2 fixes here:
- Add the enrollment field in the events so they can be grouped correctly and the importSummary is correctly calculated.
- Remove duplication of ignored count when one event is invalid in a list with other valid events