### PR TITLE
feat: Enabling context variable to define dhis2_home

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
@@ -103,34 +103,39 @@ public class DefaultLocationManager extends LogOnceLogger
                 externalDir = path;
             }
         }
-        else
-        {
-            log( log, Level.INFO, "System property " + systemProperty + " not set" );
+        else{
+            try {
+                Context initCtx = new InitialContext();
+                Context envCtx = (Context) initCtx.lookup("java:comp/env");
+                path = (String)envCtx.lookup(this.contextVariable);
+            }catch (NamingException e) {
 
-            path = System.getenv( environmentVariable );
-
+            }
             if ( path != null )
             {
-                log( log, Level.INFO, "Environment variable " + environmentVariable + " points to " + path );
+                log( log, Level.INFO, "Context variable " + contextVariable + " points to " + path );
 
                 if ( directoryIsValid( new File( path ) ) )
                 {
                     externalDir = path;
                 }
             }
-            else{
-                Context initCtx = new InitialContext();
-                Context envCtx = (Context) initCtx.lookup("java:comp/env");
-                path = (String)envCtx.lookup(this.contextVariable);
+            else
+            {
+                log( log, Level.INFO, "System property " + systemProperty + " not set" );
+
+                path = System.getenv( environmentVariable );
+
                 if ( path != null )
                 {
-                    log( log, Level.INFO, "Context variable " + contextVariable + " points to " + path );
+                    log( log, Level.INFO, "Environment variable " + environmentVariable + " points to " + path );
 
                     if ( directoryIsValid( new File( path ) ) )
                     {
                         externalDir = path;
                     }
                 }
+
                 else
                 {
                     log( log, Level.INFO, "Environment variable " + environmentVariable + " not set" );

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
@@ -73,7 +73,7 @@ public class DefaultLocationManager extends LogOnceLogger
     {
         this.environmentVariable = environmentVariable;
         this.systemProperty = systemProperty;
-        this.contextVariable = contextVariable
+        this.contextVariable = contextVariable;
     }
 
     public static DefaultLocationManager getDefault()

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
@@ -37,7 +37,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import javax.naming.Context;
-import javax.naming.InitialContext
+import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import lombok.extern.slf4j.Slf4j;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateUtils.java
@@ -117,7 +117,7 @@ public class HibernateUtils
             {
                 try
                 {
-                    PropertyDescriptor pd = new PropertyDescriptor( f.getName(), proxy.getClass() );
+                    PropertyDescriptor pd = new PropertyDescriptor( (String)f.getName(), proxy.getClass() );
 
                     Object persistentObject = pd.getReadMethod().invoke( proxy );
 


### PR DESCRIPTION
To be able to set the dhis2 home from a context var instead of system property so one can have multiple DHIS2 running without messing the env variable (and running multiple tomcat)

Solution inspired from https://stackoverflow.com/questions/372686/how-can-i-specify-system-properties-in-tomcat-configuration-on-startup

not tested