### PR TITLE
fix: support non-root deployments when matching paths for override [DHIS2-180]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -145,7 +145,7 @@ public class AppOverrideFilter
     protected void doFilterInternal( HttpServletRequest req, HttpServletResponse res, FilterChain chain )
         throws IOException, ServletException
     {
-        String requestURI = req.getRequestURI();
+        String requestURI = req.getRequestURI().substring(req.getContextPath().length());
 
         Pattern p = Pattern.compile( APP_PATH_PATTERN );
         Matcher m = p.matcher( requestURI );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -145,7 +145,7 @@ public class AppOverrideFilter
     protected void doFilterInternal( HttpServletRequest req, HttpServletResponse res, FilterChain chain )
         throws IOException, ServletException
     {
-        String requestURI = req.getRequestURI().substring(req.getContextPath().length());
+        String requestURI = req.getRequestURI().substring( req.getContextPath().length() );
 
         Pattern p = Pattern.compile( APP_PATH_PATTERN );
         Matcher m = p.matcher( requestURI );


### PR DESCRIPTION
Previously, application overrides only worked on instances deployed as ROOT.war, because the entire request URI was matched against the override regex.  This change removes the context path from the start of the request URI before performing the match.

Huge thanks to @Philip-Larsen-Donnelly for finding this and sniffing out the root cause!