### PR TITLE
fix: Reorganizing transaction logic in calls to rule engine [DHIS2-9630]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceService.java
@@ -125,20 +125,12 @@ public interface ProgramStageInstanceService
     ProgramStageInstance getProgramStageInstance( long id );
 
     /**
-     * Returns a List of {@link ProgramStageInstance}.
+     * Returns a List of {@link ProgramStageInstance}
      *
-     * @param ids a List of {@link ProgramStageInstance} primary keys
-     * @return  a List of {@link ProgramStageInstance} matching the provided primary keyss
+     * @param id the primary key of a Program Instance
+     * @return  a List of {@link ProgramStageInstance} matching the provided primary key of a Program Instance
      */
-    List<ProgramStageInstance> getProgramStageInstances( List<Long> ids );
-
-    /**
-     * Returns a List of {@link ProgramStageInstance}.
-     *
-     * @param uids a List of {@link ProgramStageInstance} uids
-     * @return  a List of {@link ProgramStageInstance} matching the provided uids
-     */
-    List<ProgramStageInstance> getProgramStageInstancesByUids( List<String> uids );
+    List<ProgramStageInstance> getProgramStageInstancesByProgramInstance( Long id );
 
     /**
      * Returns the {@link ProgramStageInstance} with the given UID.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceStore.java
@@ -74,6 +74,12 @@ public interface ProgramStageInstanceStore
      */
     List<ProgramStageInstance> get( TrackedEntityInstance entityInstance, EventStatus status );
 
+    /**
+     * Get all {@see ProgramStageInstance} linked to a {@see ProgramInstance}
+     * 
+     * @param id the primary key of a {@see ProgramInstance}
+     * @returna {@see ProgramStageInstance} list
+     */
     List<ProgramStageInstance> getProgramStageInstancesByProgramInstance( Long id );
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceStore.java
@@ -74,6 +74,8 @@ public interface ProgramStageInstanceStore
      */
     List<ProgramStageInstance> get( TrackedEntityInstance entityInstance, EventStatus status );
 
+    List<ProgramStageInstance> getProgramStageInstancesByProgramInstance( Long id );
+
     /**
      * Get the number of ProgramStageInstances updates since the given Date.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -141,7 +141,11 @@ public class DefaultProgramInstanceService
     @Transactional( readOnly = true )
     public ProgramInstance getProgramInstance( long id )
     {
-        return programInstanceStore.get( id );
+        ProgramInstance programInstance = programInstanceStore.get(id);
+        // TEMP CODE FIXME Luciano-Enrico
+        programInstance.getEntityInstance().getTrackedEntityAttributeValues().size();
+
+        return programInstance;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -141,18 +141,14 @@ public class DefaultProgramInstanceService
     @Transactional( readOnly = true )
     public ProgramInstance getProgramInstance( long id )
     {
-        ProgramInstance programInstance = programInstanceStore.get( id );
-
-        return programInstance;
+        return programInstanceStore.get( id );
     }
 
     @Override
     @Transactional( readOnly = true )
     public ProgramInstance getProgramInstance( String uid )
     {
-        ProgramInstance programInstance = programInstanceStore.getByUid( uid );
-
-        return programInstance;
+        return programInstanceStore.getByUid( uid );
     }
 
     @Override
@@ -303,9 +299,7 @@ public class DefaultProgramInstanceService
             params.setDefaultPaging();
         }
 
-        List<ProgramInstance> programInstances = programInstanceStore.getProgramInstances( params );
-
-        return programInstances;
+        return programInstanceStore.getProgramInstances( params );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -138,8 +138,6 @@ public class DefaultProgramInstanceService
     public ProgramInstance getProgramInstance( long id )
     {
         ProgramInstance programInstance = programInstanceStore.get(id);
-        // TEMP CODE FIXME Luciano-Enrico
-        programInstance.getEntityInstance().getTrackedEntityAttributeValues().size();
 
         return programInstance;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -28,7 +28,17 @@ package org.hisp.dhis.program;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import lombok.extern.slf4j.Slf4j;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -47,23 +57,19 @@ import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Abyot Asalefew
  */
 @Slf4j
 @Service( "org.hisp.dhis.program.ProgramInstanceService" )
+@AllArgsConstructor
 public class DefaultProgramInstanceService
     implements ProgramInstanceService
 {
@@ -71,35 +77,25 @@ public class DefaultProgramInstanceService
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @Autowired
-    private ProgramInstanceStore programInstanceStore;
+    @NotNull private final ProgramInstanceStore programInstanceStore;
 
-    @Autowired
-    private ProgramStageInstanceStore programStageInstanceStore;
+    @NotNull private final ProgramStageInstanceStore programStageInstanceStore;
 
-    @Autowired
-    private ProgramService programService;
+    @NotNull private final ProgramService programService;
 
-    @Autowired
-    private CurrentUserService currentUserService;
+    @NotNull private final CurrentUserService currentUserService;
 
-    @Autowired
-    private TrackedEntityInstanceService trackedEntityInstanceService;
+    @NotNull private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    @Autowired
-    private OrganisationUnitService organisationUnitService;
+    @NotNull private final OrganisationUnitService organisationUnitService;
 
-    @Autowired
-    private TrackedEntityTypeService trackedEntityTypeService;
+    @NotNull private final TrackedEntityTypeService trackedEntityTypeService;
 
-    @Autowired
-    private ApplicationEventPublisher eventPublisher;
+    @NotNull private final ApplicationEventPublisher eventPublisher;
 
-    @Autowired
-    private TrackerOwnershipManager trackerOwnershipAccessManager;
+    @NotNull private final TrackerOwnershipManager trackerOwnershipAccessManager;
 
-    @Autowired
-    private AclService aclService;
+    @NotNull private final AclService aclService;
 
     // -------------------------------------------------------------------------
     // Implementation methods
@@ -269,34 +265,13 @@ public class DefaultProgramInstanceService
 
         return params;
     }
-
+    
     // TODO consider security
     @Override
     @Transactional( readOnly = true )
     public List<ProgramInstance> getProgramInstances( ProgramInstanceQueryParams params )
     {
-        decideAccess( params );
-        validate( params );
-
-        User user = currentUserService.getCurrentUser();
-
-        if ( user != null && params.isOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE ) )
-        {
-            params.setOrganisationUnits( user.getTeiSearchOrganisationUnitsWithFallback() );
-            params.setOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS );
-        }
-        else if ( params.isOrganisationUnitMode( CHILDREN ) )
-        {
-            Set<OrganisationUnit> organisationUnits = new HashSet<>();
-            organisationUnits.addAll( params.getOrganisationUnits() );
-
-            for ( OrganisationUnit organisationUnit : params.getOrganisationUnits() )
-            {
-                organisationUnits.addAll( organisationUnit.getChildren() );
-            }
-
-            params.setOrganisationUnits( organisationUnits );
-        }
+        prepareParams( params );
 
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
@@ -310,28 +285,7 @@ public class DefaultProgramInstanceService
     @Transactional( readOnly = true )
     public int countProgramInstances( ProgramInstanceQueryParams params )
     {
-        decideAccess( params );
-        validate( params );
-
-        User user = currentUserService.getCurrentUser();
-
-        if ( user != null && params.isOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE ) )
-        {
-            params.setOrganisationUnits( user.getTeiSearchOrganisationUnitsWithFallback() );
-            params.setOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS );
-        }
-        else if ( params.isOrganisationUnitMode( CHILDREN ) )
-        {
-            Set<OrganisationUnit> organisationUnits = new HashSet<>();
-            organisationUnits.addAll( params.getOrganisationUnits() );
-
-            for ( OrganisationUnit organisationUnit : params.getOrganisationUnits() )
-            {
-                organisationUnits.addAll( organisationUnit.getChildren() );
-            }
-
-            params.setOrganisationUnits( organisationUnits );
-        }
+        prepareParams( params );
 
         params.setSkipPaging( true );
 
@@ -632,5 +586,30 @@ public class DefaultProgramInstanceService
         programInstance.setEndDate( null );
 
         updateProgramInstance( programInstance );
+    }
+
+    private void prepareParams( ProgramInstanceQueryParams params )
+    {
+        decideAccess( params );
+        validate( params );
+
+        User user = currentUserService.getCurrentUser();
+
+        if ( user != null && params.isOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE ) )
+        {
+            params.setOrganisationUnits( user.getTeiSearchOrganisationUnitsWithFallback() );
+            params.setOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS );
+        }
+        else if ( params.isOrganisationUnitMode( CHILDREN ) )
+        {
+            Set<OrganisationUnit> organisationUnits = new HashSet<>( params.getOrganisationUnits() );
+
+            for ( OrganisationUnit organisationUnit : params.getOrganisationUnits() )
+            {
+                organisationUnits.addAll( organisationUnit.getChildren() );
+            }
+
+            params.setOrganisationUnits( organisationUnits );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
@@ -138,15 +138,9 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional( readOnly = true )
-    public List<ProgramStageInstance> getProgramStageInstances( List<Long> id )
+    public List<ProgramStageInstance> getProgramStageInstancesByProgramInstance( Long id )
     {
-        return programStageInstanceStore.getById( id );
-    }
-
-    @Override
-    public List<ProgramStageInstance> getProgramStageInstancesByUids( List<String> uids )
-    {
-        return programStageInstanceStore.getByUid( uids );
+        return programStageInstanceStore.getProgramStageInstancesByProgramInstance( id );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
@@ -137,6 +137,7 @@ public class DefaultProgramStageInstanceService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<ProgramStageInstance> getProgramStageInstances( List<Long> id )
     {
         return programStageInstanceStore.getById( id );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageInstanceStore.java
@@ -123,11 +123,13 @@ public class HibernateProgramStageInstanceStore
     public List<ProgramStageInstance> getProgramStageInstancesByProgramInstance( Long id )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
-        CriteriaQuery<ProgramStageInstance> q = builder.createQuery(ProgramStageInstance.class);
-        Root<ProgramStageInstance> o = q.from(ProgramStageInstance.class);
-        o.fetch("organisationUnit", JoinType.LEFT);
-        o.fetch("programStage", JoinType.LEFT);
-        q.where(builder.equal(o.get("programInstance"), id));
+        CriteriaQuery<ProgramStageInstance> q = builder.createQuery( ProgramStageInstance.class );
+        Root<ProgramStageInstance> o = q.from( ProgramStageInstance.class );
+        // using LEFT because the org unit may be null, and we still want to get the PSI
+        o.fetch( "organisationUnit", JoinType.LEFT );
+        // using INNER because a PSI must always have a Program Stage
+        o.fetch( "programStage", JoinType.INNER );
+        q.where( builder.equal( o.get( "programInstance" ), id ) );
 
         TypedQuery<ProgramStageInstance> typedQuery = getSession().createQuery( q )
             .setCacheable( cacheable ).setHint( QueryHints.CACHEABLE, cacheable );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageInstanceStore.java
@@ -116,6 +116,15 @@ public class HibernateProgramStageInstanceStore
     }
 
     @Override
+    public List<ProgramStageInstance> getProgramStageInstancesByProgramInstance( Long id )
+    {
+        CriteriaBuilder builder = getCriteriaBuilder();
+
+        return getList( builder, newJpaParameters()
+            .addPredicate( root -> root.get( "programInstance" ).in( id ) ) );
+    }
+
+    @Override
     public long getProgramStageInstanceCountLastUpdatedAfter( Date time )
     {
         CriteriaBuilder builder = getCriteriaBuilder();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -280,10 +280,12 @@ public class ProgramStageInstanceServiceTest
         programStageInstanceA = new ProgramStageInstance( programInstanceA, stageA );
         programStageInstanceA.setDueDate( enrollmentDate );
         programStageInstanceA.setUid( "UID-A" );
+        programStageInstanceA.setOrganisationUnit( organisationUnitA );
 
         programStageInstanceB = new ProgramStageInstance( programInstanceA, stageB );
         programStageInstanceB.setDueDate( enrollmentDate );
         programStageInstanceB.setUid( "UID-B" );
+        programStageInstanceB.setOrganisationUnit( organisationUnitA );
 
         programStageInstanceC = new ProgramStageInstance( programInstanceB, stageC );
         programStageInstanceC.setDueDate( enrollmentDate );
@@ -549,6 +551,26 @@ public class ProgramStageInstanceServiceTest
 
         assertEquals( 2, programStageInstances.size() );
     }
+
+    @Test
+    public void testProgramStageInstancesByProgramInstance_fetchPSI_without_ou()
+    {
+        // Make sure that psi without an Org Unit are returned
+        // This PSI has no  Org Unit set
+
+        ProgramStageInstance programStageInstance1 = new ProgramStageInstance( programInstanceA, stageA );
+        programStageInstanceA.setDueDate( enrollmentDate );
+        programStageInstanceA.setUid( "UID-A" );
+        programStageInstanceService.addProgramStageInstance( programStageInstance1 );
+
+        programStageInstanceService.addProgramStageInstance( programStageInstanceB );
+
+        final List<ProgramStageInstance> programStageInstances = programStageInstanceService
+            .getProgramStageInstancesByProgramInstance( programInstanceA.getId() );
+
+        assertEquals( 3, programStageInstances.size() );
+    }
+
 
     private Map<String, DataElement> convertToMap( Cache<DataElement> dataElementMap )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -547,7 +547,7 @@ public class ProgramStageInstanceServiceTest
         final List<ProgramStageInstance> programStageInstances = programStageInstanceService
             .getProgramStageInstancesByProgramInstance( programInstanceA.getId() );
 
-        assertEquals( programStageInstances.size(), 2 );
+        assertEquals( 2, programStageInstances.size() );
     }
 
     private Map<String, DataElement> convertToMap( Cache<DataElement> dataElementMap )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -120,8 +120,7 @@ public class ProgramStageInstanceServiceTest
     private DataElement dataElementC;
 
     private DataElement dataElementD;
-
-
+    
     private ProgramStageDataElement stageDataElementA;
 
     private ProgramStageDataElement stageDataElementB;
@@ -193,7 +192,7 @@ public class ProgramStageInstanceServiceTest
         entityInstanceA.getTrackedEntityAttributeValues().add( attributeValue );
         entityInstanceService.updateTrackedEntityInstance( entityInstanceA );
 
-        /**
+        /*
          * Program A
          */
         programA = createProgram( 'A', new HashSet<>(), organisationUnitA );
@@ -258,7 +257,7 @@ public class ProgramStageInstanceServiceTest
         programB.setProgramStages( programStages );
         programService.updateProgram( programB );
 
-        /**
+        /*
          * Program Instance and Program Stage Instance
          */
 
@@ -410,7 +409,7 @@ public class ProgramStageInstanceServiceTest
 
         programStageInstanceService.completeProgramStageInstance( programStageInstanceA, true, mockFormat, null );
 
-        assertEquals( true, programStageInstanceService.getProgramStageInstance( idA ).isCompleted() );
+        assertTrue( programStageInstanceService.getProgramStageInstance( idA ).isCompleted() );
     }
 
     @Test
@@ -538,6 +537,17 @@ public class ProgramStageInstanceServiceTest
             .getValue();
 
         assertEquals( "3", eventDataValueCValue );
+    }
+
+    @Test
+    public void testProgramStageInstancesByProgramInstance()
+    {
+        programStageInstanceService.addProgramStageInstance( programStageInstanceB );
+
+        final List<ProgramStageInstance> programStageInstances = programStageInstanceService
+            .getProgramStageInstancesByProgramInstance( programInstanceA.getId() );
+
+        assertEquals( programStageInstances.size(), 2 );
     }
 
     private Map<String, DataElement> convertToMap( Cache<DataElement> dataElementMap )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -52,7 +52,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Created by zubair@dhis2.org on 23.10.17.
  */
-
 @Slf4j
 @Service( "org.hisp.dhis.programrule.engine.ProgramRuleEngineService" )
 @AllArgsConstructor

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import org.hisp.dhis.program.Program;
@@ -38,13 +40,12 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleValidationResult;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -53,30 +54,44 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service( "org.hisp.dhis.programrule.engine.ProgramRuleEngineService" )
-@AllArgsConstructor
 public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
 {
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @NonNull
     private final ProgramRuleEngine programRuleEngine;
 
-    @NonNull
     private final ProgramRuleEngine programRuleEngineNew;
 
-    @NonNull
     private final List<RuleActionImplementer> ruleActionImplementers;
 
-    @NonNull
     private final ProgramInstanceService programInstanceService;
 
-    @NonNull
     private final ProgramStageInstanceService programStageInstanceService;
 
-    @NonNull
     private final ProgramService programService;
+
+    public DefaultProgramRuleEngineService(
+        @Qualifier( "serviceTrackerRuleEngine" ) ProgramRuleEngine programRuleEngineNew,
+        @Qualifier( "notificationRuleEngine" ) ProgramRuleEngine programRuleEngine,
+        List<RuleActionImplementer> ruleActionImplementers, ProgramInstanceService programInstanceService,
+        ProgramStageInstanceService programStageInstanceService, ProgramService programService )
+    {
+        checkNotNull( programRuleEngine );
+        checkNotNull( programRuleEngineNew );
+        checkNotNull( ruleActionImplementers );
+        checkNotNull( programInstanceService );
+        checkNotNull( programStageInstanceService );
+        checkNotNull( programService );
+
+        this.programRuleEngine = programRuleEngine;
+        this.programRuleEngineNew = programRuleEngineNew;
+        this.ruleActionImplementers = ruleActionImplementers;
+        this.programInstanceService = programInstanceService;
+        this.programStageInstanceService = programStageInstanceService;
+        this.programService = programService;
+    }
 
     @Override
     public List<RuleEffect> evaluateEnrollmentAndRunEffects( long programInstanceId )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -73,7 +73,6 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
 
     @NonNull private final ProgramService programService;
     
-
     @Override
     public List<RuleEffect> evaluateEnrollmentAndRunEffects( long programInstanceId )
     {

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.i18n.I18nManager;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.programrule.*;

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -252,6 +252,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     }
 
     @Override
+    @Transactional( readOnly = true )
     public RuleEnrollment toMappedRuleEnrollment( ProgramInstance enrollment )
     {
         if ( enrollment == null )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.rules.models.*;
 import org.hisp.dhis.rules.utils.RuleEngineUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -167,6 +168,8 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
 
     private final ProgramRuleVariableService programRuleVariableService;
 
+    private final TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
     private final DataElementService dataElementService;
 
     private final ConstantService constantService;
@@ -175,17 +178,20 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
 
     public DefaultProgramRuleEntityMapperService( ProgramRuleService programRuleService,
         ProgramRuleVariableService programRuleVariableService, DataElementService dataElementService,
+        TrackedEntityAttributeValueService trackedEntityAttributeValueService,
         ConstantService constantService, I18nManager i18nManager )
     {
         checkNotNull( programRuleService );
         checkNotNull( programRuleVariableService );
         checkNotNull( dataElementService );
+        checkNotNull( trackedEntityAttributeValueService );
         checkNotNull( constantService );
         checkNotNull( i18nManager );
 
         this.programRuleService = programRuleService;
         this.programRuleVariableService = programRuleVariableService;
         this.dataElementService = dataElementService;
+        this.trackedEntityAttributeValueService = trackedEntityAttributeValueService;
         this.constantService = constantService;
         this.i18nManager = i18nManager;
     }
@@ -251,7 +257,6 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     }
 
     @Override
-    @Transactional( readOnly = true )
     public RuleEnrollment toMappedRuleEnrollment( ProgramInstance enrollment )
     {
         if ( enrollment == null )
@@ -271,7 +276,8 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
         List<RuleAttributeValue> ruleAttributeValues = Lists.newArrayList();
         if ( enrollment.getEntityInstance() != null )
         {
-            ruleAttributeValues = enrollment.getEntityInstance().getTrackedEntityAttributeValues()
+            ruleAttributeValues = trackedEntityAttributeValueService
+                .getTrackedEntityAttributeValues( enrollment.getEntityInstance() )
                 .stream()
                 .filter( Objects::nonNull )
                 .map( attr -> RuleAttributeValue.create( attr.getAttribute().getUid(),

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -69,7 +69,6 @@ import com.google.common.collect.Lists;
  * Created by zubair@dhis2.org on 19.10.17.
  */
 @Slf4j
-@Transactional( readOnly = true )
 @Service( "org.hisp.dhis.programrule.engine.ProgramRuleEntityMapperService" )
 public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService
 {

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.*;
 
+import com.google.common.collect.Lists;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -55,6 +56,7 @@ import org.hisp.dhis.rules.models.*;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.util.ObjectUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -139,6 +141,9 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     private ProgramRuleVariableService programRuleVariableService;
 
     @Mock
+    private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
+    @Mock
     private ConstantService constantService;
 
     @Mock
@@ -156,7 +161,7 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     public void initTest()
     {
         subject = new DefaultProgramRuleEntityMapperService( programRuleService, programRuleVariableService,
-            dataElementService, constantService, i18nManager );
+            dataElementService, trackedEntityAttributeValueService, constantService, i18nManager );
 
         setUpProgramRules();
     }
@@ -317,6 +322,10 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     public void testMappedEnrollment()
     {
+        when(
+            trackedEntityAttributeValueService.getTrackedEntityAttributeValues( programInstance.getEntityInstance() ) )
+                .thenReturn( Lists.newArrayList( trackedEntityAttributeValue ) );
+
         RuleEnrollment ruleEnrollment = subject.toMappedRuleEnrollment( programInstance );
 
         assertEquals( ruleEnrollment.enrollment(), programInstance.getUid() );


### PR DESCRIPTION
- Removed all Transactional annotation from rule engine services
- Retrieve ProgramStageInstance with all fields that are required in the rule engine process (ProgramStage and OrganisationUnit)
- Removed some code duplication