### PR TITLE
fix: backported flyway script to make it idempotent (master 2.36)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_14__Add_sequentialcounter_procedure.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_14__Add_sequentialcounter_procedure.sql
@@ -1,6 +1,7 @@
 -- remove primary key on id
-alter table sequentialnumbercounter drop constraint sequentialnumbercounter_pkey;
+alter table sequentialnumbercounter drop constraint if exists sequentialnumbercounter_pkey;
 -- create composite primary key
+alter table sequentialnumbercounter drop constraint if exists seqnumcount_pkey;
 alter table sequentialnumbercounter add constraint seqnumcount_pkey primary key (owneruid, key);
 
 CREATE OR REPLACE FUNCTION incrementSequentialCounter(counter_owner text, counter_key text, size integer) RETURNS integer AS $$


### PR DESCRIPTION
A flyway script "Add sequentialcounter procedure" has been backported until 2.33, but it was not idempotent. The same has to be made idempotent in atleast 2.34 and 2.35 so that upgrades from 2.33.6 into any 2.34.2+ or 2.35.0+ versions is possible.

On merge of this PR, there are certain development instance issues expected (with checksum) since we are changing an existing script. But since the specific script is not part of any major/patch release, we can deal with the dev checksum issues ourselves. Even on play instances depending on the db dump used we might have to fix that as well. 