### PR TITLE
fix: [DHIS2-8782] upgrade fails from 2.33 into higher versions if there is a sms gateway already configured (master) 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericHttpGetGatewayConfig.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericHttpGetGatewayConfig.java
@@ -1,0 +1,112 @@
+package org.hisp.dhis.sms.config;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Lists;
+
+/**
+ * @deprecated This is added for backward compatibility. Use
+ *             {@link #GenericHttpGatewayConfig} instead.
+ * 
+ * @author Ameen Mohamed <ameen@dhis2.org>
+ */
+@Deprecated
+public class GenericHttpGetGatewayConfig
+    extends SmsGatewayConfig
+{
+    private static final long serialVersionUID = 6340853488475760213L;
+
+    private String messageParameter;
+
+    private String recipientParameter;
+
+    private boolean useGet;
+
+    private ContentType contentType = ContentType.FORM_URL_ENCODED;
+
+    private List<GenericGatewayParameter> parameters = Lists.newArrayList();
+
+    @JsonProperty
+    public List<GenericGatewayParameter> getParameters()
+    {
+        return parameters;
+    }
+
+    public void setParameters( List<GenericGatewayParameter> parameters )
+    {
+        this.parameters = parameters;
+    }
+
+    @JsonProperty( value = "messageParameter" )
+    public String getMessageParameter()
+    {
+        return messageParameter;
+    }
+
+    public void setMessageParameter( String messageParameter )
+    {
+        this.messageParameter = messageParameter;
+    }
+
+    @JsonProperty( value = "recipientParameter" )
+    public String getRecipientParameter()
+    {
+        return recipientParameter;
+    }
+
+    public void setRecipientParameter( String recipientParameter )
+    {
+        this.recipientParameter = recipientParameter;
+    }
+
+    @JsonProperty
+    public boolean isUseGet()
+    {
+        return useGet;
+    }
+
+    public void setUseGet( boolean useGet )
+    {
+        this.useGet = useGet;
+    }
+
+    @JsonProperty
+    public ContentType getContentType()
+    {
+        return contentType;
+    }
+
+    public void setContentType( ContentType contentType )
+    {
+        this.contentType = contentType;
+    }
+} 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v34/V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v34/V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string.java
@@ -33,27 +33,46 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
+import org.hisp.dhis.sms.config.ContentType;
+import org.hisp.dhis.sms.config.GenericGatewayParameter;
+import org.hisp.dhis.sms.config.GenericHttpGatewayConfig;
+import org.hisp.dhis.sms.config.GenericHttpGetGatewayConfig;
+import org.hisp.dhis.sms.config.SmsConfiguration;
+import org.hisp.dhis.sms.config.SmsGatewayConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.SerializationUtils;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author David Katuscak (katuscak.d@gmail.com)
+ * @author Ameen Mohamed (ameen@dhis2.org)
  */
+@SuppressWarnings( "deprecation" )
 public class V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string extends BaseJavaMigration
 {
     private static final Logger log = LoggerFactory.getLogger( V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string.class );
 
     private static final String CHECK_SYSTEM_SETTING_VALUE_TYPE_SQL = "SELECT data_type FROM information_schema.columns " +
         "WHERE table_name = 'systemsetting' AND column_name = 'value';";
+    
+    private static final String SMS_CONFIGURATION_SETTING_NAME = "keySmsSetting";
+    
+    //Copied from SimplisticHttpGetGateway.java
+    public static final String KEY_TEXT = "text";
+    public static final String KEY_RECIPIENT = "recipients";
 
     @Override
     public void migrate( final Context context ) throws Exception
@@ -73,27 +92,8 @@ public class V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string ex
 
             if ( continueWithMigration )
             {
-                ObjectMapper objectMapper = new ObjectMapper();
-
                 //2. Fetch the data to convert if available
-                Set<SystemSetting> systemSettingsToConvert = new HashSet<>();
-
-                try ( Statement stmt = context.getConnection().createStatement();
-                    ResultSet rs = stmt.executeQuery( "select * from systemsetting" ); )
-                {
-                    while ( rs.next() )
-                    {
-                        String name = rs.getString( "name" );
-
-                        SystemSetting systemSetting = new SystemSetting();
-                        systemSetting.setId( rs.getLong( "systemsettingid" ) );
-                        systemSetting.setName( name );
-                        systemSetting
-                            .setValue( (Serializable) SerializationUtils.deserialize( rs.getBytes( "value" ) ) );
-
-                        systemSettingsToConvert.add( systemSetting );
-                    }
-                }
+                Set<SystemSetting> systemSettingsToConvert = fetchExistingSystemSettings( context );
 
                 //3. Create a new column of type varchar in systemsetting table
                 try ( Statement stmt = context.getConnection().createStatement() )
@@ -102,22 +102,7 @@ public class V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string ex
                 }
 
                 //4. Fill the new column with transformed data
-                try ( PreparedStatement ps = context.getConnection()
-                    .prepareStatement( "UPDATE systemsetting SET value_text = ? WHERE systemsettingid = ?" ) )
-                {
-                    for ( SystemSetting systemSetting : systemSettingsToConvert )
-                    {
-                        ps.setString( 1, objectMapper.writeValueAsString( systemSetting.getValue() ) );
-                        ps.setLong( 2, systemSetting.getId() );
-
-                        ps.execute();
-                    }
-                }
-                catch ( SQLException e )
-                {
-                    log.error( "Flyway java migration error:", e );
-                    throw new FlywayException( e );
-                }
+                fillNewColWithTransformedData( context, systemSettingsToConvert );
 
                 //5. Delete old byte array column for value in systemsetting table
                 try ( Statement stmt = context.getConnection().createStatement() )
@@ -137,6 +122,144 @@ public class V2_34_6__Convert_systemsetting_value_column_from_bytea_to_string ex
             log.error( "Exception occurred: " + e, e );
             throw e;
         }
+    }
+
+    private Set<SystemSetting> fetchExistingSystemSettings( final Context context )
+        throws SQLException
+    {
+        Set<SystemSetting> systemSettingsToConvert = new HashSet<>();
+
+        try ( Statement stmt = context.getConnection().createStatement();
+            ResultSet rs = stmt.executeQuery( "select * from systemsetting" ); )
+        {
+            while ( rs.next() )
+            {
+                String name = rs.getString( "name" );
+
+                SystemSetting systemSetting = new SystemSetting();
+                systemSetting.setId( rs.getLong( "systemsettingid" ) );
+                systemSetting.setName( name );
+               
+                if ( SMS_CONFIGURATION_SETTING_NAME.equals( name ) )
+                {
+                    SmsConfiguration smsConfiguration = (SmsConfiguration) SerializationUtils.deserialize( rs.getBytes( "value" ) );
+                    updateSmsConfiguration( smsConfiguration );
+                    systemSetting.setValue( smsConfiguration );
+                }
+                else
+                {
+                    systemSetting.setValue( (Serializable) SerializationUtils.deserialize( rs.getBytes( "value" ) ) );
+                }
+
+                systemSettingsToConvert.add( systemSetting );
+            }
+        }
+        return systemSettingsToConvert;
+    }
+
+    private void fillNewColWithTransformedData( final Context context, Set<SystemSetting> systemSettingsToConvert )
+        throws JsonProcessingException
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        ObjectMapper specialObjectMapper = new ObjectMapper();
+        specialObjectMapper.setVisibility( specialObjectMapper.getSerializationConfig()
+            .getDefaultVisibilityChecker()
+            .withFieldVisibility( Visibility.ANY )
+            .withGetterVisibility( Visibility.NONE )
+            .withSetterVisibility( Visibility.NONE )
+            .withCreatorVisibility( Visibility.NONE ) );
+        
+        try ( PreparedStatement ps = context.getConnection()
+            .prepareStatement( "UPDATE systemsetting SET value_text = ? WHERE systemsettingid = ?" ) )
+        {
+            for ( SystemSetting systemSetting : systemSettingsToConvert )
+            {
+                if ( systemSetting.getName().equals( SMS_CONFIGURATION_SETTING_NAME ) )
+                {
+                    ps.setString( 1, specialObjectMapper.writeValueAsString( systemSetting.getValue() ) );
+                }
+                else
+                {
+                    ps.setString( 1, objectMapper.writeValueAsString( systemSetting.getValue() ) );
+                }
+                ps.setLong( 2, systemSetting.getId() );
+
+                ps.execute();
+            }
+        }
+        catch ( SQLException e )
+        {
+            log.error( "Flyway java migration error:", e );
+            throw new FlywayException( e );
+        }
+    }
+
+    private void updateSmsConfiguration( SmsConfiguration smsConfiguration )
+    {
+        if ( smsConfiguration == null )
+        {
+            return;
+        }
+        
+        List<SmsGatewayConfig> existingGatewayConfigs = smsConfiguration.getGateways();
+
+        List<SmsGatewayConfig> updatedGatewayConfigs = new ArrayList<>();
+
+        for ( SmsGatewayConfig gatewayConfig : existingGatewayConfigs )
+        {
+            if ( gatewayConfig instanceof GenericHttpGetGatewayConfig )
+            {
+                GenericHttpGatewayConfig newGatewayConfig = convertToNewSmsGenericConfig( (GenericHttpGetGatewayConfig) gatewayConfig );
+                updatedGatewayConfigs.add( newGatewayConfig );
+            }
+            else
+            {
+                updatedGatewayConfigs.add( gatewayConfig );
+            }
+        }
+
+        smsConfiguration.setGateways( updatedGatewayConfigs );
+    }
+
+    private GenericHttpGatewayConfig convertToNewSmsGenericConfig( GenericHttpGetGatewayConfig gatewayConfig )
+    {
+        GenericHttpGatewayConfig newGatewayConfig = new GenericHttpGatewayConfig();
+        newGatewayConfig.setContentType( ContentType.FORM_URL_ENCODED );
+        newGatewayConfig.setDefault( gatewayConfig.isDefault() );
+        newGatewayConfig.setName( gatewayConfig.getName() );
+        newGatewayConfig.setParameters( gatewayConfig.getParameters() );
+        newGatewayConfig.setPassword( gatewayConfig.getPassword() );
+        newGatewayConfig.setUid( gatewayConfig.getUid() );
+        newGatewayConfig.setUrlTemplate( gatewayConfig.getUrlTemplate() + "?" + createConfigurationTemplateFromConfig( gatewayConfig ) );
+        newGatewayConfig.setUseGet( true );
+        newGatewayConfig.setSendUrlParameters( true );
+        newGatewayConfig.setUsername( gatewayConfig.getUsername() );
+
+        return newGatewayConfig;
+    }
+
+    private String createConfigurationTemplateFromConfig( GenericHttpGetGatewayConfig gatewayConfig )
+    {
+        StringBuilder configTemplateBuilder = new StringBuilder();
+        if ( !StringUtils.isEmpty( gatewayConfig.getMessageParameter() ) )
+        {
+            configTemplateBuilder.append( gatewayConfig.getMessageParameter() ).append( "={" ).append( KEY_TEXT ).append( "}&" );
+        }
+
+        if ( !StringUtils.isEmpty( gatewayConfig.getRecipientParameter() ) )
+        {
+            configTemplateBuilder.append( gatewayConfig.getRecipientParameter() ).append( "={" ).append( KEY_RECIPIENT ).append( "}&" );
+        }
+
+        for ( GenericGatewayParameter parameter : gatewayConfig.getParameters() )
+        {
+            if ( !parameter.isHeader() )
+            {
+                configTemplateBuilder.append( parameter.getKey() ).append( "={" ).append( parameter.getKey() ).append( "}&" );
+            }
+        }
+        return configTemplateBuilder.toString();
     }
 
     public class SystemSetting


### PR DESCRIPTION
Added back SimplisticHttpGetGatewayConfig, so that deserialization of an object serialized in 2.33 is possible. 
Modified a java flyway script to handle "keySmsSetting" system setting separately and convert SimplisticHttpGetGatewayConfig (2.33) into SimplisticHttpGatewayConfig(2.34+). 