### PR TITLE
fix: broken Hibernate5module usage

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
@@ -30,17 +30,13 @@ package org.hisp.dhis.artemis.audit.legacy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.SessionFactory;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditAttributes;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.commons.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.dbms.DbmsUtils;
 import org.hisp.dhis.system.util.AnnotationUtils;
 import org.hisp.dhis.system.util.ReflectionUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -71,12 +67,9 @@ public class DefaultAuditObjectFactory implements AuditObjectFactory
      */
     private final Map<String, Map<Field, Method>> cachedAuditAttributeFields = new ConcurrentHashMap<>();
 
-    public DefaultAuditObjectFactory( @Qualifier("jsonMapper") ObjectMapper objectMapper )
+    public DefaultAuditObjectFactory( @Qualifier( "jsonMapper" ) ObjectMapper objectMapper )
     {
         this.objectMapper = objectMapper;
-
-        // TODO consider moving this to CommonsConfig
-        objectMapper.registerModule( new Hibernate5Module() );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/config/JacksonObjectMapperConfig.java
@@ -28,16 +28,6 @@ package org.hisp.dhis.commons.config;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Date;
-
-import org.hisp.dhis.commons.config.jackson.EmptyStringToNullStdDeserializer;
-import org.hisp.dhis.commons.config.jackson.ParseDateStdDeserializer;
-import org.hisp.dhis.commons.config.jackson.WriteDateStdSerializer;
-import org.hisp.dhis.commons.config.jackson.geometry.JtsXmlModule;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -46,16 +36,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.PrecisionModel;
+import org.hisp.dhis.commons.config.jackson.EmptyStringToNullStdDeserializer;
+import org.hisp.dhis.commons.config.jackson.ParseDateStdDeserializer;
+import org.hisp.dhis.commons.config.jackson.WriteDateStdSerializer;
+import org.hisp.dhis.commons.config.jackson.geometry.JtsXmlModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Date;
 
 /**
  * Main Jackson Mapper configuration. Any component that requires JSON/XML
  * serialization should use the Jackson mappers configured in this class.
- * 
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Configuration
@@ -133,7 +131,7 @@ public class JacksonObjectMapperConfig
         module.addDeserializer( Date.class, new ParseDateStdDeserializer() );
         module.addSerializer( Date.class, new WriteDateStdSerializer() );
 
-        objectMapper.registerModules( module, new JavaTimeModule(), new Jdk8Module(), new Hibernate5Module() );
+        objectMapper.registerModules( module, new JavaTimeModule(), new Jdk8Module() );
 
         objectMapper.setSerializationInclusion( JsonInclude.Include.NON_NULL );
         objectMapper.disable( SerializationFeature.WRITE_DATES_AS_TIMESTAMPS );


### PR DESCRIPTION
* Current Hibernate5module configuration, breaks the normal deserialization usage.
 The Hibernate5module is meant to be used in context when there is no open session in view, aka. no request that initiates the operation.
 In DHIS2 this used for scheduled background tasks and the audit system.

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>