### PR TITLE
fix: Migration to bigint is very time consuming

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__Use_bigint_for_id_columns.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.32/V2_32_10__Use_bigint_for_id_columns.sql
@@ -1,5 +1,18 @@
 -- datavalueaudit table and its foreign key references
-alter table datavalueaudit alter column datavalueauditid type bigint;
+alter table datavalueaudit
+      alter column datavalueauditid type bigint,
+      alter column dataelementid type bigint,
+      alter column periodid type bigint,
+      alter column organisationunitid type bigint,
+      alter column categoryoptioncomboid type bigint,
+      alter column attributeoptioncomboid type bigint;
+
+alter table datavalue
+      alter column dataelementid type bigint,
+      alter column periodid type bigint,
+      alter column sourceid type bigint,
+      alter column categoryoptioncomboid type bigint,
+      alter column attributeoptioncomboid type bigint;
 
 -- programstageinstance table and its foreign key references
 alter table programstageinstance alter column programstageinstanceid type bigint;
@@ -262,16 +275,6 @@ alter table datasetuseraccesses alter column datasetid type bigint;
 alter table datasetusergroupaccesses alter column datasetid type bigint;
 alter table datastatistics alter column statisticsid type bigint;
 alter table datastatistics alter column lastupdatedby type bigint;
-alter table datavalue alter column dataelementid type bigint;
-alter table datavalue alter column periodid type bigint;
-alter table datavalue alter column sourceid type bigint;
-alter table datavalue alter column categoryoptioncomboid type bigint;
-alter table datavalue alter column attributeoptioncomboid type bigint;
-alter table datavalueaudit alter column dataelementid type bigint;
-alter table datavalueaudit alter column periodid type bigint;
-alter table datavalueaudit alter column organisationunitid type bigint;
-alter table datavalueaudit alter column categoryoptioncomboid type bigint;
-alter table datavalueaudit alter column attributeoptioncomboid type bigint;
 alter table deletedobject alter column deletedobjectid type bigint;
 alter table document alter column documentid type bigint;
 alter table document alter column lastupdatedby type bigint;


### PR DESCRIPTION
In 2.32 all models moved to a bigint as their primary key, the way the sql file for this migration is written makes it less ideal on very large tables.

On large tables, running the alter column multiples times in a row will be very slow and will result in a lot of disk space being needed.

By running this once, postgres will be able to alter the columns in one go, this reduces the time considerably.

I've ran this command before doing the migration, the datavalue ones took: 30 minutes, the datavalueadit took 46 minutes. But once those were done, running the migration took only 15 minutes.

When I tried to run the migration as is, it would take multiple hours and be very disk space hungry.

I've opened the PR against master, but I think this needs to be backported into 2.32. (But was't sure which version I should pick to do that)

