### PR TITLE
fix: Use Org Unit uid on Events/Enrollment table creation (#5892)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
+import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_NAME_COL_SUFFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.*;
 import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
 import static org.hisp.dhis.system.util.MathUtils.getRounded;
@@ -267,6 +268,10 @@ public abstract class AbstractJdbcEventAnalyticsManager
                 String coordSql =  "'[' || round(ST_X(" + colName + ")::numeric, 6) || ',' || round(ST_Y(" + colName + ")::numeric, 6) || ']' as " + colName;
 
                 columns.add( coordSql );
+            }
+            else if ( ValueType.ORGANISATION_UNIT == queryItem.getValueType() )
+            {
+                columns.add( quote( queryItem.getItemName() + OU_NAME_COL_SUFFIX ) );
             }
             else
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -128,7 +128,7 @@ public abstract class AbstractEventJdbcTableManager
         }
         else if ( valueType.isOrganisationUnit() )
         {
-            return "ou.name from organisationunit ou where ou.uid = (select " + columnName ;
+            return "ou.uid from organisationunit ou where ou.uid = (select " + columnName ;
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -90,6 +90,7 @@ public class JdbcEventAnalyticsTableManager
     private static final ImmutableSet<ValueType> NO_INDEX_VAL_TYPES = ImmutableSet.of( ValueType.TEXT, ValueType.LONG_TEXT );
 
     private static final String OU_GEOMETRY_COL_SUFFIX = "_geom";
+    public static final String OU_NAME_COL_SUFFIX = "_name";
 
     public JdbcEventAnalyticsTableManager( IdentifiableObjectManager idObjectManager,
         OrganisationUnitService organisationUnitService, CategoryService categoryService,
@@ -381,12 +382,20 @@ public class JdbcEventAnalyticsTableManager
         String select = getSelectClause( attribute.getValueType(), "value" );
         boolean skipIndex = NO_INDEX_VAL_TYPES.contains( attribute.getValueType() ) && !attribute.hasOptionSet();
 
-        if ( attribute.getValueType().isOrganisationUnit() && databaseInfo.isSpatialSupport() )
+        if ( attribute.getValueType().isOrganisationUnit())
         {
-            String geoSql = selectForInsert( attribute, "ou.geometry from organisationunit ou where ou.uid = (select value", dataClause );
+            if ( databaseInfo.isSpatialSupport() ) 
+            {
+                final String geoSql = selectForInsert( attribute,
+                    "ou.geometry from organisationunit ou where ou.uid = (select value", dataClause );
+                columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_GEOMETRY_COL_SUFFIX ),
+                    ColumnDataType.GEOMETRY, geoSql ).withSkipIndex( skipIndex ).withIndexType( GEOMETRY_INDEX_TYPE ) );
+            }
+            // add the OU name for this Tracked Entity Attribute
+            final String ouNameSql = selectForInsert( attribute, "ou.name from organisationunit ou where ou.uid = (select value", dataClause );
 
-            columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_GEOMETRY_COL_SUFFIX ), ColumnDataType.GEOMETRY, geoSql )
-                .withSkipIndex( skipIndex ).withIndexType( GEOMETRY_INDEX_TYPE ) );
+            columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_NAME_COL_SUFFIX ), TEXT, ouNameSql )
+                .withSkipIndex( skipIndex ) );
         }
 
         columns.add( new AnalyticsTableColumn( quote( attribute.getUid() ), dataType,
@@ -428,12 +437,24 @@ public class JdbcEventAnalyticsTableManager
 
         String sql = selectForInsert( dataElement, select, dataClause );
 
-        if ( dataElement.getValueType().isOrganisationUnit() && databaseInfo.isSpatialSupport() )
+        if ( dataElement.getValueType().isOrganisationUnit() )
         {
-            String geoSql = selectForInsert( dataElement, "ou.geometry from organisationunit ou where ou.uid = (select " + columnName, dataClause );
+            if ( databaseInfo.isSpatialSupport() )
+            {
+                String geoSql = selectForInsert( dataElement,
+                    "ou.geometry from organisationunit ou where ou.uid = (select " + columnName, dataClause );
 
-            columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_GEOMETRY_COL_SUFFIX ), ColumnDataType.GEOMETRY, geoSql )
-                .withSkipIndex( true ).withIndexType( GEOMETRY_INDEX_TYPE ) );
+                columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_GEOMETRY_COL_SUFFIX ),
+                    ColumnDataType.GEOMETRY, geoSql )
+                        .withSkipIndex( true ).withIndexType( GEOMETRY_INDEX_TYPE ) );
+            }
+
+            // add the OU name for this Data Element
+            String ouNameSql = selectForInsert( dataElement,
+                "ou.name from organisationunit ou where ou.uid = (select " + columnName, dataClause );
+
+            columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_NAME_COL_SUFFIX ), TEXT, ouNameSql )
+                .withSkipIndex( true ) );
         }
 
         columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
@@ -103,6 +103,15 @@ public abstract class EventAnalyticsTest
         return createRequestParams( withProgramStage, null );
     }
 
+    protected EventQueryParams createRequestParams( QueryItem queryItem )
+    {
+        EventQueryParams.Builder params = new EventQueryParams.Builder( _createRequestParams() );
+
+        params.addItem( queryItem );
+
+        return params.build();
+    }
+
     private EventQueryParams _createRequestParams()
     {
         OrganisationUnit ouA = createOrganisationUnit( 'A' );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
 import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.hisp.dhis.DhisConvenienceTest.createPeriod;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
@@ -128,6 +129,27 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
         assertThat( sql.getValue(), is(expected) );
     }
+
+    @Test
+    public void verifyGetEventSqlWithOrgUnitTypeDataElement()
+    {
+        mockEmptyRowSet();
+
+        DataElement dataElement = createDataElement('a');
+        QueryItem queryItem = new QueryItem( dataElement, this.programA, null,
+            ValueType.ORGANISATION_UNIT, AggregationType.SUM, null );
+
+        subject.getEvents( createRequestParams( queryItem ), createGrid(), 100 );
+
+        verify( jdbcTemplate ).queryForRowSet( sql.capture() );
+
+        String expected = "select psi,ps,executiondate,enrollmentdate,incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) " +
+                "as geometry,longitude,latitude,ouname,oucode,ax.\"monthly\",ax.\"ou\",\"" + dataElement.getUid() + "_name" + "\"  " +
+                "from " + getTable( programA.getUid() ) + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel0\" = 'ouabcdefghA' ) limit 101";
+
+        assertThat( sql.getValue(), is(expected) );
+    }
+
 
     @Test
     public void verifyGetEventSqlWithProgram()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -95,7 +95,7 @@ public class JdbcEnrollmentAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyTeiTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
+    public void verifyTeiTypeOrgUnitFetchesOuUidWhenPopulatingEventAnalyticsTable()
     {
         ArgumentCaptor<String> sql = ArgumentCaptor.forClass( String.class );
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );
@@ -117,10 +117,10 @@ public class JdbcEnrollmentAnalyticsTableManagerTest
 
         verify( jdbcTemplate ).execute( sql.capture() );
 
-        String ouQuery = "(select ou.name from organisationunit ou where ou.uid = " +
+        String ouQuery = "(select ou.%s from organisationunit ou where ou.uid = " +
             "(select value from trackedentityattributevalue where trackedentityinstanceid=pi.trackedentityinstanceid and " +
             "trackedentityattributeid=9999)) as \"" + tea.getUid() + "\"";
 
-        assertThat( sql.getValue(), containsString( ouQuery ) );
+        assertThat( sql.getValue(), containsString( String.format( ouQuery, "uid") ) );
     }
 }


### PR DESCRIPTION
* fix: Use Org Unit uid on Events/Enrollment table creation

When a Program has a Data Element or TEA of type Organisation Unit, the system was persisting the OU name in the analytics_event_* and analytics_enrollment_* tables.

This was done to fix another issue with Event/Enrollment Line List view, which was showing the Org Unit UID rather than name.
Persisting the name, rather than the UID, was causing a bug becuase the join with the Org Unit table was broken, if a user selects "Org Unit Field" in the Event table layout (Pivot App).

This fix:

- reverts the change to the JdbcTableManager, so that the Org Unit UID is used in analytics tables
- adds a new column "<dataelement>_uid" to the event analytics tables, containing the name of the OU
- modifies the Events query logic to use this new column when querying for events

* chore: renamed test method

(cherry picked from commit 5867c314d2db0f6c835424638d878c0f9626e8bf)