### PR TITLE
chore: align latest security changes in master/2.35

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -25,10 +25,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
         fetch-depth: 0 
     - uses: actions/cache@v1
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
@@ -1,0 +1,161 @@
+package org.hisp.dhis.security.oidc.provider;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthenticationMethod;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class AzureAdProvider extends DhisOidcProvider
+{
+    public static final String PROVIDER_PREFIX = "oidc.provider.azure.";
+
+    public static final String AZURE_TENANT = ".tenant";
+
+    public static final String AZURE_CLIENT_ID = ".client_id";
+
+    public static final String AZURE_CLIENT_SECRET = ".client_secret";
+
+    public static final String AZURE_REDIRECT_BASE_URL = ".redirect_baseurl";
+
+    public static final String AZURE_MAPPING_CLAIM = ".mapping_claim";
+
+    public static final String AZURE_SUPPORT_LOGOUT = ".support_logout";
+
+    private AzureAdProvider()
+    {
+        throw new IllegalStateException( "Utility class" );
+    }
+
+    public static List<DhisOidcClientRegistration> buildList( DhisConfigurationProvider config )
+    {
+        Objects.requireNonNull( config, "DhisConfigurationProvider is missing!" );
+
+        ImmutableList.Builder<DhisOidcClientRegistration> clients = ImmutableList.builder();
+
+        int i = 0;
+
+        while ( true )
+        {
+            Properties properties = config.getProperties();
+            String tenantKey = PROVIDER_PREFIX + i + AZURE_TENANT;
+            String tenant = properties.getProperty( tenantKey, "" );
+            if ( tenant.isEmpty() )
+            {
+                break;
+            }
+
+            String key = PROVIDER_PREFIX + i + AZURE_CLIENT_ID;
+            String clientId = properties.getProperty( key, "" );
+            if ( clientId.isEmpty() )
+            {
+                throw new IllegalArgumentException( "Azure client id is missing! tenant=" + tenant );
+            }
+
+            String clientSecret = config.getProperties()
+                .getProperty( PROVIDER_PREFIX + i + AZURE_CLIENT_SECRET );
+            if ( clientSecret.isEmpty() )
+            {
+                throw new IllegalArgumentException( "Azure client secret is missing! tenant=" + tenant );
+            }
+            String redirectBaseUrl = MoreObjects
+                .firstNonNull( config.getProperties().getProperty( PROVIDER_PREFIX + i + AZURE_REDIRECT_BASE_URL ),
+                    "http://localhost:8080" );
+
+            String mappingClaims = MoreObjects.firstNonNull( config.getProperties()
+                .getProperty( PROVIDER_PREFIX + i + AZURE_MAPPING_CLAIM ), "email" );
+
+            // Well known url for reference. In a perfect world we would dynamically parse this.
+            // https://login.microsoftonline.com/"+tenant+"/v2.0/.well-known/openid-configuration
+
+            String baseUrl = "https://login.microsoftonline.com/";
+
+            ClientRegistration.Builder builder = getBuilder( tenant );
+            builder.scope( "openid", "profile", "email" );
+            builder.authorizationUri( baseUrl + tenant + "/oauth2/v2.0/authorize" );
+            builder.tokenUri( baseUrl + tenant + "/oauth2/v2.0/token" );
+            builder.jwkSetUri( baseUrl + tenant + "/discovery/v2.0/keys" );
+            builder.userInfoUri( "https://graph.microsoft.com/oidc/userinfo" );
+
+            builder.clientName( tenant );
+            builder.clientId( clientId );
+            builder.clientSecret( clientSecret );
+
+            builder.redirectUriTemplate( redirectBaseUrl + DEFAULT_CODE_URL_TEMPLATE );
+            builder.userInfoAuthenticationMethod( AuthenticationMethod.HEADER );
+            builder.userNameAttributeName( IdTokenClaimNames.SUB );
+
+            boolean supportLogout = Boolean.parseBoolean( MoreObjects.firstNonNull( config.getProperties()
+                .getProperty( PROVIDER_PREFIX + i + AZURE_MAPPING_CLAIM ), "TRUE" ) );
+
+            if ( supportLogout )
+            {
+                HashMap<String, Object> metadata = new HashMap<>();
+                metadata.put( "end_session_endpoint",
+                    baseUrl + tenant + "/oauth2/v2.0/logout" );
+                builder.providerConfigurationMetadata( metadata );
+            }
+
+            DhisOidcClientRegistration dhisClient = DhisOidcClientRegistration.builder()
+                .clientRegistration( builder.build() )
+                .mappingClaimKey( mappingClaims )
+                .registrationId( tenant )
+                .build();
+
+            clients.add( dhisClient );
+
+            i++;
+        }
+
+        return clients.build();
+    }
+
+    private static ClientRegistration.Builder getBuilder( String registrationId )
+    {
+        ClientRegistration.Builder builder = ClientRegistration.withRegistrationId( registrationId );
+        builder.clientAuthenticationMethod( ClientAuthenticationMethod.BASIC );
+        builder.authorizationGrantType( AuthorizationGrantType.AUTHORIZATION_CODE );
+        builder.redirectUriTemplate( DEFAULT_REDIRECT_URL );
+        return builder;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
@@ -126,7 +126,7 @@ public class AzureAdProvider extends DhisOidcProvider
             builder.userNameAttributeName( IdTokenClaimNames.SUB );
 
             boolean supportLogout = Boolean.parseBoolean( MoreObjects.firstNonNull( config.getProperties()
-                .getProperty( PROVIDER_PREFIX + i + AZURE_MAPPING_CLAIM ), "TRUE" ) );
+                .getProperty( PROVIDER_PREFIX + i + AZURE_SUPPORT_LOGOUT ), "TRUE" ) );
 
             if ( supportLogout )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/DhisOidcProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/DhisOidcProvider.java
@@ -1,0 +1,38 @@
+package org.hisp.dhis.security.oidc.provider;/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public abstract class DhisOidcProvider
+{
+    protected static final String DEFAULT_REDIRECT_URL = "{baseUrl}/{action}/oauth2/code/{registrationId}";
+
+    protected static final String DEFAULT_CODE_URL_TEMPLATE = "/oauth2/code/{registrationId}";
+}
+

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/GoogleProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/GoogleProvider.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.security.oidc.provider;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+import java.util.Objects;
+
+import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_PROVIDER_GOOGLE_CLIENT_ID;
+import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_PROVIDER_GOOGLE_CLIENT_SECRET;
+import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM;
+import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_PROVIDER_GOOGLE_REDIR_BASE_URL;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class GoogleProvider extends DhisOidcProvider
+{
+    public static final String REGISTRATION_ID = "google";
+
+    private GoogleProvider()
+    {
+        throw new IllegalStateException( "Utility class" );
+    }
+
+    public static DhisOidcClientRegistration build( DhisConfigurationProvider config )
+    {
+        Objects.requireNonNull( config, "DhisConfigurationProvider is missing!" );
+
+        String googleClientId = config.getProperty( OIDC_PROVIDER_GOOGLE_CLIENT_ID );
+        String googleClientSecret = config.getProperty( OIDC_PROVIDER_GOOGLE_CLIENT_SECRET );
+        String googleClientRedirectBaseUri = config.getProperty( OIDC_PROVIDER_GOOGLE_REDIR_BASE_URL );
+        String googleClientMappingClaim = config.getProperty( OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM );
+
+        if ( googleClientId.isEmpty() )
+        {
+            return null;
+        }
+        if ( googleClientSecret.isEmpty() )
+        {
+            throw new IllegalArgumentException( "Google client secret is missing!" );
+        }
+
+        ClientRegistration google = CommonOAuth2Provider.GOOGLE.getBuilder( REGISTRATION_ID )
+            .clientId( googleClientId )
+            .clientSecret( googleClientSecret )
+            .redirectUriTemplate( googleClientRedirectBaseUri + DEFAULT_CODE_URL_TEMPLATE )
+            .build();
+
+        return DhisOidcClientRegistration.builder()
+            .clientRegistration( google )
+            .mappingClaimKey( googleClientMappingClaim )
+            .registrationId( REGISTRATION_ID )
+            .build();
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -60,6 +61,7 @@ import static org.mockito.Mockito.*;
  */
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( HttpUtils.class )
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*","org.w3c.*"})
 public class MetadataSyncDelegateTest
 {
     @Rule

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
@@ -60,6 +60,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.http.HttpStatus;
@@ -69,6 +70,7 @@ import org.springframework.http.HttpStatus;
  */
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( HttpUtils.class )
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*","org.w3c.*"})
 public class MetadataVersionDelegateTest
 {
     @Rule

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.artemis.audit.legacy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.audit.AuditAttribute;
@@ -71,12 +70,9 @@ public class DefaultAuditObjectFactory implements AuditObjectFactory
      */
     private final Map<String, Map<Field, Method>> cachedAuditAttributeFields = new ConcurrentHashMap<>();
 
-    public DefaultAuditObjectFactory( @Qualifier("jsonMapper") ObjectMapper objectMapper )
+    public DefaultAuditObjectFactory( @Qualifier( "jsonMapper" ) ObjectMapper objectMapper )
     {
         this.objectMapper = objectMapper;
-
-        // TODO consider moving this to CommonsConfig
-        objectMapper.registerModule( new Hibernate5Module() );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/config/JacksonObjectMapperConfig.java
@@ -28,16 +28,6 @@ package org.hisp.dhis.commons.config;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.Date;
-
-import org.hisp.dhis.commons.config.jackson.EmptyStringToNullStdDeserializer;
-import org.hisp.dhis.commons.config.jackson.ParseDateStdDeserializer;
-import org.hisp.dhis.commons.config.jackson.WriteDateStdSerializer;
-import org.hisp.dhis.commons.config.jackson.geometry.JtsXmlModule;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -46,16 +36,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.PrecisionModel;
+import org.hisp.dhis.commons.config.jackson.EmptyStringToNullStdDeserializer;
+import org.hisp.dhis.commons.config.jackson.ParseDateStdDeserializer;
+import org.hisp.dhis.commons.config.jackson.WriteDateStdSerializer;
+import org.hisp.dhis.commons.config.jackson.geometry.JtsXmlModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Date;
 
 /**
  * Main Jackson Mapper configuration. Any component that requires JSON/XML
  * serialization should use the Jackson mappers configured in this class.
- * 
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Configuration
@@ -133,7 +131,7 @@ public class JacksonObjectMapperConfig
         module.addDeserializer( Date.class, new ParseDateStdDeserializer() );
         module.addSerializer( Date.class, new WriteDateStdSerializer() );
 
-        objectMapper.registerModules( module, new JavaTimeModule(), new Jdk8Module(), new Hibernate5Module() );
+        objectMapper.registerModules( module, new JavaTimeModule(), new Jdk8Module() );
 
         objectMapper.setSerializationInclusion( JsonInclude.Include.NON_NULL );
         objectMapper.disable( SerializationFeature.WRITE_DATES_AS_TIMESTAMPS );

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -111,9 +111,10 @@ public enum ConfigurationKey
     AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false ),
 
     OIDC_OAUTH2_LOGIN_ENABLED( "oidc.oauth2.login.enabled", "off", false ),
+    OIDC_LOGOUT_REDIRECT_URL( "oidc.logout.redirect_url", "http://localhost:8080", false ),
 
-    OIDC_PROVIDER_GOOGLE_CLIENT_ID( "oidc.provider.google.client_id", "empty", true ),
-    OIDC_PROVIDER_GOOGLE_CLIENT_SECRET( "oidc.provider.google.client_secret", "empty", true ),
+    OIDC_PROVIDER_GOOGLE_CLIENT_ID( "oidc.provider.google.client_id", "", true ),
+    OIDC_PROVIDER_GOOGLE_CLIENT_SECRET( "oidc.provider.google.client_secret", "", true ),
     OIDC_PROVIDER_GOOGLE_REDIR_BASE_URL( "oidc.provider.google.redirect_baseurl", "http://localhost:8080", true ),
     OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM( "oidc.provider.google.mapping_claim", "email", true );
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -109,10 +109,8 @@ public enum ConfigurationKey
     AUDIT_METADATA_MATRIX( "audit.metadata", "", false ),
     AUDIT_TRACKER_MATRIX( "audit.tracker", "", false ),
     AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false ),
-
     OIDC_OAUTH2_LOGIN_ENABLED( "oidc.oauth2.login.enabled", "off", false ),
     OIDC_LOGOUT_REDIRECT_URL( "oidc.logout.redirect_url", "http://localhost:8080", false ),
-
     OIDC_PROVIDER_GOOGLE_CLIENT_ID( "oidc.provider.google.client_id", "", true ),
     OIDC_PROVIDER_GOOGLE_CLIENT_SECRET( "oidc.provider.google.client_secret", "", true ),
     OIDC_PROVIDER_GOOGLE_REDIR_BASE_URL( "oidc.provider.google.redirect_baseurl", "http://localhost:8080", true ),

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationProviderConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationProviderConfig.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.security.oauth2.DefaultClientDetailsUserDetailsService;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetailsSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -69,21 +70,13 @@ public class AuthenticationProviderConfig
     @Autowired
     DefaultClientDetailsUserDetailsService defaultClientDetailsUserDetailsService;
 
-    @Autowired
-    public void configureGlobal( @Lazy AuthenticationManagerBuilder auth )
-        throws Exception
-    {
-        auth.authenticationProvider( twoFactorAuthenticationProvider );
-        auth.authenticationProvider( customLdapAuthenticationProvider() );
-    }
-
     @Bean
     public TwoFactorWebAuthenticationDetailsSource twoFactorWebAuthenticationDetailsSource()
     {
         return new TwoFactorWebAuthenticationDetailsSource();
     }
 
-    @Bean
+    @Bean(name ="customLdapAuthenticationProvider")
     CustomLdapAuthenticationProvider customLdapAuthenticationProvider()
     {
         return new CustomLdapAuthenticationProvider( dhisBindAuthenticator(),

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -342,8 +342,7 @@ public class DhisWebApiWebSecurityConfig
                 .and().csrf().disable()
 
                 .exceptionHandling()
-                .accessDeniedHandler( accessDeniedHandler )
-                .authenticationEntryPoint( authenticationEntryPoint );
+                .accessDeniedHandler( accessDeniedHandler );
 
             http
                 .addFilterBefore( CorsFilter.get(), BasicAuthenticationFilter.class )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -28,10 +28,13 @@ package org.hisp.dhis.webapi.security.config;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.ImmutableList;
+import org.hisp.dhis.security.ldap.authentication.CustomLdapAuthenticationProvider;
 import org.hisp.dhis.security.oauth2.DefaultClientDetailsService;
 import org.hisp.dhis.security.oidc.DhisClientRegistrationRepository;
 import org.hisp.dhis.security.oidc.DhisOAuth2AuthorizationRequestResolver;
 import org.hisp.dhis.security.oidc.OidcEnabledCondition;
+import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.webapi.filter.CorsFilter;
 import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
 import org.hisp.dhis.webapi.oprovider.DhisOauthAuthenticationProvider;
@@ -46,6 +49,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configurers.userdetails.DaoAuthenticationConfigurer;
@@ -91,8 +96,7 @@ public class DhisWebApiWebSecurityConfig
     /**
      * This configuration class is responsible for setting up the OAuth2 /token endpoint and /authorize endpoint.
      * This config is a modification of the config that is automatically enabled by using the @EnableAuthorizationServer annotation.
-     * The spring-security-oauth2 project is deprecated but as of now 19. August 2020 there is still no other alternative ready.
-     * The candidate for replacing this is: https://github.com/spring-projects-experimental/spring-authorization-server
+     * The spring-security-oauth2 project is deprecated, but as of August 19, 2020; there is still no other viable alternative available.
      */
     @Configuration
     @Order( 1001 )
@@ -100,10 +104,20 @@ public class DhisWebApiWebSecurityConfig
     public class OAuth2SecurityConfig extends WebSecurityConfigurerAdapter implements AuthorizationServerConfigurer
     {
         @Autowired
+        private TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
+
+        @Autowired
+        @Qualifier( "customLdapAuthenticationProvider" )
+        private CustomLdapAuthenticationProvider customLdapAuthenticationProvider;
+
+        @Autowired
         private AuthorizationServerEndpointsConfiguration endpoints;
 
         @Autowired
         private DhisOauthAuthenticationProvider dhisOauthAuthenticationProvider;
+
+        @Autowired
+        private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
         @Override
         protected void configure( HttpSecurity http )
@@ -117,8 +131,7 @@ public class DhisWebApiWebSecurityConfig
             http.apply( configurer );
 
             // This is the only endpoint we need to configure.
-            // The /authorize endpoint is only accessible AFTER you have logged in,
-            // you will be redirected to the form login if you try accessing it without being authenticated.
+            // The other /authorize endpoint is only accessible AFTER you have been authorized.
             String tokenEndpointPath = handlerMapping.getServletPath( "/oauth/token" );
 
             http
@@ -139,6 +152,7 @@ public class DhisWebApiWebSecurityConfig
             extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity>
         {
             @Override
+            @SuppressWarnings( "unchecked" )
             public void init( HttpSecurity builder )
                 throws Exception
             {
@@ -156,12 +170,14 @@ public class DhisWebApiWebSecurityConfig
         public void configure( AuthorizationServerSecurityConfigurer security )
             throws Exception
         {
+            // Intentionally empty
         }
 
         @Override
         public void configure( ClientDetailsServiceConfigurer configurer )
             throws Exception
         {
+            // Intentionally empty
         }
 
         @Bean( "authorizationCodeServices" )
@@ -174,11 +190,17 @@ public class DhisWebApiWebSecurityConfig
         public void configure( final AuthorizationServerEndpointsConfigurer endpoints )
             throws Exception
         {
+            ProviderManager providerManager = new ProviderManager(
+                ImmutableList.of( twoFactorAuthenticationProvider, customLdapAuthenticationProvider ) );
+            if ( authenticationEventPublisher != null )
+            {
+                providerManager.setAuthenticationEventPublisher( authenticationEventPublisher );
+            }
             endpoints
                 .prefix( "/uaa" )
                 .authorizationCodeServices( jdbcAuthorizationCodeServices() )
                 .tokenStore( tokenStore() )
-                .authenticationManager( authenticationManager() );
+                .authenticationManager( providerManager );
         }
     }
 
@@ -188,13 +210,13 @@ public class DhisWebApiWebSecurityConfig
     @Configuration
     @Order( 1010 )
     @Conditional( value = OidcEnabledCondition.class )
-    public class OidcSecurityConfig extends WebSecurityConfigurerAdapter
+    public static class OidcSecurityConfig extends WebSecurityConfigurerAdapter
     {
         @Autowired
-        public DhisClientRegistrationRepository dhisClientRegistrationRepository;
+        private DhisClientRegistrationRepository dhisClientRegistrationRepository;
 
         @Autowired
-        public DhisOAuth2AuthorizationRequestResolver dhisOAuth2AuthorizationRequestResolver;
+        private DhisOAuth2AuthorizationRequestResolver dhisOAuth2AuthorizationRequestResolver;
 
         @Override
         protected void configure( HttpSecurity http )
@@ -234,7 +256,7 @@ public class DhisWebApiWebSecurityConfig
         return new JdbcTokenStore( dataSource );
     }
 
-    @Bean( "tokenService1" )
+    @Bean( "defaultTokenService" )
     @Primary
     public DefaultTokenServices tokenServices()
     {
@@ -252,12 +274,19 @@ public class DhisWebApiWebSecurityConfig
     public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter
     {
         @Autowired
-        @Qualifier( "tokenService1" )
-        public ResourceServerTokenServices tokenServices;
+        @Qualifier( "defaultTokenService" )
+        private ResourceServerTokenServices tokenServices;
 
         @Autowired
         @Qualifier( "defaultClientDetailsService" )
-        DefaultClientDetailsService clientDetailsService;
+        private DefaultClientDetailsService clientDetailsService;
+
+        @Autowired
+        private TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
+
+        @Autowired
+        @Qualifier( "customLdapAuthenticationProvider" )
+        private CustomLdapAuthenticationProvider customLdapAuthenticationProvider;
 
         final private SecurityExpressionHandler<FilterInvocation> expressionHandler = new OAuth2WebSecurityExpressionHandler();
 
@@ -265,7 +294,12 @@ public class DhisWebApiWebSecurityConfig
 
         final private AccessDeniedHandler accessDeniedHandler = new OAuth2AccessDeniedHandler();
 
-        final private String resourceId = "oauth2-resource";
+        public void configure( AuthenticationManagerBuilder auth )
+            throws Exception
+        {
+            auth.authenticationProvider( twoFactorAuthenticationProvider );
+            auth.authenticationProvider( customLdapAuthenticationProvider );
+        }
 
         /**
          * This AuthenticationManager is responsible for authorizing access, refresh and code
@@ -275,7 +309,7 @@ public class DhisWebApiWebSecurityConfig
         private AuthenticationManager oauthAuthenticationManager( HttpSecurity http )
         {
             OAuth2AuthenticationManager oauthAuthenticationManager = new OAuth2AuthenticationManager();
-            oauthAuthenticationManager.setResourceId( resourceId );
+            oauthAuthenticationManager.setResourceId( "oauth2-resource" );
             oauthAuthenticationManager.setTokenServices( tokenServices );
             oauthAuthenticationManager.setClientDetailsService( clientDetailsService );
 
@@ -285,12 +319,6 @@ public class DhisWebApiWebSecurityConfig
         protected void configure( HttpSecurity http )
             throws Exception
         {
-            AuthenticationManager oauthAuthenticationManager = oauthAuthenticationManager( http );
-            OAuth2AuthenticationProcessingFilter resourcesServerFilter = new OAuth2AuthenticationProcessingFilter();
-            resourcesServerFilter.setAuthenticationEntryPoint( authenticationEntryPoint );
-            resourcesServerFilter.setAuthenticationManager( oauthAuthenticationManager );
-            resourcesServerFilter.setStateless( false );
-
             http
                 .antMatcher( "/api/**" )
                 .authorizeRequests( authorize -> authorize
@@ -311,15 +339,25 @@ public class DhisWebApiWebSecurityConfig
                 )
                 .httpBasic()
                 .authenticationEntryPoint( basicAuthenticationEntryPoint() )
-                .and()
+                .and().csrf().disable()
+
                 .exceptionHandling()
                 .accessDeniedHandler( accessDeniedHandler )
-                .and()
-                .csrf().disable()
+                .authenticationEntryPoint( authenticationEntryPoint );
 
+            http
                 .addFilterBefore( CorsFilter.get(), BasicAuthenticationFilter.class )
-                .addFilterBefore( CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class )
-                .addFilterAfter( resourcesServerFilter, BasicAuthenticationFilter.class );
+                .addFilterBefore( CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class );
+
+            // This is the OAuth2 resource filter it will be checking for the "Authorization: Bearer <token>" header if
+            // the "Authorization: Basic <username:password>" header is not present or valid.
+            OAuth2AuthenticationProcessingFilter resourcesServerFilter = new OAuth2AuthenticationProcessingFilter();
+            resourcesServerFilter.setAuthenticationEntryPoint( authenticationEntryPoint );
+            resourcesServerFilter.setAuthenticationManager( oauthAuthenticationManager( http ) );
+            resourcesServerFilter.setStateless( false );
+
+            // Adds the resource (oath2 token) filter after http basic filer.
+            http.addFilterAfter( resourcesServerFilter, BasicAuthenticationFilter.class );
 
             setHttpHeaders( http );
         }
@@ -331,6 +369,12 @@ public class DhisWebApiWebSecurityConfig
         }
     }
 
+    /**
+     * Customizes various "global" security related headers.
+     *
+     * @param http http config
+     * @throws Exception
+     */
     public static void setHttpHeaders( HttpSecurity http )
         throws Exception
     {

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/btn_google_light_normal_ios.svg
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/btn_google_light_normal_ios.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="46px" height="46px" viewBox="0 0 46 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+<svg width="46px" height="46px" viewBox="0 0 46 46" version="1.1" xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
     <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
     <title>btn_google_light_normal_ios</title>
     <desc>Created with Sketch.</desc>
@@ -7,10 +8,12 @@
         <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-1">
             <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
             <feGaussianBlur stdDeviation="0.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
-            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.168 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.168 0" in="shadowBlurOuter1" type="matrix"
+                           result="shadowMatrixOuter1"></feColorMatrix>
             <feOffset dx="0" dy="0" in="SourceAlpha" result="shadowOffsetOuter2"></feOffset>
             <feGaussianBlur stdDeviation="0.5" in="shadowOffsetOuter2" result="shadowBlurOuter2"></feGaussianBlur>
-            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.084 0" in="shadowBlurOuter2" type="matrix" result="shadowMatrixOuter2"></feColorMatrix>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.084 0" in="shadowBlurOuter2" type="matrix"
+                           result="shadowMatrixOuter2"></feColorMatrix>
             <feMerge>
                 <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
                 <feMergeNode in="shadowMatrixOuter2"></feMergeNode>
@@ -31,10 +34,14 @@
                 </g>
             </g>
             <g id="logo_googleg_48dp" sketch:type="MSLayerGroup" transform="translate(15.000000, 15.000000)">
-                <path d="M17.64,9.20454545 C17.64,8.56636364 17.5827273,7.95272727 17.4763636,7.36363636 L9,7.36363636 L9,10.845 L13.8436364,10.845 C13.635,11.97 13.0009091,12.9231818 12.0477273,13.5613636 L12.0477273,15.8195455 L14.9563636,15.8195455 C16.6581818,14.2527273 17.64,11.9454545 17.64,9.20454545 L17.64,9.20454545 Z" id="Shape" fill="#4285F4" sketch:type="MSShapeGroup"></path>
-                <path d="M9,18 C11.43,18 13.4672727,17.1940909 14.9563636,15.8195455 L12.0477273,13.5613636 C11.2418182,14.1013636 10.2109091,14.4204545 9,14.4204545 C6.65590909,14.4204545 4.67181818,12.8372727 3.96409091,10.71 L0.957272727,10.71 L0.957272727,13.0418182 C2.43818182,15.9831818 5.48181818,18 9,18 L9,18 Z" id="Shape" fill="#34A853" sketch:type="MSShapeGroup"></path>
-                <path d="M3.96409091,10.71 C3.78409091,10.17 3.68181818,9.59318182 3.68181818,9 C3.68181818,8.40681818 3.78409091,7.83 3.96409091,7.29 L3.96409091,4.95818182 L0.957272727,4.95818182 C0.347727273,6.17318182 0,7.54772727 0,9 C0,10.4522727 0.347727273,11.8268182 0.957272727,13.0418182 L3.96409091,10.71 L3.96409091,10.71 Z" id="Shape" fill="#FBBC05" sketch:type="MSShapeGroup"></path>
-                <path d="M9,3.57954545 C10.3213636,3.57954545 11.5077273,4.03363636 12.4404545,4.92545455 L15.0218182,2.34409091 C13.4631818,0.891818182 11.4259091,0 9,0 C5.48181818,0 2.43818182,2.01681818 0.957272727,4.95818182 L3.96409091,7.29 C4.67181818,5.16272727 6.65590909,3.57954545 9,3.57954545 L9,3.57954545 Z" id="Shape" fill="#EA4335" sketch:type="MSShapeGroup"></path>
+                <path d="M17.64,9.20454545 C17.64,8.56636364 17.5827273,7.95272727 17.4763636,7.36363636 L9,7.36363636 L9,10.845 L13.8436364,10.845 C13.635,11.97 13.0009091,12.9231818 12.0477273,13.5613636 L12.0477273,15.8195455 L14.9563636,15.8195455 C16.6581818,14.2527273 17.64,11.9454545 17.64,9.20454545 L17.64,9.20454545 Z"
+                      id="Shape" fill="#4285F4" sketch:type="MSShapeGroup"></path>
+                <path d="M9,18 C11.43,18 13.4672727,17.1940909 14.9563636,15.8195455 L12.0477273,13.5613636 C11.2418182,14.1013636 10.2109091,14.4204545 9,14.4204545 C6.65590909,14.4204545 4.67181818,12.8372727 3.96409091,10.71 L0.957272727,10.71 L0.957272727,13.0418182 C2.43818182,15.9831818 5.48181818,18 9,18 L9,18 Z"
+                      id="Shape" fill="#34A853" sketch:type="MSShapeGroup"></path>
+                <path d="M3.96409091,10.71 C3.78409091,10.17 3.68181818,9.59318182 3.68181818,9 C3.68181818,8.40681818 3.78409091,7.83 3.96409091,7.29 L3.96409091,4.95818182 L0.957272727,4.95818182 C0.347727273,6.17318182 0,7.54772727 0,9 C0,10.4522727 0.347727273,11.8268182 0.957272727,13.0418182 L3.96409091,10.71 L3.96409091,10.71 Z"
+                      id="Shape" fill="#FBBC05" sketch:type="MSShapeGroup"></path>
+                <path d="M9,3.57954545 C10.3213636,3.57954545 11.5077273,4.03363636 12.4404545,4.92545455 L15.0218182,2.34409091 C13.4631818,0.891818182 11.4259091,0 9,0 C5.48181818,0 2.43818182,2.01681818 0.957272727,4.95818182 L3.96409091,7.29 C4.67181818,5.16272727 6.65590909,3.57954545 9,3.57954545 L9,3.57954545 Z"
+                      id="Shape" fill="#EA4335" sketch:type="MSShapeGroup"></path>
                 <path d="M0,0 L18,0 L18,18 L0,18 L0,0 Z" id="Shape" sketch:type="MSShapeGroup"></path>
             </g>
             <g id="handles_square" sketch:type="MSLayerGroup"></g>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -156,20 +156,20 @@ public class AppOverrideFilter
             String appName = m.group( 1 );
             String resourcePath = m.group( 2 );
 
-            log.info( "AppOverrideFilter :: Matched for URI " + requestURI );
+            log.debug( "AppOverrideFilter :: Matched for URI " + requestURI );
 
             App app = appManager.getApp( appName );
 
             if ( app != null && app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
             {
-                log.info( "AppOverrideFilter :: Overridden app " + appName + " found, serving override" );
+                log.debug( "AppOverrideFilter :: Overridden app " + appName + " found, serving override" );
                 serveInstalledAppResource( app, resourcePath, req, res );
 
                 return;
             }
             else
             {
-                log.info( "AppOverrideFilter :: App " + appName + " not found, falling back to bundled app" );
+                log.debug( "AppOverrideFilter :: App " + appName + " not found, falling back to bundled app" );
             }
         }
 


### PR DESCRIPTION
This commit contains a list of cherry-picked commits from master that I think we really should consider adding.
The new feature here is that we can also add Azure AD OIDC providers. This is already added in the docs for 2.35.0
The fix for HIbernate5Module is also critical and there is already a separate PR coming. This goes together with Viet's fix for the broken audit serialization that is coming also. 
Consider to wait for these two PR's before this gets potentially merged.