### PR TITLE
fix: [DHIS2-9724] Period extraction in Indicators evaluation is wrong

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.analytics;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hisp.dhis.common.DimensionType.CATEGORY;
 import static org.hisp.dhis.common.DimensionType.CATEGORY_OPTION_GROUP_SET;
 import static org.hisp.dhis.common.DimensionType.DATA_X;
@@ -2333,17 +2335,22 @@ public class DataQueryParams
     }
 
     /**
-     * Returns a Period object based on the "startDate" and "endDate" dates.
-     * 
-     * @return the Period
+     * Returns a single list containing a Period object based on the "startDate" and "endDate" dates.
+     *
+     * @return a single Period list or empty list if "startDate" or "endDate" is null.
      */
-    public Period getStartEndDatesAsPeriod()
+    public List<Period> getStartEndDatesToSingleList()
     {
-        final Period period = new Period();
-        period.setStartDate( getStartDate() );
-        period.setEndDate( getEndDate() );
+        if ( getStartDate() != null && getEndDate() != null )
+        {
+            final Period period = new Period();
+            period.setStartDate( getStartDate() );
+            period.setEndDate( getEndDate() );
 
-        return period;
+            return singletonList( period );
+        }
+
+        return emptyList();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
@@ -240,7 +240,7 @@ public class DataHandler
             // "startDate/endDate" periods.
             List<Period> filterPeriods = isNotEmpty( dataSourceParams.getTypedFilterPeriods() )
                 ? dataSourceParams.getTypedFilterPeriods()
-                : singletonList( dataSourceParams.getStartEndDatesAsPeriod() );
+                : dataSourceParams.getStartEndDatesToSingleList();
 
             Map<String, Constant> constantMap = constantService.getConstantMap();
 


### PR DESCRIPTION
This fixes the cases where we have the period set as a pe with relative range - like LAST_12_MONTH (2.36)

This is a "forward" port from patch/2.35.0