### PR TITLE
chore: Bump ANTLR library version [DHIS2-9444]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -601,7 +601,7 @@
       <dependency>
         <groupId>org.hisp.dhis.parser</groupId>
         <artifactId>dhis-antlr-expression-parser</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
       </dependency>
       <dependency>
         <groupId>org.hisp.dhis</groupId>


### PR DESCRIPTION
 New ANTLR library will provide user-friendly messages in case the expression has a syntactical error.