### PR TITLE
refactor: bind @RequestParam to object in Analytics controller

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticsQueryCriteria.java
@@ -1,0 +1,184 @@
+package org.hisp.dhis.common;
+
+import java.util.Date;
+import java.util.Set;
+
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.SortOrder;
+import org.hisp.dhis.analytics.UserOrgUnitType;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This class contains all the criteria that can be used to execute a DHIS2
+ * analytics query using the {@see AnalyticsController}
+ */
+@Data
+@NoArgsConstructor
+public class AnalyticsQueryCriteria
+{
+    /**
+     * The analytics dimensions
+     */
+    private Set<String> dimension;
+
+    /**
+     * Filters to apply to the analytics query
+     */
+    private Set<String> filter;
+
+    /**
+     * The {@see AggregationType}
+     */
+    private AggregationType aggregationType;
+
+    /**
+     * Filters for the data/measures (options: EQ | GT | GE | LT | LE )
+     */
+    private String measureCriteria;
+
+    /**
+     * Filters for the data/measure, applied before aggregation is performed.
+     * (options: EQ | GT | GE | LT | LE )
+     */
+    private String preAggregationMeasureCriteria;
+
+    /**
+     * Start date for a date range. Will be applied as a filter. Can not be used
+     * together with a period dimension or filter.
+     */
+    private Date startDate;
+
+    /**
+     * End date for date range. Will be applied as a filter. Can not be used
+     * together with a period dimension or filter.
+     */
+    private Date endDate;
+
+    private UserOrgUnitType userOrgUnitType;
+
+    /**
+     * The {@see SortOrder}
+     */
+    private SortOrder order;
+
+    /**
+     * The time field to base event aggregation on. Applies to event data items
+     * only. Can be a predefined option or the ID of an attribute or data element
+     * with a time-based value type.
+     */
+    private String timeField;
+
+    /**
+     * The organisation unit field to base event aggregation on. Applies to event
+     * data items only. Can be the ID of an attribute or data element with the
+     * Organisation unit value type. The default option is specified as omitting the
+     * query parameter.
+     */
+    private String orgUnitField;
+
+    /**
+     * Whether meta-data should be excluded from the response.
+     */
+    private boolean skipMeta;
+
+    /**
+     * Whether data should be excluded from the response.
+     */
+    private boolean skipData;
+
+    /**
+     * Skip rounding of data values, i.e. provide full precision.
+     */
+    private boolean skipRounding;
+
+    /**
+     * Whether to only show completed events
+     */
+    private boolean completedOnly;
+
+    /**
+     *  Whether to include names of organisation unit ancestors and hierarchy paths of
+     * organisation units in the metadata.
+     */
+    private boolean hierarchyMeta;
+
+    /**
+     * Whether to ignore the limit on max 50 000 records in response.
+     */
+    private boolean ignoreLimit;
+
+    /**
+     * Whether to hide empty rows in response, applicable when table layout is
+     * true.
+     */
+    private boolean hideEmptyRows;
+
+    /**
+     * Whether to hide empty columns in response, applicable when table layout is
+     * true.
+     */
+    private boolean hideEmptyColumns;
+
+    /**
+     * Whether to display full org unit hierarchy path together with org unit name.
+     */
+    private boolean showHierarchy;
+
+    /**
+     * Whether to include the numerator and denominator used to calculate the value
+     * in the response.
+     */
+    private boolean includeNumDen;
+
+    /**
+     * Whether to include metadata details to raw data response.
+     */
+    private boolean includeMetadataDetails;
+
+    /**
+     * Property to display for metadata.
+     */
+    private DisplayProperty displayProperty;
+
+    /**
+     * Identifier scheme to use for metadata items the query response, can be
+     * identifier, code or attributes. ( options: UID | CODE | ATTRIBUTE:<ID> )
+     */
+    private IdScheme outputIdScheme;
+
+    /**
+     * Identifier scheme to use for metadata items in the query request, can be an
+     * identifier, code or attributes. ( options: UID | CODE | ATTRIBUTE:<ID> )
+     */
+    private IdScheme inputIdScheme;
+
+    /**
+     * Include data which has been approved at least up to the given approval level,
+     * refers to identifier of approval level.
+     */
+    private String approvalLevel;
+
+    /**
+     * Date identifier e.g: "2016-01-01". Overrides the start date of the relative
+     * period
+     */
+    private Date relativePeriodDate;
+
+    /**
+     * Organisation unit identifiers, overrides organisation units associated with
+     * current user, single or array
+     */
+    private String userOrgUnit;
+
+    /**
+     * Data dimensions to include in table as columns
+     */
+    private String columns;
+
+    /**
+     * Data dimensions to include in table as rows
+     */
+    private String rows;
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataQueryRequest.java
@@ -462,6 +462,38 @@ public class DataQueryRequest
             return request;
         }
 
+        public DataQueryRequestBuilder fromCriteria( AnalyticsQueryCriteria criteria )
+        {
+            this.request.aggregationType = criteria.getAggregationType();
+            this.request.approvalLevel = criteria.getApprovalLevel();
+            this.request.completedOnly = criteria.isCompletedOnly();
+            this.request.dimension = criteria.getDimension();
+            this.request.displayProperty = criteria.getDisplayProperty();
+            this.request.endDate = criteria.getEndDate();
+            this.request.filter = criteria.getFilter();
+            this.request.hideEmptyColumns = criteria.isHideEmptyColumns();
+            this.request.hideEmptyRows = criteria.isHideEmptyRows();
+            this.request.hierarchyMeta = criteria.isHierarchyMeta();
+            this.request.ignoreLimit = criteria.isIgnoreLimit();
+            this.request.includeMetadataDetails = criteria.isIncludeMetadataDetails();
+            this.request.includeNumDen = criteria.isIncludeNumDen();
+            this.request.inputIdScheme = criteria.getInputIdScheme();
+            this.request.measureCriteria = criteria.getMeasureCriteria();
+            this.request.order = criteria.getOrder();
+            this.request.orgUnitField = criteria.getOrgUnitField();
+            this.request.outputIdScheme = criteria.getOutputIdScheme();
+            this.request.preAggregationMeasureCriteria = criteria.getPreAggregationMeasureCriteria();
+            this.request.relativePeriodDate = criteria.getRelativePeriodDate();
+            this.request.showHierarchy = criteria.isShowHierarchy();
+            this.request.skipData = criteria.isSkipData();
+            this.request.skipMeta = criteria.isSkipMeta();
+            this.request.skipRounding = criteria.isSkipRounding();
+            this.request.startDate = criteria.getStartDate();
+            this.request.timeField = criteria.getTimeField();
+            this.request.userOrgUnit = criteria.getUserOrgUnit();
+            this.request.userOrgUnitType = criteria.getUserOrgUnitType();
+            return this;
+        }
     }
 
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
@@ -29,25 +29,30 @@ package org.hisp.dhis.webapi.controller;
  */
 
 import static org.hisp.dhis.common.DimensionalObjectUtils.getItemsFromParam;
-
-import java.util.Date;
-import java.util.Set;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.hisp.dhis.analytics.*;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import org.hisp.dhis.analytics.AnalyticsService;
+import org.hisp.dhis.analytics.AnalyticsTableType;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.DataQueryService;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.AnalyticsQueryCriteria;
+import org.hisp.dhis.common.DataQueryRequest;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
@@ -55,401 +60,93 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+@AllArgsConstructor
 public class AnalyticsController
 {
     private static final String RESOURCE_PATH = "/analytics";
     private static final String DATA_VALUE_SET_PATH = "/dataValueSet";
     private static final String RAW_DATA_PATH = "/rawData";
 
-    private final DataQueryService dataQueryService;
+    @NonNull private final DataQueryService dataQueryService;
 
-    private final AnalyticsService analyticsService;
+    @NonNull private final AnalyticsService analyticsService;
 
-    private final ContextUtils contextUtils;
-
-    public AnalyticsController( DataQueryService dataQueryService, AnalyticsService analyticsService,
-        ContextUtils contextUtils )
-    {
-        this.dataQueryService = dataQueryService;
-        this.analyticsService = analyticsService;
-        this.contextUtils = contextUtils;
-    }
+    @NonNull private final ContextUtils contextUtils;
 
     // -------------------------------------------------------------------------
     // Resources
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = RESOURCE_PATH, method = RequestMethod.GET, produces = { "application/json", "application/javascript" } )
+    @GetMapping( value = RESOURCE_PATH, produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public @ResponseBody Grid getJson( // JSON, JSONP
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
-        HttpServletResponse response ) throws Exception
+        HttpServletResponse response )
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder().dimension( dimension ).filter( filter )
-            .aggregationType( aggregationType ).measureCriteria( measureCriteria )
-            .preAggregationMeasureCriteria( preAggregationMeasureCriteria ).startDate( startDate ).endDate( endDate )
-            .skipMeta( skipMeta ).skipData( skipData ).skipRounding( skipRounding ).completedOnly( completedOnly )
-            .hierarchyMeta( hierarchyMeta ).ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows )
-            .hideEmptyColumns( hideEmptyColumns ).showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion ).order( order )
-            .timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType ).build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
-
-        contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_JSON, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
-        return analyticsService.getAggregatedDataValues( params, getItemsFromParam( columns ), getItemsFromParam( rows ) );
+        return getGrid( criteria, apiVersion, ContextUtils.CONTENT_TYPE_JSON, response );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".xml", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + ".xml" )
     public void getXml(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
-        HttpServletResponse response ) throws Exception
+        HttpServletResponse response )
+        throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType )
-            .measureCriteria( measureCriteria ).preAggregationMeasureCriteria( preAggregationMeasureCriteria )
-            .startDate( startDate ).endDate( endDate ).skipMeta( skipMeta ).skipData( skipData )
-            .skipRounding( skipRounding ).completedOnly( completedOnly ).hierarchyMeta( hierarchyMeta )
-            .ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows ).hideEmptyColumns( hideEmptyColumns )
-            .showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion )
-            .order( order ).timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType )
-            .build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
-
-        contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
-        Grid grid = analyticsService.getAggregatedDataValues( params, getItemsFromParam( columns ), getItemsFromParam( rows ) );
-        GridUtils.toXml( grid, response.getOutputStream() );
+        GridUtils.toXml( getGrid( criteria, apiVersion, ContextUtils.CONTENT_TYPE_XML, response ),
+            response.getOutputStream() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".html", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + ".html" )
     public void getHtml(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
         HttpServletResponse response ) throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType )
-            .measureCriteria( measureCriteria ).preAggregationMeasureCriteria( preAggregationMeasureCriteria )
-            .startDate( startDate ).endDate( endDate ).skipMeta( skipMeta ).skipData( skipData )
-            .skipRounding( skipRounding ).completedOnly( completedOnly ).hierarchyMeta( hierarchyMeta )
-            .ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows ).hideEmptyColumns( hideEmptyColumns )
-            .showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion )
-            .order( order ).timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType )
-            .build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
-
-        contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
-        Grid grid = analyticsService.getAggregatedDataValues( params, getItemsFromParam( columns ), getItemsFromParam( rows ) );
-        GridUtils.toHtml( grid, response.getWriter() );
+        GridUtils.toHtml( getGrid( criteria, apiVersion, ContextUtils.CONTENT_TYPE_HTML, response ),
+            response.getWriter() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".html+css", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + ".html+css" )
     public void getHtmlCss(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
         HttpServletResponse response ) throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType )
-            .measureCriteria( measureCriteria ).preAggregationMeasureCriteria( preAggregationMeasureCriteria )
-            .startDate( startDate ).endDate( endDate ).skipMeta( skipMeta ).skipData( skipData )
-            .skipRounding( skipRounding ).completedOnly( completedOnly ).hierarchyMeta( hierarchyMeta )
-            .ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows ).hideEmptyColumns( hideEmptyColumns )
-            .showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion )
-            .order( order ).timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType )
-            .build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
-
-        contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
-        Grid grid = analyticsService.getAggregatedDataValues( params, getItemsFromParam( columns ), getItemsFromParam( rows ) );
-        GridUtils.toHtmlCss( grid, response.getWriter() );
+        GridUtils.toHtmlCss( getGrid( criteria, apiVersion, ContextUtils.CONTENT_TYPE_HTML, response ),
+            response.getWriter() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".csv", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + ".csv" )
     public void getCsv(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
         HttpServletResponse response ) throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType )
-            .measureCriteria( measureCriteria ).preAggregationMeasureCriteria( preAggregationMeasureCriteria )
-            .startDate( startDate ).endDate( endDate ).skipMeta( skipMeta ).skipData( skipData )
-            .skipRounding( skipRounding ).completedOnly( completedOnly ).hierarchyMeta( hierarchyMeta )
-            .ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows ).hideEmptyColumns( hideEmptyColumns )
-            .showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion )
-            .order( order ).timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType )
-            .build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
-
-        contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.RESPECT_SYSTEM_SETTING, "data.csv", true, params.getLatestEndDate() );
-        Grid grid = analyticsService.getAggregatedDataValues( params, getItemsFromParam( columns ), getItemsFromParam( rows ) );
-        GridUtils.toCsv( grid, response.getWriter() );
+        GridUtils.toCsv(
+            getGridWithAttachment( criteria, apiVersion, ContextUtils.CONTENT_TYPE_CSV, "data.csv", response ),
+            response.getWriter() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".xls", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + ".xls" )
     public void getXls(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
         HttpServletResponse response ) throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType )
-            .measureCriteria( measureCriteria ).preAggregationMeasureCriteria( preAggregationMeasureCriteria )
-            .startDate( startDate ).endDate( endDate ).skipMeta( skipMeta ).skipData( skipData )
-            .skipRounding( skipRounding ).completedOnly( completedOnly ).hierarchyMeta( hierarchyMeta )
-            .ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows ).hideEmptyColumns( hideEmptyColumns )
-            .showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion )
-            .order( order ).timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType )
-            .build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
-
-        contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_EXCEL, CacheStrategy.RESPECT_SYSTEM_SETTING, "data.xls", true, params.getLatestEndDate() );
-        Grid grid = analyticsService.getAggregatedDataValues( params, getItemsFromParam( columns ), getItemsFromParam( rows ) );
-        GridUtils.toXls( grid, response.getOutputStream() );
+        GridUtils.toXls(
+            getGridWithAttachment( criteria, apiVersion, ContextUtils.CONTENT_TYPE_EXCEL, "data.xls", response ),
+            response.getOutputStream() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".jrxml", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + ".jrxml" )
     public void getJrxml(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) OutputFormat outputFormat,
-        @RequestParam( required = false ) Integer approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
         HttpServletResponse response ) throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).startDate( startDate ).endDate( endDate ).skipMeta( true )
-            .apiVersion( apiVersion ).order( order ).userOrgUnitType( userOrgUnitType ).build();
-
+        final DataQueryRequest request = DataQueryRequest.newBuilder().fromCriteria( criteria ).apiVersion( apiVersion )
+            .skipMeta( true ).build();
         DataQueryParams params = dataQueryService.getFromRequest( request );
 
         contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING, "data.jrxml", false, params.getLatestEndDate() );
@@ -458,56 +155,13 @@ public class AnalyticsController
         GridUtils.toJrxml( grid, null, response.getWriter() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + "/debug/sql", method = RequestMethod.GET, produces = { "text/html", "text/plain" } )
+    @GetMapping( value = RESOURCE_PATH + "/debug/sql", produces = { TEXT_HTML_VALUE, TEXT_PLAIN_VALUE } )
     public @ResponseBody String getDebugSql(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) UserOrgUnitType userOrgUnitType,
-        @RequestParam( required = false ) SortOrder order,
-        @RequestParam( required = false ) String timeField,
-        @RequestParam( required = false ) String orgUnitField,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
-        HttpServletResponse response ) throws Exception
+        HttpServletResponse response )
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType )
-            .measureCriteria( measureCriteria ).preAggregationMeasureCriteria( preAggregationMeasureCriteria )
-            .startDate( startDate ).endDate( endDate ).skipMeta( skipMeta ).skipData( skipData )
-            .skipRounding( skipRounding ).completedOnly( completedOnly ).hierarchyMeta( hierarchyMeta )
-            .ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows ).hideEmptyColumns( hideEmptyColumns )
-            .showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).approvalLevel( approvalLevel )
-            .relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit ).apiVersion( apiVersion )
-            .order( order ).timeField( timeField ).orgUnitField( orgUnitField ).userOrgUnitType( userOrgUnitType )
-            .build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
+        DataQueryParams params = dataQueryService.getFromRequest( mapFromCriteria( criteria, apiVersion) );
 
         contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_TEXT, CacheStrategy.NO_CACHE, "debug.sql", false, params.getLatestEndDate() );
         return AnalyticsUtils.getDebugDataSql( params );
@@ -517,61 +171,29 @@ public class AnalyticsController
     // Raw data
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = RESOURCE_PATH + RAW_DATA_PATH + ".json", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + RAW_DATA_PATH + ".json" )
     public @ResponseBody Grid getRawDataJson(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String userOrgUnit,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
-        HttpServletResponse response ) throws Exception
+        HttpServletResponse response )
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).startDate( startDate ).endDate( endDate ).skipMeta( skipMeta )
-            .skipData( skipData ).hierarchyMeta( hierarchyMeta ).showHierarchy( showHierarchy )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).userOrgUnit( userOrgUnit )
-            .allowAllPeriods( true ).apiVersion( apiVersion ).build();
+        final DataQueryRequest request = DataQueryRequest.newBuilder().fromCriteria( criteria ).apiVersion( apiVersion )
+            .allowAllPeriods( true ).build();
 
         DataQueryParams params = dataQueryService.getFromRequest( request );
-
+        
         contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_JSON, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
         return analyticsService.getRawDataValues( params );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + RAW_DATA_PATH + ".csv", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + RAW_DATA_PATH + ".csv" )
     public void getRawDataCsv(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) String userOrgUnit,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
         HttpServletResponse response ) throws Exception
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).startDate( startDate ).endDate( endDate ).skipMeta( skipMeta )
-            .skipData( skipData ).hierarchyMeta( hierarchyMeta ).showHierarchy( showHierarchy )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).userOrgUnit( userOrgUnit )
-            .allowAllPeriods( true ).apiVersion( apiVersion ).build();
+        final DataQueryRequest request = DataQueryRequest.newBuilder().fromCriteria( criteria ).apiVersion( apiVersion )
+                .allowAllPeriods( true ).build();
 
         DataQueryParams params = dataQueryService.getFromRequest( request );
 
@@ -585,109 +207,63 @@ public class AnalyticsController
     // Data value set
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = RESOURCE_PATH + DATA_VALUE_SET_PATH + ".xml", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + DATA_VALUE_SET_PATH + ".xml" )
     public @ResponseBody DataValueSet getDataValueSetXml(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) boolean duplicatesOnly,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
-        HttpServletResponse response ) throws Exception
+        HttpServletResponse response )
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType ).measureCriteria( measureCriteria )
-            .preAggregationMeasureCriteria( preAggregationMeasureCriteria ).startDate( startDate ).endDate( endDate )
-            .skipMeta( skipMeta ).skipData( skipData ).skipRounding( skipRounding ).completedOnly( completedOnly )
-            .hierarchyMeta( hierarchyMeta ).ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows )
-            .hideEmptyColumns( hideEmptyColumns ).showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).duplicatesOnly( duplicatesOnly )
-            .approvalLevel( approvalLevel ).relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit )
-            .apiVersion( apiVersion ).build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
+        DataQueryParams params = dataQueryService.getFromRequest( mapFromCriteria( criteria, apiVersion) );
 
         contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
         return analyticsService.getAggregatedDataValueSet( params );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + DATA_VALUE_SET_PATH + ".json", method = RequestMethod.GET )
+    @GetMapping( value = RESOURCE_PATH + DATA_VALUE_SET_PATH + ".json" )
     public @ResponseBody DataValueSet getDataValueSetJson(
-        @RequestParam Set<String> dimension,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) AggregationType aggregationType,
-        @RequestParam( required = false ) String measureCriteria,
-        @RequestParam( required = false ) String preAggregationMeasureCriteria,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) boolean skipData,
-        @RequestParam( required = false ) boolean skipRounding,
-        @RequestParam( required = false ) boolean completedOnly,
-        @RequestParam( required = false ) boolean hierarchyMeta,
-        @RequestParam( required = false ) boolean ignoreLimit,
-        @RequestParam( required = false ) boolean hideEmptyRows,
-        @RequestParam( required = false ) boolean hideEmptyColumns,
-        @RequestParam( required = false ) boolean showHierarchy,
-        @RequestParam( required = false ) boolean includeNumDen,
-        @RequestParam( required = false ) boolean includeMetadataDetails,
-        @RequestParam( required = false ) DisplayProperty displayProperty,
-        @RequestParam( required = false ) IdScheme outputIdScheme,
-        @RequestParam( required = false ) IdScheme inputIdScheme,
-        @RequestParam( required = false ) boolean duplicatesOnly,
-        @RequestParam( required = false ) String approvalLevel,
-        @RequestParam( required = false ) Date relativePeriodDate,
-        @RequestParam( required = false ) String userOrgUnit,
-        @RequestParam( required = false ) String columns,
-        @RequestParam( required = false ) String rows,
+        AnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
-        Model model,
-        HttpServletResponse response ) throws Exception
+        HttpServletResponse response )
     {
-        DataQueryRequest request = DataQueryRequest.newBuilder()
-            .dimension( dimension ).filter( filter ).aggregationType( aggregationType ).measureCriteria( measureCriteria )
-            .preAggregationMeasureCriteria( preAggregationMeasureCriteria ).startDate( startDate ).endDate( endDate )
-            .skipMeta( skipMeta ).skipData( skipData ).skipRounding( skipRounding ).completedOnly( completedOnly )
-            .hierarchyMeta( hierarchyMeta ).ignoreLimit( ignoreLimit ).hideEmptyRows( hideEmptyRows )
-            .hideEmptyColumns( hideEmptyColumns ).showHierarchy( showHierarchy ).includeNumDen( includeNumDen )
-            .includeMetadataDetails( includeMetadataDetails ).displayProperty( displayProperty )
-            .outputIdScheme( outputIdScheme ).inputIdScheme( inputIdScheme ).duplicatesOnly( duplicatesOnly )
-            .approvalLevel( approvalLevel ).relativePeriodDate( relativePeriodDate ).userOrgUnit( userOrgUnit )
-            .apiVersion( apiVersion ).build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( request );
+        DataQueryParams params = dataQueryService.getFromRequest( mapFromCriteria( criteria, apiVersion) );
 
         contextUtils.configureAnalyticsResponse( response, ContextUtils.CONTENT_TYPE_JSON, CacheStrategy.RESPECT_SYSTEM_SETTING, null, false, params.getLatestEndDate() );
         return analyticsService.getAggregatedDataValueSet( params );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + "/tableTypes", method = RequestMethod.GET, produces = { "application/json", "application/javascript" } )
+    @GetMapping( value = RESOURCE_PATH + "/tableTypes", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public @ResponseBody AnalyticsTableType[] getTableTypes()
     {
         return AnalyticsTableType.values();
+    }
+
+    private Grid getGrid( AnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, String contentType,
+        HttpServletResponse response )
+    {
+        DataQueryParams params = dataQueryService.getFromRequest(  mapFromCriteria( criteria, apiVersion)  );
+
+        contextUtils.configureAnalyticsResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, null,
+            false, params.getLatestEndDate() );
+
+        return analyticsService.getAggregatedDataValues( params, getItemsFromParam( criteria.getColumns() ),
+            getItemsFromParam( criteria.getRows() ) );
+    }
+
+    private Grid getGridWithAttachment( AnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, String contentType, String file,
+                          HttpServletResponse response )
+    {
+        DataQueryParams params = dataQueryService.getFromRequest( mapFromCriteria( criteria, apiVersion) );
+
+        contextUtils.configureAnalyticsResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, file,
+            true, params.getLatestEndDate() );
+
+        return analyticsService.getAggregatedDataValues( params, getItemsFromParam( criteria.getColumns() ),
+            getItemsFromParam( criteria.getRows() ) );
+    }
+    
+    private DataQueryRequest mapFromCriteria( AnalyticsQueryCriteria criteria, DhisApiVersion apiVersion )
+    {
+        return DataQueryRequest.newBuilder().fromCriteria( criteria ).apiVersion( apiVersion )
+            .build();
     }
 }


### PR DESCRIPTION
This refactor aims at improving maintenance of the Analytics controller arguments by removing the list of `@RequestParam` annotations in each method of the controller and replacing it with a new class that encapsulates all the Analytics argument.
Additionally, the `@RequestMapping` annotation has been replaced with `@GetMapping`