### PR TITLE
fix: [DHIS2-9625] totalPages param when used ignores maxteicount setting (master 2.36)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -227,9 +227,10 @@ public class TrackedEntityInstanceController
 
         RootNode rootNode = NodeUtils.createMetadata();
 
+        int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, false );
+
         if ( queryParams.isPaging() && queryParams.isTotalPages() )
         {
-            int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, false );
             Pager pager = new Pager( queryParams.getPageWithDefault(), count, queryParams.getPageSizeWithDefault() );
             rootNode.addChild( NodeUtils.createPager( pager ) );
         }


### PR DESCRIPTION
Count will be checked irrespective of `totalPages` param. 