### PR TITLE
chore: [DHIS2-9797] upgrade flyway to version 7.0.4

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1283,7 +1283,7 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
-        <version>6.0.0</version>
+        <version>7.0.4</version>
       </dependency>
 
       <!-- Apache jClouds -->


### PR DESCRIPTION
Upgraded flyway version to 7.0.4. Official support for pg v13. 