### PR TITLE
fix: Deserialization issue of DashboardItem.users

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardItem.java
@@ -28,22 +28,16 @@ package org.hisp.dhis.dashboard;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
-import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
-import static org.springframework.beans.BeanUtils.copyProperties;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.chart.Chart;
 import org.hisp.dhis.chart.Series;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.EmbeddedObject;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.InterpretableObject;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.document.Document;
 import org.hisp.dhis.eventchart.EventChart;
 import org.hisp.dhis.eventreport.EventReport;
@@ -52,18 +46,23 @@ import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.report.Report;
 import org.hisp.dhis.reporttable.ReportParams;
 import org.hisp.dhis.reporttable.ReportTable;
+import org.hisp.dhis.schema.annotation.PropertyTransformer;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.visualization.Axis;
 import org.hisp.dhis.visualization.ReportingParams;
 import org.hisp.dhis.visualization.Visualization;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.hisp.dhis.visualization.VisualizationType;
 import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
+import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
+import static org.springframework.beans.BeanUtils.copyProperties;
 
 /**
  * Represents an item in the dashboard. An item can represent an embedded object
@@ -415,15 +414,17 @@ public class DashboardItem
         this.text = text;
     }
 
-    @JsonProperty( "users" )
-    @JsonSerialize( contentAs = BaseIdentifiableObject.class )
-    @JacksonXmlElementWrapper( localName = "users", namespace = DXF_2_0 )
-    @JacksonXmlProperty( localName = "user", namespace = DXF_2_0 )
+    @JsonProperty
+    @JsonSerialize( contentUsing = UserPropertyTransformer.JacksonSerialize.class )
+    @PropertyTransformer( UserPropertyTransformer.class )
+    @JacksonXmlElementWrapper( localName = "users", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "user", namespace = DxfNamespaces.DXF_2_0 )
     public List<User> getUsers()
     {
         return users;
     }
 
+    @JsonDeserialize( contentUsing = UserPropertyTransformer.JacksonDeserialize.class )
     public void setUsers( List<User> users )
     {
         this.users = users;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-9632

Not sure why but Jackson failed to find the custom deserializer on getter, it works with setter. 
I haven't seen this issue anywhere else.

```Level: ERROR, category: METADATA_IMPORT, time: Mon Sep 28 09:51:25 UTC 2020, message: Process failed: could not extract ResultSet] (InMemoryNotifier.java [taskScheduler-7])
com.fasterxml.jackson.databind.JsonMappingException: Problem deserializing property 'users' (expected type: [collection type; class java.util.List, contains [simple type, class org.hisp.dhis.user.User]]; actual type: `org.hisp.dhis.user.User`), problem: java.lang.ClassCastException@53ab7d22
at [Source: (ZipInputStream); line: 19, column: 93408] (through reference chain: org.hisp.dhis.dxf2.metadata.Metadata["dashboards"]>java.util.ArrayList[20]>org.hisp.dhis.dashboard.Dashboard["dashboardItems"]>java.util.ArrayList[1]>org.hisp.dhis.dashboard.DashboardItem["users"])```