### PR TITLE
chore: remove junit and hamcrest related warnings

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/fileresource/FileResourceKeyUtilTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/fileresource/FileResourceKeyUtilTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.fileresource;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Optional;
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/relationship/RelationshipEntityTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/relationship/RelationshipEntityTest.java
@@ -30,8 +30,9 @@ package org.hisp.dhis.relationship;
 
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
 public class RelationshipEntityTest
 {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationSerializationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationSerializationTest.java
@@ -6,7 +6,13 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.hamcrest.Matchers;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
-import org.junit.Assert;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -84,20 +90,20 @@ public class JobConfigurationSerializationTest
             "      <cronExpression>0 0 12 ? * MON-FRI</cronExpression>\n" +
             "    </jobConfiguration>", JobConfiguration.class );
 
-        Assert.assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
-        Assert.assertEquals( "Test Analytic", jc.getDisplayName() );
-        Assert.assertTrue( jc.isEnabled() );
-        Assert.assertTrue( jc.isLeaderOnlyJob() );
-        Assert.assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        Assert.assertNull( jc.getNextExecutionTime() );
-        Assert.assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
+        assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
+        assertEquals( "Test Analytic", jc.getDisplayName() );
+        assertTrue( jc.isEnabled() );
+        assertTrue( jc.isLeaderOnlyJob() );
+        assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
+        assertNull( jc.getNextExecutionTime() );
+        assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
 
-        Assert.assertNotNull( jc.getJobParameters() );
-        Assert.assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
-        Assert.assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
-        Assert.assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
-        Assert.assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
-        Assert.assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
+        assertNotNull( jc.getJobParameters() );
+        assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
+        assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
+        assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
+        assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
+        assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
     }
 
     @Test
@@ -135,21 +141,21 @@ public class JobConfigurationSerializationTest
             "      <cronExpression>0 0 12 ? * MON-FRI</cronExpression>\n" +
             "    </jobConfiguration>", JobConfiguration.class );
 
-        Assert.assertEquals( "uB9oC4R2nTn", jc.getUid() );
-        Assert.assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
-        Assert.assertEquals( "Test Analytic", jc.getName() );
-        Assert.assertEquals( "Test Analytic", jc.getDisplayName() );
-        Assert.assertTrue( jc.isEnabled() );
-        Assert.assertTrue( jc.isLeaderOnlyJob() );
-        Assert.assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        Assert.assertNull( jc.getNextExecutionTime() );
-        Assert.assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
+        assertEquals( "uB9oC4R2nTn", jc.getUid() );
+        assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
+        assertEquals( "Test Analytic", jc.getName() );
+        assertEquals( "Test Analytic", jc.getDisplayName() );
+        assertTrue( jc.isEnabled() );
+        assertTrue( jc.isLeaderOnlyJob() );
+        assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
+        assertNull( jc.getNextExecutionTime() );
+        assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
 
-        Assert.assertNotNull( jc.getJobParameters() );
-        Assert.assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
-        Assert.assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
-        Assert.assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
-        Assert.assertEquals( 0, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
+        assertNotNull( jc.getJobParameters() );
+        assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
+        assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
+        assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
+        assertEquals( 0, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
     }
 
     @Test
@@ -190,21 +196,21 @@ public class JobConfigurationSerializationTest
             "      <cronExpression>0 0 12 ? * MON-FRI</cronExpression>\n" +
             "    </jobConfiguration>", JobConfiguration.class );
 
-        Assert.assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
-        Assert.assertEquals( "Test Analytic", jc.getName() );
-        Assert.assertEquals( "Test Analytic", jc.getDisplayName() );
-        Assert.assertTrue( jc.isEnabled() );
-        Assert.assertTrue( jc.isLeaderOnlyJob() );
-        Assert.assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        Assert.assertNull( jc.getNextExecutionTime() );
-        Assert.assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
+        assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
+        assertEquals( "Test Analytic", jc.getName() );
+        assertEquals( "Test Analytic", jc.getDisplayName() );
+        assertTrue( jc.isEnabled() );
+        assertTrue( jc.isLeaderOnlyJob() );
+        assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
+        assertNull( jc.getNextExecutionTime() );
+        assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
 
-        Assert.assertNotNull( jc.getJobParameters() );
-        Assert.assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
-        Assert.assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
-        Assert.assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
-        Assert.assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
-        Assert.assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
+        assertNotNull( jc.getJobParameters() );
+        assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
+        assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
+        assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
+        assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
+        assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
     }
 
     @Test
@@ -248,21 +254,21 @@ public class JobConfigurationSerializationTest
             "      \"userAccesses\": []\n" +
             "    },", JobConfiguration.class );
 
-        Assert.assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
-        Assert.assertEquals( "Test Analytic", jc.getName() );
-        Assert.assertEquals( "Test Analytic", jc.getDisplayName() );
-        Assert.assertTrue( jc.isEnabled() );
-        Assert.assertTrue( jc.isLeaderOnlyJob() );
-        Assert.assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        Assert.assertNull( jc.getNextExecutionTime() );
-        Assert.assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
+        assertEquals( JobStatus.SCHEDULED, jc.getJobStatus() );
+        assertEquals( "Test Analytic", jc.getName() );
+        assertEquals( "Test Analytic", jc.getDisplayName() );
+        assertTrue( jc.isEnabled() );
+        assertTrue( jc.isLeaderOnlyJob() );
+        assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
+        assertNull( jc.getNextExecutionTime() );
+        assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
 
-        Assert.assertNotNull( jc.getJobParameters() );
-        Assert.assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
-        Assert.assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
-        Assert.assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
-        Assert.assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
-        Assert.assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
+        assertNotNull( jc.getJobParameters() );
+        assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
+        assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
+        assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
+        assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
+        assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
     }
 
     @Test
@@ -306,20 +312,20 @@ public class JobConfigurationSerializationTest
             "      \"userAccesses\": []\n" +
             "    },", JobConfiguration.class );
 
-        Assert.assertEquals( JobStatus.DISABLED, jc.getJobStatus() );
-        Assert.assertEquals( "Test Analytic", jc.getName() );
-        Assert.assertEquals( "Test Analytic", jc.getDisplayName() );
-        Assert.assertFalse( jc.isEnabled() );
-        Assert.assertTrue( jc.isLeaderOnlyJob() );
-        Assert.assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        Assert.assertNull( jc.getNextExecutionTime() );
-        Assert.assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
+        assertEquals( JobStatus.DISABLED, jc.getJobStatus() );
+        assertEquals( "Test Analytic", jc.getName() );
+        assertEquals( "Test Analytic", jc.getDisplayName() );
+        assertFalse( jc.isEnabled() );
+        assertTrue( jc.isLeaderOnlyJob() );
+        assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
+        assertNull( jc.getNextExecutionTime() );
+        assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
 
-        Assert.assertNotNull( jc.getJobParameters() );
-        Assert.assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
-        Assert.assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
-        Assert.assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
-        Assert.assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
-        Assert.assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
+        assertNotNull( jc.getJobParameters() );
+        assertEquals( (Integer) 2, ( (AnalyticsJobParameters) jc.getJobParameters() ).getLastYears() );
+        assertTrue( ( (AnalyticsJobParameters) jc.getJobParameters() ).isSkipResourceTables() );
+        assertNotNull( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes() );
+        assertEquals( 3, ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes().size() );
+        assertThat( ( (AnalyticsJobParameters) jc.getJobParameters() ).getSkipTableTypes(), Matchers.hasItems( AnalyticsTableType.ENROLLMENT, AnalyticsTableType.ORG_UNIT_TARGET, AnalyticsTableType.VALIDATION_RESULT ) );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/UserCredentialsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/UserCredentialsTest.java
@@ -29,7 +29,11 @@ package org.hisp.dhis.user;
  */
 
 import org.hamcrest.Matchers;
-import org.junit.Assert;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,8 +76,8 @@ public class UserCredentialsTest
         final UserCredentials userCredentials = new UserCredentials();
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super, userAuthorityGroup2 ) ) );
 
-        Assert.assertTrue( userCredentials.isSuper() );
-        Assert.assertTrue( userCredentials.isSuper() );
+        assertTrue( userCredentials.isSuper() );
+        assertTrue( userCredentials.isSuper() );
     }
 
     @Test
@@ -82,8 +86,8 @@ public class UserCredentialsTest
         final UserCredentials userCredentials = new UserCredentials();
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup2 ) ) );
 
-        Assert.assertFalse( userCredentials.isSuper() );
-        Assert.assertFalse( userCredentials.isSuper() );
+        assertFalse( userCredentials.isSuper() );
+        assertFalse( userCredentials.isSuper() );
     }
 
     @Test
@@ -92,10 +96,10 @@ public class UserCredentialsTest
         final UserCredentials userCredentials = new UserCredentials();
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super, userAuthorityGroup2 ) ) );
 
-        Assert.assertTrue( userCredentials.isSuper() );
+        assertTrue( userCredentials.isSuper() );
 
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup2 ) ) );
-        Assert.assertFalse( userCredentials.isSuper() );
+        assertFalse( userCredentials.isSuper() );
     }
 
     @Test
@@ -105,10 +109,10 @@ public class UserCredentialsTest
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super ) ) );
 
         Set<String> authorities1 = userCredentials.getAllAuthorities();
-        Assert.assertThat( authorities1, Matchers.containsInAnyOrder( "x1", "x2", "z1", UserAuthorityGroup.AUTHORITY_ALL ) );
+        assertThat( authorities1, Matchers.containsInAnyOrder( "x1", "x2", "z1", UserAuthorityGroup.AUTHORITY_ALL ) );
 
         Set<String> authorities2 = userCredentials.getAllAuthorities();
-        Assert.assertSame( authorities1, authorities2 );
+        assertSame( authorities1, authorities2 );
     }
 
     @Test
@@ -118,10 +122,10 @@ public class UserCredentialsTest
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup1Super ) ) );
 
         Set<String> authorities1 = userCredentials.getAllAuthorities();
-        Assert.assertThat( authorities1, Matchers.containsInAnyOrder( "x1", "x2", "z1", UserAuthorityGroup.AUTHORITY_ALL ) );
+        assertThat( authorities1, Matchers.containsInAnyOrder( "x1", "x2", "z1", UserAuthorityGroup.AUTHORITY_ALL ) );
 
         userCredentials.setUserAuthorityGroups( new HashSet<>( Arrays.asList( userAuthorityGroup1, userAuthorityGroup2 ) ) );
         Set<String> authorities2 = userCredentials.getAllAuthorities();
-        Assert.assertThat( authorities2, Matchers.containsInAnyOrder( "x1", "x2", "y1", "y2" ) );
+        assertThat( authorities2, Matchers.containsInAnyOrder( "x1", "x2", "y1", "y2" ) );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
@@ -31,13 +31,18 @@ package org.hisp.dhis.util;
 import static java.util.Calendar.DATE;
 import static java.util.Calendar.MILLISECOND;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hisp.dhis.util.DateUtils.dateIsValid;
 import static org.hisp.dhis.util.DateUtils.dateTimeIsValid;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.util.DateUtils.getMediumDate;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -48,7 +53,6 @@ import java.util.TimeZone;
 
 import org.hisp.dhis.calendar.impl.NepaliCalendar;
 import org.joda.time.DateTime;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
@@ -101,7 +105,7 @@ public class DateUtilsTest
     @Test
     public void testDaysBetween()
     {
-        Assert.assertEquals( 6, DateUtils.daysBetween( new DateTime( 2014, 3, 1, 0, 0 ).toDate(),
+        assertEquals( 6, DateUtils.daysBetween( new DateTime( 2014, 3, 1, 0, 0 ).toDate(),
             new DateTime( 2014, 3, 7, 0, 0 ).toDate() ) );
     }
 
@@ -189,7 +193,7 @@ public class DateUtilsTest
         assertEquals( date1, DateUtils.min( Sets.newHashSet( date1, date2, date3 ) ) );
         assertEquals( date1, DateUtils.min( Sets.newHashSet( date1, date2, date3 ) ) );
         assertEquals( date3, DateUtils.min( Sets.newHashSet( date3, date4, date5 ) ) );
-        assertEquals( null, DateUtils.min( Sets.newHashSet( date4, date5, date6 ) ) );
+        assertNull( DateUtils.min( Sets.newHashSet( date4, date5, date6 ) ) );
         assertEquals( date1, DateUtils.min( Sets.newHashSet( date1, date5, date4 ) ) );
 
         assertNull( DateUtils.max( Sets.newHashSet( date4, date5, date6 ) ) );

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/DimensionDescriptorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/DimensionDescriptorTest.java
@@ -30,16 +30,15 @@ package org.hisp.dhis.visualization;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.common.DimensionType.DATA_X;
 import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.visualization.DimensionDescriptor.getDimensionIdentifierFor;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
-import org.hisp.dhis.common.DimensionType;
 import org.junit.Test;
 
 public class DimensionDescriptorTest
@@ -49,8 +48,7 @@ public class DimensionDescriptorTest
     {
         // Given
         final String anyDimensionValue = "dx";
-        final DimensionType theDimensionType = DATA_X;
-        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, theDimensionType );
+        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, DATA_X );
         final String dimensionAbbreviation = "dx";
 
         // When
@@ -65,8 +63,7 @@ public class DimensionDescriptorTest
     {
         // Given
         final String anyDimensionValue = "dx";
-        final DimensionType theDimensionType = DATA_X;
-        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, theDimensionType );
+        final DimensionDescriptor aDimensionDescriptor = new DimensionDescriptor( anyDimensionValue, DATA_X );
         final String nonExistingDimensionAbbreviation = "ou";
 
         // When

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
@@ -40,7 +40,7 @@ import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_PROGRESSIVE_TTL_F
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_TTL_MODE;
 import static org.hisp.dhis.setting.SettingKey.CACHE_STRATEGY;
 import static org.hisp.dhis.util.DateUtils.calculateDateFrom;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.junit.MockitoJUnit.rule;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hisp.dhis.analytics.cache.TimeToLive.DEFAULT_MULTIPLIER;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_PROGRESSIVE_TTL_FACTOR;
 import static org.hisp.dhis.util.DateUtils.calculateDateFrom;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_ORGUNIT;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
 import static org.hisp.dhis.common.DimensionalObject.OPTION_SEP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -85,9 +86,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAuthorityGroup;
 import org.hisp.dhis.user.UserService;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.Lists;
@@ -174,9 +173,6 @@ public class DataQueryServiceTest
 
     @Autowired
     private UserService internalUserService;
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Override
     public void setUpTest()
@@ -827,8 +823,6 @@ public class DataQueryServiceTest
     @Test
     public void testGetFromUrlInvalidOrganisationUnits()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E7124 );
-
         Set<String> dimensionParams = new HashSet<>();
         dimensionParams.add( "dx:" + BASE_UID + "A;" + BASE_UID + "B;" + BASE_UID + "C;" + BASE_UID + "D" );
         dimensionParams.add( "ou:aTr6yTgX7t5;gBgf2G2j4GR" );
@@ -836,7 +830,9 @@ public class DataQueryServiceTest
         DataQueryRequest dataQueryRequest = DataQueryRequest.newBuilder()
             .dimension( dimensionParams ).build();
 
-        dataQueryService.getFromRequest( dataQueryRequest );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataQueryService.getFromRequest( dataQueryRequest ) ),
+            ErrorCode.E7124 );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.hisp.dhis.common.DimensionalObject.*;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.analytics.*;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
 import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
@@ -31,35 +31,25 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hisp.dhis.analytics.event.data.JdbcEventAnalyticsManager.ExceptionHandler.handle;
 import static org.hisp.dhis.feedback.ErrorCode.E7132;
 import static org.hisp.dhis.feedback.ErrorCode.E7133;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.Assert.assertThrows;
 import static org.postgresql.util.PSQLState.BAD_DATETIME_FORMAT;
 import static org.postgresql.util.PSQLState.DIVISION_BY_ZERO;
 
 import org.hisp.dhis.common.QueryRuntimeException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.postgresql.util.PSQLException;
 import org.springframework.dao.DataIntegrityViolationException;
 
 public class JdbcEventAnalyticsManagerTest
 {
-
-    @Rule
-    public final ExpectedException expectedException = none();
-
     @Test
     public void testHandlingDataIntegrityExceptionWhenDivisionByZero()
     {
         // Given
         final DataIntegrityViolationException aDivisionByZeroException = mockDataIntegrityExceptionDivisionByZero();
 
-        // Then
-        expectedException.expect( QueryRuntimeException.class );
-        expectedException.expectMessage( E7132.getMessage() );
-
         // When
-        handle( aDivisionByZeroException );
+        assertThrows( E7132.getMessage(), QueryRuntimeException.class, () -> handle( aDivisionByZeroException ) );
     }
 
     @Test
@@ -68,12 +58,8 @@ public class JdbcEventAnalyticsManagerTest
         // Given
         final DataIntegrityViolationException anyDataIntegrityException = mockAnyOtherDataIntegrityException();
 
-        // Then
-        expectedException.expect( QueryRuntimeException.class );
-        expectedException.expectMessage( E7133.getMessage() );
-
         // When
-        handle( anyDataIntegrityException );
+        assertThrows( E7133.getMessage(), QueryRuntimeException.class, () -> handle( anyDataIntegrityException ) );
     }
 
     @Test
@@ -82,12 +68,8 @@ public class JdbcEventAnalyticsManagerTest
         // Given
         final DataIntegrityViolationException aNullException = null;
 
-        // Then
-        expectedException.expect( QueryRuntimeException.class );
-        expectedException.expectMessage( E7133.getMessage() );
-
         // When
-        handle( aNullException );
+        assertThrows( E7133.getMessage(), QueryRuntimeException.class, () -> handle( aNullException ) );
     }
 
     @Test
@@ -97,12 +79,7 @@ public class JdbcEventAnalyticsManagerTest
         final DataIntegrityViolationException aNullExceptionCause = new DataIntegrityViolationException( "null",
             null );
 
-        // Then
-        expectedException.expect( QueryRuntimeException.class );
-        expectedException.expectMessage( E7133.getMessage() );
-
-        // When
-        handle( aNullExceptionCause );
+        assertThrows( E7133.getMessage(), QueryRuntimeException.class, () -> handle( aNullExceptionCause ) );
     }
 
     @Test
@@ -113,31 +90,25 @@ public class JdbcEventAnalyticsManagerTest
         final DataIntegrityViolationException aNonPSQLExceptionCause = new DataIntegrityViolationException(
             "not caused by PSQLException", aRandomCause );
 
-        // Then
-        expectedException.expect( QueryRuntimeException.class );
-        expectedException.expectMessage( E7133.getMessage() );
-
         // When
-        handle( aNonPSQLExceptionCause );
+        assertThrows( E7133.getMessage(), QueryRuntimeException.class, () -> handle( aNonPSQLExceptionCause ) );
     }
 
     private DataIntegrityViolationException mockDataIntegrityExceptionDivisionByZero()
     {
         final PSQLException psqlException = new PSQLException( "ERROR: division by zero", DIVISION_BY_ZERO );
-        final DataIntegrityViolationException mockedException = new DataIntegrityViolationException(
+
+        return new DataIntegrityViolationException(
             "ERROR: division by zero; nested exception is org.postgresql.util.PSQLException: ERROR: division by zero",
             psqlException );
-
-        return mockedException;
     }
 
     private DataIntegrityViolationException mockAnyOtherDataIntegrityException()
     {
         final PSQLException psqlException = new PSQLException( "ERROR: bad time format", BAD_DATETIME_FORMAT );
-        final DataIntegrityViolationException mockedException = new DataIntegrityViolationException(
+
+        return new DataIntegrityViolationException(
             "ERROR: bad time format; nested exception is org.postgresql.util.PSQLException: ERROR: bad time format",
             psqlException );
-
-        return mockedException;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.analytics.event.data.programindicator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hisp.dhis.DhisConvenienceTest.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
@@ -28,8 +28,25 @@ package org.hisp.dhis.analytics.event.data.queryItem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
+import static org.hisp.dhis.DhisConvenienceTest.createLegendSet;
+import static org.hisp.dhis.DhisConvenienceTest.createOptionSet;
+import static org.hisp.dhis.DhisConvenienceTest.createProgram;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramStage;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramStageDataElement;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramTrackedEntityAttribute;
+import static org.hisp.dhis.DhisConvenienceTest.createTrackedEntityAttribute;
+import static org.hisp.dhis.common.DimensionalObject.ITEM_SEP;
+import static org.hisp.dhis.common.DimensionalObject.PROGRAMSTAGE_SEP;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.event.QueryItemLocator;
 import org.hisp.dhis.analytics.event.data.DefaultQueryItemLocator;
@@ -41,7 +58,12 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.legend.LegendSetService;
 import org.hisp.dhis.option.OptionSet;
-import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
+import org.hisp.dhis.program.ProgramIndicatorService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageService;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -49,18 +71,12 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.hamcrest.Matchers.*;
-import static org.hisp.dhis.DhisConvenienceTest.*;
-import static org.hisp.dhis.common.DimensionalObject.ITEM_SEP;
-import static org.hisp.dhis.common.DimensionalObject.PROGRAMSTAGE_SEP;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Luciano Fiandesio
@@ -90,9 +106,6 @@ public class QueryItemLocatorTest
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     private Program programA;
 
     private String dimension;
@@ -114,20 +127,17 @@ public class QueryItemLocatorTest
     @Test
     public void verifyExceptionOnEmptyDimension()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage(
-            "Item identifier does not reference any data element, attribute or indicator part of the program" );
-
-        subject.getQueryItemFromDimension( "", programA, EventOutputType.ENROLLMENT );
+        assertThrows( "Item identifier does not reference any data element, attribute or indicator part of the program",
+            IllegalQueryException.class,
+            () -> subject.getQueryItemFromDimension( "", programA, EventOutputType.ENROLLMENT ) );
     }
 
     @Test
     public void verifyExceptionOnEmptyProgram()
     {
-        exception.expect( NullPointerException.class );
-        exception.expectMessage( "Program can not be null" );
-
-        subject.getQueryItemFromDimension( dimension, null, EventOutputType.ENROLLMENT );
+        assertThrows( "Program can not be null",
+            NullPointerException.class,
+            () -> subject.getQueryItemFromDimension( dimension, null, EventOutputType.ENROLLMENT ) );
     }
 
     @Test
@@ -156,9 +166,6 @@ public class QueryItemLocatorTest
     @Test
     public void verifyDimensionFailsWhenProgramStageIsMissingForEnrollmentQuery()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Program stage is mandatory for data element dimensions in enrollment analytics queries" );
-
         DataElement dataElementA = createDataElement( 'A' );
 
         ProgramStage programStageA = createProgramStage( 'A', programA );
@@ -170,7 +177,9 @@ public class QueryItemLocatorTest
 
         when( dataElementService.getDataElement( dimension ) ).thenReturn( dataElementA );
 
-        subject.getQueryItemFromDimension( dimension, programA, EventOutputType.ENROLLMENT );
+        assertThrows( "Program stage is mandatory for data element dimensions in enrollment analytics queries",
+            IllegalQueryException.class,
+            () -> subject.getQueryItemFromDimension( dimension, programA, EventOutputType.ENROLLMENT ) );
     }
 
     @Test
@@ -333,13 +342,11 @@ public class QueryItemLocatorTest
         programIndicatorA.setUid( dimension );
 
         when( programIndicatorService.getProgramIndicatorByUid( programIndicatorA.getUid() ) )
-                .thenReturn( programIndicatorA );
+            .thenReturn( programIndicatorA );
 
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage(
-                "Item identifier does not reference any data element, attribute or indicator part of the program" );
-
-        subject.getQueryItemFromDimension( dimension, programA, EventOutputType.ENROLLMENT );
+        assertThrows( "Item identifier does not reference any data element, attribute or indicator part of the program",
+            IllegalQueryException.class,
+            () -> subject.getQueryItemFromDimension( dimension, programA, EventOutputType.ENROLLMENT ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/orgunit/OrgUnitAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/orgunit/OrgUnitAnalyticsServiceTest.java
@@ -28,11 +28,12 @@
 
 package org.hisp.dhis.analytics.orgunit;
 
+import static org.junit.Assert.assertThrows;
+
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.Lists;
@@ -46,18 +47,14 @@ public class OrgUnitAnalyticsServiceTest
     @Autowired
     private OrgUnitAnalyticsService subject;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void testValidateNoOrgUnits()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E7300 );
-
         OrgUnitQueryParams params = new OrgUnitQueryParams.Builder()
             .withOrgUnitGroupSets( Lists.newArrayList( createOrganisationUnitGroupSet( 'A' ) ) )
             .build();
 
-        subject.validate( params );
+        assertIllegalQueryEx( assertThrows( IllegalQueryException.class, () -> subject.validate( params ) ),
+            ErrorCode.E7300 );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramTrackedEntityAttribute;
 import static org.hisp.dhis.DhisConvenienceTest.createTrackedEntityAttribute;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsColumnAsserter.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsColumnAsserter.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.analytics.util;
  */
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.analytics.util;
  */
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/PeriodOffsetUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/PeriodOffsetUtilsTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.datavalue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -38,15 +39,14 @@ import java.util.List;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.Lists;
@@ -69,9 +69,6 @@ public class DataValueServiceTest
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     // -------------------------------------------------------------------------
     // Supporting data
@@ -495,20 +492,20 @@ public class DataValueServiceTest
     @Test
     public void testMissingPeriod()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2002 );
-
-        dataValueService.getDataValues( new DataExportParams()
-            .setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
-            .setOrganisationUnits( Sets.newHashSet( sourceB ) ) );
+        assertIllegalQueryEx( assertThrows( IllegalQueryException.class,
+            () -> dataValueService.getDataValues( new DataExportParams()
+                .setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
+                .setOrganisationUnits( Sets.newHashSet( sourceB ) ) ) ),
+            ErrorCode.E2002 );
     }
 
     @Test
     public void testMissingOrgUnit()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2006 );
-
-        dataValueService.getDataValues( new DataExportParams()
-            .setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
-            .setPeriods( Sets.newHashSet( periodB ) ) );
+        assertIllegalQueryEx( assertThrows( IllegalQueryException.class,
+            () -> dataValueService.getDataValues( new DataExportParams()
+                .setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
+                .setPeriods( Sets.newHashSet( periodB ) ) ) ),
+            ErrorCode.E2006 );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deletedobject/DeletedObjectServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deletedobject/DeletedObjectServiceTest.java
@@ -37,8 +37,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
@@ -28,17 +28,56 @@ package org.hisp.dhis.dimension;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT_OPERAND;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_ATTRIBUTE;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_DATA_ELEMENT;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_INDICATOR;
+import static org.hisp.dhis.common.DimensionItemType.REPORTING_RATE;
+import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
+import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
+import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
+import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_USER_ORGUNIT;
+import static org.hisp.dhis.period.RelativePeriodEnum.LAST_12_MONTHS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.*;
-import org.hisp.dhis.dataelement.*;
+import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionService;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.ReportingRate;
+import org.hisp.dhis.common.ReportingRateMetric;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementDomain;
+import org.hisp.dhis.dataelement.DataElementGroup;
+import org.hisp.dhis.dataelement.DataElementGroupSet;
+import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.eventreport.EventReport;
 import org.hisp.dhis.legend.LegendSet;
-import org.hisp.dhis.organisationunit.*;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
@@ -51,18 +90,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hisp.dhis.common.DimensionItemType.*;
-import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
-import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
-import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
-import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_USER_ORGUNIT;
-import static org.hisp.dhis.period.RelativePeriodEnum.LAST_12_MONTHS;
-import static org.junit.Assert.*;
+import com.google.common.collect.Lists;
 
 /**
  * @author Lars Helge Overland

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.expression;
  */
 
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
@@ -36,10 +37,13 @@ import static org.hisp.dhis.expression.Expression.SEPARATOR;
 import static org.hisp.dhis.expression.ParseType.*;
 import static org.hisp.dhis.expression.ExpressionService.*;
 import static org.hisp.dhis.expression.MissingValueStrategy.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import java.util.*;
 
 import com.google.common.collect.ImmutableMap;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.fileresource;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.io.File;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramInstanceStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramInstanceStoreTest.java
@@ -55,10 +55,13 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_ENROLLMENT_DATE;
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_INCIDENT_DATE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Chau Thu Tran

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -71,6 +70,7 @@ import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_SQL;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -103,9 +103,6 @@ public class ProgramSqlGeneratorFunctionsTest
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private ProgramIndicatorService programIndicatorService;
@@ -494,8 +491,8 @@ public class ProgramSqlGeneratorFunctionsTest
     @Test
     public void testIllegalFunction()
     {
-        thrown.expect( ParserException.class );
-        test( "d2:zztop(#{ProgrmStagA.DataElmentA})" );
+        assertThrows( ParserException.class,
+            () -> test( "d2:zztop(#{ProgrmStagA.DataElmentA})" ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableMap;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.antlr.AntlrExprLiteral;
 import org.hisp.dhis.antlr.Parser;
-import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.antlr.literal.DefaultLiteral;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
@@ -51,9 +50,7 @@ import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -71,6 +68,7 @@ import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_SAMPLE_PERIODS
 import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_SQL;
 import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
@@ -99,9 +97,6 @@ public class ProgramSqlGeneratorItemsTest
 
     @org.junit.Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private ProgramIndicatorService programIndicatorService;
@@ -183,8 +178,7 @@ public class ProgramSqlGeneratorItemsTest
         when( constantService.getConstant( constantA.getUid() ) ).thenReturn( constantA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
 
-        thrown.expect( org.hisp.dhis.antlr.ParserException.class );
-        test( "#{ProgrmStagA.NotElementA}" );
+        assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "#{ProgrmStagA.NotElementA}" ) );
     }
 
     @Test
@@ -208,8 +202,7 @@ public class ProgramSqlGeneratorItemsTest
     @Test
     public void testAttributeNotFound()
     {
-        thrown.expect( org.hisp.dhis.antlr.ParserException.class );
-        test( "A{NoAttribute}" );
+        assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "A{NoAttribute}" ) );
     }
 
     @Test
@@ -222,15 +215,13 @@ public class ProgramSqlGeneratorItemsTest
     @Test
     public void testConstantNotFound()
     {
-        thrown.expect( org.hisp.dhis.antlr.ParserException.class );
-        test( "C{notConstant}" );
+        assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "C{notConstant}" ) );
     }
 
     @Test
     public void testInvalidItemType()
     {
-        thrown.expect( ParserException.class );
-        test( "I{notValidItm}" );
+        assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "I{notValidItm}" ) );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -28,6 +28,20 @@ package org.hisp.dhis.program;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_SAMPLE_PERIODS;
+import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_SQL;
+import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.antlr.AntlrExprLiteral;
 import org.hisp.dhis.antlr.Parser;
@@ -45,23 +59,9 @@ import org.hisp.dhis.util.DateUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_SAMPLE_PERIODS;
-import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
-import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_SQL;
-import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 
 /**
  * @author Luciano Fiandesio
@@ -77,9 +77,6 @@ public class ProgramSqlGeneratorVariablesTest
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private Date startDate = getDate( 2018, 1, 1 );
 
@@ -305,8 +302,8 @@ public class ProgramSqlGeneratorVariablesTest
     @Test
     public void testInvalidVariable()
     {
-        thrown.expect( ParserException.class );
-        test( "V{undefined_variable}", new DefaultLiteral(), eventIndicator );
+        assertThrows( ParserException.class,
+            () -> test( "V{undefined_variable}", new DefaultLiteral(), eventIndicator ) );
     }
 
     private Object test( String expression, AntlrExprLiteral exprLiteral, ProgramIndicator programIndicator )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.query;
 
 import static org.hamcrest.core.Is.is;
 import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 
 import java.beans.PropertyDescriptor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 
 /**
@@ -107,7 +108,7 @@ public class OrderTest
     {
         object1.setValue( "Test1" );
         object2.setValue( "Test2" );
-        Assert.assertThat( orderAsc.compare( object1, object2 ), lessThan( 0 ) );
+        assertThat( orderAsc.compare( object1, object2 ), lessThan( 0 ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.query;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
@@ -28,16 +28,11 @@ package org.hisp.dhis.query;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.schema.Property;
-import org.hisp.dhis.schema.Schema;
-import org.hisp.dhis.user.User;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +40,13 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.user.User;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -54,12 +55,8 @@ public class QueryUtilsTest
 {
     private Schema schema;
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Before
     public void setUp()
-        throws Exception
     {
         schema = new Schema( Attribute.class, "attribute", "attributes" );
 
@@ -115,8 +112,8 @@ public class QueryUtilsTest
         assertNotNull( value1 );
         assertNotNull( value2 );
 
-        assertSame( 10, value1 );
-        assertSame( 100, value2 );
+        org.junit.Assert.assertSame( 10, value1 );
+        org.junit.Assert.assertSame( 100, value2 );
     }
 
     @Test( expected = QueryParserException.class )
@@ -168,13 +165,11 @@ public class QueryUtilsTest
         final Class<User> nonSupportedClass = User.class;
         final String anyValue = "wewee-4343";
 
-        // Then
-        exceptionRule.expect( QueryParserException.class );
-        exceptionRule
-                .expectMessage( "Unable to parse `" + anyValue + "` to `" + nonSupportedClass.getSimpleName() + "`." );
-
         // When
-        QueryUtils.parseValue( nonSupportedClass, anyValue );
+        final QueryParserException e = assertThrows( QueryParserException.class,
+            () -> QueryUtils.parseValue( nonSupportedClass, anyValue ) );
+        assertThat( "Unable to parse `" + anyValue + "` to `" + nonSupportedClass.getSimpleName() + "`.",
+            is( e.getMessage() ) );
     }
 
     @Test
@@ -222,7 +217,7 @@ public class QueryUtilsTest
     @Test
     public void testConvertOrderStringsNull()
     {
-        Assert.assertEquals( Collections.emptyList(), QueryUtils.convertOrderStrings( null, schema ) );
+        assertEquals( Collections.emptyList(), QueryUtils.convertOrderStrings( null, schema ) );
     }
 
     @Test
@@ -230,11 +225,11 @@ public class QueryUtilsTest
     {
         List<Order> orders = QueryUtils.convertOrderStrings( Arrays.asList( "value1:asc", "value2:asc", "value3:iasc",
             "value4:desc", "value5:idesc", "value6:xdesc", "value7" ), schema );
-        Assert.assertEquals( 5, orders.size() );
-        Assert.assertEquals( orders.get( 0 ), Order.from( "asc", schema.getProperty( "value1" ) ) );
-        Assert.assertEquals( orders.get( 1 ), Order.from( "iasc", schema.getProperty( "value3" ) ) );
-        Assert.assertEquals( orders.get( 2 ), Order.from( "desc", schema.getProperty( "value4" ) ) );
-        Assert.assertEquals( orders.get( 3 ), Order.from( "idesc", schema.getProperty( "value5" ) ) );
-        Assert.assertEquals( orders.get( 4 ), Order.from( "asc", schema.getProperty( "value7" ) ) );
+        assertEquals( 5, orders.size() );
+        assertEquals( orders.get( 0 ), Order.from( "asc", schema.getProperty( "value1" ) ) );
+        assertEquals( orders.get( 1 ), Order.from( "iasc", schema.getProperty( "value3" ) ) );
+        assertEquals( orders.get( 2 ), Order.from( "desc", schema.getProperty( "value4" ) ) );
+        assertEquals( orders.get( 3 ), Order.from( "idesc", schema.getProperty( "value5" ) ) );
+        assertEquals( orders.get( 4 ), Order.from( "asc", schema.getProperty( "value7" ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/DefaultReservedValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/DefaultReservedValueServiceTest.java
@@ -28,7 +28,19 @@ package org.hisp.dhis.reservedvalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import static java.util.Calendar.DATE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.collections4.ListUtils;
 import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -39,22 +51,10 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static java.util.Calendar.DATE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.google.common.collect.Lists;
 
 public class DefaultReservedValueServiceTest
     extends IntegrationTestBase
@@ -64,9 +64,6 @@ public class DefaultReservedValueServiceTest
 
     @Autowired
     private ReservedValueStore reservedValueStore;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     // Preset values
     private static Date future;
@@ -229,12 +226,10 @@ public class DefaultReservedValueServiceTest
 
     @Test
     public void testReserveReserveTooManySequentialValuesWhenNoneExists()
-        throws Exception
     {
-        thrown.expect( ReserveValueException.class );
-        thrown.expectMessage( "Could not reserve value: Not enough values left to reserve 101 values." );
-
-        reservedValueService.reserve( simpleSequentialTextPattern, 101, new HashMap<>(), future );
+        assertThrows( "Could not reserve value: Not enough values left to reserve 101 values.",
+            ReserveValueException.class,
+            () -> reservedValueService.reserve( simpleSequentialTextPattern, 101, new HashMap<>(), future ) );
     }
 
     @Test
@@ -244,10 +239,9 @@ public class DefaultReservedValueServiceTest
         assertEquals( 99,
             reservedValueService.reserve( simpleSequentialTextPattern, 99, new HashMap<>(), future ).size() );
 
-        thrown.expect( ReserveValueException.class );
-        thrown.expectMessage( "Could not reserve value: Not enough values left to reserve 1 values." );
-
-        reservedValueService.reserve( simpleSequentialTextPattern, 1, new HashMap<>(), future );
+        assertThrows( "Could not reserve value: Not enough values left to reserve 1 values.",
+            ReserveValueException.class,
+            () -> reservedValueService.reserve( simpleSequentialTextPattern, 1, new HashMap<>(), future ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/hibernate/HibernateSequentialNumberCounterStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/hibernate/HibernateSequentialNumberCounterStoreTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.reservedvalue.hibernate;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
@@ -28,17 +28,33 @@ package org.hisp.dhis.sms;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.outboundmessage.OutboundMessage;
 import org.hisp.dhis.outboundmessage.OutboundMessageBatch;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
-import org.hisp.dhis.sms.config.*;
+import org.hisp.dhis.sms.config.BulkSmsGatewayConfig;
+import org.hisp.dhis.sms.config.BulkSmsHttpGateway;
+import org.hisp.dhis.sms.config.GenericHttpGatewayConfig;
+import org.hisp.dhis.sms.config.SmsGateway;
+import org.hisp.dhis.sms.config.SmsGatewayConfig;
 import org.hisp.dhis.sms.outbound.GatewayResponse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -49,14 +65,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 /**
  * @author Zubair Asghar.
@@ -71,9 +79,6 @@ public class BulkSmsGatewayTest extends DhisConvenienceTest
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private RestTemplate restTemplate;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
@@ -28,10 +28,23 @@ package org.hisp.dhis.sms;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Sets;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.hisp.dhis.sms.config.ContentType;
 import org.hisp.dhis.sms.config.GenericGatewayParameter;
 import org.hisp.dhis.sms.config.GenericHttpGatewayConfig;
@@ -40,7 +53,6 @@ import org.hisp.dhis.sms.config.SmsGateway;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -55,20 +67,10 @@ import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 import org.testcontainers.shaded.org.apache.commons.lang.text.StrSubstitutor;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.net.URI;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.google.common.collect.Sets;
 
 /**
- * @Author Zubair Asghar.
+ * @author Zubair Asghar.
  */
 public class GenericSmsGatewayTest
 {
@@ -83,9 +85,6 @@ public class GenericSmsGatewayTest
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private RestTemplate restTemplate;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/textpattern/TestTextPatternParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/textpattern/TestTextPatternParser.java
@@ -28,22 +28,16 @@ package org.hisp.dhis.textpattern;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 public class TestTextPatternParser
 {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    private Class<TextPatternParser.TextPatternParsingException> ParsingException = TextPatternParser.TextPatternParsingException.class;
-
     private final String EXAMPLE_TEXT_SEGMENT = "\"Hello world!\"";
 
     private final String EXAMPLE_TEXT_SEGMENT_WITH_ESCAPED_QUOTES = "\"This is an \\\"escaped\\\" text\"";
@@ -54,60 +48,46 @@ public class TestTextPatternParser
 
     @Test
     public void testParseNullExpressionThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        TextPatternParser.parse( null );
+        assertThrows( TextPatternParser.TextPatternParsingException.class, () -> TextPatternParser.parse( null ) );
     }
 
     @Test
     public void testParseEmptyExpressionThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        TextPatternParser.parse( "" );
+        assertThrows( TextPatternParser.TextPatternParsingException.class, () -> TextPatternParser.parse( "" ) );
     }
 
     @Test
     public void testParseWhitespaceOnlyExpressionThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        TextPatternParser.parse( "   " );
+        assertThrows( TextPatternParser.TextPatternParsingException.class, () -> TextPatternParser.parse( "   " ) );
     }
 
     @Test
     public void testParseWithUnexpectedPlusThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        TextPatternParser.parse( "+" );
-
+        assertThrows( TextPatternParser.TextPatternParsingException.class, () -> TextPatternParser.parse( "+" ) );
     }
 
     @Test
     public void testParseWithInvalidInputThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        TextPatternParser.parse( "Z" );
+        assertThrows( TextPatternParser.TextPatternParsingException.class, () -> TextPatternParser.parse( "Z" ) );
 
     }
 
     @Test
     public void testParseBadTextSegment()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-
-        TextPatternParser.parse( "\"This segment has no end" );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> TextPatternParser.parse( "\"This segment has no end" ) );
     }
 
     @Test
     public void testParseTextSegment()
         throws TextPatternParser.TextPatternParsingException
     {
-
         testParseOK( EXAMPLE_TEXT_SEGMENT, TextPatternMethod.TEXT );
     }
 
@@ -115,7 +95,6 @@ public class TestTextPatternParser
     public void testParseTextWithEscapedQuotes()
         throws TextPatternParser.TextPatternParsingException
     {
-
         testParseOK( EXAMPLE_TEXT_SEGMENT_WITH_ESCAPED_QUOTES, TextPatternMethod.TEXT );
     }
 
@@ -128,26 +107,23 @@ public class TestTextPatternParser
 
     @Test
     public void testParseSequentialSegmentInvalidPatternThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        testParseOK( "SEQUENTIAL(X)", TextPatternMethod.SEQUENTIAL );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> testParseOK( "SEQUENTIAL(X)", TextPatternMethod.SEQUENTIAL ) );
     }
 
     @Test
     public void testParseSequentialSegmentWithNoEndThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        testParseOK( "SEQUENTIAL(#", TextPatternMethod.SEQUENTIAL );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> testParseOK( "SEQUENTIAL(#", TextPatternMethod.SEQUENTIAL ) );
     }
 
     @Test
     public void testParseSequentialSegmentWithNoPatternThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        testParseOK( "SEQUENTIAL()", TextPatternMethod.SEQUENTIAL );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> testParseOK( "SEQUENTIAL()", TextPatternMethod.SEQUENTIAL ) );
     }
 
     @Test
@@ -159,26 +135,23 @@ public class TestTextPatternParser
 
     @Test
     public void testParseRandomSegmentInvalidPatternThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        testParseOK( "RANDOM(S)", TextPatternMethod.RANDOM );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> testParseOK( "RANDOM(S)", TextPatternMethod.RANDOM ) );
     }
 
     @Test
     public void testParseRandomSegmentWithNoEndThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        testParseOK( "RANDOM(#", TextPatternMethod.RANDOM );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> testParseOK( "RANDOM(#", TextPatternMethod.RANDOM ) );
     }
 
     @Test
     public void testParseRandomSegmentWithNoPatternThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
-        thrown.expect( ParsingException );
-        testParseOK( "RANDOM()", TextPatternMethod.RANDOM );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> testParseOK( "RANDOM()", TextPatternMethod.RANDOM ) );
     }
 
     @Test
@@ -203,12 +176,10 @@ public class TestTextPatternParser
 
     @Test
     public void testParsePatternEndWithJoinThrowsException()
-        throws TextPatternParser.TextPatternParsingException
     {
         String pattern = "RANDOM(#) + ";
-
-        thrown.expect( ParsingException );
-        TextPatternParser.parse( pattern );
+        assertThrows( TextPatternParser.TextPatternParsingException.class,
+            () -> TextPatternParser.parse( pattern ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
@@ -28,9 +28,12 @@ package org.hisp.dhis.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -51,9 +51,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.joda.time.DateTime;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -112,9 +110,6 @@ public class TrackedEntityInstanceServiceTest
     private TrackedEntityAttribute attrE = createTrackedEntityAttribute( 'E' );
     private TrackedEntityAttribute filtF = createTrackedEntityAttribute( 'F' );
     private TrackedEntityAttribute filtG = createTrackedEntityAttribute( 'G' );
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Override
     public void setUpTest()

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
@@ -28,6 +28,20 @@ package org.hisp.dhis.trackedentity;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -44,16 +58,6 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-
 /**
  * @author Lars Helge Overland
  */
@@ -83,21 +87,31 @@ public class TrackedEntityInstanceStoreTest
     private ProgramInstanceService programInstanceService;
 
     private TrackedEntityInstance teiA;
+
     private TrackedEntityInstance teiB;
+
     private TrackedEntityInstance teiC;
+
     private TrackedEntityInstance teiD;
+
     private TrackedEntityInstance teiE;
+
     private TrackedEntityInstance teiF;
 
     private TrackedEntityAttribute atA;
+
     private TrackedEntityAttribute atB;
+
     private TrackedEntityAttribute atC;
 
     private OrganisationUnit ouA;
+
     private OrganisationUnit ouB;
+
     private OrganisationUnit ouC;
 
     private Program prA;
+
     private Program prB;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationRuleTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationRuleTest.java
@@ -28,8 +28,8 @@ package org.hisp.dhis.user;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.setting.SettingKey;
@@ -49,7 +49,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.List;
 
 /**
- * @Author Zubair Asghar.
+ * @author Zubair Asghar.
  */
 public class PasswordValidationRuleTest
 {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerTest.java
@@ -2,7 +2,7 @@ package org.hisp.dhis.dxf2;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.InvocationTargetException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -29,9 +29,18 @@ package org.hisp.dhis.dxf2.dataset;
  */
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hisp.dhis.DhisConvenienceTest.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.DhisConvenienceTest.assertIllegalQueryEx;
+import static org.hisp.dhis.DhisConvenienceTest.createCategoryCombo;
+import static org.hisp.dhis.DhisConvenienceTest.createCategoryOption;
+import static org.hisp.dhis.DhisConvenienceTest.createCategoryOptionCombo;
+import static org.hisp.dhis.DhisConvenienceTest.createDataSet;
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.hisp.dhis.DhisConvenienceTest.createPeriod;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
@@ -40,7 +49,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.cache.DefaultCacheProvider;
 import org.hisp.dhis.category.CategoryCombo;
@@ -49,6 +57,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.dataset.CompleteDataSetRegistration;
@@ -82,7 +91,6 @@ import org.hisp.quick.BatchHandlerFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -185,9 +193,6 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     private CategoryOptionCombo DEFAULT_COC;
 
     @Before
@@ -196,7 +201,6 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
         user = new User();
 
         when( environment.getActiveProfiles() ).thenReturn( new String[] { "test" } );
-        when( currentUserService.getCurrentUser() ).thenReturn( user );
         CacheProvider cacheProvider = new DefaultCacheProvider();
 
         InputUtils inputUtils = new InputUtils( categoryService, idObjManager, environment, cacheProvider );
@@ -211,36 +215,6 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
             messageService, JacksonObjectMapperConfig.staticJsonMapper() );
 
         DEFAULT_COC = new CategoryOptionCombo();
-
-        when( notifier.clear( null ) ).thenReturn( notifier );
-        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS ) ).thenReturn( false );
-        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS ) )
-            .thenReturn( false );
-        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS ) )
-            .thenReturn( false );
-        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO ) )
-            .thenReturn( false );
-
-        when( currentUserService.getCurrentUserOrganisationUnits() )
-            .thenReturn( Collections.singleton( createOrganisationUnit( 'A' ) ) );
-        when( i18nManager.getI18n() ).thenReturn( i18n );
-
-        when( categoryService.getDefaultCategoryOptionCombo() ).thenReturn( DEFAULT_COC );
-        when( batchHandlerFactory.createBatchHandler( CompleteDataSetRegistrationBatchHandler.class ) )
-            .thenReturn( batchHandler );
-        when( batchHandler.init() ).thenReturn( batchHandler );
-
-        // caches
-        when( metaDataCaches.getDataSets() ).thenReturn( datasetCache );
-        when( metaDataCaches.getPeriods() ).thenReturn( periodCache );
-        when( metaDataCaches.getOrgUnits() ).thenReturn( orgUnitCache );
-        aocCache = new CachingMap<>();
-        when( metaDataCaches.getAttrOptionCombos() ).thenReturn( aocCache );
-        when( metaDataCaches.getOrgUnitInHierarchyMap() ).thenReturn( orgUnitInHierarchyCache );
-        when( metaDataCaches.getAttrOptComboOrgUnitMap() ).thenReturn( attrOptComboOrgUnitCache );
-
-        //
-        when( notifier.notify( null, NotificationLevel.INFO, "Import done", true ) ).thenReturn( notifier );
     }
 
     @Test
@@ -256,10 +230,12 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
             categoryOptionB );
         Period period = createPeriod( "201907" );
 
-        String payload = createPayload( period, organisationUnit, dataSetA, categoryCombo, categoryOptionA, categoryOptionB );
+        String payload = createPayload( period, organisationUnit, dataSetA, categoryCombo, categoryOptionA,
+            categoryOptionB );
 
         whenNew( MetadataCaches.class ).withNoArguments().thenReturn( metaDataCaches );
-
+        when( currentUserService.getCurrentUser() ).thenReturn( user );
+        when( batchHandler.init() ).thenReturn( batchHandler );
         when( idObjManager.get( CategoryCombo.class, categoryCombo.getUid() ) ).thenReturn( categoryCombo );
         when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionA.getUid() ) )
             .thenReturn( categoryOptionA );
@@ -284,6 +260,35 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
         when( aclService.canDataWrite( user, categoryOptionA ) ).thenReturn( false );
         when( aclService.canDataWrite( user, categoryOptionB ) ).thenReturn( true );
 
+        when( notifier.clear( null ) ).thenReturn( notifier );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS ) ).thenReturn( false );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS ) )
+            .thenReturn( false );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS ) )
+            .thenReturn( false );
+        when( systemSettingManager.getSystemSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO ) )
+            .thenReturn( false );
+
+        when( currentUserService.getCurrentUserOrganisationUnits() )
+            .thenReturn( Collections.singleton( createOrganisationUnit( 'A' ) ) );
+        when( i18nManager.getI18n() ).thenReturn( i18n );
+
+        when( categoryService.getDefaultCategoryOptionCombo() ).thenReturn( DEFAULT_COC );
+        when( batchHandlerFactory.createBatchHandler( CompleteDataSetRegistrationBatchHandler.class ) )
+            .thenReturn( batchHandler );
+
+        // caches
+        when( metaDataCaches.getDataSets() ).thenReturn( datasetCache );
+        when( metaDataCaches.getPeriods() ).thenReturn( periodCache );
+        when( metaDataCaches.getOrgUnits() ).thenReturn( orgUnitCache );
+        aocCache = new CachingMap<>();
+        when( metaDataCaches.getAttrOptionCombos() ).thenReturn( aocCache );
+        when( metaDataCaches.getOrgUnitInHierarchyMap() ).thenReturn( orgUnitInHierarchyCache );
+        when( metaDataCaches.getAttrOptComboOrgUnitMap() ).thenReturn( attrOptComboOrgUnitCache );
+
+
+        when( notifier.notify( null, NotificationLevel.INFO, "Import done", true ) ).thenReturn( notifier );
+
         // call method under test
         ImportSummary summary = subject.saveCompleteDataSetRegistrationsJson(
             new ByteArrayInputStream( payload.getBytes() ), new ImportOptions() );
@@ -298,20 +303,21 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
     @Test
     public void testValidateAssertMissingDataSet()
     {
-        DhisConvenienceTest.assertIllegalQueryEx( exception, ErrorCode.E2013 );
-
         ExportParams params = new ExportParams()
             .setOrganisationUnits( Sets.newHashSet( new OrganisationUnit() ) )
             .setPeriods( Sets.newHashSet( new Period() ) );
 
-        subject.validate( params );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> subject.validate( params ) ),
+            ErrorCode.E2013 );
     }
 
     private String createPayload( Period period, OrganisationUnit organisationUnit, DataSet dataSet,
         CategoryCombo categoryCombo, CategoryOption... categoryOptions )
     {
         return "{\"completeDataSetRegistrations\":[{\"cc\":\"" + categoryCombo.getUid() + "\","
-            + "\"cp\":\"" + Arrays.stream( categoryOptions ).map( CategoryOption::getUid ).collect( Collectors.joining( ";" ) )
+            + "\"cp\":\""
+            + Arrays.stream( categoryOptions ).map( CategoryOption::getUid ).collect( Collectors.joining( ";" ) )
             + "\"," + "\"dataSet\":\"" + dataSet.getUid() + "\"," + "\"period\":\"" + period.getIsoDate() + "\","
             + "\"organisationUnit\":\"" + organisationUnit.getUid() + "\"," + "\"completed\":true}]}";
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceExportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceExportTest.java
@@ -1,3 +1,5 @@
+package org.hisp.dhis.dxf2.datavalueset;
+
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -26,10 +28,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.dxf2.datavalueset;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -46,6 +48,7 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
@@ -64,14 +67,11 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
-
 
 /**
  * @author Lars Helge Overland
@@ -105,9 +105,6 @@ public class DataValueSetServiceExportTest
 
     @Autowired
     private ObjectMapper jsonMapper;
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     private DataElement deA;
     private DataElement deB;
@@ -461,36 +458,34 @@ public class DataValueSetServiceExportTest
     @Test
     public void testMissingDataSetElementGroup()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2001 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
             .setOrganisationUnits( Sets.newHashSet( ouB ) )
             .setPeriods( Sets.newHashSet( peA ) );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2001 );
     }
 
     @Test
     public void testMissingPeriodStartEndDate()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2002 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
             .setDataSets( Sets.newHashSet( dsA ) )
             .setOrganisationUnits( Sets.newHashSet( ouA ) );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2002 );
     }
 
     @Test
     public void testPeriodAndStartEndDate()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2003 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
@@ -500,13 +495,14 @@ public class DataValueSetServiceExportTest
             .setStartDate( getDate( 2019, 1, 1 ) )
             .setEndDate( getDate( 2019, 1, 31 ) );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2003 );
     }
 
     @Test
     public void testStartDateAfterEndDate()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2004 );
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -516,28 +512,28 @@ public class DataValueSetServiceExportTest
             .setStartDate( getDate( 2019, 3, 1 ) )
             .setEndDate( getDate( 2019, 1, 31 ) );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2004 );
     }
 
     @Test
     public void testMissingOrgUnit()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2006 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
             .setDataSets( Sets.newHashSet( dsA ) )
             .setPeriods( Sets.newHashSet( peA ) );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2006 );
     }
 
     @Test
     public void testAtLestOneOrgUnitWithChildren()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2008 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
@@ -546,14 +542,14 @@ public class DataValueSetServiceExportTest
             .setOrganisationUnitGroups( Sets.newHashSet( ogA ) )
             .setIncludeChildren( true );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2008 );
     }
 
     @Test
     public void testLimitLimitNotLessThanZero()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2009 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
@@ -562,14 +558,14 @@ public class DataValueSetServiceExportTest
             .setOrganisationUnits( Sets.newHashSet( ouB ) )
             .setLimit( -2 );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2009 );
     }
 
     @Test
     public void testAccessOutsideOrgUnitHierarchy()
     {
-        assertIllegalQueryEx( exception, ErrorCode.E2012 );
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         DataExportParams params = new DataExportParams()
@@ -577,7 +573,9 @@ public class DataValueSetServiceExportTest
             .setOrganisationUnits( Sets.newHashSet( ouC ) )
             .setPeriods( Sets.newHashSet( peA ) );
 
-        dataValueSetService.writeDataValueSetJson( params, out );
+        assertIllegalQueryEx(
+            assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),
+            ErrorCode.E2012 );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -32,7 +32,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Calendar;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/RegistrationMultiEventsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/RegistrationMultiEventsServiceTest.java
@@ -28,7 +28,11 @@ package org.hisp.dhis.dxf2.events;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -55,7 +59,11 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageDataElement;
+import org.hisp.dhis.program.ProgramStageDataElementService;
+import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.UserService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/RegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/RegistrationSingleEventServiceTest.java
@@ -62,7 +62,7 @@ import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -48,7 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/ImportStrategyAccumulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/ImportStrategyAccumulatorTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.dxf2.events.importer;
  */
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.hisp.dhis.dxf2.events.importer.context.AttributeOptionComboLoader.SQL_GET_CATEGORYOPTIONCOMBO;
 import static org.hisp.dhis.dxf2.events.importer.context.AttributeOptionComboLoader.SQL_GET_CATEGORYOPTIONCOMBO_BY_CATEGORYIDS;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -51,7 +52,6 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -73,9 +73,6 @@ public class AttributeOptionComboLoaderTest
 
     @Captor
     private ArgumentCaptor<String> sqlCaptor;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private AttributeOptionComboLoader subject;
 
@@ -114,18 +111,17 @@ public class AttributeOptionComboLoaderTest
     @Test
     public void verifyGetAttributeOptionComboWithNullCategoryCombo()
     {
-        thrown.expect( IllegalQueryException.class );
-        thrown.expectMessage( "Illegal category combo" );
-        subject.getAttributeOptionCombo( null, "", "", IdScheme.UID );
+        assertThrows( "Illegal category combo", IllegalQueryException.class,
+            () -> subject.getAttributeOptionCombo( null, "", "", IdScheme.UID ) );
     }
 
     @Test
     public void verifyGetAttributeOptionComboWithNonExistingCategoryOption()
     {
-        thrown.expect( IllegalQueryException.class );
-        thrown.expectMessage( "Illegal category option identifier: abcdef" );
         CategoryCombo cc = new CategoryCombo();
-        subject.getAttributeOptionCombo( cc, "abcdef", "", IdScheme.UID );
+
+        assertThrows( "Illegal category option identifier: abcdef", IllegalQueryException.class,
+            () -> subject.getAttributeOptionCombo( cc, "abcdef", "", IdScheme.UID ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/CategoryOptionComboSupplierTest.java
@@ -29,9 +29,9 @@ package org.hisp.dhis.dxf2.events.importer.context;
  */
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -48,6 +48,7 @@ import org.hisp.dhis.program.Program;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/EventDataValueAggregatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/EventDataValueAggregatorTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
 import static org.hamcrest.Matchers.*;
 import static org.hisp.dhis.dxf2.events.importer.EventTestUtils.createDataValue;
 import static org.hisp.dhis.dxf2.events.importer.EventTestUtils.createEventDataValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/OrganisationUnitSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/OrganisationUnitSupplierTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramInstanceSupplierTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramStageInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramStageInstanceSupplierTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierAclIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierAclIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hisp.dhis.dxf2.common.ImportOptions.getDefaultImportOptions;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
  */
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/TrackedEntityInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/TrackedEntityInstanceSupplierTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/EventGeometryPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/EventGeometryPreProcessorTest.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.dxf2.events.importer.insert.preprocess;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/ImportOptionsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/ImportOptionsPreProcessorTest.java
@@ -1,13 +1,13 @@
 package org.hisp.dhis.dxf2.events.importer.shared.preprocess;
 
+import static org.junit.Assert.assertThrows;
+
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.UnrecoverableImportException;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
-import org.hisp.dhis.dxf2.events.importer.shared.preprocess.ImportOptionsPreProcessor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -45,9 +45,6 @@ import org.mockito.junit.MockitoRule;
 public class ImportOptionsPreProcessorTest
 {
     @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
     private ImportOptionsPreProcessor subject;
@@ -61,10 +58,9 @@ public class ImportOptionsPreProcessorTest
     @Test
     public void verifyExceptionIsThrownOnMissingImportOptions()
     {
-        thrown.expect( UnrecoverableImportException.class );
-
         WorkContext wc = WorkContext.builder().build();
-        subject.process( new Event(), wc );
+        
+        assertThrows( UnrecoverableImportException.class, () -> subject.process( new Event(), wc ) );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/validation/BaseValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/validation/BaseValidationTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.dxf2.events.importer.validation;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hisp.dhis.dxf2.events.importer.EventTestUtils.createBaseEvent;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContextTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContextTest.java
@@ -28,20 +28,24 @@ package org.hisp.dhis.dxf2.metadata.jobs;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.feedback.Status;
-import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
+import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.retry.RetryContext;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 /**
  * @author aamerm
@@ -49,6 +53,9 @@ import static org.mockito.Mockito.*;
 public class MetadataRetryContextTest
     extends DhisSpringTest
 {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     @Mock
     RetryContext retryContext;
 
@@ -60,21 +67,19 @@ public class MetadataRetryContextTest
     private String testMessage = "testMessage";
 
     @Before
-    public void setUp() throws Exception
+    public void setUp()
     {
-        MockitoAnnotations.initMocks( this );
-
         mockVersion = mock( MetadataVersion.class );
     }
 
     @Test
-    public void testShouldGetRetryContextCorrectly() throws Exception
+    public void testShouldGetRetryContextCorrectly()
     {
         assertEquals( retryContext, metadataRetryContext.getRetryContext() );
     }
 
     @Test
-    public void testShouldSetRetryContextCorrectly() throws Exception
+    public void testShouldSetRetryContextCorrectly()
     {
         RetryContext newMock = mock( RetryContext.class );
 
@@ -84,7 +89,7 @@ public class MetadataRetryContextTest
     }
 
     @Test
-    public void testIfVersionIsNull() throws Exception
+    public void testIfVersionIsNull()
     {
         metadataRetryContext.updateRetryContext( testKey, testMessage, null );
 
@@ -93,7 +98,7 @@ public class MetadataRetryContextTest
     }
 
     @Test
-    public void testIfVersionIsNotNull() throws Exception
+    public void testIfVersionIsNotNull()
     {
         metadataRetryContext.updateRetryContext( testKey, testMessage, mockVersion );
 
@@ -102,7 +107,7 @@ public class MetadataRetryContextTest
     }
 
     @Test
-    public void testIfSummaryIsNull() throws Exception
+    public void testIfSummaryIsNull()
     {
         MetadataSyncSummary metadataSyncSummary = mock( MetadataSyncSummary.class );
 
@@ -114,7 +119,7 @@ public class MetadataRetryContextTest
     }
 
     @Test
-    public void testIfSummaryIsNotNull() throws Exception
+    public void testIfSummaryIsNotNull()
     {
         MetadataSyncSummary testSummary = new MetadataSyncSummary();
         ImportReport importReport = new ImportReport();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -28,6 +28,18 @@ package org.hisp.dhis.dxf2.metadata.jobs;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPostProcessor;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPreProcessor;
@@ -42,26 +54,16 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.retry.support.RetryTemplate;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
 
 /**
  * @author aamerm
  */
 public class MetadataSyncJobParametersTest
 {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
     private SystemSettingManager systemSettingManager;
 
@@ -97,8 +99,6 @@ public class MetadataSyncJobParametersTest
     @Before
     public void setUp()
     {
-        MockitoAnnotations.initMocks( this );
-
         metadataSyncSummary = mock( MetadataSyncSummary.class );
         metadataVersion = mock( MetadataVersion.class );
         metadataVersions = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
@@ -30,7 +30,13 @@ package org.hisp.dhis.dxf2.metadata.sync;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,7 +54,6 @@ import org.hisp.dhis.metadata.version.VersionType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
@@ -77,9 +82,6 @@ public class DefaultMetadataSyncServiceTest
     private Map<String, List<String>> parameters;
 
     @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Before
@@ -95,20 +97,17 @@ public class DefaultMetadataSyncServiceTest
     public void testShouldThrowExceptionWhenVersionNameNotPresentInParameters()
         throws MetadataSyncServiceException
     {
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "Missing required parameter: 'versionName'" );
-
-        metadataSyncService.getParamsFromMap( parameters );
+        assertThrows( "Missing required parameter: 'versionName'", MetadataSyncServiceException.class,
+            () -> metadataSyncService.getParamsFromMap( parameters ) );
     }
 
     @Test
     public void testShouldThrowExceptionWhenParametersAreNull()
         throws MetadataSyncServiceException
     {
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "Missing required parameter: 'versionName'" );
+        assertThrows( "Missing required parameter: 'versionName'", MetadataSyncServiceException.class,
+            () -> metadataSyncService.getParamsFromMap( null ) );
 
-        metadataSyncService.getParamsFromMap( null );
     }
 
     @Test
@@ -117,10 +116,8 @@ public class DefaultMetadataSyncServiceTest
     {
         parameters.put( "versionName", null );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "Missing required parameter: 'versionName'" );
-
-        metadataSyncService.getParamsFromMap( parameters );
+        assertThrows( "Missing required parameter: 'versionName'", MetadataSyncServiceException.class,
+            () -> metadataSyncService.getParamsFromMap( parameters ) );
     }
 
     @Test
@@ -129,10 +126,8 @@ public class DefaultMetadataSyncServiceTest
     {
         parameters.put( "versionName", new ArrayList<>() );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "Missing required parameter: 'versionName'" );
-
-        metadataSyncService.getParamsFromMap( parameters );
+        assertThrows( "Missing required parameter: 'versionName'", MetadataSyncServiceException.class,
+            () -> metadataSyncService.getParamsFromMap( parameters ) );
     }
 
     @Test
@@ -165,11 +160,11 @@ public class DefaultMetadataSyncServiceTest
 
         when( metadataVersionDelegate.getRemoteMetadataVersion( "testVersion" ) ).thenReturn( null );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage(
-            "The MetadataVersion could not be fetched from the remote server for the versionName: testVersion" );
+        assertThrows(
+            "The MetadataVersion could not be fetched from the remote server for the versionName: testVersion",
+            MetadataSyncServiceException.class,
+            () -> metadataSyncService.getParamsFromMap( parameters ) );
 
-        metadataSyncService.getParamsFromMap( parameters );
     }
 
     @Test
@@ -187,31 +182,27 @@ public class DefaultMetadataSyncServiceTest
 
     @Test
     public void testShouldThrowExceptionWhenSyncParamsIsNull()
-        throws DhisVersionMismatchException
     {
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "MetadataSyncParams cant be null" );
-
-        metadataSyncService.doMetadataSync( null );
+        assertThrows(
+            "MetadataSyncParams cant be null",
+            MetadataSyncServiceException.class,
+            () -> metadataSyncService.doMetadataSync( null ) );
     }
 
     @Test
     public void testShouldThrowExceptionWhenVersionIsNulInSyncParams()
-        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = new MetadataSyncParams();
         syncParams.setVersion( null );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException
-            .expectMessage( "MetadataVersion for the Sync cant be null. The ClassListMap could not be constructed." );
-
-        metadataSyncService.doMetadataSync( syncParams );
+        assertThrows(
+            "MetadataVersion for the Sync cant be null. The ClassListMap could not be constructed.",
+            MetadataSyncServiceException.class,
+            () -> metadataSyncService.doMetadataSync( syncParams ) );
     }
 
     @Test
     public void testShouldThrowExceptionWhenSnapshotReturnsNullForGivenVersion()
-        throws DhisVersionMismatchException
     {
 
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
@@ -220,15 +211,15 @@ public class DefaultMetadataSyncServiceTest
         when( syncParams.getVersion() ).thenReturn( metadataVersion );
         when( metadataVersionDelegate.downloadMetadataVersionSnapshot( metadataVersion ) ).thenReturn( null );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "Metadata snapshot can't be null." );
+        assertThrows(
+            "Metadata snapshot can't be null.",
+            MetadataSyncServiceException.class,
+            () -> metadataSyncService.doMetadataSync( syncParams ) );
 
-        metadataSyncService.doMetadataSync( syncParams );
     }
 
     @Test
     public void testShouldThrowExceptionWhenDHISVersionsMismatch()
-        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
@@ -241,11 +232,10 @@ public class DefaultMetadataSyncServiceTest
         when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) )
             .thenReturn( true );
 
-        expectedException.expect( DhisVersionMismatchException.class );
-        expectedException
-            .expectMessage( "Metadata sync failed because your version of DHIS does not match the master version" );
-
-        metadataSyncService.doMetadataSync( syncParams );
+        assertThrows(
+            "Metadata sync failed because your version of DHIS does not match the master version",
+            DhisVersionMismatchException.class,
+            () -> metadataSyncService.doMetadataSync( syncParams ) );
     }
 
     @Test
@@ -268,7 +258,6 @@ public class DefaultMetadataSyncServiceTest
 
     @Test
     public void testShouldThrowExceptionWhenSnapshotNotPassingIntegrity()
-        throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
@@ -280,10 +269,10 @@ public class DefaultMetadataSyncServiceTest
         when( metadataVersionService.isMetadataPassingIntegrity( metadataVersion, expectedMetadataSnapshot ) )
             .thenReturn( false );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "Metadata snapshot is corrupted." );
-
-        metadataSyncService.doMetadataSync( syncParams );
+        assertThrows(
+            "Metadata snapshot is corrupted.",
+            MetadataSyncServiceException.class,
+            () -> metadataSyncService.doMetadataSync( syncParams ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
@@ -28,8 +28,15 @@ package org.hisp.dhis.dxf2.metadata.sync;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
 import org.hisp.dhis.dxf2.metadata.systemsettings.DefaultMetadataSystemSettingService;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
@@ -39,7 +46,6 @@ import org.hisp.dhis.system.util.HttpUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -50,11 +56,8 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author aamerm
@@ -64,9 +67,6 @@ import static org.mockito.Mockito.*;
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*","org.w3c.*"})
 public class MetadataSyncDelegateTest
 {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -100,7 +100,7 @@ public class MetadataSyncDelegateTest
     }
 
     @Test
-    public void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInRemote() throws IOException
+    public void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInRemote()
     {
         String versionSnapshot = "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         SystemInfo systemInfo = new SystemInfo();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
@@ -29,7 +29,13 @@ package org.hisp.dhis.dxf2.metadata.sync;
  */
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,7 +54,6 @@ import org.hisp.dhis.render.RenderService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -59,9 +64,6 @@ import org.mockito.junit.MockitoRule;
  */
 public class MetadataSyncImportHandlerTest
 {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
     MetadataImportService metadataImportService;
 
@@ -98,9 +100,8 @@ public class MetadataSyncImportHandlerTest
     public void testShouldThrowExceptionWhenNoVersionSet()
     {
         syncParams.setImportParams( null );
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "MetadataVersion for the Sync cant be null." );
-        metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot );
+        assertThrows( "MetadataImportParams for the Sync cant be null.", MetadataSyncServiceException.class,
+            () -> metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) );
     }
 
     @Test
@@ -109,10 +110,8 @@ public class MetadataSyncImportHandlerTest
         syncParams.setVersion( metadataVersion );
         syncParams.setImportParams( null );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "MetadataImportParams for the Sync cant be null." );
-
-        metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot );
+        assertThrows( "MetadataImportParams for the Sync cant be null.", MetadataSyncServiceException.class,
+            () -> metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) );
     }
 
     @Test
@@ -123,8 +122,8 @@ public class MetadataSyncImportHandlerTest
 
         when( metadataImportService.importMetadata( syncParams.getImportParams() ) )
             .thenThrow( new MetadataSyncServiceException( "" ) );
-        expectedException.expect( MetadataSyncImportException.class );
-        metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot );
+        assertThrows( MetadataSyncImportException.class,
+            () -> metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) );
         verify( metadataVersionDelegate, never() ).addNewMetadataVersion( metadataVersion );
     }
 
@@ -193,12 +192,9 @@ public class MetadataSyncImportHandlerTest
 
         when( renderService.fromMetadata( any( InputStream.class ), eq( RenderFormat.JSON ) ) ).thenReturn( null );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException.expectMessage( "ClassListMap can't be null" );
+        assertThrows( "ClassListMap can't be null", MetadataSyncServiceException.class,
+            () -> metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) );
 
-        metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot );
-
-        verify( renderService ).fromMetadata( any( InputStream.class ), RenderFormat.JSON );
         verify( metadataImportService, never() ).importMetadata( syncParams.getImportParams() );
         verify( metadataVersionDelegate, never() ).addNewMetadataVersion( metadataVersion );
         verify( metadataVersionDelegate, never() ).addNewMetadataVersion( metadataVersion );
@@ -215,13 +211,10 @@ public class MetadataSyncImportHandlerTest
         when( renderService.fromMetadata( any( InputStream.class ), eq( RenderFormat.JSON ) ) )
             .thenThrow( new IOException() );
 
-        expectedException.expect( MetadataSyncServiceException.class );
-        expectedException
-            .expectMessage( "Exception occurred while trying to do JSON conversion while parsing class list map" );
+        assertThrows( "Exception occurred while trying to do JSON conversion while parsing class list map",
+            MetadataSyncServiceException.class,
+            () -> metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot ) );
 
-        metadataSyncImportHandler.importMetadata( syncParams, expectedMetadataSnapshot );
-
-        verify( renderService ).fromMetadata( any( InputStream.class ), RenderFormat.JSON );
         verify( metadataImportService, never() ).importMetadata( syncParams.getImportParams() );
         verify( metadataVersionDelegate, never() ).addNewMetadataVersion( metadataVersion );
         verify( metadataVersionDelegate, never() ).addNewMetadataVersion( metadataVersion );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessorTest.java
@@ -28,6 +28,18 @@ package org.hisp.dhis.dxf2.metadata.sync;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import org.hisp.dhis.IntegrationTest;
 import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
@@ -45,25 +57,10 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
 
 /**
  * @author aamerm
@@ -73,36 +70,22 @@ import static org.mockito.Mockito.*;
 public class MetadataSyncPreProcessorTest
     extends IntegrationTestBase
 {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Autowired
-    @Mock
     private SynchronizationManager synchronizationManager;
 
     @Autowired
-    @Mock
     private SystemSettingManager systemSettingManager;
 
-    @InjectMocks
     @Autowired
     private MetadataSyncPreProcessor metadataSyncPreProcessor;
 
     @Autowired
-    @Mock
     private MetadataVersionService metadataVersionService;
 
     @Autowired
-    @Mock
     private MetadataVersionDelegate metadataVersionDelegate;
 
     private final MetadataSyncJobParameters metadataSyncJobParameters = new MetadataSyncJobParameters();
-
-    @Before
-    public void setup()
-    {
-        MockitoAnnotations.initMocks( this );
-    }
 
     // TODO: Do not assert for methods to be executed. Assert for the result not on how it happens.
 
@@ -118,7 +101,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test( expected = MetadataSyncServiceException.class )
-    public void testhandleAggregateDataPushShouldThrowExceptionWhenDataPushIsUnsuccessful() throws Exception
+    public void testhandleAggregateDataPushShouldThrowExceptionWhenDataPushIsUnsuccessful()
     {
         MetadataRetryContext mockRetryContext = mock( MetadataRetryContext.class );
         ImportSummary expectedSummary = new ImportSummary();
@@ -133,7 +116,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test
-    public void testhandleAggregateDataPushShouldNotThrowExceptionWhenDataPushIsSuccessful() throws Exception
+    public void testhandleAggregateDataPushShouldNotThrowExceptionWhenDataPushIsSuccessful()
     {
         MetadataRetryContext mockRetryContext = mock( MetadataRetryContext.class );
         ImportSummary expectedSummary = new ImportSummary();
@@ -147,7 +130,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test
-    public void testHandleMetadataVersionsListShouldReturnDifferenceOfVersionsFromBaselineVersion() throws Exception
+    public void testHandleMetadataVersionsListShouldReturnDifferenceOfVersionsFromBaselineVersion()
     {
         MetadataRetryContext mockRetryContext = mock( MetadataRetryContext.class );
 
@@ -172,7 +155,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test
-    public void testHandleMetadataVersionsListShouldReturnNullIfInstanceDoesNotHaveAnyVersions() throws Exception
+    public void testHandleMetadataVersionsListShouldReturnNullIfInstanceDoesNotHaveAnyVersions()
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
@@ -184,13 +167,14 @@ public class MetadataSyncPreProcessorTest
         currentVersion.setCreated( new Date() );
         currentVersion.setHashCode( "samplehashcode" );
 
-        when( metadataVersionDelegate.getMetaDataDifference( currentVersion ) ).thenReturn( new ArrayList<MetadataVersion>() );
-        List<MetadataVersion> expectedListOfVersions = metadataSyncPreProcessor.handleMetadataVersionsList( mockRetryContext, currentVersion );
-        assertTrue( expectedListOfVersions.size() == 0 );
+        when( metadataVersionDelegate.getMetaDataDifference( currentVersion ) ).thenReturn( new ArrayList<>() );
+        List<MetadataVersion> expectedListOfVersions = metadataSyncPreProcessor
+            .handleMetadataVersionsList( mockRetryContext, currentVersion );
+        assertEquals( 0, expectedListOfVersions.size() );
     }
 
     @Test
-    public void testHandleMetadataVersionsListShouldReturnEmptyListIfInstanceIsAlreadyOnLatestVersion() throws Exception
+    public void testHandleMetadataVersionsListShouldReturnEmptyListIfInstanceIsAlreadyOnLatestVersion()
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
@@ -209,7 +193,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test( expected = MetadataSyncServiceException.class )
-    public void testHandleMetadataVersionsListShouldThrowExceptionIfAnyIssueWithMetadataDifference() throws Exception
+    public void testHandleMetadataVersionsListShouldThrowExceptionIfAnyIssueWithMetadataDifference()
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
@@ -228,7 +212,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test
-    public void testHandleCurrentMetadataVersionShouldReturnCurrentVersionOfSystem() throws Exception
+    public void testHandleCurrentMetadataVersionShouldReturnCurrentVersionOfSystem()
     {
         MetadataRetryContext mockRetryContext = mock( MetadataRetryContext.class );
         MetadataVersion currentVersion = new MetadataVersion();
@@ -243,7 +227,7 @@ public class MetadataSyncPreProcessorTest
     }
 
     @Test
-    public void testShouldGetLatestMetadataVersionForTheGivenVersionList() throws ParseException
+    public void testShouldGetLatestMetadataVersionForTheGivenVersionList()
     {
         MetadataRetryContext mockRetryContext = mock( MetadataRetryContext.class );
         DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern( "yyyy-MM-dd HH:mm:ssZ" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSystemSettingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSystemSettingServiceTest.java
@@ -28,16 +28,18 @@ package org.hisp.dhis.dxf2.metadata.sync;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dxf2.metadata.systemsettings.DefaultMetadataSystemSettingService;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author anilkumk
@@ -52,11 +54,12 @@ public class MetadataSystemSettingServiceTest
     @Autowired
     DefaultMetadataSystemSettingService metadataSystemSettingService;
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     @Before
     public void setup()
     {
-        MockitoAnnotations.initMocks( this );
-
         systemSettingManager.saveSystemSetting( SettingKey.REMOTE_INSTANCE_URL, "http://localhost:9080" );
         systemSettingManager.saveSystemSetting( SettingKey.REMOTE_INSTANCE_USERNAME, "username" );
         systemSettingManager.saveSystemSetting( SettingKey.REMOTE_INSTANCE_PASSWORD, "password" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -28,6 +28,15 @@ package org.hisp.dhis.dxf2.metadata.version;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.List;
+
 import org.apache.commons.lang.time.DateUtils;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -39,18 +48,11 @@ import org.hisp.dhis.keyjsonvalue.MetadataKeyJsonService;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.security.NoSuchAlgorithmException;
-import java.util.Date;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author sultanm
@@ -69,6 +71,9 @@ public class DefaultMetadataVersionServiceTest
 
     @Autowired
     private MetadataSystemSettingService metadataSystemSettingService;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     private MetadataVersion versionA;
     private MetadataVersion versionB;
@@ -94,7 +99,6 @@ public class DefaultMetadataVersionServiceTest
     @Override
     protected void setUpTest()
     {
-        MockitoAnnotations.initMocks( this );
         versionA = new MetadataVersion( "Version_1", VersionType.ATOMIC );
         versionA.setHashCode( "12345" );
         versionB = new MetadataVersion( "Version_2", VersionType.BEST_EFFORT );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/sync/SyncUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/sync/SyncUtilsTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author David Katuscak <katuscak.d@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -64,6 +64,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Unit tests for {@link DefaultFieldFilterService}.
  *
@@ -150,7 +152,7 @@ public class DefaultFieldFilterServiceTest
         Assert.assertEquals( "id", simpleNode.getName() );
         ouIds.add( String.valueOf( simpleNode.getValue() ) );
 
-        Assert.assertThat( ouIds, Matchers.containsInAnyOrder( "abc1", "abc2" ) );
+        assertThat( ouIds, Matchers.containsInAnyOrder( "abc1", "abc2" ) );
     }
 
     @Test
@@ -191,7 +193,7 @@ public class DefaultFieldFilterServiceTest
         Assert.assertEquals( "name", simpleNode.getName() );
         ouIds.add( String.valueOf( simpleNode.getValue() ) );
 
-        Assert.assertThat( ouIds, Matchers.containsInAnyOrder( "OU 1", "OU 2" ) );
+        assertThat( ouIds, Matchers.containsInAnyOrder( "OU 1", "OU 2" ) );
     }
 
     @Test
@@ -245,7 +247,7 @@ public class DefaultFieldFilterServiceTest
         Assert.assertEquals( "id", simpleNode.getName() );
         coIds.add( String.valueOf( simpleNode.getValue() ) );
 
-        Assert.assertThat( coIds, Matchers.containsInAnyOrder( "abc1", "abc3" ) );
+        assertThat( coIds, Matchers.containsInAnyOrder( "abc1", "abc3" ) );
     }
 
     @Test
@@ -303,8 +305,8 @@ public class DefaultFieldFilterServiceTest
         Assert.assertEquals( "name", simpleNode.getName() );
         ouNames.add( String.valueOf( simpleNode.getValue() ) );
 
-        Assert.assertThat( ouIds, Matchers.containsInAnyOrder( "abc1", "abc2" ) );
-        Assert.assertThat( ouNames, Matchers.containsInAnyOrder( "Test 1", "Test 2" ) );
+        assertThat( ouIds, Matchers.containsInAnyOrder( "abc1", "abc2" ) );
+        assertThat( ouNames, Matchers.containsInAnyOrder( "Test 1", "Test 2" ) );
     }
 
     private Node getNamedNode( @Nonnull Collection<? extends Node> nodes, @Nonnull String name )

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/CollectionNodeTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/types/CollectionNodeTest.java
@@ -32,6 +32,9 @@ import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
 /**
  * Unit tests for {@link CollectionNodeTest}.
  *
@@ -43,16 +46,16 @@ public class CollectionNodeTest
     public void createEmpty()
     {
         final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
-        Assert.assertEquals( "tests", collectionNode.getName() );
-        Assert.assertEquals( 0, collectionNode.getUnorderedChildren().size() );
+        assertEquals( "tests", collectionNode.getName() );
+        assertEquals( 0, collectionNode.getUnorderedChildren().size() );
     }
 
     @Test
     public void createNonEmpty()
     {
         final CollectionNode collectionNode = new CollectionNode( "tests", 10 );
-        Assert.assertEquals( "tests", collectionNode.getName() );
-        Assert.assertEquals( 0, collectionNode.getUnorderedChildren().size() );
+        assertEquals( "tests", collectionNode.getName() );
+        assertEquals( 0, collectionNode.getUnorderedChildren().size() );
     }
 
     @Test
@@ -89,14 +92,14 @@ public class CollectionNodeTest
         collectionNode.addChild( simpleNode2 );
         collectionNode.addChild( simpleNode3 );
 
-        Assert.assertThat( collectionNode.getChildren(), Matchers.contains( simpleNode2, simpleNode1, simpleNode3 ) );
+        assertThat( collectionNode.getChildren(), Matchers.contains( simpleNode2, simpleNode1, simpleNode3 ) );
     }
 
     @Test
     public void getEmptyChildren()
     {
         final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
-        Assert.assertEquals( 0, collectionNode.getChildren().size() );
+        assertEquals( 0, collectionNode.getChildren().size() );
     }
 
     @Test
@@ -105,6 +108,6 @@ public class CollectionNodeTest
         final CollectionNode collectionNode = new CollectionNode( "tests", 0 );
         final SimpleNode simpleNode1 = new SimpleNode( "id", "My Test 1" );
         collectionNode.addChild( simpleNode1 );
-        Assert.assertThat( collectionNode.getChildren(), Matchers.contains( simpleNode1 ) );
+        assertThat( collectionNode.getChildren(), Matchers.contains( simpleNode1 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
@@ -28,7 +28,12 @@ package org.hisp.dhis.programrule;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -39,16 +44,18 @@ import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.deletedobject.DeletedObjectQuery;
 import org.hisp.dhis.deletedobject.DeletedObjectStore;
-import org.hisp.dhis.program.*;
-import org.junit.Rule;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageSection;
+import org.hisp.dhis.program.ProgramStageSectionService;
+import org.hisp.dhis.program.ProgramStageService;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.Sets;
 
-public class ProgramRuleServiceTest
-    extends IntegrationTestBase
+public class ProgramRuleServiceTest extends IntegrationTestBase
 {
     private Program programA;
     private Program programB;
@@ -85,9 +92,6 @@ public class ProgramRuleServiceTest
 
     @Autowired
     private DeletedObjectStore deletedObjectStore;
-
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
 
     @Override
     public boolean emptyDatabaseAfterTest()
@@ -176,7 +180,7 @@ public class ProgramRuleServiceTest
         ProgramRule retrievedProgramRule = programRuleService.getProgramRule( idA );
         Set<ProgramRuleActionEvaluationTime> evaluationTimesForActions = retrievedProgramRule.getProgramRuleActions()
             .stream()
-            .map( action -> action.getProgramRuleActionEvaluationTime() ).collect(
+            .map( ProgramRuleAction::getProgramRuleActionEvaluationTime ).collect(
                 Collectors.toSet() );
         Set<ProgramRuleActionEvaluationEnvironment> evaluationEnvironmentsForActions = retrievedProgramRule
             .getProgramRuleActions().stream()
@@ -213,7 +217,7 @@ public class ProgramRuleServiceTest
         ProgramRule retrievedProgramRule = programRuleService.getProgramRule( idA );
         Set<ProgramRuleActionEvaluationTime> evaluationTimesForActions = retrievedProgramRule.getProgramRuleActions()
             .stream()
-            .map( action -> action.getProgramRuleActionEvaluationTime() ).collect(
+            .map( ProgramRuleAction::getProgramRuleActionEvaluationTime ).collect(
                 Collectors.toSet() );
         Set<ProgramRuleActionEvaluationEnvironment> evaluationEnvironmentsForActions = retrievedProgramRule
             .getProgramRuleActions().stream()
@@ -501,69 +505,59 @@ public class ProgramRuleServiceTest
     @Test
     public void testDoNotAllowDeleteProgramStageBecauseOfLinkWithProgramRule()
     {
-        expectedEx.expect( DeleteNotAllowedException.class );
-        expectedEx.expectMessage( "ProgramRuleA" );
-
         programRuleA.setProgramStage( programStageA );
         programRuleService.updateProgramRule( programRuleA );
 
-        programStageService.deleteProgramStage( programStageA );
+        assertThrows( "ProgramRuleA", DeleteNotAllowedException.class,
+            () -> programStageService.deleteProgramStage( programStageA ) );
     }
 
     @Test
     public void testDoNotAllowDeleteProgramStageSectionBecauseOfLinkWithProgramRuleAction()
     {
-        expectedEx.expect( DeleteNotAllowedException.class );
-        expectedEx.expectMessage( "ProgramRuleA" );
-
         programRuleActionA.setProgramStageSection( programStageSectionA );
         programRuleActonService.updateProgramRuleAction( programRuleActionA );
 
         programRuleA.getProgramRuleActions().add( programRuleActionA );
         programRuleService.updateProgramRule( programRuleA );
 
-        programStageSectionService.deleteProgramStageSection( programStageSectionA );
+        assertThrows( "ProgramRuleA", DeleteNotAllowedException.class,
+            () -> programStageSectionService.deleteProgramStageSection( programStageSectionA ) );
     }
 
     @Test
     public void testDoNotAllowDeleteProgramStageBecauseOfLinkWithProgramRuleActionAndSection()
     {
-        expectedEx.expect( DeleteNotAllowedException.class );
-        expectedEx.expectMessage( "ProgramRuleA" );
-
         programRuleActionA.setProgramStageSection( programStageSectionA );
         programRuleActonService.updateProgramRuleAction( programRuleActionA );
 
         programRuleA.getProgramRuleActions().add( programRuleActionA );
         programRuleService.updateProgramRule( programRuleA );
 
-        programStageService.deleteProgramStage( programStageB );
+        assertThrows( "ProgramRuleA", DeleteNotAllowedException.class,
+            () -> programStageService.deleteProgramStage( programStageB ) );
     }
 
     @Test
     public void testDoNotAllowDeleteProgramStageBecauseOfLinkWithProgramRuleAction()
     {
-        expectedEx.expect( DeleteNotAllowedException.class );
-        expectedEx.expectMessage( "ProgramRuleA" );
-
         programRuleActionA.setProgramStage( programStageA );
         programRuleActonService.updateProgramRuleAction( programRuleActionA );
 
         programRuleA.getProgramRuleActions().add( programRuleActionA );
         programRuleService.updateProgramRule( programRuleA );
 
-        programStageService.deleteProgramStage( programStageA );
+        assertThrows( "ProgramRuleA", DeleteNotAllowedException.class,
+            () -> programStageService.deleteProgramStage( programStageA ) );
     }
 
     @Test
     public void testDoNotAllowDeleteProgramStageBecauseOfLinkWithProgramRuleVariable()
     {
-        expectedEx.expect( DeleteNotAllowedException.class );
-        expectedEx.expectMessage( "ProgramRuleVariableA" );
-
         programRuleVariableA.setProgramStage( programStageA );
         programRuleVariableService.updateProgramRuleVariable( programRuleVariableA );
 
-        programStageService.deleteProgramStage( programStageA );
+        assertThrows( "ProgramRuleVariableA", DeleteNotAllowedException.class,
+            () -> programStageService.deleteProgramStage( programStageA ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
@@ -28,8 +28,17 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 
@@ -55,7 +64,6 @@ import org.hisp.dhis.rules.models.RuleEffect;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -88,9 +96,6 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
     @Mock
     private NotificationLoggingService loggingService;
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @InjectMocks
     private RuleActionSendMessageImplementer implementer;
@@ -241,10 +246,8 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     @Test
     public void test_NothingHappensIfActionIsNull()
     {
-        exception.expect( NullPointerException.class );
-        exception.expectMessage( "Rule Effect cannot be null" );
-
-        implementer.implement( null, programInstance );
+        assertThrows( "Rule Effect cannot be null", NullPointerException.class,
+            () -> implementer.implement( null, programInstance ) );
     }
 
     // -------------------------------------------------------------------------
@@ -280,7 +283,6 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
         OrganisationUnit organisationUnitA = createOrganisationUnit( 'A' );
 
         Program programA = createProgram( 'A', new HashSet<>(), organisationUnitA );
-        ProgramStage programStageA = createProgramStage( 'A', programA );
 
         programRuleA = createProgramRule( 'R', programA );
 
@@ -290,7 +292,7 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
         programInstance.setProgram( programA );
         programInstance.setAutoFields();
 
-        programStageA = createProgramStage( 'S', programA );
+        ProgramStage programStageA = createProgramStage( 'S', programA );
         programA.getProgramStages().add( programStageA );
 
         programStageInstance = new ProgramStageInstance();

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -30,11 +30,16 @@ package org.hisp.dhis.programrule.engine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.ValueType;
@@ -47,18 +52,33 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
-import org.hisp.dhis.programrule.*;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
+import org.hisp.dhis.programrule.ProgramRuleService;
+import org.hisp.dhis.programrule.ProgramRuleVariable;
+import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
 import org.hisp.dhis.rules.DataItem;
-import org.hisp.dhis.rules.models.*;
+import org.hisp.dhis.rules.models.Rule;
+import org.hisp.dhis.rules.models.RuleDataValue;
+import org.hisp.dhis.rules.models.RuleEnrollment;
+import org.hisp.dhis.rules.models.RuleEvent;
+import org.hisp.dhis.rules.models.RuleVariable;
+import org.hisp.dhis.rules.models.RuleVariableAttribute;
+import org.hisp.dhis.rules.models.RuleVariableCalculatedValue;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.util.ObjectUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -128,9 +148,6 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
 
     @org.junit.Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @org.junit.Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private ProgramRuleService programRuleService;
@@ -231,20 +248,17 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     public void testExceptionWhenMandatoryFieldIsMissingInRuleEvent()
     {
-        thrown.expect( IllegalStateException.class );
-
-        subject.toMappedRuleEvent( programStageInstanceC );
+        assertThrows( IllegalStateException.class, () -> subject.toMappedRuleEvent( programStageInstanceC ) );
     }
 
     @Test
     public void testExceptionIfDataElementIsNull()
     {
-        thrown.expect( RuntimeException.class );
-        thrown.expectMessage( "Required DataElement(" + dataElement.getUid() + ") was not found." );
-
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( null );
 
-        subject.toMappedRuleEvent( programStageInstanceA );
+        assertThrows( "Required DataElement(" + dataElement.getUid() + ") was not found.", RuntimeException.class,
+            () -> subject.toMappedRuleEvent( programStageInstanceA ) );
+        
     }
 
     @Test
@@ -309,9 +323,7 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     public void testExceptionWhenMandatoryValueMissingMappedEnrollment()
     {
-        thrown.expect( IllegalStateException.class );
-
-        subject.toMappedRuleEnrollment( programInstanceB );
+        assertThrows( IllegalStateException.class, () -> subject.toMappedRuleEnrollment( programInstanceB ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 import java.util.stream.IntStream;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.hisp.dhis.expression.ParseType.SIMPLE_TEST;
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/SchemaTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/SchemaTest.java
@@ -40,7 +40,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link Schema}.
@@ -63,19 +68,19 @@ public class SchemaTest
     @Test
     public void isSecondaryMetadataObject()
     {
-        Assert.assertTrue( new Schema( SecondaryMetadata.class, "singular", "plural" ).isSecondaryMetadata() );
+        assertTrue( new Schema( SecondaryMetadata.class, "singular", "plural" ).isSecondaryMetadata() );
     }
 
     @Test
     public void isSecondaryMetadataObjectMetadata()
     {
-        Assert.assertTrue( new Schema( SecondaryMetadata.class, "singular", "plural" ).isMetadata() );
+        assertTrue( new Schema( SecondaryMetadata.class, "singular", "plural" ).isMetadata() );
     }
 
     @Test
     public void isSecondaryMetadataObjectNot()
     {
-        Assert.assertFalse( new Schema( Metadata.class, "singular", "plural" ).isSecondaryMetadata() );
+        assertFalse( new Schema( Metadata.class, "singular", "plural" ).isSecondaryMetadata() );
     }
 
     @Test
@@ -85,11 +90,11 @@ public class SchemaTest
         schema.setAuthorities( authorities );
 
         List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE );
-        Assert.assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
+        assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
 
         List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE );
-        Assert.assertThat( list2, contains( "x1", "x2", "y1", "y2" ) );
-        Assert.assertSame( list1, list2 );
+        assertThat( list2, contains( "x1", "x2", "y1", "y2" ) );
+        assertSame( list1, list2 );
     }
 
     @Test
@@ -99,14 +104,14 @@ public class SchemaTest
         schema.setAuthorities( authorities );
 
         List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE );
-        Assert.assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
+        assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
 
         List<String> list3 = schema.getAuthorityByType( AuthorityType.DELETE );
-        Assert.assertThat( list3, contains( "z1", "z2" ) );
+        assertThat( list3, contains( "z1", "z2" ) );
 
         List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE );
-        Assert.assertThat( list2, contains( "x1", "x2", "y1", "y2" ) );
-        Assert.assertSame( list1, list2 );
+        assertThat( list2, contains( "x1", "x2", "y1", "y2" ) );
+        assertSame( list1, list2 );
     }
 
     @Test
@@ -116,11 +121,11 @@ public class SchemaTest
         schema.setAuthorities( authorities );
 
         List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE_PRIVATE );
-        Assert.assertTrue( list1.isEmpty() );
+        assertTrue( list1.isEmpty() );
 
         List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE_PRIVATE );
-        Assert.assertTrue( list2.isEmpty() );
-        Assert.assertSame( list1, list2 );
+        assertTrue( list2.isEmpty() );
+        assertSame( list1, list2 );
     }
 
     @Test
@@ -130,14 +135,14 @@ public class SchemaTest
         schema.setAuthorities( authorities );
 
         List<String> list1 = schema.getAuthorityByType( AuthorityType.CREATE );
-        Assert.assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
+        assertThat( list1, contains( "x1", "x2", "y1", "y2" ) );
 
         authorities.add( new Authority( AuthorityType.CREATE, Arrays.asList( "a1", "a2" ) ) );
         schema.setAuthorities( authorities );
 
         List<String> list2 = schema.getAuthorityByType( AuthorityType.CREATE );
-        Assert.assertThat( list2, contains( "x1", "x2", "y1", "y2", "a1", "a2" ) );
-        Assert.assertNotSame( list1, list2 );
+        assertThat( list2, contains( "x1", "x2", "y1", "y2", "a1", "a2" ) );
+        assertNotSame( list1, list2 );
     }
 
     private static class SecondaryMetadata implements SecondaryMetadataObject

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/TrackerBundleParamsConverterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/TrackerBundleParamsConverterTest.java
@@ -28,9 +28,16 @@
 
 package org.hisp.dhis.tracker.converter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundleParams;
@@ -39,19 +46,11 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Luciano Fiandesio
@@ -61,9 +60,6 @@ public class TrackerBundleParamsConverterTest
     private ObjectMapper objectMapper = new ObjectMapper();
 
     private BeanRandomizer rnd = new BeanRandomizer();
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Before
     public void setUp()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/RelationshipImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/RelationshipImportValidationTest.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.tracker.validation.RelationshipStubs.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -32,7 +32,7 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
@@ -40,7 +40,7 @@ import static org.hisp.dhis.audit.AuditType.SEARCH;
 import static org.hisp.dhis.audit.AuditType.SECURITY;
 import static org.hisp.dhis.audit.AuditType.UPDATE;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryTypeTest.java
@@ -37,6 +37,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotSame;
+
 /**
  * Unit tests for {@link JsonListBinaryType}.
  *
@@ -76,8 +79,8 @@ public class JsonListBinaryTypeTest
     public void deepCopy()
     {
         final List<Translation> result = (List<Translation>) jsonBinaryType.deepCopy( translations );
-        Assert.assertNotSame( translations, result );
-        Assert.assertThat( result, Matchers.contains( translation1, translation2 ) );
+        assertNotSame( translations, result );
+        assertThat( result, Matchers.contains( translation1, translation2 ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryTypeTest.java
@@ -30,12 +30,15 @@ package org.hisp.dhis.hibernate.jsonb.type;
 
 import org.hamcrest.Matchers;
 import org.hisp.dhis.translation.Translation;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * Unit tests for {@link JsonSetBinaryType}.
@@ -76,13 +79,13 @@ public class JsonSetBinaryTypeTest
     public void deepCopy()
     {
         final Set<Translation> result = (Set<Translation>) jsonBinaryType.deepCopy( translations );
-        Assert.assertNotSame( translations, result );
-        Assert.assertThat( result, Matchers.containsInAnyOrder( translation1, translation2 ) );
+        assertNotSame( translations, result );
+        assertThat( result, Matchers.containsInAnyOrder( translation1, translation2 ) );
     }
 
     @Test
     public void deepCopyNull()
     {
-        Assert.assertNull( jsonBinaryType.deepCopy( null ) );
+        assertNull( jsonBinaryType.deepCopy( null ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -32,8 +32,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.vividsolutions.jts.geom.Geometry;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.UserOrgUnitType;
 import org.hisp.dhis.attribute.Attribute;
@@ -143,7 +141,6 @@ import org.hisp.dhis.validation.notification.ValidationNotificationTemplate;
 import org.hisp.dhis.visualization.Visualization;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDateTime;
-import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.Advised;
@@ -184,6 +181,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 
 /**
@@ -357,15 +356,12 @@ public abstract class DhisConvenienceTest
      * Asserts that a {@link IllegalQueryException} is thrown with the given
      * {@link ErrorCode}.
      *
-     * @param exception the {@link ExpectedException}.
+     * @param exception the {@link IllegalQueryException}.
      * @param errorCode the {@link ErrorCode}.
      */
-    public static void assertIllegalQueryEx( ExpectedException exception, ErrorCode errorCode )
+    public static void assertIllegalQueryEx( IllegalQueryException exception, ErrorCode errorCode )
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expect( Matchers.hasProperty( "errorCode", CoreMatchers.is( errorCode ) ) );
-        exception.reportMissingExceptionWithMessage( String.format(
-            "Test does not throw an IllegalQueryException with error code: '%s'", errorCode ) );
+        assertThat( errorCode, is( exception.getErrorCode() ) );
     }
 
     // -------------------------------------------------------------------------
@@ -682,8 +678,7 @@ public abstract class DhisConvenienceTest
 
     public static AttributeValue createAttributeValue( Attribute attribute, String value )
     {
-        AttributeValue attributeValue = new AttributeValue( value, attribute );
-        return attributeValue;
+        return new AttributeValue( value, attribute );
     }
 
     /**

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.servlet.filter;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.external.conf.ConfigurationKey.*;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.junit.MockitoJUnit.rule;

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -32,39 +32,30 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.google.common.collect.Sets;
-import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dashboard.DashboardItemType;
 import org.hisp.dhis.dashboard.DashboardService;
 import org.hisp.dhis.dxf2.metadata.MetadataExportService;
-import org.hisp.dhis.dxf2.metadata.MetadataImportService;
-import org.hisp.dhis.dxf2.metadata.collection.CollectionService;
-import org.hisp.dhis.fieldfilter.FieldFilterService;
-import org.hisp.dhis.patch.PatchService;
-import org.hisp.dhis.query.QueryService;
-import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.schema.MergeService;
-import org.hisp.dhis.schema.SchemaService;
-import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.webapi.service.ContextService;
-import org.hisp.dhis.webapi.service.LinkService;
-import org.hisp.dhis.webapi.service.WebMessageService;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.google.common.collect.Sets;
 
 /**
  * @author Luciano Fiandesio
  */
 public class DashboardControllerTest
 {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     private MockMvc mockMvc;
 
@@ -75,52 +66,10 @@ public class DashboardControllerTest
     protected IdentifiableObjectManager manager;
 
     @Mock
-    protected CurrentUserService currentUserService;
-
-    @Mock
-    protected FieldFilterService fieldFilterService;
-
-    @Mock
-    protected AclService aclService;
-
-    @Mock
-    protected SchemaService schemaService;
-
-    @Mock
-    protected LinkService linkService;
-
-    @Mock
-    protected RenderService renderService;
-
-    @Mock
-    protected MetadataImportService importService;
-
-    @Mock
     protected MetadataExportService exportService;
 
     @Mock
     protected ContextService contextService;
-
-    @Mock
-    protected QueryService queryService;
-
-    @Mock
-    protected WebMessageService webMessageService;
-
-    @Mock
-    protected HibernateCacheManager hibernateCacheManager;
-
-    @Mock
-    protected UserSettingService userSettingService;
-
-    @Mock
-    protected CollectionService collectionService;
-
-    @Mock
-    protected MergeService mergeService;
-
-    @Mock
-    protected PatchService patchService;
 
     @InjectMocks
     private DashboardController dashboardController;
@@ -130,7 +79,6 @@ public class DashboardControllerTest
     @Before
     public void setUp()
     {
-        MockitoAnnotations.initMocks( this );
         mockMvc = MockMvcBuilders.standaloneSetup( dashboardController ).build();
     }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -28,32 +28,27 @@ package org.hisp.dhis.webapi.controller;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.UserAccessService;
-import org.hisp.dhis.user.UserGroupAccessService;
-import org.hisp.dhis.user.UserGroupService;
-import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.webapi.service.WebMessageService;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
-
-import static org.hamcrest.core.StringContains.containsString;
 
 /**
  * Unit tests for {@link SharingController}.
@@ -69,28 +64,7 @@ public class SharingControllerTest
     private IdentifiableObjectManager manager;
 
     @Mock
-    private UserGroupService userGroupService;
-
-    @Mock
-    private UserService userService;
-
-    @Mock
-    private UserGroupAccessService userGroupAccessService;
-
-    @Mock
-    private UserAccessService userAccessService;
-
-    @Mock
     private AclService aclService;
-
-    @Mock
-    private WebMessageService webMessageService;
-
-    @Mock
-    private RenderService renderService;
-
-    @Mock
-    private SchemaService schemaService;
 
     private MockHttpServletRequest request = new MockHttpServletRequest();
 
@@ -107,9 +81,9 @@ public class SharingControllerTest
     {
         final OrganisationUnit organisationUnit = new OrganisationUnit();
 
-        Mockito.doReturn( OrganisationUnit.class ).when( aclService ).classForType( Mockito.eq( "organisationUnit" ) );
-        Mockito.when( aclService.isShareable( Mockito.eq( OrganisationUnit.class ) ) ).thenReturn( true );
-        Mockito.doReturn( organisationUnit ).when( manager ).get( Mockito.eq( OrganisationUnit.class ), Mockito.eq( "kkSjhdhks" ) );
+        doReturn( OrganisationUnit.class ).when( aclService ).classForType( eq( "organisationUnit" ) );
+        when( aclService.isShareable( eq( OrganisationUnit.class ) ) ).thenReturn( true );
+        doReturn( organisationUnit ).when( manager ).get( eq( OrganisationUnit.class ), eq( "kkSjhdhks" ) );
 
         sharingController.setSharing( "organisationUnit", "kkSjhdhks", response, request );
     }
@@ -120,9 +94,9 @@ public class SharingControllerTest
         final Category category = new Category();
         category.setName( Category.DEFAULT_NAME + "x" );
 
-        Mockito.doReturn( Category.class ).when( aclService ).classForType( Mockito.eq( "category" ) );
-        Mockito.when( aclService.isShareable( Mockito.eq( Category.class ) ) ).thenReturn( true );
-        Mockito.when( manager.get( Mockito.eq( Category.class ), Mockito.eq( "kkSjhdhks" ) ) ).thenReturn( category );
+        doReturn( Category.class ).when( aclService ).classForType( eq( "category" ) );
+        when( aclService.isShareable( eq( Category.class ) ) ).thenReturn( true );
+        when( manager.get( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
 
         sharingController.setSharing( "category", "kkSjhdhks", response, request );
     }
@@ -133,9 +107,9 @@ public class SharingControllerTest
         final Category category = new Category();
         category.setName( Category.DEFAULT_NAME );
 
-        Mockito.doReturn( Category.class ).when( aclService ).classForType( Mockito.eq( "category" ) );
-        Mockito.when( aclService.isShareable( Mockito.eq( Category.class ) ) ).thenReturn( true );
-        Mockito.when( manager.get( Mockito.eq( Category.class ), Mockito.eq( "kkSjhdhks" ) ) ).thenReturn( category );
+        doReturn( Category.class ).when( aclService ).classForType( eq( "category" ) );
+        when( aclService.isShareable( eq( Category.class ) ) ).thenReturn( true );
+        when( manager.get( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
 
         try
         {
@@ -143,7 +117,7 @@ public class SharingControllerTest
         }
         catch ( WebMessageException e )
         {
-            Assert.assertThat( e.getWebMessage().getMessage(), containsString( "Sharing settings of system default metadata object" ) );
+            assertThat( e.getWebMessage().getMessage(), containsString( "Sharing settings of system default metadata object" ) );
             throw e;
         }
     }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -51,10 +51,12 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.DefaultContextService;
 import org.hisp.dhis.webapi.service.LinkService;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -68,6 +70,8 @@ import com.jayway.jsonpath.JsonPath;
  */
 public class DataElementOperandControllerTest
 {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     private MockMvc mockMvc;
 
@@ -98,8 +102,6 @@ public class DataElementOperandControllerTest
     @Before
     public void setUp()
     {
-        MockitoAnnotations.initMocks( this );
-
         rnd = new BeanRandomizer();
 
         ContextService contextService = new DefaultContextService();

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryControllerTest.java
@@ -28,14 +28,14 @@ package org.hisp.dhis.webapi.controller.dataitem;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -64,7 +64,6 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoRule;
 import org.springframework.http.ResponseEntity;
@@ -86,9 +85,6 @@ public class DataItemQueryControllerTest
     @Rule
     public MockitoRule mockitoRule = rule();
 
-    @Rule
-    public ExpectedException expectedException = none();
-
     private DataItemQueryController dataItemQueryController;
 
     @Before
@@ -106,8 +102,8 @@ public class DataItemQueryControllerTest
         final OrderParams anyOrderParams = new OrderParams();
         final User anyUser = new User();
         final Set<Class<? extends BaseDimensionalItemObject>> targetEntities = new HashSet<>(
-            asList( Indicator.class ) );
-        final List<BaseDimensionalItemObject> itemsFound = asList( new Indicator() );
+            singletonList( Indicator.class ) );
+        final List<BaseDimensionalItemObject> itemsFound = singletonList( new Indicator() );
 
         // When
         when( dataItemServiceFacade.extractTargetEntities( anyList() ) ).thenReturn( targetEntities );
@@ -134,7 +130,7 @@ public class DataItemQueryControllerTest
         final OrderParams anyOrderParams = new OrderParams();
         final User anyUser = new User();
         final Set<Class<? extends BaseDimensionalItemObject>> targetEntities = new HashSet<>(
-            asList( Indicator.class ) );
+            singletonList( Indicator.class ) );
         final List<BaseDimensionalItemObject> itemsFound = emptyList();
 
         // When
@@ -161,17 +157,15 @@ public class DataItemQueryControllerTest
         final OrderParams anyOrderParams = new OrderParams();
         final User anyUser = new User();
         final Set<Class<? extends BaseDimensionalItemObject>> targetEntities = new HashSet<>(
-            asList( Indicator.class ) );
+            singletonList( Indicator.class ) );
         final boolean invalidAcl = false;
-
-        // Then
-        expectedException.expect( IllegalQueryException.class );
-        expectedException
-            .expectMessage( containsString( "does not have read access for object" ) );
 
         // When
         when( dataItemServiceFacade.extractTargetEntities( anyList() ) ).thenReturn( targetEntities );
         when( aclService.canRead( anyUser, Indicator.class ) ).thenReturn( invalidAcl );
-        dataItemQueryController.getJson( anyUrlParameters, anyOrderParams, anyUser );
+
+        final IllegalQueryException ex = assertThrows(IllegalQueryException.class,
+                () -> dataItemQueryController.getJson(anyUrlParameters, anyOrderParams, anyUser));
+        assertThat(ex.getMessage(), containsString( "does not have read access for object" ));
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
@@ -33,6 +33,7 @@ import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -41,8 +42,6 @@ import static org.hisp.dhis.webapi.controller.dataitem.DataItemServiceFacade.DAT
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE_SIZE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGING;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
@@ -67,7 +66,6 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoRule;
 
@@ -78,9 +76,6 @@ public class DataItemServiceFacadeTest
 
     @Rule
     public MockitoRule mockitoRule = rule();
-
-    @Rule
-    public ExpectedException expectedException = none();
 
     private DataItemServiceFacade dataItemServiceFacade;
 

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE_SIZE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGING;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelperTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelperTest.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.webapi.controller.dataitem.helper;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -36,8 +37,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hisp.dhis.webapi.controller.dataitem.DataItemServiceFacade.DATA_TYPE_ENTITY_MAP;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntitiesFromInFilter;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntityFromEqualFilter;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -46,15 +46,10 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.indicator.Indicator;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class FilteringHelperTest
 {
-    @Rule
-    public ExpectedException expectedException = none();
-
     @Test
     public void testExtractEntitiesFromInFilter()
     {
@@ -77,14 +72,11 @@ public class FilteringHelperTest
         // Given
         final String filtersWithInvalidType = "dimensionItemType:in:[INVALID_TYPE,DATA_SET]";
 
-        // Expect
-        expectedException.expect( IllegalQueryException.class );
-        expectedException.expectMessage(
+        // Then
+        assertThrows(
             "Unable to parse element `" + "INVALID_TYPE` on filter `dimensionItemType`. The values available are: "
-                + Arrays.toString( DATA_TYPE_ENTITY_MAP.keySet().toArray() ) );
-
-        // When
-        extractEntitiesFromInFilter( filtersWithInvalidType );
+                + Arrays.toString( DATA_TYPE_ENTITY_MAP.keySet().toArray() ),
+            IllegalQueryException.class, () -> extractEntitiesFromInFilter( filtersWithInvalidType ) );
     }
 
     @Test
@@ -93,12 +85,11 @@ public class FilteringHelperTest
         // Given
         final String filtersWithInvalidType = "dimensionItemType:in:[,]";
 
-        // Expect
-        expectedException.expect( IllegalQueryException.class );
-        expectedException.expectMessage( "Unable to parse filter `" + filtersWithInvalidType + "`" );
-
         // When
-        extractEntitiesFromInFilter( filtersWithInvalidType );
+        assertThrows(
+            "Unable to parse filter `" + filtersWithInvalidType + "`",
+            IllegalQueryException.class, () -> extractEntitiesFromInFilter( filtersWithInvalidType ) );
+
     }
 
     @Test
@@ -138,14 +129,12 @@ public class FilteringHelperTest
         // Given
         final String filtersWithInvalidType = "dimensionItemType:eq:INVALID_TYPE";
 
-        // Expect
-        expectedException.expect( IllegalQueryException.class );
-        expectedException.expectMessage(
-                "Unable to parse element `" + "INVALID_TYPE` on filter `dimensionItemType`. The values available are: "
-                        + Arrays.toString( DATA_TYPE_ENTITY_MAP.keySet().toArray() ) );
-
         // When
-        extractEntityFromEqualFilter( filtersWithInvalidType );
+        assertThrows(
+            "Unable to parse element `" + "INVALID_TYPE` on filter `dimensionItemType`. The values available are: "
+                + Arrays.toString( DATA_TYPE_ENTITY_MAP.keySet().toArray() ),
+            IllegalQueryException.class, () -> extractEntityFromEqualFilter( filtersWithInvalidType ) );
+
     }
 
     @Test
@@ -154,11 +143,9 @@ public class FilteringHelperTest
         // Given
         final String invalidFilter = "dimensionItemType:eq:";
 
-        // Expect
-        expectedException.expect( IllegalQueryException.class );
-        expectedException.expectMessage( "Unable to parse filter `" + invalidFilter + "`" );
-
         // When
-        extractEntityFromEqualFilter( invalidFilter );
+        assertThrows(
+            "Unable to parse filter `" + invalidFilter + "`",
+            IllegalQueryException.class, () -> extractEntityFromEqualFilter( invalidFilter ) );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/OrderingHelperTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/OrderingHelperTest.java
@@ -28,13 +28,13 @@ package org.hisp.dhis.webapi.controller.dataitem.helper;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.OrderingHelper.sort;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,15 +45,10 @@ import java.util.Set;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dxf2.common.OrderParams;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class OrderingHelperTest
 {
-    @Rule
-    public ExpectedException expectedException = none();
-
     @Test
     public void sortWhenDimensionalItemsIsEmpty()
     {
@@ -87,7 +82,7 @@ public class OrderingHelperTest
     public void sortWhenOrderParamsIsAsc()
     {
         // Given
-        final Set<String> orderings = new HashSet<>( asList( "name:asc" ) );
+        final Set<String> orderings = new HashSet<>( singletonList( "name:asc" ) );
         final OrderParams orderParams = new OrderParams( orderings );
         final List<BaseDimensionalItemObject> anyDimensionalItems = mockDimensionalItems( 2 );
         final List<BaseDimensionalItemObject> ascList = mockDimensionalItems( 2 );
@@ -104,7 +99,7 @@ public class OrderingHelperTest
     public void sortWhenOrderParamsIsDesc()
     {
         // Given
-        final Set<String> orderings = new HashSet<>( asList( "name:desc" ) );
+        final Set<String> orderings = new HashSet<>( singletonList( "name:desc" ));
         final OrderParams orderParams = new OrderParams( orderings );
         final List<BaseDimensionalItemObject> anyDimensionalItems = mockDimensionalItems( 2 );
         final List<BaseDimensionalItemObject> ascList = mockDimensionalItems( 2 );
@@ -121,16 +116,14 @@ public class OrderingHelperTest
     public void sortWhenOrderParamsIsInvalid()
     {
         // Given
-        final Set<String> orderingWithNoValue = new HashSet<>( asList( "name:" ) );
+        final Set<String> orderingWithNoValue = new HashSet<>( singletonList( "name:" ) );
         final OrderParams orderParams = new OrderParams( orderingWithNoValue );
         final List<BaseDimensionalItemObject> anyDimensionalItems = mockDimensionalItems( 2 );
 
-        // Expect
-        expectedException.expect( IllegalQueryException.class );
-        expectedException.expectMessage( "Unable to parse order param: `" + "name:" + "`" );
 
         // When
-        sort( anyDimensionalItems, orderParams );
+        assertThrows( "Unable to parse order param: `" + "name:" + "`", IllegalQueryException.class,
+            () -> sort( anyDimensionalItems, orderParams ) );
     }
 
     private List<BaseDimensionalItemObject> mockDimensionalItems( final int totalOfItems )

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/PaginationHelperTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/PaginationHelperTest.java
@@ -36,8 +36,8 @@ import static org.hisp.dhis.webapi.controller.dataitem.helper.PaginationHelper.s
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE_SIZE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGING;
-import static org.junit.Assert.assertThat;
-import static org.junit.rules.ExpectedException.none;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,15 +46,10 @@ import java.util.Map;
 
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class PaginationHelperTest
 {
-    @Rule
-    public ExpectedException expectedException = none();
-
     @Test
     public void testSliceWhenFirstPage()
     {
@@ -123,12 +118,9 @@ public class PaginationHelperTest
         final WebOptions theWebOptions = mockWebOptions( pageSize, lastPage );
         final List<BaseDimensionalItemObject> anyDimensionalItems = mockDimensionalItems( totalOfItems );
 
-        // Expect
-        expectedException.expect( IllegalStateException.class );
-        expectedException.expectMessage( "Page size must be greater than zero." );
-
         // When
-        slice( theWebOptions, anyDimensionalItems );
+        assertThrows( "Page size must be greater than zero.", IllegalStateException.class,
+            () -> slice( theWebOptions, anyDimensionalItems ) );
     }
 
     @Test
@@ -159,12 +151,9 @@ public class PaginationHelperTest
         final WebOptions theWebOptions = mockWebOptions( pageSize, currentPage );
         final List<BaseDimensionalItemObject> emptyDimensionalItems = emptyList();
 
-        // Expect
-        expectedException.expect( IllegalStateException.class );
-        expectedException.expectMessage( "Current page must be greater than zero." );
-
         // When
-        slice( theWebOptions, emptyDimensionalItems );
+        assertThrows( "Current page must be greater than zero.", IllegalStateException.class,
+            () -> slice( theWebOptions, emptyDimensionalItems ) );
     }
 
     private WebOptions mockWebOptions( final int pageSize, final int pageNumber )

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
@@ -59,7 +59,7 @@ import java.util.ResourceBundle;
 
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.common.ValueType.BOOLEAN;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static org.mockito.junit.MockitoJUnit.rule;

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dimension/DimensionItemPageHandlerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dimension/DimensionItemPageHandlerTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE_SIZE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGING;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -28,7 +28,8 @@
 
 package org.hisp.dhis.webapi.controller.event;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,10 +43,12 @@ import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.util.NestedServletException;
@@ -55,6 +58,9 @@ import org.springframework.web.util.NestedServletException;
  */
 public class RelationshipControllerTest
 {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     private MockMvc mockMvc;
 
     private static final String TEI_ID = "TEI_ID";
@@ -90,7 +96,6 @@ public class RelationshipControllerTest
     @Before
     public void setUp()
     {
-        MockitoAnnotations.initMocks( this );
         mockMvc = MockMvcBuilders.standaloneSetup( relationshipController ).build();
     }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapperTest.java
@@ -2,8 +2,10 @@ package org.hisp.dhis.webapi.controller.event.mapper;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
@@ -31,9 +33,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.event.TrackedEntityInstanceCriteria;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -79,9 +79,6 @@ public class TrackedEntityCriteriaMapperTest
     private TrackedEntityAttribute filtF = createTrackedEntityAttribute( 'F' );
 
     private TrackedEntityAttribute filtG = createTrackedEntityAttribute( 'G' );
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Override
     public void setUpTest()
@@ -199,88 +196,82 @@ public class TrackedEntityCriteriaMapperTest
     @Test
     public void verifyCriteriaMappingFailOnMissingAttribute()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Attribute does not exist: missing" );
-
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setAttribute( newHashSet( attrD.getUid(), attrE.getUid(), "missing" ) );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Attribute does not exist: missing", e.getMessage() );
     }
 
     @Test
     public void verifyCriteriaMappingFailOnMissingFilter()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Attribute does not exist: missing" );
-
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setFilter( newHashSet( filtF.getUid(), filtG.getUid(), "missing" ) );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Attribute does not exist: missing", e.getMessage() );
     }
 
     @Test
     public void verifyCriteriaMappingFailOnMissingProgram()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Program does not exist: " + programA.getUid() + "A" );
-
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setProgram( programA.getUid() + 'A' );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Program does not exist: " + programA.getUid() + "A", e.getMessage() );
     }
 
     @Test
     public void verifyCriteriaMappingFailOnMissingTrackerEntityType()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Tracked entity type does not exist: " + trackedEntityTypeA.getUid() + "A" );
-
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setTrackedEntityType( trackedEntityTypeA.getUid() + "A" );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Tracked entity type does not exist: " + trackedEntityTypeA.getUid() + "A", e.getMessage() );
     }
 
     @Test
     public void verifyCriteriaMappingFailOnMissingOrgUnit()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Organisation unit does not exist: " + organisationUnit.getUid() + "A" );
-
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setOu( organisationUnit.getUid() + "A" );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Organisation unit does not exist: " + organisationUnit.getUid() + "A", e.getMessage() );
     }
 
     @Test
     public void verifyCriteriaMappingFailOnUserNonInOuHierarchy()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Organisation unit is not part of the search scope: " + organisationUnit.getUid() );
-
         // Force Current User Service to return a User without search org unit
         ReflectionTestUtils.setField( trackedEntityCriteriaMapper, "currentUserService",
             new MockCurrentUserService( createUser( "testUser2" ) ) );
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setOu( organisationUnit.getUid() );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Organisation unit is not part of the search scope: " + organisationUnit.getUid(),
+            e.getMessage() );
     }
 
     @Test
     public void testGetFromUrlFailOnNonProvidedAndAssignedUsers()
     {
-        exception.expect( IllegalQueryException.class );
-        exception.expectMessage( "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
-
         TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
         criteria.setAssignedUser( "user-1;user-2" );
         criteria.setAssignedUserMode( AssignedUserSelectionMode.CURRENT );
 
-        trackedEntityCriteriaMapper.map( criteria );
+        IllegalQueryException e = assertThrows( IllegalQueryException.class,
+            () -> trackedEntityCriteriaMapper.map( criteria ) );
+        assertEquals( "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED", e.getMessage() );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureControllerTest.java
@@ -33,7 +33,9 @@ import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
 
@@ -42,17 +44,17 @@ import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.DataQueryService;
 import org.hisp.dhis.common.DataQueryRequest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -61,20 +63,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  */
 public class GeoFeatureControllerTest
 {
-
     private MockMvc mockMvc;
 
     @Mock
     private DataQueryService dataQueryService;
 
-    @Mock
-    private OrganisationUnitGroupService organisationUnitGroupService;
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private CurrentUserService currentUserService;
-
-    @Mock
-    private RenderService renderService;
 
     private BeanRandomizer beanRandomizer = new BeanRandomizer();
 
@@ -94,7 +92,6 @@ public class GeoFeatureControllerTest
     @Before
     public void setUp()
     {
-        MockitoAnnotations.initMocks( this );
         mockMvc = MockMvcBuilders.standaloneSetup( geoFeatureController ).build();
     }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/WebCacheTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/WebCacheTest.java
@@ -46,7 +46,7 @@ import static org.hisp.dhis.common.cache.Cacheability.PRIVATE;
 import static org.hisp.dhis.common.cache.Cacheability.PUBLIC;
 import static org.hisp.dhis.setting.SettingKey.CACHEABILITY;
 import static org.hisp.dhis.setting.SettingKey.CACHE_STRATEGY;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static org.mockito.junit.MockitoJUnit.rule;


### PR DESCRIPTION
This PR removes a large number of deprecation-related compilation warnings introduced with the recent (d84f849d9ae4c9d7018df6f325f4a4ceb1c68232) Junit upgrade.

- Replace deprecated `org.junit.Assert.assertThat` import with `org.hamcrest.MatcherAssert.assertThat`.

- Remove usage of deprecated:

```
@Rule
public ExpectedException exception = ExpectedException.none();
```

and replace it with `org.junit.Assert.assertThrows` to assert on Exception types and messages

- Replace deprecated `MockitoAnnotations.initMocks( this )` with:

```
@Rule
public MockitoRule mockitoRule = MockitoJUnit.rule();
```

**THIS PR ONLY MODIFIES TEST FILES**