### PR TITLE
fix: don't append duplicate app name to icon url in Module (DHIS2-9786)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/Module.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/Module.java
@@ -86,8 +86,7 @@ public class Module
         
         String defaultAction = app.getLaunchUrl();
 
-        String icon = hasIcon ? icon = app.getBaseUrl() + "/" + app.getUrlFriendlyName() +
-            "/" + app.getIcons().getIcon48() : null;
+        String icon = hasIcon ? app.getBaseUrl() + "/" + app.getIcons().getIcon48() : null;
 
         String description = TextUtils.subString( app.getDescription(), 0, 80 );
         


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-9786

The getModules.action endpoint was appending a duplicate app name to the icon URL, causing broken app icon images

Requires release control board approval before merging