### PR TITLE
refactor: simplified calls to error reporting

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.tracker.report;
 import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -92,6 +93,12 @@ public class TrackerErrorReport
         public TrackerErrorReportBuilder addArg( Object arg )
         {
             this.arguments.add( arg );
+            return this;
+        }
+
+        public TrackerErrorReportBuilder addArgs( Object ... args )
+        {
+            this.arguments.addAll( Arrays.asList( args ) );
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.validation.hooks;
  */
 
 import static com.google.api.client.util.Preconditions.checkNotNull;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1012;
 import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.*;
 
@@ -36,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.ValueType;
@@ -316,8 +318,6 @@ public abstract class AbstractTrackerDtoValidationHook
                 return;
             }
         }
-
-        return;
     }
 
     protected void validateGeometry( ValidationErrorReporter errorReporter, Geometry geometry, FeatureType featureType )
@@ -334,8 +334,7 @@ public abstract class AbstractTrackerDtoValidationHook
 
         if ( FeatureType.NONE == featureType || featureType != typeFromName )
         {
-            errorReporter.addError( newReport( TrackerErrorCode.E1012 )
-                .addArg( featureType.name() ) );
+            addError( errorReporter, E1012, featureType.name() );
         }
     }
 
@@ -349,5 +348,28 @@ public abstract class AbstractTrackerDtoValidationHook
     public boolean isValidDateStringAndNotNull( String dateString )
     {
         return dateString != null && DateUtils.dateIsValid( dateString );
+    }
+    
+    protected void addError( ValidationErrorReporter report, TrackerErrorCode errorCode, Object... args )
+    {
+        report.addError( newReport( errorCode ).addArgs( args ) );
+    }
+
+    protected void addErrorIf( Supplier<Boolean> expression, ValidationErrorReporter report, TrackerErrorCode errorCode,
+        Object... args )
+    {
+        if ( expression.get() )
+        {
+            addError( report, errorCode, args );
+        }
+    }
+
+    protected void addErrorIfNull( Object object, ValidationErrorReporter report, TrackerErrorCode errorCode,
+        Object... args )
+    {
+        if ( object == null )
+        {
+            addError( report, errorCode, args );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
@@ -28,22 +28,24 @@ package org.hisp.dhis.tracker.validation.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.api.client.util.Preconditions.checkNotNull;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1020;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1021;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1023;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1025;
+import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ENROLLMENT_CANT_BE_NULL;
+import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL;
+
+import java.util.Date;
+
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
-
-import static com.google.api.client.util.Preconditions.checkNotNull;
-import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
-import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ENROLLMENT_CANT_BE_NULL;
-import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -71,7 +73,7 @@ public class EnrollmentDateValidationHook
         if ( Boolean.TRUE.equals( program.getDisplayIncidentDate() ) &&
             !isValidDateStringAndNotNull( enrollment.getOccurredAt() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1023 ).addArg( enrollment.getOccurredAt() ) );
+            addError( reporter, E1023, enrollment.getOccurredAt() );
         }
     }
 
@@ -81,8 +83,7 @@ public class EnrollmentDateValidationHook
 
         if ( !isValidDateStringAndNotNull( enrollment.getEnrolledAt() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1025 )
-                .addArg( enrollment.getEnrolledAt() ) );
+            addError( reporter, E1025, enrollment.getEnrolledAt() );
         }
     }
 
@@ -96,16 +97,14 @@ public class EnrollmentDateValidationHook
             && Boolean.FALSE.equals( program.getSelectEnrollmentDatesInFuture() )
             && DateUtils.parseDate( enrollment.getEnrolledAt() ).after( new Date() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1020 )
-                .addArg( enrollment.getEnrolledAt() ) );
+            addError( reporter, E1020, enrollment.getEnrolledAt() );
         }
 
         if ( isValidDateStringAndNotNull( enrollment.getOccurredAt() )
             && Boolean.FALSE.equals( program.getSelectIncidentDatesInFuture() )
             && DateUtils.parseDate( enrollment.getOccurredAt() ).after( new Date() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1021 )
-                .addArg( enrollment.getOccurredAt() ) );
+            addError( reporter, E1021, enrollment.getOccurredAt() );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -48,6 +48,8 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 
 import static com.google.api.client.util.Preconditions.checkNotNull;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1056;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1057;
 import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 
 /**
@@ -58,12 +60,14 @@ import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 public class EventCategoryOptValidationHook
     extends AbstractTrackerDtoValidationHook
 {
-    @Autowired
-    protected I18nManager i18nManager;
+    private final I18nManager i18nManager;
 
-    public EventCategoryOptValidationHook( TrackedEntityAttributeService teAttrService )
+    public EventCategoryOptValidationHook( TrackedEntityAttributeService teAttrService, I18nManager i18nManager )
     {
         super( Event.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
+        
+        checkNotNull( i18nManager );
+        this.i18nManager = i18nManager;
     }
 
     @Override
@@ -108,18 +112,13 @@ public class EventCategoryOptValidationHook
         {
             if ( option.getStartDate() != null && eventDate.compareTo( option.getStartDate() ) < 0 )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1056 )
-                    .addArg( i18nFormat.formatDate( eventDate ) )
-                    .addArg( i18nFormat.formatDate( option.getStartDate() ) )
-                    .addArg( option.getName() ) );
+                addError( reporter, E1056, i18nFormat.formatDate( eventDate ),
+                    i18nFormat.formatDate( option.getStartDate() ), option.getName() );
             }
 
             if ( option.getEndDate() != null && eventDate.compareTo( option.getEndDate() ) > 0 )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1057 ).
-                    addArg( eventDate )
-                    .addArg( option.getEndDate() )
-                    .addArg( categoryOptionCombo ) );
+                addError( reporter, E1057, eventDate, option.getEndDate(),  categoryOptionCombo );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -46,6 +46,12 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 
 import static com.google.api.client.util.Preconditions.checkNotNull;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1042;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1043;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1046;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1047;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1051;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1052;
 import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 
 /**
@@ -102,17 +108,12 @@ public class EventDateValidationHook
                 completedDate = DateUtils.parseDate( event.getCompletedAt() );
             }
 
-            if ( completedDate == null )
-            {
-                reporter.addError( newReport( TrackerErrorCode.E1042 )
-                    .addArg( event ) );
-            }
+            addErrorIfNull( completedDate, reporter, E1042, event );
 
             if ( completedDate != null && (new Date())
                 .after( DateUtils.getDateAfterAddition( completedDate, program.getCompleteEventsExpiryDays() ) ) )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1043 )
-                    .addArg( event ) );
+                addError( reporter, E1043, event );
             }
         }
     }
@@ -131,18 +132,14 @@ public class EventDateValidationHook
         }
 
         String referenceDate = event.getOccurredAt() != null ? event.getOccurredAt() : event.getScheduledAt();
-        if ( referenceDate == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1046 )
-                .addArg( event ) );
-        }
+        
+        addErrorIfNull( referenceDate, reporter, E1046, event );
 
         Period period = periodType.createPeriod( new Date() );
 
         if ( DateUtils.parseDate( referenceDate ).before( period.getStartDate() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1047 )
-                .addArg( event ) );
+            addError( reporter, E1047, event );
         }
     }
 
@@ -152,14 +149,12 @@ public class EventDateValidationHook
 
         if ( event.getScheduledAt() != null && isNotValidDateString( event.getScheduledAt() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1051 )
-                .addArg( event.getScheduledAt() ) );
+            addError( reporter, E1051, event.getScheduledAt() );
         }
 
         if ( event.getOccurredAt() != null && isNotValidDateString( event.getOccurredAt() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1052 )
-                .addArg( event.getOccurredAt() ) );
+            addError( reporter, E1052, event.getScheduledAt() );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -47,6 +49,7 @@ public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
         TrackedEntityCommentService commentService )
     {
         super( Event.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
+        checkNotNull( commentService );
         this.commentService = commentService;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -61,6 +61,16 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1014;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1022;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1036;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1037;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1038;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1039;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1040;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1068;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1115;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1116;
 import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 
 /**
@@ -99,26 +109,16 @@ public class PreCheckDataRelationsValidationHook
 
         Program program = context.getProgram( enrollment.getProgram() );
 
-        if ( !program.isRegistration() )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1014 )
-                .addArg( program ) );
-        }
+        addErrorIf( () -> !program.isRegistration(), reporter, E1014, program );
 
         TrackedEntityInstance tei = context.getTrackedEntityInstance( enrollment.getTrackedEntity() );
 
-        if ( tei == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1068 )
-                .addArg( enrollment.getTrackedEntity() ) );
-        }
+        addErrorIf( () -> tei == null,  reporter, E1068, enrollment.getTrackedEntity() );
 
         if ( tei != null && program.getTrackedEntityType() != null
             && !program.getTrackedEntityType().equals( tei.getTrackedEntityType() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1022 )
-                .addArg( tei )
-                .addArg( program ) );
+            addError( reporter, E1022, tei, program );
         }
     }
 
@@ -134,8 +134,7 @@ public class PreCheckDataRelationsValidationHook
         {
             if ( context.getTrackedEntityInstance( event.getTrackedEntity() ) == null )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1036 )
-                    .addArg( event ) );
+                addError( reporter, E1036, event );
             }
 
             if ( strategy.isCreate() )
@@ -169,15 +168,11 @@ public class PreCheckDataRelationsValidationHook
 
                 if ( count == 0 )
                 {
-                    reporter.addError( newReport( TrackerErrorCode.E1037 )
-                        .addArg( tei )
-                        .addArg( program ) );
+                    addError( reporter, E1037, tei, program );
                 }
                 else if ( count > 1 )
                 {
-                    reporter.addError( newReport( TrackerErrorCode.E1038 )
-                        .addArg( tei )
-                        .addArg( program ) );
+                    addError( reporter, E1038, tei, program );
                 }
                 else
                 {
@@ -199,11 +194,8 @@ public class PreCheckDataRelationsValidationHook
 
             int count = programInstanceService.countProgramInstances( params );
 
-            if ( count > 1 )
-            {
-                // TODO: this also needs to be changed to match original code.
-                reporter.addError( newReport( TrackerErrorCode.E1040 ).addArg( program ) );
-            }
+            // TODO: this also needs to be changed to match original code.
+            addErrorIf( () -> count > 1, reporter, E1040, program );
         }
     }
 
@@ -218,7 +210,7 @@ public class PreCheckDataRelationsValidationHook
             && !programStage.getRepeatable()
             && programInstance.hasProgramStageInstance( programStage ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1039 ).addArg( programStage ) );
+            addError( reporter, E1039, programStage );
         }
     }
 
@@ -248,14 +240,12 @@ public class PreCheckDataRelationsValidationHook
 
         if ( categoryOptionCombo == null )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1115 )
-                .addArg( event.getAttributeOptionCombo() ) );
+            addError( reporter, E1115, event.getAttributeOptionCombo() );
         }
         else
         {
             reporter.getValidationContext()
                 .cacheEventCategoryOptionCombo( event.getUid(), categoryOptionCombo );
-
         }
     }
 
@@ -323,8 +313,7 @@ public class PreCheckDataRelationsValidationHook
             CategoryOption categoryOption = reporter.getValidationContext().getCategoryOption( uid );
             if ( categoryOption == null )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1116 )
-                    .addArg( uid ) );
+                addError( reporter, E1116, uid );
                 return null;
             }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -38,12 +38,18 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.springframework.stereotype.Component;
-
-import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1002;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1030;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1032;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1063;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1080;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1081;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1082;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1113;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1114;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -52,15 +58,13 @@ import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 public class PreCheckExistenceValidationHook
     extends AbstractTrackerDtoValidationHook
 {
-
     public PreCheckExistenceValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( teAttrService );
     }
 
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter,
-        TrackedEntity trackedEntity )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
         TrackerBundle bundle = context.getBundle();
@@ -82,18 +86,15 @@ public class PreCheckExistenceValidationHook
         }
         else if ( existingTe != null && importStrategy.isCreate() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1002 )
-                .addArg( trackedEntity.getTrackedEntity() ) );
+            addError( reporter, E1002, trackedEntity.getTrackedEntity() );
         }
         else if ( existingTe != null && existingTe.isDeleted() && importStrategy.isDelete() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1114 )
-                .addArg( trackedEntity.getTrackedEntity() ) );
+            addError( reporter, E1114, trackedEntity.getTrackedEntity() );
         }
         else if ( existingTe == null && importStrategy.isUpdateOrDelete() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1063 )
-                .addArg( trackedEntity.getTrackedEntity() ) );
+            addError( reporter, E1063, trackedEntity.getTrackedEntity() );
         }
         else
         {
@@ -123,18 +124,15 @@ public class PreCheckExistenceValidationHook
         }
         else if ( existingPi != null && importStrategy.isCreate() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1080 )
-                .addArg( enrollment.getEnrollment() ) );
+            addError( reporter, E1080, enrollment.getEnrollment() );
         }
         else if ( existingPi != null && existingPi.isDeleted() && importStrategy.isDelete() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1113 )
-                .addArg( enrollment.getEnrollment() ) );
+            addError( reporter, E1113, enrollment.getEnrollment() );
         }
         else if ( existingPi == null && importStrategy.isUpdateOrDelete() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1081 )
-                .addArg( enrollment.getEnrollment() ) );
+            addError( reporter, E1081, enrollment.getEnrollment() );
         }
         else
         {
@@ -164,18 +162,15 @@ public class PreCheckExistenceValidationHook
         }
         else if ( existingPsi != null && importStrategy.isCreate() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1030 )
-                .addArg( event.getEvent() ) );
+            addError( reporter, E1030, event.getEvent() );
         }
         else if ( existingPsi != null && existingPsi.isDeleted() && importStrategy.isDelete() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1082 )
-                .addArg( event.getEvent() ) );
+            addError( reporter, E1082, event.getEvent() );
         }
         else if ( existingPsi == null && importStrategy.isUpdateOrDelete() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1032 )
-                .addArg( event.getEvent() ) );
+            addError( reporter, E1032, event.getEvent() );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
@@ -48,6 +49,17 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.springframework.stereotype.Component;
 
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1005;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1011;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1035;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1041;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1069;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1070;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1086;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1087;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1088;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1089;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1094;
 import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 
 /**
@@ -71,15 +83,13 @@ public class PreCheckMetaValidationHook
         OrganisationUnit organisationUnit = context.getOrganisationUnit( tei.getOrgUnit() );
         if ( organisationUnit == null )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1049 )
-                .addArg( reporter ) );
+            addError( reporter, TrackerErrorCode.E1049, tei.getOrgUnit() );
         }
 
         TrackedEntityType entityType = context.getTrackedEntityType( tei.getTrackedEntityType() );
         if ( entityType == null )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1005 )
-                .addArg( tei.getTrackedEntityType() ) );
+            addError( reporter, E1005, tei.getTrackedEntityType());
         }
     }
 
@@ -90,25 +100,14 @@ public class PreCheckMetaValidationHook
         TrackerImportStrategy strategy = context.getStrategy( enrollment );
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( enrollment.getOrgUnit() );
-        if ( organisationUnit == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1070 )
-                .addArg( enrollment.getOrgUnit() ) );
-        }
+        addErrorIfNull( organisationUnit, reporter, E1070, enrollment.getOrgUnit() );
 
         Program program = context.getProgram( enrollment.getProgram() );
-        if ( program == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1069 )
-                .addArg( enrollment.getProgram() ) );
-        }
+        addErrorIfNull( program,  reporter, E1069, enrollment.getProgram() );
 
         if ( (program != null && organisationUnit != null) && !program.hasOrganisationUnit( organisationUnit ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1041 )
-                .addArg( organisationUnit )
-                .addArg( program )
-                .addArg( program.getOrganisationUnits() ) );
+            addError( reporter, E1041, organisationUnit, program, program.getOrganisationUnits() );
         }
 
         if ( strategy.isUpdate() )
@@ -117,9 +116,7 @@ public class PreCheckMetaValidationHook
             Program existingProgram = pi.getProgram();
             if ( !existingProgram.equals( program ) )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1094 )
-                    .addArg( pi )
-                    .addArg( existingProgram ) );
+                addError( reporter, E1094, pi, existingProgram );
             }
         }
     }
@@ -132,11 +129,7 @@ public class PreCheckMetaValidationHook
         TrackerBundle bundle = context.getBundle();
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( event.getOrgUnit() );
-        if ( organisationUnit == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1011 )
-                .addArg( event.getOrgUnit() ) );
-        }
+        addErrorIfNull( organisationUnit, reporter, E1011, event.getOrgUnit() );
 
         Program program = context.getProgram( event.getProgram() );
         ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
@@ -150,13 +143,13 @@ public class PreCheckMetaValidationHook
     {
         event.getDataValues()
             .stream()
-            .map( dv -> dv.getDataElement() )
+            .map( DataValue::getDataElement )
             .forEach( de -> {
                 DataElement dataElement = context.getBundle().getPreheat().get( TrackerIdScheme.UID, DataElement.class,
                     de );
                 if ( dataElement == null )
                 {
-                    reporter.addError( newReport( TrackerErrorCode.E1087 ).addArg( event.getEvent() ).addArg( de ) );
+                    addError( reporter, E1087, event.getEvent(), de );
                 }
             } );
     }
@@ -167,10 +160,7 @@ public class PreCheckMetaValidationHook
     {
         if ( program == null && programStage == null )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1088 )
-                .addArg( event )
-                .addArg( event.getProgram() )
-                .addArg( event.getProgramStage() ) );
+            addError( reporter, E1088, event, event.getProgram(), event.getProgramStage() );
         }
 
         if ( program == null && programStage != null )
@@ -180,9 +170,7 @@ public class PreCheckMetaValidationHook
 
         if ( program != null && programStage == null && program.isRegistration() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1086 )
-                .addArg( event )
-                .addArg( program ) );
+            addError( reporter, E1086, event, program );
         }
 
         if ( program != null )
@@ -192,17 +180,11 @@ public class PreCheckMetaValidationHook
                 : programStage;
         }
 
-        if ( programStage == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1035 )
-                .addArg( event ) );
-        }
+        addErrorIfNull( programStage, reporter, E1035, event );
 
         if ( program != null && programStage != null && !program.equals( programStage.getProgram() ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1089 )
-                .addArg( program )
-                .addArg( programStage ) );
+            addError( reporter, E1089, event, program, programStage );
         }
 
         if ( strategy.isUpdate() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -69,6 +69,10 @@ public class RelationshipsValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     private final static String RELATIONSHIP_TYPE = "relationshipType";
+    private final static String TRACKED_ENTITY = "trackedEntity";
+    private final static String ENROLLMENT = "enrollment";
+    private final static String EVENT = "event";
+
     public RelationshipsValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( Relationship.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
@@ -135,7 +139,7 @@ public class RelationshipsValidationHook
 
         if ( !optionalRelationshipType.isPresent() )
         {
-            addError( reporter, E4004, "relationshipType" );
+            addError( reporter, E4004, RELATIONSHIP_TYPE );
             return;
         }
 
@@ -180,21 +184,21 @@ public class RelationshipsValidationHook
             // Should be not be null
             if ( item.getTrackedEntity() == null )
             {
-                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "trackedEntity" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4002 ).addArg( TRACKED_ENTITY ).addArg( RELATIONSHIP_TYPE )
                     .addArg( TRACKED_ENTITY_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEnrollment() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "enrollment" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( ENROLLMENT ).addArg( RELATIONSHIP_TYPE )
                     .addArg( TRACKED_ENTITY_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEvent() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "event" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( EVENT ).addArg( RELATIONSHIP_TYPE )
                     .addArg( TRACKED_ENTITY_INSTANCE ) );
             }
 
@@ -205,21 +209,21 @@ public class RelationshipsValidationHook
             // Should be null
             if ( item.getTrackedEntity() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "trackedEntity" ).addArg(RELATIONSHIP_TYPE)
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( TRACKED_ENTITY ).addArg(RELATIONSHIP_TYPE)
                     .addArg( PROGRAM_INSTANCE ) );
             }
 
             // Should not be null
             if ( item.getEnrollment() == null )
             {
-                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "enrollment" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4002 ).addArg( ENROLLMENT ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEvent() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "event" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( EVENT ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_INSTANCE ) );
             }
 
@@ -229,21 +233,21 @@ public class RelationshipsValidationHook
             // Should be null
             if ( item.getTrackedEntity() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "trackedEntity" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( TRACKED_ENTITY ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_STAGE_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEnrollment() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "enrollment" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( ENROLLMENT ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_STAGE_INSTANCE ) );
             }
 
             // Should not be null
             if ( item.getEvent() == null )
             {
-                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "event" ).addArg( RELATIONSHIP_TYPE )
+                result.add( newReport( TrackerErrorCode.E4002 ).addArg( EVENT ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_STAGE_INSTANCE ) );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Lists;
 public class RelationshipsValidationHook
     extends AbstractTrackerDtoValidationHook
 {
-
+    private final static String RELATIONSHIP_TYPE = "relationshipType";
     public RelationshipsValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( Relationship.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
@@ -177,26 +177,24 @@ public class RelationshipsValidationHook
 
         if ( relationshipType.getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
-
             // Should be not be null
             if ( item.getTrackedEntity() == null )
             {
-                
-                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "trackedEntity" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "trackedEntity" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( TRACKED_ENTITY_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEnrollment() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "enrollment" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "enrollment" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( TRACKED_ENTITY_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEvent() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "event" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "event" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( TRACKED_ENTITY_INSTANCE ) );
             }
 
@@ -207,49 +205,47 @@ public class RelationshipsValidationHook
             // Should be null
             if ( item.getTrackedEntity() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "trackedEntity" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "trackedEntity" ).addArg(RELATIONSHIP_TYPE)
                     .addArg( PROGRAM_INSTANCE ) );
             }
 
             // Should not be null
             if ( item.getEnrollment() == null )
             {
-                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "enrollment" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "enrollment" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEvent() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "event" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "event" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_INSTANCE ) );
             }
 
         }
         else if ( relationshipType.getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
-
             // Should be null
             if ( item.getTrackedEntity() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "trackedEntity" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "trackedEntity" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_STAGE_INSTANCE ) );
             }
 
             // Should be null
             if ( item.getEnrollment() != null )
             {
-                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "enrollment" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4001 ).addArg( "enrollment" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_STAGE_INSTANCE ) );
             }
 
             // Should not be null
             if ( item.getEvent() == null )
             {
-                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "event" ).addArg( "relationshipType" )
+                result.add( newReport( TrackerErrorCode.E4002 ).addArg( "event" ).addArg( RELATIONSHIP_TYPE )
                     .addArg( PROGRAM_STAGE_INSTANCE ) );
             }
-
         }
 
         return result;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -28,6 +28,26 @@ package org.hisp.dhis.tracker.validation.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.api.client.util.Preconditions.checkNotNull;
+import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsValid;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1006;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1008;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1009;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1076;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1077;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1084;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1085;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1112;
+import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
+import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ATTRIBUTE_CANT_BE_NULL;
+import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_CANT_BE_NULL;
+import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -45,20 +65,7 @@ import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static com.google.api.client.util.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsValid;
-import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
-import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ATTRIBUTE_CANT_BE_NULL;
-import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_CANT_BE_NULL;
-import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -69,16 +76,19 @@ public class TrackedEntityAttributeValidationHook
 {
     private static final int MAX_ATTR_VALUE_LENGTH = 1200;
 
-    public TrackedEntityAttributeValidationHook( TrackedEntityAttributeService teAttrService )
+    private final ReservedValueService reservedValueService;
+    
+    private final DhisConfigurationProvider dhisConfigurationProvider;
+    
+    public TrackedEntityAttributeValidationHook( TrackedEntityAttributeService teAttrService,
+        ReservedValueService reservedValueService, DhisConfigurationProvider dhisConfigurationProvider )
     {
-        super( TrackedEntity.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService  );
+        super( TrackedEntity.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
+        checkNotNull( reservedValueService );
+        checkNotNull( dhisConfigurationProvider );
+        this.reservedValueService = reservedValueService;
+        this.dhisConfigurationProvider = dhisConfigurationProvider;
     }
-
-    @Autowired
-    private ReservedValueService reservedValueService;
-
-    @Autowired
-    private DhisConfigurationProvider dhisConfigurationProvider;
 
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
@@ -111,8 +121,7 @@ public class TrackedEntityAttributeValidationHook
 
             if ( tea == null )
             {
-                reporter.addError( newReport( TrackerErrorCode.E1006 )
-                    .addArg( attribute.getAttribute() ) );
+                addError( reporter, E1006, attribute.getAttribute() );
                 continue;
             }
 
@@ -122,8 +131,8 @@ public class TrackedEntityAttributeValidationHook
                 //continue; ??? Just continue on empty and null?
                 // TODO: Is this really correct? This check was not here originally
                 //  Enrollment attr check fails on null so why not here too?
-                reporter.addError( newReport( TrackerErrorCode.E1076 )
-                    .addArg( attribute ) );
+                addError( reporter, E1076, attribute );
+
                 continue;
             }
 
@@ -143,30 +152,16 @@ public class TrackedEntityAttributeValidationHook
         checkNotNull( value, TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL );
 
         // Validate value (string) don't exceed the max length
-        if ( value.length() > MAX_ATTR_VALUE_LENGTH )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1077 )
-                .addArg( value )
-                .addArg( MAX_ATTR_VALUE_LENGTH ) );
-        }
-
+        addErrorIf( () -> value.length() > MAX_ATTR_VALUE_LENGTH, reporter, E1077, value, MAX_ATTR_VALUE_LENGTH );
+        
         // Validate if that encryption is configured properly if someone sets value to (confidential)
         boolean isConfidential = tea.isConfidentialBool();
         boolean encryptionStatusOk = dhisConfigurationProvider.getEncryptionStatus().isOk();
-        if ( isConfidential && !encryptionStatusOk )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1112 )
-                .addArg( value ) );
-        }
+        addErrorIf( () -> isConfidential && !encryptionStatusOk, reporter, E1112, value );
 
         // Uses ValidationUtils to check that the data value corresponds to the data value type set on the attribute
         String result = dataValueIsValid( value, tea.getValueType() );
-        if ( result != null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1085 )
-                .addArg( tea )
-                .addArg( result ) );
-        }
+        addErrorIfNull( result, reporter, E1085, tea, result );
     }
 
     protected void validateTextPattern( ValidationErrorReporter reporter,
@@ -203,12 +198,8 @@ public class TrackedEntityAttributeValidationHook
             boolean isValidPattern = TextPatternValidationUtils
                 .validateTextPatternValue( tea.getTextPattern(), attribute.getValue() );
 
-            if ( !isReservedOrAlreadyAssigned && !isValidPattern )
-            {
-                reporter.addError( newReport( TrackerErrorCode.E1008 )
-                    .addArg( attribute.getValue() )
-                    .addArg( tea.getTextPattern() ) );
-            }
+            addErrorIf( () -> !isReservedOrAlreadyAssigned && !isValidPattern, reporter, E1008, attribute.getValue(),
+                tea.getTextPattern() );
         }
     }
 
@@ -234,17 +225,8 @@ public class TrackedEntityAttributeValidationHook
 
         FileResource fileResource = reporter.getValidationContext().getBundle().getPreheat()
             .get( TrackerIdScheme.UID, FileResource.class, attr.getValue() );
-
-        if ( fileResource == null )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1084 )
-                .addArg( attr.getValue() ) );
-        }
-
-        if ( fileResource != null && fileResource.isAssigned() )
-        {
-            reporter.addError( newReport( TrackerErrorCode.E1009 )
-                .addArg( attr.getValue() ) );
-        }
+        
+        addErrorIfNull( fileResource, reporter, E1084, attr.getValue() );
+        addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, E1009, attr.getValue() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -160,8 +160,8 @@ public class TrackedEntityAttributeValidationHook
         addErrorIf( () -> isConfidential && !encryptionStatusOk, reporter, E1112, value );
 
         // Uses ValidationUtils to check that the data value corresponds to the data value type set on the attribute
-        String result = dataValueIsValid( value, tea.getValueType() );
-        addErrorIfNull( result, reporter, E1085, tea, result );
+        final String result = dataValueIsValid( value, tea.getValueType() );
+        addErrorIf( () -> result != null, reporter, E1085, tea, result );
     }
 
     protected void validateTextPattern( ValidationErrorReporter reporter,


### PR DESCRIPTION
In order to reduce the amount of code required to generate an error report during Tracker validation, I have introduced a couple of helper methods in the validation abstract class.