### PR TITLE
chore: lower the log level on the AppOverrideFilter

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -156,20 +156,20 @@ public class AppOverrideFilter
             String appName = m.group( 1 );
             String resourcePath = m.group( 2 );
 
-            log.info( "AppOverrideFilter :: Matched for URI " + requestURI );
+            log.debug( "AppOverrideFilter :: Matched for URI " + requestURI );
 
             App app = appManager.getApp( appName );
 
             if ( app != null && app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
             {
-                log.info( "AppOverrideFilter :: Overridden app " + appName + " found, serving override" );
+                log.debug( "AppOverrideFilter :: Overridden app " + appName + " found, serving override" );
                 serveInstalledAppResource( app, resourcePath, req, res );
 
                 return;
             }
             else
             {
-                log.info( "AppOverrideFilter :: App " + appName + " not found, falling back to bundled app" );
+                log.debug( "AppOverrideFilter :: App " + appName + " not found, falling back to bundled app" );
             }
         }
 


### PR DESCRIPTION
* The AppOverrideFilter is too verbose, change log level from INFO to DEBUG

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>