### PR TITLE
fix: Make db pool connection test enabled to avoid deadlocks (#6412)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -36,13 +36,13 @@ import java.util.Optional;
  */
 public enum ConfigurationKey
 {
-    SYSTEM_READ_ONLY_MODE( "system.read_only_mode", "off", false ),
+    SYSTEM_READ_ONLY_MODE( "system.read_only_mode", Constants.OFF, false ),
     SYSTEM_SESSION_TIMEOUT( "system.session.timeout", "3600", false ),
-    SYSTEM_INTERNAL_SERVICE_API( "system.internal_service_api", "off", false ),
+    SYSTEM_INTERNAL_SERVICE_API( "system.internal_service_api", Constants.OFF, false ),
     SYSTEM_MONITORING_URL( "system.monitoring.url" ),
     SYSTEM_MONITORING_USERNAME( "system.monitoring.username" ),
     SYSTEM_MONITORING_PASSWORD( "system.monitoring.password" ),
-    SYSTEM_SQL_VIEW_TABLE_PROTECTION( "system.sql_view_table_protection", "on", false ),
+    SYSTEM_SQL_VIEW_TABLE_PROTECTION( "system.sql_view_table_protection", Constants.ON, false ),
     NODE_ID( "node.id", "", false ),
     ENCRYPTION_PASSWORD( "encryption.password", "", true ),
     CONNECTION_DIALECT( "connection.dialect", "", false ),
@@ -58,8 +58,8 @@ public enum ConfigurationKey
     CONNECTION_POOL_MAX_IDLE_TIME( "connection.pool.max_idle_time", "7200", false ),
     CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON( "connection.pool.max_idle_time_excess_con", "0", false ),
     CONNECTION_POOL_IDLE_CON_TEST_PERIOD( "connection.pool.idle.con.test.period", "0", false ),
-    CONNECTION_POOL_TEST_ON_CHECKOUT( "connection.pool.test.on.checkout", "false", false ),
-    CONNECTION_POOL_TEST_ON_CHECKIN( "connection.pool.test.on.checkin", "true", false ),
+    CONNECTION_POOL_TEST_ON_CHECKOUT( "connection.pool.test.on.checkout", Constants.FALSE, false ),
+    CONNECTION_POOL_TEST_ON_CHECKIN( "connection.pool.test.on.checkin", Constants.TRUE, false ),
     LDAP_URL( "ldap.url", "ldaps://0:1", false ),
     LDAP_MANAGER_DN( "ldap.manager.dn", "", false ),
     LDAP_MANAGER_PASSWORD( "ldap.manager.password", "", true ),
@@ -80,9 +80,9 @@ public enum ConfigurationKey
     REDIS_HOST( "redis.host", "localhost", false ),
     REDIS_PORT( "redis.port", "6379", false ),
     REDIS_PASSWORD( "redis.password", "", true ),
-    REDIS_ENABLED( "redis.enabled", "false", false ),
-    REDIS_USE_SSL( "redis.use.ssl", "false", false ),
-    FLYWAY_OUT_OF_ORDER_MIGRATION( "flyway.migrate_out_of_order", "false", false ),
+    REDIS_ENABLED( "redis.enabled", Constants.FALSE, false ),
+    REDIS_USE_SSL( "redis.use.ssl", Constants.FALSE, false ),
+    FLYWAY_OUT_OF_ORDER_MIGRATION( "flyway.migrate_out_of_order", Constants.FALSE, false ),
     PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT( "tracker.temporary.ownership.timeout", "3", false ),
     LEADER_TIME_TO_LIVE( "leader.time.to.live.minutes", "2", false ),
     ANALYTICS_CACHE_EXPIRATION( "analytics.cache.expiration", "0" ),
@@ -91,39 +91,38 @@ public enum ConfigurationKey
     ARTEMIS_PORT( "artemis.port", "25672" ),
     ARTEMIS_USERNAME( "artemis.username", "guest", true ),
     ARTEMIS_PASSWORD( "artemis.password", "guest", true ),
-    ARTEMIS_EMBEDDED_SECURITY( "artemis.embedded.security", "false" ),
-    ARTEMIS_EMBEDDED_PERSISTENCE( "artemis.embedded.persistence", "false" ),
+    ARTEMIS_EMBEDDED_SECURITY( "artemis.embedded.security", Constants.FALSE ),
+    ARTEMIS_EMBEDDED_PERSISTENCE( "artemis.embedded.persistence", Constants.FALSE ),
     LOGGING_FILE_MAX_SIZE( "logging.file.max_size", "100MB" ),
     LOGGING_FILE_MAX_ARCHIVES( "logging.file.max_archives", "1" ),
     SERVER_BASE_URL( "server.base.url", "", false ),
-    SERVER_HTTPS( "server.https", "off" ),
+    SERVER_HTTPS( "server.https", Constants.OFF ),
     MONITORING_PROVIDER( "monitoring.provider", "prometheus" ),
-    MONITORING_API_ENABLED( "monitoring.api.enabled", "off", false ),
-    MONITORING_JVM_ENABLED( "monitoring.jvm.enabled", "off", false ),
-    MONITORING_DBPOOL_ENABLED( "monitoring.dbpool.enabled", "off", false ),
-    MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", "off", false ),
-    MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", "off", false ),
-    MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", "off", false ),
-    MONITORING_LOG_REQUESTID_ENABLED( "monitoring.requestidlog.enabled", "off", false ),
+    MONITORING_API_ENABLED( "monitoring.api.enabled", Constants.OFF, false ),
+    MONITORING_JVM_ENABLED( "monitoring.jvm.enabled", Constants.OFF, false ),
+    MONITORING_DBPOOL_ENABLED( "monitoring.dbpool.enabled", Constants.OFF, false ),
+    MONITORING_HIBERNATE_ENABLED( "monitoring.hibernate.enabled", Constants.OFF, false ),
+    MONITORING_UPTIME_ENABLED( "monitoring.uptime.enabled", Constants.OFF, false ),
+    MONITORING_CPU_ENABLED( "monitoring.cpu.enabled", Constants.OFF, false ),
+    MONITORING_LOG_REQUESTID_ENABLED( "monitoring.requestidlog.enabled", Constants.OFF, false ),
     MONITORING_LOG_REQUESTID_HASHALGO( "monitoring.requestidlog.hash", "SHA-256", false ),
     MONITORING_LOG_REQUESTID_MAXSIZE( "monitoring.requestidlog.maxsize", "-1", false ),
     APPHUB_BASE_URL( "apphub.base.url", "https://apps.dhis2.org", false ),
     APPHUB_API_URL( "apphub.api.url", "https://apps.dhis2.org/api", false ),
-    CHANGELOG_AGGREGATE( "changelog.aggregate", "on" ),
-    CHANGELOG_TRACKER( "changelog.tracker", "on" ),
-    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "off" ),
-    AUDIT_LOGGER( "audit.logger", "off", false ),
-    AUDIT_DATABASE( "audit.database", "on", false ),
+    CHANGELOG_AGGREGATE( "changelog.aggregate", Constants.ON ),
+    CHANGELOG_TRACKER( "changelog.tracker", Constants.ON ),
+    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", Constants.OFF ),
+    AUDIT_LOGGER( "audit.logger", Constants.OFF, false ),
+    AUDIT_DATABASE( "audit.database", Constants.ON, false ),
     AUDIT_METADATA_MATRIX( "audit.metadata", "", false ),
     AUDIT_TRACKER_MATRIX( "audit.tracker", "", false ),
     AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false ),
-    OIDC_OAUTH2_LOGIN_ENABLED( "oidc.oauth2.login.enabled", "off", false ),
+    OIDC_OAUTH2_LOGIN_ENABLED( "oidc.oauth2.login.enabled", Constants.OFF, false ),
     OIDC_LOGOUT_REDIRECT_URL( "oidc.logout.redirect_url", "http://localhost:8080", false ),
     OIDC_PROVIDER_GOOGLE_CLIENT_ID( "oidc.provider.google.client_id", "", true ),
     OIDC_PROVIDER_GOOGLE_CLIENT_SECRET( "oidc.provider.google.client_secret", "", true ),
     OIDC_PROVIDER_GOOGLE_REDIR_BASE_URL( "oidc.provider.google.redirect_baseurl", "http://localhost:8080", true ),
     OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM( "oidc.provider.google.mapping_claim", "email", true );
-
 
     private final String key;
 
@@ -170,5 +169,16 @@ public enum ConfigurationKey
     public static Optional<ConfigurationKey> getByKey( String key )
     {
         return Arrays.stream( ConfigurationKey.values() ).filter( k -> k.key.equals( key ) ).findFirst();
+    }
+
+    private static final class Constants
+    {
+        public static final String FALSE = Boolean.FALSE.toString();
+
+        public static final String TRUE = Boolean.TRUE.toString();
+
+        public static final String OFF = Constants.OFF;
+
+        public static final String ON = Constants.ON;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -52,6 +52,14 @@ public enum ConfigurationKey
     CONNECTION_PASSWORD( "connection.password", "", true ),
     CONNECTION_SCHEMA( "connection.schema", "", false ),
     CONNECTION_POOL_MAX_SIZE( "connection.pool.max_size", "80", false ),
+    CONNECTION_POOL_MIN_SIZE( "connection.pool.min_size", "5", false ),
+    CONNECTION_POOL_INITIAL_SIZE( "connection.pool.initial_size", "5", false ),
+    CONNECTION_POOL_ACQUIRE_INCR( "connection.pool.acquire_incr", "5", false ),
+    CONNECTION_POOL_MAX_IDLE_TIME( "connection.pool.max_idle_time", "7200", false ),
+    CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON( "connection.pool.max_idle_time_excess_con", "0", false ),
+    CONNECTION_POOL_IDLE_CON_TEST_PERIOD( "connection.pool.idle.con.test.period", "0", false ),
+    CONNECTION_POOL_TEST_ON_CHECKOUT( "connection.pool.test.on.checkout", "false", false ),
+    CONNECTION_POOL_TEST_ON_CHECKIN( "connection.pool.test.on.checkin", "true", false ),
     LDAP_URL( "ldap.url", "ldaps://0:1", false ),
     LDAP_MANAGER_DN( "ldap.manager.dn", "", false ),
     LDAP_MANAGER_PASSWORD( "ldap.manager.password", "", true ),
@@ -115,6 +123,7 @@ public enum ConfigurationKey
     OIDC_PROVIDER_GOOGLE_CLIENT_SECRET( "oidc.provider.google.client_secret", "", true ),
     OIDC_PROVIDER_GOOGLE_REDIR_BASE_URL( "oidc.provider.google.redirect_baseurl", "http://localhost:8080", true ),
     OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM( "oidc.provider.google.mapping_claim", "email", true );
+
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -177,8 +177,8 @@ public enum ConfigurationKey
 
         public static final String TRUE = Boolean.TRUE.toString();
 
-        public static final String OFF = Constants.OFF;
+        public static final String OFF = "off";
 
-        public static final String ON = Constants.ON;
+        public static final String ON = "on";
     }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.datasource.DefaultDataSourceManager;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dbms.HibernateDbmsManager;
 import org.hisp.dhis.deletedobject.DeletedObject;
+import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.hibernate.DefaultHibernateConfigurationProvider;
 import org.hisp.dhis.hibernate.HibernateConfigurationProvider;
@@ -115,11 +116,23 @@ public class HibernateConfig
         dataSource.setJdbcUrl( (String) getConnectionProperty( "hibernate.connection.url" ) );
         dataSource.setUser( (String) getConnectionProperty( "hibernate.connection.username" ) );
         dataSource.setPassword( (String) getConnectionProperty( "hibernate.connection.password" ) );
-        dataSource.setMinPoolSize( 5 );
         dataSource.setMaxPoolSize( Integer.parseInt( (String) getConnectionProperty( "hibernate.c3p0.max_size" ) ) );
-        dataSource.setInitialPoolSize( 5 );
-        dataSource.setAcquireIncrement( 5 );
-        dataSource.setMaxIdleTime( 7200 );
+        dataSource.setMinPoolSize( Integer
+            .parseInt( (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_MIN_SIZE.getKey() ) ) );
+        dataSource.setInitialPoolSize( Integer
+            .parseInt( (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_INITIAL_SIZE.getKey() ) ) );
+        dataSource.setAcquireIncrement( Integer
+            .parseInt( (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_ACQUIRE_INCR.getKey() ) ) );
+        dataSource.setMaxIdleTime( Integer
+            .parseInt( (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME.getKey() ) ) );
+        dataSource.setTestConnectionOnCheckin( Boolean.parseBoolean(
+            (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN.getKey() ) ) );
+        dataSource.setTestConnectionOnCheckout( Boolean.parseBoolean(
+            (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT.getKey() ) ) );
+        dataSource.setMaxIdleTimeExcessConnections( Integer.parseInt(
+            (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON.getKey() ) ) );
+        dataSource.setIdleConnectionTestPeriod( Integer.parseInt(
+            (String) getConnectionProperty( ConfigurationKey.CONNECTION_POOL_IDLE_CON_TEST_PERIOD.getKey() ) ) );
 
         return dataSource;
     }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/DefaultHibernateConfigurationProvider.java
@@ -232,6 +232,22 @@ public class DefaultHibernateConfigurationProvider
         putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_USERNAME ), Environment.USER, props );
         putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_PASSWORD ), Environment.PASS, props );
         putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_MAX_SIZE ), Environment.C3P0_MAX_SIZE, props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_MIN_SIZE ),
+            ConfigurationKey.CONNECTION_POOL_MIN_SIZE.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_INITIAL_SIZE ),
+            ConfigurationKey.CONNECTION_POOL_INITIAL_SIZE.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_ACQUIRE_INCR ),
+            ConfigurationKey.CONNECTION_POOL_ACQUIRE_INCR.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME ),
+            ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON ),
+            ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_IDLE_CON_TEST_PERIOD ),
+            ConfigurationKey.CONNECTION_POOL_IDLE_CON_TEST_PERIOD.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN ),
+            ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN.getKey(), props );
+        putIfExists( configurationProvider.getProperty( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT ),
+            ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT.getKey(), props );
         putIfExists( configurationProvider.getProperty( ConfigurationKey.ENCRYPTION_PASSWORD ), ConfigurationKey.ENCRYPTION_PASSWORD.getKey(), props );
 
         if ( SystemUtils.isTestRun(environment.getActiveProfiles()) )


### PR DESCRIPTION
* Make most of the db pool settings configurable. 
* Enable test connection on checkin, default value "true", this change fixes the issue making the db pool deadlock on very high concurrency load right after startup.