### PR TITLE
feat: add SMS Configuration App

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -69,6 +69,7 @@ public interface AppManager
         "reports",
         "scheduler",
         "settings",
+        "sms-configuration",
         "tracker-capture",
         "translations",
         "usage-analytics",

--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -18,6 +18,7 @@
     "https://github.com/d2-ci/pivot-tables-app",
     "https://github.com/d2-ci/reports-app",
     "https://github.com/d2-ci/scheduler-app",
+    "https://github.com/d2-ci/sms-configuration-app",
     "https://github.com/d2-ci/settings-app",
     "https://github.com/d2-ci/tracker-capture-app",
     "https://github.com/d2-ci/translations-app",

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -207,8 +207,7 @@ public class DhisWebCommonsWebSecurityConfig
                 .antMatchers( "/dhis-web-messaging/**" ).hasAnyAuthority( "ALL", "M_dhis-web-messaging" )
                 .antMatchers( "/dhis-web-datastore/**" ).hasAnyAuthority( "ALL", "M_dhis-web-datastore" )
                 .antMatchers( "/dhis-web-scheduler/**" ).hasAnyAuthority( "ALL", "M_dhis-web-scheduler" )
-                .antMatchers( "/dhis-web-sms-configuration/**" )
-                .hasAnyAuthority( "ALL", "M_dhis-web-sms-configuration" )
+                .antMatchers( "/dhis-web-sms-configuration/**" ).hasAnyAuthority( "ALL", "M_dhis-web-sms-configuration" )
                 .antMatchers( "/dhis-web-user/**" ).hasAnyAuthority( "ALL", "M_dhis-web-user" )
 
                 .antMatchers( "/**" ).authenticated()


### PR DESCRIPTION
I think this was omitted from `master` (2.36) because we would want to install it from App Hub, but we don't have CI set up yet so we should probably bundle this for now to make QA easier, and opt to unbundle it before cutting 2.36 if we get everything set up.