### PR TITLE
fix: remove default value for AggregationType in Event criteria object

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -129,7 +129,7 @@ public class EventsAnalyticsQueryCriteria
     /**
      * Aggregation type for the value dimension. Default is AVERAGE.
      */
-    private AggregationType aggregationType = AggregationType.AVERAGE;
+    private AggregationType aggregationType;
 
     /**
      * Whether to exclude the meta data part of the response.


### PR DESCRIPTION
Remove the default value for `AggregationType` in the newly introduced object
`EventsAnalyticsQueryCriteria`. The value must be null (unless specified by the client), otherwise the query validation fails.