### PR TITLE
fix: eventDataValue is blank for audit entry

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventdatavalue/EventDataValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventdatavalue/EventDataValue.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hisp.dhis.common.DxfNamespaces;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -131,6 +132,7 @@ public class EventDataValue implements Serializable
     // -------------------------------------------------------------------------
     // Getters and setters
     // -------------------------------------------------------------------------
+    @JsonProperty
     public Boolean getProvidedElsewhere()
     {
         return providedElsewhere;
@@ -152,6 +154,7 @@ public class EventDataValue implements Serializable
         return dataElement;
     }
 
+    @JsonProperty
     public Date getCreated()
     {
         return created;
@@ -162,6 +165,7 @@ public class EventDataValue implements Serializable
         this.created = created;
     }
 
+    @JsonProperty
     public Date getLastUpdated()
     {
         return lastUpdated;
@@ -185,11 +189,13 @@ public class EventDataValue implements Serializable
         this.value = value;
     }
 
+    @JsonProperty
     public String getValue()
     {
         return value;
     }
 
+    @JsonProperty
     public String getStoredBy()
     {
         return storedBy;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValue.java
@@ -218,6 +218,7 @@ public class TrackedEntityAttributeValue
     // Getters and setters
     // -------------------------------------------------------------------------
 
+    @AuditAttribute
     @JsonProperty
     @JacksonXmlProperty( isAttribute = true )
     public Date getCreated()
@@ -231,6 +232,7 @@ public class TrackedEntityAttributeValue
         return this;
     }
 
+    @AuditAttribute
     @JsonProperty
     @JacksonXmlProperty( isAttribute = true )
     public Date getLastUpdated()
@@ -298,6 +300,7 @@ public class TrackedEntityAttributeValue
      *
      * @return String with value, either plain-text or decrypted.
      */
+    @AuditAttribute
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getValue()


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-9441

EventDataValue doesn't have `@JsonProperty` declared so it was serialized and saved to DB as blank in audit table

Note that `@JsonIgnore` has been added to `getDataElement()` before,  there should be a reason for this... not sure if I should remove it.


sample record after this fix 

`org.hisp.dhis.program.ProgramStageInstance | y0xpS1oOBzx | {"uid": "y0xpS1oOBzx", "status": "ACTIVE", "deleted": false, "programStage": "A03MvHHogjR", "attributeValues": [], "eventDataValues": [{"value": "asdasdasd", "created": "2020-10-07T15:49:20.666", "lastUpdated": "2020-10-09T00:04:17.169"}], "programInstance": "uX36vBo3vfF", "organisationUnit": "DiszpKrYNg8", "attributeOptionCombo": "HllvX50cXC0"} | UPDATE    |`