### PR TITLE
fix: [DHIS2-9286] handled exception messages filtered out in final report (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -273,6 +273,8 @@ public class DefaultTrackerImportService
         filteredTrackerImportReport.getTrackerValidationReport()
             .setWarningReports( importReport.getTrackerValidationReport().getWarningReports() );
         filteredTrackerImportReport.setBundleReport( importReport.getBundleReport() );
+        filteredTrackerImportReport.setStatus( importReport.getStatus() );
+        filteredTrackerImportReport.setMessage( importReport.getMessage() );
 
         switch ( reportMode )
         {


### PR DESCRIPTION
The importReport.status and importReport.message was not copied into the filteredImportReport which always causes the status to show as "OK" even if there are errors.