### PR TITLE
ci: enable rc docker images

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -46,7 +46,17 @@ pipeline {
 
             steps {
                 script {
-                    DOCKER_IMAGE_TAG = "${env.BRANCH_NAME}"
+                    def branchName = "${env.BRANCH_NAME}"
+
+                    DOCKER_IMAGE_TAG = branchName;
+
+                    if ( branchName.contains('/') ) {
+                        DOCKER_IMAGE_TAG = branchName.split('/')[1]
+                    }
+
+                    if ( branchName.startsWith('patch/') ) {
+                        DOCKER_IMAGE_TAG += '-rc'
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR enables the use of the same multibranch pipeline we use for publishing dev and release images.

The problem was, that we use the branch name as the image name. When the branch name contained `/`, like `patch/2.35.0`, docker failed to tag the image. This should eliminate the problem. Additionally, `-rc` will be appended to the image name.

Alternatively, we could have a separate channel for release candidates, eg. `dhis2/core-rc`, but I think `dhis2/core-dev` works too.

I tested this on jenkins and published `2.35.0-rc` images.

This will need to be backported to all supported branches.