### PR TITLE
fix: file resource is expected only when attribute value is not empty…

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
@@ -176,7 +176,8 @@ public class DefaultTrackedEntityAttributeValueService
 
         attributeValue.setAutoFields();
 
-        if ( attributeValue.getAttribute().getValueType().isFile() && !addFileValue( attributeValue ) )
+        if ( attributeValue.getAttribute().getValueType().isFile() &&
+            !StringUtils.isEmpty( attributeValue.getValue() ) && !addFileValue( attributeValue ) )
         {
             throw new IllegalQueryException(
                 String.format( "FileResource with id '%s' not found", attributeValue.getValue() ) );


### PR DESCRIPTION
… (#6442)

(cherry picked from commit 0f191b8a1dbfbd26e7acaeec082ddfc32dcc7d84)