### PR TITLE
fix: [DHIS2-9817] [DHIS2-9825] serialization and deserialization of TrackerImportReport and excception handling (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundleParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundleService;
 import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.report.TrackerBundleReport;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.preprocess.TrackerPreprocessService;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
@@ -53,10 +54,13 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.base.Enums;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Service
+@Slf4j
 public class DefaultTrackerImportService
     implements TrackerImportService
 {
@@ -100,31 +104,58 @@ public class DefaultTrackerImportService
         {
             notifier.notify( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Start" );
         }
-
-        TrackerBundle trackerBundle = preheatBundle( params, importReport );
-
-        trackerBundle = preProcessBundle( trackerBundle, importReport );
-
-        TrackerValidationReport validationReport = validateBundle( params, importReport, trackerBundle );
-
-        if ( validationReport.hasErrors() && params.getAtomicMode() == AtomicMode.ALL )
+        
+        try
         {
-            importReport.setStatus( TrackerStatus.ERROR );
-        }
-        else
-        {
-            if ( TrackerImportStrategy.DELETE == params.getImportStrategy() )
+
+            TrackerBundle trackerBundle = preheatBundle( params, importReport );
+
+            trackerBundle = preProcessBundle( trackerBundle, importReport );
+
+            TrackerValidationReport validationReport = validateBundle( params, importReport, trackerBundle );
+
+            if ( validationReport.hasErrors() && params.getAtomicMode() == AtomicMode.ALL )
             {
-                deleteBundle( params, importReport, trackerBundle );
+                importReport.setStatus( TrackerStatus.ERROR );
             }
             else
             {
-                commitBundle( params, importReport, trackerBundle );
+                if ( TrackerImportStrategy.DELETE == params.getImportStrategy() )
+                {
+                    deleteBundle( params, importReport, trackerBundle );
+                }
+                else
+                {
+                    commitBundle( params, importReport, trackerBundle );
+                }
+            }
+
+            importReport.getTimings().setTotalImport( requestTimer.toString() );
+           
+        }
+        
+        catch ( Exception e )
+        {
+            log.error( "Exception thrown during import.",e );
+
+            TrackerValidationReport tvr = importReport.getTrackerValidationReport();
+
+            if ( tvr == null )
+            {
+                tvr = new TrackerValidationReport();
+            }
+
+            tvr.getErrorReports().add( new TrackerErrorReport( "Exception:" + e.getMessage(), TrackerErrorCode.E9999 ) );
+            importReport.setTrackerValidationReport( tvr );
+            importReport.setStatus( TrackerStatus.ERROR );
+
+            if ( params.hasJobConfiguration() )
+            {
+                notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Failed with exception: " + e.getMessage(), true );
+                notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
             }
         }
-
-        importReport.getTimings().setTotalImport( requestTimer.toString() );
-
+        
         if ( params.hasJobConfiguration() )
         {
             notifier
@@ -134,10 +165,7 @@ public class DefaultTrackerImportService
             notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
         }
 
-        long ignored = importReport.getTrackerValidationReport().getErrorReports().stream()
-            .map( TrackerErrorReport::getUid )
-            .distinct().count();
-        importReport.setIgnored( (int) ignored );
+       
         return importReport;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -131,6 +131,12 @@ public class DefaultTrackerImportService
             }
 
             importReport.getTimings().setTotalImport( requestTimer.toString() );
+            
+            if ( params.hasJobConfiguration() )
+            {
+                notifier.update( params.getJobConfiguration(), "(" + params.getUsername() + ") Import:Done took " + requestTimer, true );
+                notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
+            }
            
         }
         
@@ -155,16 +161,6 @@ public class DefaultTrackerImportService
                 notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
             }
         }
-        
-        if ( params.hasJobConfiguration() )
-        {
-            notifier
-                .update( params.getJobConfiguration(),
-                    "(" + params.getUsername() + ") Import:Done took " + requestTimer, true );
-
-            notifier.addJobSummary( params.getJobConfiguration(), importReport, TrackerImportReport.class );
-        }
-
        
         return importReport;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -42,10 +42,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundleMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundleParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundleService;
 import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
-import org.hisp.dhis.tracker.report.TrackerBundleReport;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.preprocess.TrackerPreprocessService;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.TrackerBundleReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
@@ -144,15 +142,7 @@ public class DefaultTrackerImportService
         {
             log.error( "Exception thrown during import.",e );
 
-            TrackerValidationReport tvr = importReport.getTrackerValidationReport();
-
-            if ( tvr == null )
-            {
-                tvr = new TrackerValidationReport();
-            }
-
-            tvr.getErrorReports().add( new TrackerErrorReport( "Exception:" + e.getMessage(), TrackerErrorCode.E9999 ) );
-            importReport.setTrackerValidationReport( tvr );
+            importReport.setMessage( "Exception:" + e.getMessage() );
             importReport.setStatus( TrackerStatus.ERROR );
 
             if ( params.hasJobConfiguration() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -67,13 +67,21 @@ public class TrackerErrorReport
     private final String uid;
 
     @JsonCreator
-    public TrackerErrorReport( @JsonProperty( "errorMessage" ) String errorMessage, @JsonProperty( "errorCode" ) TrackerErrorCode errorCode,
+    public TrackerErrorReport( @JsonProperty( "message" ) String errorMessage, @JsonProperty( "errorCode" ) TrackerErrorCode errorCode,
         @JsonProperty( "trackerType" ) TrackerType trackerType, @JsonProperty( "uid" ) String uid )
     {
         this.errorMessage = errorMessage;
         this.errorCode = errorCode;
         this.trackerType = trackerType;
         this.uid = uid;
+    }
+    
+    public TrackerErrorReport( String errorMessage, TrackerErrorCode errorCode )
+    {
+        this.errorMessage = errorMessage;
+        this.errorCode = errorCode;
+        this.trackerType = null;
+        this.uid = null;
     }
 
     @JsonProperty
@@ -86,6 +94,18 @@ public class TrackerErrorReport
     public String getMessage()
     {
         return errorMessage;
+    }
+    
+    @JsonProperty
+    public TrackerType getTrackerType()
+    {
+        return trackerType;
+    }
+    
+    @JsonProperty
+    public String getUid()
+    {
+        return uid;
     }
 
     public static class TrackerErrorReportBuilder

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -76,14 +76,6 @@ public class TrackerErrorReport
         this.uid = uid;
     }
     
-    public TrackerErrorReport( String errorMessage, TrackerErrorCode errorCode )
-    {
-        this.errorMessage = errorMessage;
-        this.errorCode = errorCode;
-        this.trackerType = null;
-        this.uid = null;
-    }
-
     @JsonProperty
     public TrackerErrorCode getErrorCode()
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
@@ -112,6 +112,11 @@ public class TrackerImportReport
     
     private int calculateIgnored()
     {
+        if ( getTrackerValidationReport() == null || getTrackerValidationReport().getErrorReports() == null )
+        {
+            return 0;
+        }
+        
         return (int) getTrackerValidationReport().getErrorReports().stream()
         .map( TrackerErrorReport::getUid )
         .distinct().count();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.tracker.report;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Data;
@@ -42,9 +41,6 @@ import lombok.NoArgsConstructor;
 public class TrackerImportReport
 {
 
-    @JsonIgnore
-    private int ignored;
-
     private TrackerStatus status = TrackerStatus.OK;
 
     private TrackerTimingsStats timings = new TrackerTimingsStats();
@@ -57,14 +53,20 @@ public class TrackerImportReport
     public TrackerStats getStats()
     {
         TrackerStats stats = bundleReport.getStats();
-        stats.setIgnored( ignored );
+        stats.setIgnored( calculateIgnored() );
         return stats;
     }
-
+    
     @JsonProperty
     public TrackerStatus getStatus()
     {
         return status;
+    }
+    
+    @JsonProperty
+    public TrackerBundleReport getBundleReport()
+    {
+        return bundleReport;
     }
 
     @JsonProperty
@@ -78,7 +80,7 @@ public class TrackerImportReport
     {
         return trackerValidationReport;
     }
-
+    
     //-----------------------------------------------------------------------------------
     // Utility Methods
     //-----------------------------------------------------------------------------------
@@ -91,5 +93,12 @@ public class TrackerImportReport
     public boolean isEmpty()
     {
         return bundleReport.isEmpty();
+    }
+    
+    private int calculateIgnored()
+    {
+        return (int) getTrackerValidationReport().getErrorReports().stream()
+        .map( TrackerErrorReport::getUid )
+        .distinct().count();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
@@ -1,5 +1,7 @@
 package org.hisp.dhis.tracker.report;
 
+import org.apache.commons.lang3.StringUtils;
+
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -48,6 +50,8 @@ public class TrackerImportReport
     private TrackerBundleReport bundleReport = new TrackerBundleReport();
 
     private TrackerValidationReport trackerValidationReport = new TrackerValidationReport();
+    
+    private String message;
 
     @JsonProperty
     public TrackerStats getStats()
@@ -79,6 +83,17 @@ public class TrackerImportReport
     public TrackerValidationReport getTrackerValidationReport()
     {
         return trackerValidationReport;
+    }
+    
+    @JsonProperty
+    public String message()
+    {
+        if ( StringUtils.isEmpty( message ) )
+        {
+            return getStatus().name();
+        }
+        
+        return message;
     }
     
     //-----------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import org.hisp.dhis.tracker.TrackerType;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Data;
@@ -76,6 +77,31 @@ public class TrackerObjectReport
         this.uid = uid;
         this.index = index;
     }
+    
+    @JsonCreator
+    public TrackerObjectReport( @JsonProperty( "trackerType" ) TrackerType trackerType, @JsonProperty( "uid" ) String uid, @JsonProperty( "index" ) int index,
+        @JsonProperty( "errorReports" ) List<TrackerErrorReport> errorReports )
+    {
+        this.trackerType = trackerType;
+        this.uid = uid;
+        this.index = index;
+        if ( errorReports != null )
+        {
+            List<TrackerErrorReport> errorCodeReportList = null;
+            for ( TrackerErrorReport errorReport : errorReports )
+            {
+                errorCodeReportList = this.errorReportsByCode.get( errorReport.getErrorCode() );
+
+                if ( errorCodeReportList == null )
+                {
+                    errorCodeReportList = new ArrayList<>();
+                }
+                errorCodeReportList.add( errorReport );
+                this.errorReportsByCode.put( errorReport.getErrorCode(), errorCodeReportList );
+            }
+        }
+    }
+
 
     @JsonProperty
     public List<TrackerErrorReport> getErrorReports()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerTypeReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerTypeReport.java
@@ -28,15 +28,18 @@ package org.hisp.dhis.tracker.report;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -58,6 +61,24 @@ public class TrackerTypeReport
     public TrackerTypeReport( TrackerType trackerType )
     {
         this.trackerType = trackerType;
+    }
+    
+    @JsonCreator
+    public TrackerTypeReport( @JsonProperty( "trackerType" ) TrackerType trackerType, @JsonProperty( "stats" ) TrackerStats stats,
+        @JsonProperty( "sideEffectDataBundles" ) List<TrackerSideEffectDataBundle> sideEffectDataBundles,
+        @JsonProperty( "objectReports" ) List<TrackerObjectReport> objectReports )
+    {
+        this.trackerType = trackerType;
+        this.stats = stats;
+        this.sideEffectDataBundles = sideEffectDataBundles;
+
+        if ( objectReports != null )
+        {
+            for ( TrackerObjectReport objectReport : objectReports )
+            {
+                this.objectReportMap.put( objectReport.getIndex(), objectReport );
+            }
+        }
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -27,8 +27,14 @@ package org.hisp.dhis.tracker.report;
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-import static org.junit.Assert.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.tracker.TrackerBundleReportMode;
@@ -37,6 +43,10 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
@@ -44,6 +54,9 @@ public class TrackerBundleImportReportTest extends DhisSpringTest
 {
     @Autowired
     private TrackerImportService trackerImportService;
+    
+    @Autowired
+    private ObjectMapper jsonMapper;
 
     @Test
     public void testImportReportBasic()
@@ -101,6 +114,91 @@ public class TrackerBundleImportReportTest extends DhisSpringTest
         assertEquals("3 sec.", report.getTimings().getPreheat() );
         assertEquals("4 sec.", report.getTimings().getValidation() );
         assertEquals("10 sec.", report.getTimings().getTotalImport() );
+    }
+    
+    @Test
+    public void testSerializingAndDeserializingImportReport()
+        throws JsonMappingException,
+        JsonProcessingException
+    {
+        TrackerImportReport toSerializeReport = new TrackerImportReport();
+        toSerializeReport.getBundleReport().setStatus( TrackerStatus.ERROR );
+        Map<TrackerType, TrackerTypeReport> typeReportMap = new HashMap<>();
+        TrackerTypeReport typeReport = new TrackerTypeReport( TrackerType.TRACKED_ENTITY );
+        TrackerObjectReport trackerObjectReport = new TrackerObjectReport( TrackerType.TRACKED_ENTITY );
+        List<TrackerErrorReport> trackerErrorReports = new ArrayList<>();
+        TrackerErrorReport errorReport1 = new TrackerErrorReport( "Could not find OrganisationUnit: ``, linked to Tracked Entity.", TrackerErrorCode.E1049,
+            TrackerType.TRACKED_ENTITY, "BltTZV9HvEZ" );
+        TrackerErrorReport errorReport2 = new TrackerErrorReport( "Could not find TrackedEntityType: `Q9GufDoplCL`.", TrackerErrorCode.E1049,
+            TrackerType.TRACKED_ENTITY, "BltTZV9HvEZ" );
+        trackerErrorReports.add( errorReport1 );
+        trackerErrorReports.add( errorReport2 );
+        trackerObjectReport.getErrorReports().addAll( trackerErrorReports );
+        trackerObjectReport.setIndex( 0 );
+        trackerObjectReport.setUid( "BltTZV9HvEZ" );
+
+        typeReport.addObjectReport( trackerObjectReport );
+        typeReport.getStats().setCreated( 1 );
+        typeReport.getStats().setUpdated( 2 );
+        typeReport.getStats().setDeleted( 3 );
+        typeReportMap.put( TrackerType.TRACKED_ENTITY, typeReport );
+        toSerializeReport.getBundleReport().setTypeReportMap( typeReportMap );
+
+        TrackerTimingsStats timingStats = new TrackerTimingsStats();
+        timingStats.setCommit( "0.1 sec." );
+        timingStats.setPreheat( "0.2 sec." );
+        timingStats.setProgramrule( "0.3 sec." );
+        timingStats.setTotalImport( "0.4 sec." );
+        timingStats.setPrepareRequest( "0.5 sec." );
+        timingStats.setTotalRequest( "0.6 sec." );
+
+        toSerializeReport.setTimings( timingStats );
+
+        TrackerValidationReport tvr = toSerializeReport.getTrackerValidationReport();
+
+        tvr.getErrorReports().add( new TrackerErrorReport( "Could not find OrganisationUnit: ``, linked to Tracked Entity.", TrackerErrorCode.E1049,
+            TrackerType.TRACKED_ENTITY, "BltTZV9HvEZ" ) );
+        toSerializeReport.setTrackerValidationReport( tvr );
+        toSerializeReport.setStatus( TrackerStatus.ERROR );
+
+        String jsonString = jsonMapper.writeValueAsString( toSerializeReport );
+
+        TrackerImportReport deserializedReport = jsonMapper.readValue( jsonString, TrackerImportReport.class );
+
+        assertEquals( toSerializeReport.getStats().getIgnored(), deserializedReport.getStats().getIgnored() );
+        assertEquals( toSerializeReport.getStats().getDeleted(), deserializedReport.getStats().getDeleted() );
+        assertEquals( toSerializeReport.getStats().getUpdated(), deserializedReport.getStats().getUpdated() );
+        assertEquals( toSerializeReport.getStats().getCreated(), deserializedReport.getStats().getCreated() );
+        assertEquals( toSerializeReport.getStats().getTotal(), deserializedReport.getStats().getTotal() );
+
+        assertEquals( toSerializeReport.getBundleReport().getStatus(), deserializedReport.getBundleReport().getStatus() );
+
+        assertEquals( toSerializeReport.getBundleReport().getStats().getIgnored(), deserializedReport.getBundleReport().getStats().getIgnored() );
+        assertEquals( toSerializeReport.getBundleReport().getStats().getDeleted(), deserializedReport.getBundleReport().getStats().getDeleted() );
+        assertEquals( toSerializeReport.getBundleReport().getStats().getUpdated(), deserializedReport.getBundleReport().getStats().getUpdated() );
+        assertEquals( toSerializeReport.getBundleReport().getStats().getCreated(), deserializedReport.getBundleReport().getStats().getCreated() );
+        assertEquals( toSerializeReport.getBundleReport().getStats().getTotal(), deserializedReport.getBundleReport().getStats().getTotal() );
+
+        assertEquals( toSerializeReport.getBundleReport().getTypeReportMap().get( TrackerType.TRACKED_ENTITY ),
+            deserializedReport.getBundleReport().getTypeReportMap().get( TrackerType.TRACKED_ENTITY ) );
+
+        assertEquals( toSerializeReport.getTrackerValidationReport().getErrorReports().get( 0 ).getErrorMessage(),
+            deserializedReport.getTrackerValidationReport().getErrorReports().get( 0 ).getErrorMessage() );
+        assertEquals( toSerializeReport.getTrackerValidationReport().getErrorReports().get( 0 ).getErrorCode(),
+            deserializedReport.getTrackerValidationReport().getErrorReports().get( 0 ).getErrorCode() );
+        assertEquals( toSerializeReport.getTrackerValidationReport().getErrorReports().get( 0 ).getUid(),
+            deserializedReport.getTrackerValidationReport().getErrorReports().get( 0 ).getUid() );
+
+        assertEquals( toSerializeReport.getTimings().getCommit(), deserializedReport.getTimings().getCommit() );
+        assertEquals( toSerializeReport.getTimings().getPreheat(), deserializedReport.getTimings().getPreheat() );
+        assertEquals( toSerializeReport.getTimings().getPrepareRequest(), deserializedReport.getTimings().getPrepareRequest() );
+        assertEquals( toSerializeReport.getTimings().getProgramrule(), deserializedReport.getTimings().getProgramrule() );
+        assertEquals( toSerializeReport.getTimings().getTotalImport(), deserializedReport.getTimings().getTotalImport() );
+        assertEquals( toSerializeReport.getTimings().getTotalRequest(), deserializedReport.getTimings().getTotalRequest() );
+        assertEquals( toSerializeReport.getTimings().getValidation(), deserializedReport.getTimings().getValidation() );
+
+        assertEquals( toSerializeReport.getStats(), deserializedReport.getStats() );
+
     }
 
     private void assertStats( TrackerImportReport report) {


### PR DESCRIPTION
Two issues are resolved in this PR as it was a bit tightly coupled.
1. Added exception handling within the ImportService to catch any exceptions and mark the job as completed with failure. The changes for this was already merged into 2.35 but for some reason, the forward port merge of 2.35 into master missed that change. Simply added a try catch block in DefaultTrackerImportService to catch exceptions and notify the job to be completed with failures.
2. Added support for serializing and deserializing TrackerImportReport so that no data is lost. Added necessary annotations to help Jackson serialize and deserialize TrackerImportReport. 