### PR TITLE
fix: (2.35.0) SMS confidential values [DHIS2-9582]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericGatewayParameter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericGatewayParameter.java
@@ -70,12 +70,6 @@ public class GenericGatewayParameter
 
     public String getValue()
     {
-        return confidential ? "" : value;
-    }
-
-    @JsonIgnore
-    public String getDisplayValue()
-    {
         return value;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericHttpGatewayConfig.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericHttpGatewayConfig.java
@@ -63,7 +63,7 @@ public class GenericHttpGatewayConfig
     public Map<String, String> getParametersMap()
     {
         return parameters.stream()
-            .collect( Collectors.toMap( GenericGatewayParameter::getKey, GenericGatewayParameter::getDisplayValue ) );
+            .collect( Collectors.toMap( GenericGatewayParameter::getKey, GenericGatewayParameter::getValue ) );
     }
 
     public void setParameters( List<GenericGatewayParameter> parameters )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsGatewayConfig.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsGatewayConfig.java
@@ -65,7 +65,7 @@ public abstract class SmsGatewayConfig
     @JsonView( SmsConfigurationViews.Public.class )
     private String username;
 
-    @JsonView( SmsConfigurationViews.Internal.class )
+    @JsonView( SmsConfigurationViews.Public.class )
     private String password;
 
     @JsonView( SmsConfigurationViews.Public.class )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
@@ -157,7 +157,7 @@ public class SimplisticHttpGetGateWay
         {
             if ( parameter.isHeader() )
             {
-                httpHeaders.put(parameter.getKey(), Collections.singletonList( parameter.getDisplayValue() ) );
+                httpHeaders.put(parameter.getKey(), Collections.singletonList( parameter.getValue() ) );
             }
         }
 
@@ -174,7 +174,7 @@ public class SimplisticHttpGetGateWay
         {
             if ( !parameter.isHeader() )
             {
-                valueStore.put( parameter.getKey(), parameter.getDisplayValue() );
+                valueStore.put( parameter.getKey(), parameter.getValue() );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
@@ -180,7 +180,7 @@ public class GenericSmsGatewayTest
             if ( parameter.isHeader() )
             {
                 assertTrue( httpHeaders.containsKey( parameter.getKey() ) );
-                assertEquals( parameter.getDisplayValue(), httpHeaders.get( parameter.getKey() ).get( 0 ) );
+                assertEquals( parameter.getValue(), httpHeaders.get( parameter.getKey() ).get( 0 ) );
             }
         }
     }
@@ -191,8 +191,8 @@ public class GenericSmsGatewayTest
         username.setHeader( false );
         password.setHeader( false );
 
-        valueStore.put( username.getKey(), username.getDisplayValue() );
-        valueStore.put( password.getKey(), password.getDisplayValue() );
+        valueStore.put( username.getKey(), username.getValue() );
+        valueStore.put( password.getKey(), password.getValue() );
 
         strSubstitutor = new StrSubstitutor( valueStore );
 


### PR DESCRIPTION
Include confidential parameters in response while fetching SMS configurations. 