### PR TITLE
fix: remove custom serialization for OU.getChildren()

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -872,7 +872,7 @@ public class OrganisationUnit
     }
 
     @JsonProperty
-    @JsonSerialize( contentUsing = JacksonOrganisationUnitChildrenSerializer.class )
+    @JsonSerialize( contentAs = BaseIdentifiableObject.class )
     @JacksonXmlElementWrapper( localName = "children", namespace = DxfNamespaces.DXF_2_0 )
     @JacksonXmlProperty( localName = "child", namespace = DxfNamespaces.DXF_2_0 )
     public Set<OrganisationUnit> getChildren()


### PR DESCRIPTION
This custom serialization causing lazy exception for audit service
It also calling `children.isEmpty()` for attribute `hasChild` which in result will fetch the whole hierarchy.