### PR TITLE
chore: lock CodeQL analysis pull_request param to master branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ name: "CodeQL"
 on:
   pull_request:
     branches:
-      - '**'
+      - master
   schedule:
     - cron: '0 12 * * *'
 


### PR DESCRIPTION
* CodeQL will not understand which base branch to compare against using wildcards see:
https://bluecolibri.org/2020/10/05/github-enabling-code-scanning-for-a-repository

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>