### PR TITLE
fix: ProgramStageInstanceFilterSchemaDescriptor has now defaultPrivat…

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramStageInstanceFilterSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramStageInstanceFilterSchemaDescriptor.java
@@ -50,6 +50,7 @@ public class ProgramStageInstanceFilterSchemaDescriptor implements SchemaDescrip
     {
         Schema schema = new Schema( ProgramStageInstanceFilter.class, SINGULAR, PLURAL );
         schema.setRelativeApiEndpoint( API_ENDPOINT );
+        schema.setDefaultPrivate( true );
         return schema;
     }
 


### PR DESCRIPTION
…… (#6394)

* fix: ProgramStageInstanceFilterSchemaDescriptor has now defaultPrivate set to "true"

* Update dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramStageInstanceFilterSchemaDescriptor.java

Co-authored-by: Stian Sandvold <stian@dhis2.org>
(cherry picked from commit b1a3ce67dae068c6282d7442142ad820bb8349a0)