### PR TITLE
fix: (2.34) Add fix for program rule action [DHIS2-9489]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +80,7 @@ public class DefaultProgramRuleEngineService
     }
 
     @Override
+    @Transactional
     public List<RuleEffect> evaluateEnrollmentAndRunEffects( long programInstanceId )
     {
         ProgramInstance programInstance = programInstanceService.getProgramInstance( programInstanceId );
@@ -97,6 +99,7 @@ public class DefaultProgramRuleEngineService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<RuleEffect> evaluateEnrollment( String programInstanceUid )
     {
         ProgramInstance programInstance = programInstanceService.getProgramInstance( programInstanceUid );
@@ -121,9 +124,11 @@ public class DefaultProgramRuleEngineService
     }
 
     @Override
+    @Transactional
     public List<RuleEffect> evaluateEventAndRunEffects( long programStageInstanceId )
     {
         ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( programStageInstanceId );
+
         List<RuleEffect> ruleEffects = getRuleEffects( psi );
 
         for ( RuleEffect effect : ruleEffects )
@@ -140,6 +145,7 @@ public class DefaultProgramRuleEngineService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<RuleEffect> evaluateEvent( String programStageInstanceUid )
     {
         ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( programStageInstanceUid );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
@@ -28,7 +28,7 @@ package org.hisp.dhis.tracker;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.programrule.engine.DefaultProgramRuleEngineService;
+import org.hisp.dhis.programrule.engine.ProgramRuleEngineService;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -37,19 +37,18 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * @author Enrico Colasante
  */
-@Service
+@Service( "org.hisp.dhis.tracker.TrackerProgramRuleService")
 public class DefaultTrackerProgramRuleService
     implements TrackerProgramRuleService
 {
-    private final DefaultProgramRuleEngineService programRuleEngineService;
+    private final ProgramRuleEngineService programRuleEngineService;
 
-    public DefaultTrackerProgramRuleService( DefaultProgramRuleEngineService programRuleEngineService )
+    public DefaultTrackerProgramRuleService( ProgramRuleEngineService programRuleEngineService )
     {
         this.programRuleEngineService = programRuleEngineService;
     }


### PR DESCRIPTION
PR fixes the problem with SENDMESSAGE/SCHEDULEMESSAGE program rule action. It was caused by a lazy initialization issue and was resolved by annotating ProgramRuleEngineService class with `@Transactional `annotation. 