### PR TITLE
fix: options are not shown on UI after import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
@@ -61,7 +61,7 @@ public class OptionSetObjectBundleHook
 
     private void updateOption( OptionSet optionSet )
     {
-        if ( optionSet.getOptions() != null && !optionSet.getOptions().isEmpty() )
+        if ( optionSet.getOptions() == null || optionSet.getOptions().isEmpty() )
         {
             return;
         }


### PR DESCRIPTION
Update the logic for returning null if optionSet.getOptions is empty.
Otherwise proceed to update/refresh the option.Optionset association 