### PR TITLE
chore: remove duplicate get in integrity check getter/setter

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityReport.java
@@ -28,8 +28,18 @@ package org.hisp.dhis.dataintegrity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.dataelement.DataElement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
 import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.indicator.Indicator;
@@ -44,68 +54,58 @@ import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.validation.ValidationRule;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
 public class DataIntegrityReport
 {
     private List<DataElement> dataElementsWithoutDataSet = new ArrayList<>();
-    
+
     private List<DataElement> dataElementsWithoutGroups = new ArrayList<>();
-    
+
     private Map<DataElement, Collection<DataSet>> dataElementsAssignedToDataSetsWithDifferentPeriodTypes = new HashMap<>();
-    
+
     private SortedMap<DataElement, Collection<DataElementGroup>> dataElementsViolatingExclusiveGroupSets = new TreeMap<>();
 
     private SortedMap<DataSet, Collection<DataElement>> dataElementsInDataSetNotInForm = new TreeMap<>();
-    
+
     private List<CategoryCombo> invalidCategoryCombos = new ArrayList<>();
 
     private List<DataSet> dataSetsNotAssignedToOrganisationUnits = new ArrayList<>();
-    
+
     private Set<Set<Indicator>> indicatorsWithIdenticalFormulas = new HashSet<>();
-    
+
     private List<Indicator> indicatorsWithoutGroups = new ArrayList<>();
-    
+
     private Map<Indicator, String> invalidIndicatorNumerators = new HashMap<>();
-    
+
     private Map<Indicator, String> invalidIndicatorDenominators = new HashMap<>();
-    
+
     private SortedMap<Indicator, Collection<IndicatorGroup>> indicatorsViolatingExclusiveGroupSets = new TreeMap<>();
-    
+
     private List<Period> duplicatePeriods = new ArrayList<>();
-    
+
     private List<OrganisationUnit> organisationUnitsWithCyclicReferences = new ArrayList<>();
-    
+
     private List<OrganisationUnit> orphanedOrganisationUnits = new ArrayList<>();
-    
+
     private List<OrganisationUnit> organisationUnitsWithoutGroups = new ArrayList<>();
-    
+
     private SortedMap<OrganisationUnit, Collection<OrganisationUnitGroup>> organisationUnitsViolatingExclusiveGroupSets = new TreeMap<>();
-    
+
     private List<OrganisationUnitGroup> organisationUnitGroupsWithoutGroupSets = new ArrayList<>();
-    
+
     private List<ValidationRule> validationRulesWithoutGroups = new ArrayList<>();
-    
+
     private Map<ValidationRule, String> invalidValidationRuleLeftSideExpressions = new HashMap<>();
-    
+
     private Map<ValidationRule, String> invalidValidationRuleRightSideExpressions = new HashMap<>();
 
     private Map<ProgramIndicator, String> invalidProgramIndicatorExpressions = new HashMap<>();
 
     private Map<ProgramIndicator, String> invalidProgramIndicatorFilters = new HashMap<>();
 
-    private List<ProgramIndicator> getProgramIndicatorWithNoExpression = new ArrayList<>();
+    private List<ProgramIndicator> programIndicatorsWithNoExpression = new ArrayList<>();
 
     private Map<Program, Collection<ProgramRule>> programRulesWithoutCondition = new HashMap<>();
 
@@ -125,18 +125,18 @@ public class DataIntegrityReport
 
     private Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoStageId = new HashMap<>();
 
-    //-------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
     // Constructors
-    //-------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
 
     public DataIntegrityReport()
     {
 
     }
 
-    //-------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
     // Getters and setters
-    //-------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
 
     public List<DataElement> getDataElementsWithoutDataSet()
     {
@@ -163,7 +163,8 @@ public class DataIntegrityReport
         return dataElementsAssignedToDataSetsWithDifferentPeriodTypes;
     }
 
-    public void setDataElementsAssignedToDataSetsWithDifferentPeriodTypes( Map<DataElement, Collection<DataSet>> dataElementsAssignedToDataSetsWithDifferentPeriodTypes )
+    public void setDataElementsAssignedToDataSetsWithDifferentPeriodTypes(
+        Map<DataElement, Collection<DataSet>> dataElementsAssignedToDataSetsWithDifferentPeriodTypes )
     {
         this.dataElementsAssignedToDataSetsWithDifferentPeriodTypes = dataElementsAssignedToDataSetsWithDifferentPeriodTypes;
     }
@@ -173,7 +174,8 @@ public class DataIntegrityReport
         return dataElementsViolatingExclusiveGroupSets;
     }
 
-    public void setDataElementsViolatingExclusiveGroupSets( SortedMap<DataElement, Collection<DataElementGroup>> dataElementsViolatingExclusiveGroupSets )
+    public void setDataElementsViolatingExclusiveGroupSets(
+        SortedMap<DataElement, Collection<DataElementGroup>> dataElementsViolatingExclusiveGroupSets )
     {
         this.dataElementsViolatingExclusiveGroupSets = dataElementsViolatingExclusiveGroupSets;
     }
@@ -183,7 +185,8 @@ public class DataIntegrityReport
         return dataElementsInDataSetNotInForm;
     }
 
-    public void setDataElementsInDataSetNotInForm( SortedMap<DataSet, Collection<DataElement>> dataElementsInDataSetNotInForm )
+    public void setDataElementsInDataSetNotInForm(
+        SortedMap<DataSet, Collection<DataElement>> dataElementsInDataSetNotInForm )
     {
         this.dataElementsInDataSetNotInForm = dataElementsInDataSetNotInForm;
     }
@@ -253,7 +256,8 @@ public class DataIntegrityReport
         return indicatorsViolatingExclusiveGroupSets;
     }
 
-    public void setIndicatorsViolatingExclusiveGroupSets( SortedMap<Indicator, Collection<IndicatorGroup>> indicatorsViolatingExclusiveGroupSets )
+    public void setIndicatorsViolatingExclusiveGroupSets(
+        SortedMap<Indicator, Collection<IndicatorGroup>> indicatorsViolatingExclusiveGroupSets )
     {
         this.indicatorsViolatingExclusiveGroupSets = indicatorsViolatingExclusiveGroupSets;
     }
@@ -303,7 +307,8 @@ public class DataIntegrityReport
         return organisationUnitsViolatingExclusiveGroupSets;
     }
 
-    public void setOrganisationUnitsViolatingExclusiveGroupSets( SortedMap<OrganisationUnit, Collection<OrganisationUnitGroup>> organisationUnitsViolatingExclusiveGroupSets )
+    public void setOrganisationUnitsViolatingExclusiveGroupSets(
+        SortedMap<OrganisationUnit, Collection<OrganisationUnitGroup>> organisationUnitsViolatingExclusiveGroupSets )
     {
         this.organisationUnitsViolatingExclusiveGroupSets = organisationUnitsViolatingExclusiveGroupSets;
     }
@@ -313,7 +318,8 @@ public class DataIntegrityReport
         return organisationUnitGroupsWithoutGroupSets;
     }
 
-    public void setOrganisationUnitGroupsWithoutGroupSets( List<OrganisationUnitGroup> organisationUnitGroupsWithoutGroupSets )
+    public void setOrganisationUnitGroupsWithoutGroupSets(
+        List<OrganisationUnitGroup> organisationUnitGroupsWithoutGroupSets )
     {
         this.organisationUnitGroupsWithoutGroupSets = organisationUnitGroupsWithoutGroupSets;
     }
@@ -333,7 +339,8 @@ public class DataIntegrityReport
         return invalidValidationRuleLeftSideExpressions;
     }
 
-    public void setInvalidValidationRuleLeftSideExpressions( Map<ValidationRule, String> invalidValidationRuleLeftSideExpressions )
+    public void setInvalidValidationRuleLeftSideExpressions(
+        Map<ValidationRule, String> invalidValidationRuleLeftSideExpressions )
     {
         this.invalidValidationRuleLeftSideExpressions = invalidValidationRuleLeftSideExpressions;
     }
@@ -343,7 +350,8 @@ public class DataIntegrityReport
         return invalidValidationRuleRightSideExpressions;
     }
 
-    public void setInvalidValidationRuleRightSideExpressions( Map<ValidationRule, String> invalidValidationRuleRightSideExpressions )
+    public void setInvalidValidationRuleRightSideExpressions(
+        Map<ValidationRule, String> invalidValidationRuleRightSideExpressions )
     {
         this.invalidValidationRuleRightSideExpressions = invalidValidationRuleRightSideExpressions;
     }
@@ -358,14 +366,14 @@ public class DataIntegrityReport
         this.invalidProgramIndicatorFilters = invalidProgramIndicatorFilters;
     }
 
-    public List<ProgramIndicator> getGetProgramIndicatorWithNoExpression()
+    public List<ProgramIndicator> getProgramIndicatorsWithNoExpression()
     {
-        return getProgramIndicatorWithNoExpression;
+        return programIndicatorsWithNoExpression;
     }
 
-    public void setGetProgramIndicatorWithNoExpression( List<ProgramIndicator> getProgramIndicatorWithNoExpression )
+    public void setProgramIndicatorsWithNoExpression( List<ProgramIndicator> programIndicatorsWithNoExpression )
     {
-        this.getProgramIndicatorWithNoExpression = getProgramIndicatorWithNoExpression;
+        this.programIndicatorsWithNoExpression = programIndicatorsWithNoExpression;
     }
 
     public Map<ProgramIndicator, String> getInvalidProgramIndicatorExpressions()
@@ -373,7 +381,8 @@ public class DataIntegrityReport
         return invalidProgramIndicatorExpressions;
     }
 
-    public void setInvalidProgramIndicatorExpressions( Map<ProgramIndicator, String> invalidProgramIndicatorExpressions )
+    public void setInvalidProgramIndicatorExpressions(
+        Map<ProgramIndicator, String> invalidProgramIndicatorExpressions )
     {
         this.invalidProgramIndicatorExpressions = invalidProgramIndicatorExpressions;
     }
@@ -413,7 +422,8 @@ public class DataIntegrityReport
         return programRuleVariablesWithNoDataElement;
     }
 
-    public void setProgramRuleVariablesWithNoDataElement( Map<Program, Collection<ProgramRuleVariable>> programRuleVariablesWithNoDataElement )
+    public void setProgramRuleVariablesWithNoDataElement(
+        Map<Program, Collection<ProgramRuleVariable>> programRuleVariablesWithNoDataElement )
     {
         this.programRuleVariablesWithNoDataElement = programRuleVariablesWithNoDataElement;
     }
@@ -423,7 +433,8 @@ public class DataIntegrityReport
         return programRuleVariablesWithNoAttribute;
     }
 
-    public void setProgramRuleVariablesWithNoAttribute( Map<Program, Collection<ProgramRuleVariable>> programRuleVariablesWithNoAttribute )
+    public void setProgramRuleVariablesWithNoAttribute(
+        Map<Program, Collection<ProgramRuleVariable>> programRuleVariablesWithNoAttribute )
     {
         this.programRuleVariablesWithNoAttribute = programRuleVariablesWithNoAttribute;
     }
@@ -433,7 +444,8 @@ public class DataIntegrityReport
         return programRuleActionsWithNoDataObject;
     }
 
-    public void setProgramRuleActionsWithNoDataObject( Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoDataObject )
+    public void setProgramRuleActionsWithNoDataObject(
+        Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoDataObject )
     {
         this.programRuleActionsWithNoDataObject = programRuleActionsWithNoDataObject;
     }
@@ -443,7 +455,8 @@ public class DataIntegrityReport
         return programRuleActionsWithNoNotification;
     }
 
-    public void setProgramRuleActionsWithNoNotification( Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoNotification )
+    public void setProgramRuleActionsWithNoNotification(
+        Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoNotification )
     {
         this.programRuleActionsWithNoNotification = programRuleActionsWithNoNotification;
     }
@@ -453,7 +466,8 @@ public class DataIntegrityReport
         return programRuleActionsWithNoSectionId;
     }
 
-    public void setProgramRuleActionsWithNoSectionId( Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoSectionId )
+    public void setProgramRuleActionsWithNoSectionId(
+        Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoSectionId )
     {
         this.programRuleActionsWithNoSectionId = programRuleActionsWithNoSectionId;
     }
@@ -463,7 +477,8 @@ public class DataIntegrityReport
         return programRuleActionsWithNoStageId;
     }
 
-    public void setProgramRuleActionsWithNoStageId( Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoStageId )
+    public void setProgramRuleActionsWithNoStageId(
+        Map<ProgramRule, Collection<ProgramRuleAction>> programRuleActionsWithNoStageId )
     {
         this.programRuleActionsWithNoStageId = programRuleActionsWithNoStageId;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
@@ -28,10 +28,6 @@ package org.hisp.dhis.dataintegrity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.IdentifiableObject;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -41,9 +37,15 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.IdentifiableObject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
- * Flattened, easily serializable object derivable from the more complex DataIntegrityReport.
- * Use an instance of this object to serialize and deliver a DataIntegrityReport.
+ * Flattened, easily serializable object derivable from the more complex
+ * DataIntegrityReport. Use an instance of this object to serialize and deliver
+ * a DataIntegrityReport.
  *
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
@@ -154,17 +156,21 @@ public class FlattenedDataIntegrityReport
 
         dataElementsWithoutGroups = transformCollection( report.getDataElementsWithoutGroups() );
 
-        dataElementsAssignedToDataSetsWithDifferentPeriodTypes = transformMapOfCollections( report.getDataElementsAssignedToDataSetsWithDifferentPeriodTypes() );
+        dataElementsAssignedToDataSetsWithDifferentPeriodTypes = transformMapOfCollections(
+            report.getDataElementsAssignedToDataSetsWithDifferentPeriodTypes() );
 
-        dataElementsViolatingExclusiveGroupSets = transformSortedMap( report.getDataElementsViolatingExclusiveGroupSets() );
+        dataElementsViolatingExclusiveGroupSets = transformSortedMap(
+            report.getDataElementsViolatingExclusiveGroupSets() );
 
         dataElementsInDataSetNotInForm = transformSortedMap( report.getDataElementsInDataSetNotInForm() );
 
         invalidCategoryCombos = transformCollection( report.getInvalidCategoryCombos() );
 
-        dataSetsNotAssignedToOrganisationUnits = transformCollection( report.getDataSetsNotAssignedToOrganisationUnits() );
+        dataSetsNotAssignedToOrganisationUnits = transformCollection(
+            report.getDataSetsNotAssignedToOrganisationUnits() );
 
-        indicatorsWithIdenticalFormulas = transformCollectionOfCollections( report.getIndicatorsWithIdenticalFormulas() );
+        indicatorsWithIdenticalFormulas = transformCollectionOfCollections(
+            report.getIndicatorsWithIdenticalFormulas() );
 
         indicatorsWithoutGroups = transformCollection( report.getIndicatorsWithoutGroups() );
 
@@ -176,23 +182,28 @@ public class FlattenedDataIntegrityReport
 
         duplicatePeriods = transformCollection( report.getDuplicatePeriods() );
 
-        organisationUnitsWithCyclicReferences = transformCollection( report.getOrganisationUnitsWithCyclicReferences() );
+        organisationUnitsWithCyclicReferences = transformCollection(
+            report.getOrganisationUnitsWithCyclicReferences() );
 
         orphanedOrganisationUnits = transformCollection( report.getOrphanedOrganisationUnits() );
 
         organisationUnitsWithoutGroups = transformCollection( report.getOrganisationUnitsWithoutGroups() );
 
-        organisationUnitsViolatingExclusiveGroupSets = transformSortedMap( report.getOrganisationUnitsViolatingExclusiveGroupSets() );
+        organisationUnitsViolatingExclusiveGroupSets = transformSortedMap(
+            report.getOrganisationUnitsViolatingExclusiveGroupSets() );
 
-        organisationUnitGroupsWithoutGroupSets = transformCollection( report.getOrganisationUnitGroupsWithoutGroupSets() );
+        organisationUnitGroupsWithoutGroupSets = transformCollection(
+            report.getOrganisationUnitGroupsWithoutGroupSets() );
 
         validationRulesWithoutGroups = transformCollection( report.getValidationRulesWithoutGroups() );
 
-        invalidValidationRuleLeftSideExpressions = transformMapOfStrings( report.getInvalidValidationRuleLeftSideExpressions() );
+        invalidValidationRuleLeftSideExpressions = transformMapOfStrings(
+            report.getInvalidValidationRuleLeftSideExpressions() );
 
-        invalidValidationRuleRightSideExpressions = transformMapOfStrings( report.getInvalidValidationRuleRightSideExpressions() );
+        invalidValidationRuleRightSideExpressions = transformMapOfStrings(
+            report.getInvalidValidationRuleRightSideExpressions() );
 
-        programIndicatorsWithNoExpression = transformCollection( report.getGetProgramIndicatorWithNoExpression() );
+        programIndicatorsWithNoExpression = transformCollection( report.getProgramIndicatorsWithNoExpression() );
 
         invalidProgramIndicatorExpressions = transformMapOfStrings( report.getInvalidProgramIndicatorExpressions() );
 
@@ -204,13 +215,17 @@ public class FlattenedDataIntegrityReport
 
         programRulesWithNoAction = transformMapOfCollections( report.getProgramRulesWithNoAction() );
 
-        programRuleVariablesWithNoDataElement = transformMapOfCollections( report.getProgramRuleVariablesWithNoDataElement() );
+        programRuleVariablesWithNoDataElement = transformMapOfCollections(
+            report.getProgramRuleVariablesWithNoDataElement() );
 
-        programRuleVariablesWithNoAttribute = transformMapOfCollections( report.getProgramRuleVariablesWithNoAttribute() );
+        programRuleVariablesWithNoAttribute = transformMapOfCollections(
+            report.getProgramRuleVariablesWithNoAttribute() );
 
-        programRuleActionsWithNoDataObject = transformMapOfCollections( report.getProgramRuleActionsWithNoDataObject() );
+        programRuleActionsWithNoDataObject = transformMapOfCollections(
+            report.getProgramRuleActionsWithNoDataObject() );
 
-        programRuleActionsWithNoNotification = transformMapOfCollections( report.getProgramRuleActionsWithNoNotification() );
+        programRuleActionsWithNoNotification = transformMapOfCollections(
+            report.getProgramRuleActionsWithNoNotification() );
 
         programRuleActionsWithNoSectionId = transformMapOfCollections( report.getProgramRuleActionsWithNoSectionId() );
 
@@ -221,7 +236,8 @@ public class FlattenedDataIntegrityReport
     // Supportive methods
     // -------------------------------------------------------------------------
 
-    private Collection<Collection<String>> transformCollectionOfCollections( Collection<? extends Collection<? extends IdentifiableObject>> collection )
+    private Collection<Collection<String>> transformCollectionOfCollections(
+        Collection<? extends Collection<? extends IdentifiableObject>> collection )
     {
         Collection<Collection<String>> newCollection = new HashSet<>();
 
@@ -245,11 +261,13 @@ public class FlattenedDataIntegrityReport
         return newMap;
     }
 
-    private Map<String, Collection<String>> transformMapOfCollections( Map<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> map )
+    private Map<String, Collection<String>> transformMapOfCollections(
+        Map<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> map )
     {
         HashMap<String, Collection<String>> newMap = new HashMap<>();
 
-        for ( Map.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map.entrySet() )
+        for ( Map.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map
+            .entrySet() )
         {
             Collection<String> value = new HashSet<>();
             value.addAll( transformCollection( entry.getValue() ) );
@@ -272,11 +290,13 @@ public class FlattenedDataIntegrityReport
         return newCollection;
     }
 
-    private SortedMap<String, Collection<String>> transformSortedMap( SortedMap<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> map )
+    private SortedMap<String, Collection<String>> transformSortedMap(
+        SortedMap<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> map )
     {
         SortedMap<String, Collection<String>> newMap = new TreeMap<>();
 
-        for ( SortedMap.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map.entrySet() )
+        for ( SortedMap.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map
+            .entrySet() )
         {
             newMap.put( defaultIfNull( entry.getKey() ), transformCollection( entry.getValue() ) );
         }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
@@ -295,7 +295,7 @@ public class FlattenedDataIntegrityReport
     {
         SortedMap<String, Collection<String>> newMap = new TreeMap<>();
 
-        for ( SortedMap.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map
+        for ( Map.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map
             .entrySet() )
         {
             newMap.put( defaultIfNull( entry.getKey() ), transformCollection( entry.getValue() ) );

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -36,9 +36,11 @@ import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.common.ListMap;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
@@ -69,8 +71,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Lars Helge Overland
@@ -284,7 +284,8 @@ public class DefaultDataIntegrityService
     {
         Collection<DataSet> dataSets = dataSetService.getAllDataSets();
 
-        return dataSets.stream().filter( ds -> ds.getSources() == null || ds.getSources().isEmpty() ).collect( Collectors.toList() );
+        return dataSets.stream().filter( ds -> ds.getSources() == null || ds.getSources().isEmpty() )
+            .collect( Collectors.toList() );
     }
 
     // -------------------------------------------------------------------------
@@ -344,11 +345,12 @@ public class DefaultDataIntegrityService
 
         for ( Indicator indicator : indicatorService.getAllIndicators() )
         {
-            ExpressionValidationOutcome result = expressionService.expressionIsValid( indicator.getNumerator(), INDICATOR_EXPRESSION );
+            ExpressionValidationOutcome result = expressionService.expressionIsValid( indicator.getNumerator(),
+                INDICATOR_EXPRESSION );
 
             if ( !result.isValid() )
             {
-                invalids.put( indicator, i18n.getString(result.getKey()) );
+                invalids.put( indicator, i18n.getString( result.getKey() ) );
             }
         }
 
@@ -363,11 +365,12 @@ public class DefaultDataIntegrityService
 
         for ( Indicator indicator : indicatorService.getAllIndicators() )
         {
-            ExpressionValidationOutcome result = expressionService.expressionIsValid( indicator.getDenominator(), INDICATOR_EXPRESSION );
+            ExpressionValidationOutcome result = expressionService.expressionIsValid( indicator.getDenominator(),
+                INDICATOR_EXPRESSION );
 
             if ( !result.isValid() )
             {
-                invalids.put( indicator, i18n.getString(result.getKey()) );
+                invalids.put( indicator, i18n.getString( result.getKey() ) );
             }
         }
 
@@ -478,7 +481,9 @@ public class DefaultDataIntegrityService
     {
         List<OrganisationUnit> units = organisationUnitService.getAllOrganisationUnits();
 
-        return units.stream().filter( ou -> ou.getParent() == null && ( ou.getChildren() == null || ou.getChildren().size() == 0 ) ).collect( Collectors.toList() );
+        return units.stream()
+            .filter( ou -> ou.getParent() == null && (ou.getChildren() == null || ou.getChildren().size() == 0) )
+            .collect( Collectors.toList() );
     }
 
     @Override
@@ -492,8 +497,7 @@ public class DefaultDataIntegrityService
     {
         Collection<OrganisationUnitGroupSet> groupSets = organisationUnitGroupService.getAllOrganisationUnitGroupSets();
 
-        TreeMap<OrganisationUnit, Collection<OrganisationUnitGroup>> targets =
-            new TreeMap<>();
+        TreeMap<OrganisationUnit, Collection<OrganisationUnitGroup>> targets = new TreeMap<>();
 
         for ( OrganisationUnitGroupSet groupSet : groupSets )
         {
@@ -526,7 +530,8 @@ public class DefaultDataIntegrityService
     {
         Collection<ValidationRule> validationRules = validationRuleService.getAllValidationRules();
 
-        return validationRules.stream().filter( r -> r.getGroups() == null || r.getGroups().isEmpty() ).collect( Collectors.toList() );
+        return validationRules.stream().filter( r -> r.getGroups() == null || r.getGroups().isEmpty() )
+            .collect( Collectors.toList() );
     }
 
     @Override
@@ -537,11 +542,12 @@ public class DefaultDataIntegrityService
 
         for ( ValidationRule rule : validationRuleService.getAllValidationRules() )
         {
-            ExpressionValidationOutcome result = expressionService.expressionIsValid( rule.getLeftSide().getExpression(), VALIDATION_RULE_EXPRESSION );
+            ExpressionValidationOutcome result = expressionService
+                .expressionIsValid( rule.getLeftSide().getExpression(), VALIDATION_RULE_EXPRESSION );
 
             if ( !result.isValid() )
             {
-                invalids.put( rule, i18n.getString(result.getKey()) );
+                invalids.put( rule, i18n.getString( result.getKey() ) );
             }
         }
 
@@ -556,11 +562,12 @@ public class DefaultDataIntegrityService
 
         for ( ValidationRule rule : validationRuleService.getAllValidationRules() )
         {
-            ExpressionValidationOutcome result = expressionService.expressionIsValid( rule.getRightSide().getExpression(), VALIDATION_RULE_EXPRESSION );
+            ExpressionValidationOutcome result = expressionService
+                .expressionIsValid( rule.getRightSide().getExpression(), VALIDATION_RULE_EXPRESSION );
 
             if ( !result.isValid() )
             {
-                invalids.put( rule, i18n.getString(result.getKey()) );
+                invalids.put( rule, i18n.getString( result.getKey() ) );
             }
         }
 
@@ -574,14 +581,16 @@ public class DefaultDataIntegrityService
 
         report.setDataElementsWithoutDataSet( new ArrayList<>( getDataElementsWithoutDataSet() ) );
         report.setDataElementsWithoutGroups( new ArrayList<>( getDataElementsWithoutGroups() ) );
-        report.setDataElementsAssignedToDataSetsWithDifferentPeriodTypes( getDataElementsAssignedToDataSetsWithDifferentPeriodTypes() );
+        report.setDataElementsAssignedToDataSetsWithDifferentPeriodTypes(
+            getDataElementsAssignedToDataSetsWithDifferentPeriodTypes() );
         report.setDataElementsViolatingExclusiveGroupSets( getDataElementsViolatingExclusiveGroupSets() );
         report.setDataElementsInDataSetNotInForm( getDataElementsInDataSetNotInForm() );
         report.setInvalidCategoryCombos( getInvalidCategoryCombos() );
 
         log.info( "Checked data elements" );
 
-        report.setDataSetsNotAssignedToOrganisationUnits( new ArrayList<>( getDataSetsNotAssignedToOrganisationUnits() ) );
+        report.setDataSetsNotAssignedToOrganisationUnits(
+            new ArrayList<>( getDataSetsNotAssignedToOrganisationUnits() ) );
 
         log.info( "Checked data sets" );
 
@@ -597,11 +606,13 @@ public class DefaultDataIntegrityService
 
         log.info( "Checked periods" );
 
-        report.setOrganisationUnitsWithCyclicReferences( new ArrayList<>( getOrganisationUnitsWithCyclicReferences() ) );
+        report
+            .setOrganisationUnitsWithCyclicReferences( new ArrayList<>( getOrganisationUnitsWithCyclicReferences() ) );
         report.setOrphanedOrganisationUnits( new ArrayList<>( getOrphanedOrganisationUnits() ) );
         report.setOrganisationUnitsWithoutGroups( new ArrayList<>( getOrganisationUnitsWithoutGroups() ) );
         report.setOrganisationUnitsViolatingExclusiveGroupSets( getOrganisationUnitsViolatingExclusiveGroupSets() );
-        report.setOrganisationUnitGroupsWithoutGroupSets( new ArrayList<>( getOrganisationUnitGroupsWithoutGroupSets() ) );
+        report.setOrganisationUnitGroupsWithoutGroupSets(
+            new ArrayList<>( getOrganisationUnitGroupsWithoutGroupSets() ) );
         report.setValidationRulesWithoutGroups( new ArrayList<>( getValidationRulesWithoutGroups() ) );
 
         log.info( "Checked organisation units" );
@@ -613,7 +624,7 @@ public class DefaultDataIntegrityService
 
         report.setInvalidProgramIndicatorExpressions( getInvalidProgramIndicatorExpressions() );
         report.setInvalidProgramIndicatorFilters( getInvalidProgramIndicatorFilters() );
-        report.setGetProgramIndicatorWithNoExpression( getProgramIndicatorsWithNoExpression() );
+        report.setProgramIndicatorsWithNoExpression( getProgramIndicatorsWithNoExpression() );
 
         log.info( "Checked ProgramIndicators" );
 
@@ -759,10 +770,11 @@ public class DefaultDataIntegrityService
     {
         List<ProgramRuleAction> ruleActions = programRuleActionService.getProgramRuleActionsWithNoStageId();
 
-        return groupActionsByProgramRule( ruleActions );    }
+        return groupActionsByProgramRule( ruleActions );
+    }
 
     @Override
-    public  Map<Program, Collection<ProgramRuleVariable>> getProgramRuleVariablesWithNoDataElement()
+    public Map<Program, Collection<ProgramRuleVariable>> getProgramRuleVariablesWithNoDataElement()
     {
         List<ProgramRuleVariable> ruleVariables = programRuleVariableService.getVariablesWithNoDataElement();
 
@@ -785,7 +797,7 @@ public class DefaultDataIntegrityService
         }
         catch ( ParserException e )
         {
-           return e.getMessage();
+            return e.getMessage();
         }
 
         return null;
@@ -810,7 +822,8 @@ public class DefaultDataIntegrityService
         return collectionMap;
     }
 
-    private  Map<Program, Collection<ProgramRuleVariable>> groupVariablesByProgram( List<ProgramRuleVariable> ruleVariables )
+    private Map<Program, Collection<ProgramRuleVariable>> groupVariablesByProgram(
+        List<ProgramRuleVariable> ruleVariables )
     {
         Map<Program, Collection<ProgramRuleVariable>> collectionMap = new HashMap<>();
 
@@ -829,7 +842,8 @@ public class DefaultDataIntegrityService
         return collectionMap;
     }
 
-    private  Map<ProgramRule, Collection<ProgramRuleAction>> groupActionsByProgramRule( List<ProgramRuleAction> ruleActions )
+    private Map<ProgramRule, Collection<ProgramRuleAction>> groupActionsByProgramRule(
+        List<ProgramRuleAction> ruleActions )
     {
         Map<ProgramRule, Collection<ProgramRuleAction>> collectionMap = new HashMap<>();
 


### PR DESCRIPTION
This is a non-functional change.  For some reason the getter and setter for one integrity check had an extra `get` in the name:

```
private List<ProgramIndicator> getProgramIndicatorWithNoExpression; // not a getter, shouldn't start with get
public List<ProgramIndicator> getGetProgramIndicatorWithNoExpression; // extra get in getter name
public void setGetProgramIndicatorWithNoExpression; // extra get in setter name
```

The variable, getter, and setter names were also singular instead of plural (`Indicator` not `Indicators`)

This is a purely code quality and readability change - the serializable class `FlattenedDataIntegrityReport.java` correctly renamed the variable to `programIndicatorsWithNoExpression` (no prefix, plural), so there is no change in the API response.

The pre-commit style plugin caused a lot of noise in this PR, sorry about that...