### PR TITLE
feat: improve note validation during Tracker import

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentService.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.trackedentitycomment;
  */
 
 
-import java.util.List;
-
 /**
  * @author Chau Thu Tran
  */
@@ -60,24 +58,6 @@ public interface TrackedEntityCommentService
      * @return true/false depending on result
      */
     boolean trackedEntityCommentExists( String uid );
-
-    /**
-     * Filters out existing {@see TrackedEntityComment} uids from a List of uids.
-     *
-     * Given a List:
-     *
-     * uid: abcd
-     * uid: cdef
-     * uid: ghil
-     * uid: mnop
-     *
-     * and assuming that "cdef" and "abcd" are associated to two TrackedEntityComment in the database,
-     * this method returns "ghil" and "mnop"
-     *
-     * @param uids a List of {@see TrackedEntityComment} uid
-     * @return a List of uid that are not present in the database
-     */
-    List<String> filterExistingNotes( List<String> uids );
 
     /**
      * Updates an {@link TrackedEntityComment}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentStore.java
@@ -56,8 +56,6 @@ package org.hisp.dhis.trackedentitycomment;/*
 
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
-import java.util.List;
-
 /**
  * @author David Katuscak
  */
@@ -72,24 +70,5 @@ public interface TrackedEntityCommentStore
      * @return true/false depending on result.
      */
     boolean exists( String uid );
-
-    /**
-     * Filters out existing {@see TrackedEntityComment} uid.
-     *
-     * Given:
-     *
-     * uid: abcd
-     * uid: cdef
-     * uid: ghil
-     * uid: mnop
-     *
-     * and assuming that "cdef" and "abcd" are associated to two TrackedEntityComment in the database,
-     * this method returns "ghil" and "mnop"
-     *
-     *
-     * @param noteUids a List of {@see TrackedEntityComment} uid
-     * @return a List of uid that are not present in the database
-     */
-    List<String> filterExisting( List<String> noteUids);
 
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/DefaultTrackedEntityCommentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/DefaultTrackedEntityCommentService.java
@@ -28,12 +28,10 @@ package org.hisp.dhis.trackedentitycomment;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Chau Thu Tran
@@ -80,13 +78,6 @@ public class DefaultTrackedEntityCommentService
     public boolean trackedEntityCommentExists( String uid )
     {
         return commentStore.exists( uid );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<String> filterExistingNotes( List<String> uids )
-    {
-        return this.commentStore.filterExisting( uids );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/hibernate/HibernateTrackedEntityCommentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/hibernate/HibernateTrackedEntityCommentStore.java
@@ -56,12 +56,7 @@
 
 package org.hisp.dhis.trackedentitycomment.hibernate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.hibernate.SessionFactory;
-import org.hibernate.query.Query;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
@@ -94,15 +89,4 @@ public class HibernateTrackedEntityCommentStore
             .getSingleResult();
     }
 
-    @Override
-    public List<String> filterExisting( List<String> noteUids )
-    {
-        if ( noteUids == null || noteUids.isEmpty() )
-        {
-            return new ArrayList<>();
-        }
-        final Query<String> query = getTypedQuery( "select uid from TrackedEntityComment where uid in (:uids)" );
-        final List<String> foundUids = query.setParameterList( "uids", noteUids ).getResultList();
-        return noteUids.stream().filter( uid -> !foundUids.contains( uid ) ).collect( Collectors.toList() );
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentServiceTest.java
@@ -28,24 +28,15 @@ package org.hisp.dhis.trackedentitycomment;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.common.CodeGenerator;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.CodeGenerator;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Chau Thu Tran
@@ -129,39 +120,4 @@ public class TrackedEntityCommentServiceTest
 
         assertTrue( commentService.trackedEntityCommentExists( commentA.getUid() ) );
     }
-
-    @Test
-    public void testFilterExistingNotes()
-    {
-        // create 15 comments
-        List<String> commentUids = createComments( 15 );
-        // add 3 uids to the existing comments UID
-        List<String> newUids = IntStream.rangeClosed( 1, 3 ).boxed().map( x -> CodeGenerator.generateUid() )
-            .collect( Collectors.toList() );
-        commentUids.addAll( newUids );
-
-        final List<String> filteredUid = commentService.filterExistingNotes( commentUids );
-        assertThat(filteredUid, hasSize(3));
-        for ( String uid : filteredUid )
-        {
-            assertTrue( newUids.contains( uid ) );
-        }
-    }
-    
-    private List<String> createComments( int size )
-    {
-        List<String> commentUids = new ArrayList<>( size );
-        for ( int i = 0; i < size; i++ )
-        {
-            TrackedEntityComment comment = new TrackedEntityComment();
-            comment.setUid( CodeGenerator.generateUid() );
-            comment.setCreated( new Date() );
-            comment.setCommentText( RandomStringUtils.randomAlphabetic( 20 ) );
-            commentService.addTrackedEntityComment( comment );
-            commentUids.add( comment.getUid() );
-
-        }
-        return commentUids;
-    }
-    
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -57,7 +57,6 @@ import org.springframework.stereotype.Service;
 public class EnrollmentTrackerConverterService
     implements TrackerConverterService<Enrollment, ProgramInstance>
 {
-
     private final NotesConverterService notesConverterService;
 
     public EnrollmentTrackerConverterService( NotesConverterService notesConverterService )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Note.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Note.java
@@ -28,8 +28,8 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -57,7 +57,4 @@ public class Note
 
     @JsonProperty
     private String value;
-
-    @JsonIgnore
-    private boolean newNote;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
@@ -58,8 +58,9 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.trackedentity.*;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentStore;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerIdentifierCollector;
@@ -111,6 +112,8 @@ public class DefaultTrackerPreheatService
 
     private final TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
+    private final TrackedEntityCommentStore trackedEntityCommentStore;
+
     private List<TrackerPreheatHook> preheatHooks = new ArrayList<>();
 
     @Autowired( required = false )
@@ -130,7 +133,8 @@ public class DefaultTrackerPreheatService
         ProgramStageInstanceStore programStageInstanceStore,
         RelationshipStore relationshipStore,
         TrackedEntityAttributeService trackedEntityAttributeService,
-        TrackedEntityAttributeValueService trackedEntityAttributeValueService )
+        TrackedEntityAttributeValueService trackedEntityAttributeValueService,
+        TrackedEntityCommentStore trackedEntityCommentStore )
     {
         this.schemaService = schemaService;
         this.queryService = queryService;
@@ -143,6 +147,7 @@ public class DefaultTrackerPreheatService
         this.relationshipStore = relationshipStore;
         this.trackedEntityAttributeService = trackedEntityAttributeService;
         this.trackedEntityAttributeValueService = trackedEntityAttributeValueService;
+        this.trackedEntityCommentStore = trackedEntityCommentStore;
     }
 
     @Override
@@ -244,6 +249,11 @@ public class DefaultTrackerPreheatService
                         .getByUid( ids, preheat.getUser() );
                     preheat.putRelationships( TrackerIdScheme.UID, relationships );
                 }
+            }
+            else if ( klass.isAssignableFrom( TrackedEntityComment.class ) )
+            {
+                splitList
+                    .forEach( ids -> preheat.putNotes( trackedEntityCommentStore.getByUid( ids, preheat.getUser() ) ) );
             }
             else
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerIdentifierParams;
@@ -56,8 +57,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -128,6 +132,11 @@ public class TrackerPreheat
      * for object merging.
      */
     private Map<TrackerIdScheme, Map<String, Relationship>> relationships = new EnumMap<>( TrackerIdScheme.class );
+
+    /**
+     * Internal map of all preheated notes (events and enrollments)
+     */
+    private Map<TrackerIdScheme, Map<String, TrackedEntityComment>> notes = new EnumMap<>( TrackerIdScheme.class );
 
     /**
      * A Map of event uid and preheated {@see ProgramInstance}. The value is a List,
@@ -570,6 +579,19 @@ public class TrackerPreheat
         events.get( identifier ).put( event, programStageInstance );
     }
 
+    public void putNotes( List<TrackedEntityComment> trackedEntityComments )
+    {
+        // Notes are always using UID scheme
+        notes.put( TrackerIdScheme.UID, trackedEntityComments.stream().collect(
+            Collectors.toMap( TrackedEntityComment::getUid, Function.identity() ) ) );
+
+    }
+    
+    public Optional<TrackedEntityComment> getNote( String uid )
+    {
+        return Optional.ofNullable( notes.get( TrackerIdScheme.UID ).get( uid ) );
+    }
+    
     public Map<TrackerIdScheme, Map<String, Relationship>> getRelationships()
     {
         return relationships;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -28,8 +28,19 @@ package org.hisp.dhis.tracker.preheat;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.api.client.util.Lists;
-import javassist.util.proxy.ProxyFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
@@ -50,18 +61,9 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import com.google.api.client.util.Lists;
+
+import javassist.util.proxy.ProxyFactory;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -584,12 +586,11 @@ public class TrackerPreheat
         // Notes are always using UID scheme
         notes.put( TrackerIdScheme.UID, trackedEntityComments.stream().collect(
             Collectors.toMap( TrackedEntityComment::getUid, Function.identity() ) ) );
-
     }
     
     public Optional<TrackedEntityComment> getNote( String uid )
     {
-        return Optional.ofNullable( notes.get( TrackerIdScheme.UID ).get( uid ) );
+        return Optional.ofNullable( notes.getOrDefault( TrackerIdScheme.UID, new HashMap<>() ).get( uid ) );
     }
     
     public Map<TrackerIdScheme, Map<String, Relationship>> getRelationships()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -110,6 +110,7 @@ public enum TrackerErrorCode
     E1113( "Enrollment: `{0}`, is already deleted." ),
     E1114( "TrackedEntity: `{0}`, is already deleted." ),
     E1118( "Assigned user `{0}` is not a valid uid."),
+    E1119( "A Tracker Note with uid `{0}` already exists."),
 
     //TODO: See TODO on error usage
     E1017( "Attribute: `{0}`, does not exist." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -172,6 +173,11 @@ public class TrackerImportValidationContext
     public ProgramInstance getProgramInstance( String id )
     {
         return bundle.getPreheat().getEnrollment( bundle.getIdentifier(), id );
+    }
+
+    public Optional<TrackedEntityComment> getNote( String uid )
+    {
+        return bundle.getPreheat().getNote( uid );
     }
 
     public ProgramStage getProgramStage( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.validation.hooks;
  */
 
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -41,18 +40,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class EnrollmentNoteValidationHook extends AbstractTrackerDtoValidationHook
 {
-    private final TrackedEntityCommentService commentService;
-
-    public EnrollmentNoteValidationHook( TrackedEntityAttributeService teAttrService,
-        TrackedEntityCommentService commentService )
+    public EnrollmentNoteValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( Enrollment.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
-        this.commentService = commentService;
     }
 
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        enrollment.setNotes( NoteValidationUtils.getPersistableNotes( this.commentService, enrollment.getNotes() ) );
+        enrollment.setNotes( NoteValidationUtils.validate( reporter, enrollment.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -29,13 +29,10 @@ package org.hisp.dhis.tracker.validation.hooks;
  */
 
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -43,19 +40,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Component
 public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
 {
-    private final TrackedEntityCommentService commentService;
-
-    public EventNoteValidationHook( TrackedEntityAttributeService teAttrService,
-        TrackedEntityCommentService commentService )
+    public EventNoteValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( Event.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
-        checkNotNull( commentService );
-        this.commentService = commentService;
     }
 
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        event.setNotes( NoteValidationUtils.getPersistableNotes( commentService, event.getNotes() ) );
+        event.setNotes( NoteValidationUtils.validate( reporter, event.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/NoteValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/NoteValidationUtils.java
@@ -1,77 +1,41 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
-/*
- * Copyright (c) 2004-2020, University of Oslo
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of the HISP project nor the names of its contributors may
- * be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+import static org.apache.commons.lang3.StringUtils.*;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1119;
+import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 
-import com.google.common.collect.Streams;
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
-import org.hisp.dhis.tracker.domain.Note;
-
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+
+import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 
 /**
  * @author Luciano Fiandesio
  */
-public class NoteValidationUtils {
-
-    private NoteValidationUtils()
+public class NoteValidationUtils
+{
+    protected static List<Note> validate( ValidationErrorReporter reporter, List<Note> notesToCheck )
     {
-    }
+        TrackerImportValidationContext context = reporter.getValidationContext();
 
-    /**
-     * Filters out from a List of {@see Note}, notes that have no value (empty note)
-     * and notes with an uid that already exist in the database.
-     *
-     * @param commentService an instance of {@see TrackedEntityCommentService},
-     *        required to check if a note uid already exist in the db
-     * @param notes the list of {@see Note} to filter
-     * @return a filtered list of {@see Note}}
-     */
-    static List<Note> getPersistableNotes( TrackedEntityCommentService commentService, List<Note> notes )
-    {
-        // Check which notes are already on the DB and skip them
-        // Only check notes that are marked NOT marked as "new note"
-        // FIXME: do we really need this? Currently trackedentitycomment uid is a unique
-        // key in the db, can't we simply catch the exception
-        List<String> nonExistingUid = commentService.filterExistingNotes( notes.stream()
-            .filter( n -> StringUtils.isNotEmpty( n.getValue() ) )
-            .filter( n -> !n.isNewNote() )
-            .map( Note::getNote )
-            .collect( Collectors.toList() ) );
-
-        return Streams.concat(
-            notes.stream()
-                .filter( Note::isNewNote )
-                .filter( n -> StringUtils.isNotEmpty( n.getValue() ) ),
-            notes.stream()
-                .filter( n -> nonExistingUid.contains( n.getNote() ) ) )
-            .collect( Collectors.toList() );
+        final List<Note> notes = new ArrayList<>();
+        for ( Note note : notesToCheck )
+        {
+            if ( isNotEmpty( note.getValue() ) ) // Ignore notes with no text
+            {
+                // If a note having the same UID already exist in the db, raise error
+                if ( isNotEmpty( note.getNote() ) && context.getNote( note.getNote() ).isPresent() )
+                {
+                    reporter.addError( newReport( E1119 ).addArgs( note.getNote() ) );
+                }
+                else
+                {
+                    notes.add( note );
+                }
+            }
+        }
+        return notes;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/NoteValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/NoteValidationUtils.java
@@ -1,5 +1,33 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import static org.apache.commons.lang3.StringUtils.*;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1119;
 import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckValidateAndGenerateUidHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckValidateAndGenerateUidHook.java
@@ -133,7 +133,6 @@ public class PreCheckValidateAndGenerateUidHook
                 if ( note.getNote() == null )
                 {
                     note.setNote( CodeGenerator.generateUid() );
-                    note.setNewNote( true );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/NotesConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/NotesConverterServiceTest.java
@@ -40,8 +40,8 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
@@ -1,0 +1,332 @@
+package org.hisp.dhis.tracker.preheat;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.fieldfilter.Defaults;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.PeriodStore;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.ProgramStageInstanceStore;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.relationship.RelationshipStore;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentStore;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultTrackerPreheatServiceTest
+{
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private QueryService queryService;
+
+    @Mock
+    private IdentifiableObjectManager manager;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private PeriodStore periodStore;
+
+    @Mock
+    private TrackedEntityInstanceStore trackedEntityInstanceStore;
+
+    @Mock
+    private ProgramInstanceStore programInstanceStore;
+
+    @Mock
+    private ProgramStageInstanceStore programStageInstanceStore;
+
+    @Mock
+    private RelationshipStore relationshipStore;
+
+    @Mock
+    private TrackedEntityAttributeService trackedEntityAttributeService;
+
+    @Mock
+    private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
+    @Mock
+    private TrackedEntityCommentStore trackedEntityCommentStore;
+
+    @InjectMocks
+    private DefaultTrackerPreheatService subject;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private BeanRandomizer rnd = new BeanRandomizer();
+
+    @Test
+    public void verifyTrackedEntitiesPreheated()
+    {
+        // Given
+        final List<TrackedEntity> trackedEntities = rnd.randomObjects( TrackedEntity.class, 3 );
+        final List<TrackedEntityInstance> preheatTeis = rnd.randomObjects( TrackedEntityInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> preheatTeis.get( i ).setUid( trackedEntities.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( trackedEntityInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatTeis );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .trackedEntities( trackedEntities )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        final Map<String, TrackedEntityInstance> teis = preheat.getTrackedEntities().get( TrackerIdScheme.UID );
+
+        assertThat( teis.keySet(), hasSize( 3 ) );
+        assertThat( teis.keySet(), containsInAnyOrder( trackedEntities.get( 0 ).getUid(),
+            trackedEntities.get( 1 ).getUid(), trackedEntities.get( 2 ).getUid() ) );
+    }
+
+    @Test
+    public void verifyEnrollmentsPreheated()
+    {
+        // Given
+        final List<Enrollment> enrollments = rnd.randomObjects( Enrollment.class, 3 );
+        final List<ProgramInstance> preheatPi = rnd.randomObjects( ProgramInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> preheatPi.get( i ).setUid( enrollments.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPi );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .enrollments( enrollments )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        final Map<String, ProgramInstance> pis = preheat.getEnrollments().get( TrackerIdScheme.UID );
+
+        assertThat( pis.keySet(), hasSize( 3 ) );
+        assertThat( pis.keySet(), containsInAnyOrder( enrollments.get( 0 ).getUid(),
+            enrollments.get( 1 ).getUid(), enrollments.get( 2 ).getUid() ) );
+    }
+
+    @Test
+    public void verifyEventsPreheated()
+    {
+        // Given
+        final List<Event> events = rnd.randomObjects( Event.class, 3 );
+        final List<ProgramStageInstance> preheatPsi = rnd.randomObjects( ProgramStageInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> preheatPsi.get( i ).setUid( events.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programStageInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPsi );
+
+        // When
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .events( events )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        final Map<String, ProgramStageInstance> psis = preheat.getEvents().get( TrackerIdScheme.UID );
+
+        assertThat( psis.keySet(), hasSize( 3 ) );
+        assertThat( psis.keySet(), containsInAnyOrder( events.get( 0 ).getUid(),
+            events.get( 1 ).getUid(), events.get( 2 ).getUid() ) );
+    }
+
+    @Test
+    public void verifyOrgUnitsPreheated()
+    {
+        // Given
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass( Query.class );
+        final List<OrganisationUnit> organisationUnits = rnd.randomObjects( OrganisationUnit.class, 3 );
+        final List<TrackedEntity> trackedEntitiesIithOu = rnd.randomObjects( TrackedEntity.class, 3 );
+
+        IntStream.range( 0, 3 )
+            .forEach( i -> trackedEntitiesIithOu.get( i ).setOrgUnit( organisationUnits.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( schemaService.getDynamicSchema( OrganisationUnit.class ) )
+            .thenReturn( new OrganisationUnitSchemaDescriptor().getSchema() );
+
+        doReturn( organisationUnits ).when( queryService ).query( queryCaptor.capture() );
+
+        // When
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .trackedEntities( trackedEntitiesIithOu )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        assertThat( getGeneric( preheat, OrganisationUnit.class, organisationUnits.get( 0 ).getUid() ),
+            is( notNullValue() ) );
+        assertThat( getGeneric( preheat, OrganisationUnit.class, organisationUnits.get( 1 ).getUid() ),
+            is( notNullValue() ) );
+        assertThat( getGeneric( preheat, OrganisationUnit.class, organisationUnits.get( 2 ).getUid() ),
+            is( notNullValue() ) );
+
+        final Query query = queryCaptor.getValue();
+        assertThat( query.getSchema().getKlass().getName(), is( OrganisationUnit.class.getName() ) );
+        assertThat( query.getDefaults(), is( Defaults.INCLUDE ) );
+        assertThat( query.getUser().getUid(), is( "user1234" ) );
+    }
+
+    @Test
+    public void verifyEnrollmentsNotesPreheated()
+    {
+        // Given
+        final List<Enrollment> enrollments = rnd.randomObjects( Enrollment.class, 3 );
+        final List<TrackedEntityComment> notes = rnd.randomObjects( TrackedEntityComment.class, 3 );
+        final List<ProgramInstance> preheatPi = rnd.randomObjects( ProgramInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> {
+            enrollments.get( i ).setNotes( Collections.singletonList(
+                new Note( CodeGenerator.generateUid(), "", "", RandomStringUtils.randomAlphabetic( 3 ) ) ) );
+            preheatPi.get( i ).setUid( enrollments.get( i ).getUid() );
+            notes.get( 0 ).setUid( enrollments.get( i ).getNotes().get( 0 ).getNote() );
+        } );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPi );
+        when( trackedEntityCommentStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( notes );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .enrollments( enrollments )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        assertTrue( preheat.getNote( notes.get( 0 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 1 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 2 ).getUid() ).isPresent());
+    }
+
+    @Test
+    public void verifyEventsNotesPreheated()
+    {
+        // Given
+        final List<Event> events = rnd.randomObjects( Event.class, 3 );
+        final List<ProgramStageInstance> preheatPsi = rnd.randomObjects( ProgramStageInstance.class, 3, "uid" );
+        final List<TrackedEntityComment> notes = rnd.randomObjects( TrackedEntityComment.class, 3 );
+
+        IntStream.range( 0, 3 ).forEach( i -> {
+            events.get( i ).setNotes( Collections.singletonList(
+                    new Note( CodeGenerator.generateUid(), "", "", RandomStringUtils.randomAlphabetic( 3 ) ) ) );
+            preheatPsi.get( i ).setUid( events.get( i ).getUid() );
+            notes.get( 0 ).setUid( events.get( i ).getNotes().get( 0 ).getNote() );
+        } );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programStageInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPsi );
+        when( trackedEntityCommentStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( notes );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+                .user( getUser() )
+                .events( events )
+                .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        assertTrue( preheat.getNote( notes.get( 0 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 1 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 2 ).getUid() ).isPresent());
+
+    }
+
+    private <T extends IdentifiableObject> T getGeneric( TrackerPreheat preheat, Class<T> klazz, String uid )
+    {
+        return preheat.get( TrackerIdScheme.UID, klazz, uid );
+    }
+
+    private User getUser()
+    {
+        User user = new User();
+        user.setUid( "user1234" );
+        return user;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -118,7 +118,6 @@ public class TrackerPreheatServiceTest
 
     @Test
     public void testCollectIdentifiersSimple()
-        throws IOException
     {
         TrackerBundleParams params = new TrackerBundleParams();
         Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -632,7 +632,6 @@ insert into programinstance (uid, created, lastUpdated, createdAtClient, lastUpd
 
         assertEquals( 1, validationReport.getErrorReports().size() );
 
-
         assertThat( validationReport.getErrorReports(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1048 ) ) ) );
     }
@@ -646,12 +645,15 @@ insert into programinstance (uid, created, lastUpdated, createdAtClient, lastUpd
         assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
         assertEquals( TrackerStatus.OK, createAndUpdate.getCommitReport().getStatus() );
 
+
         createAndUpdate = validateAndCommit(
             "tracker/validations/enrollments_bad-note-uuid-exists-part2.json", TrackerImportStrategy.CREATE );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
 
-        assertEquals( 0, validationReport.getErrorReports().size() );
+        assertEquals( 1, validationReport.getErrorReports().size() );
+        assertThat( validationReport.getErrorReports(),
+                everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1119 ) ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -28,29 +28,31 @@ package org.hisp.dhis.tracker.validation.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -62,9 +64,6 @@ public class EventNoteValidationHookTest
 {
     // Class under test
     private EventNoteValidationHook hook;
-
-    @Mock
-    private TrackedEntityCommentService commentService;
 
     @Mock
     private TrackedEntityAttributeService teAttrService;
@@ -79,94 +78,81 @@ public class EventNoteValidationHookTest
     @Before
     public void setUp()
     {
-        this.hook = new EventNoteValidationHook( teAttrService, commentService );
+        this.hook = new EventNoteValidationHook( teAttrService );
         rnd = new BeanRandomizer();
         event = rnd.randomObject( Event.class );
     }
 
     @Test
-    public void verifyAllNotesArePersistedWhenNotesAreNotOnDatabase()
+    public void testNoteWithExistingUidFails()
     {
         // Given
-        final List<Note> notes = rnd.randomObjects( Note.class, 5, "newNote" );
-        final List<String> notesUid = notes.stream().map( Note::getNote ).collect( Collectors.toList() );
+        final Note note = rnd.randomObject( Note.class );
 
-        event.setNotes( notes );
+        TrackerBundle trackerBundle = mock( TrackerBundle.class );
+        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+
+        when( ctx.getBundle() ).thenReturn( trackerBundle );
+        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, Note.class );
+
+        event.setNotes( Collections.singletonList( note ) );
 
         // When
-        when( commentService.filterExistingNotes( notesUid ) ).thenReturn( notesUid );
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
+        this.hook.validateEvent( reporter, event );
 
         // Then
-        assertThat( event.getNotes(), hasSize( 5 ) );
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1119 ) );
+        assertThat( event.getNotes(), hasSize( 0 ) );
     }
 
     @Test
-    public void verifyAllNewNotesArePersisted()
+    public void testNoteWithExistingUidAndNoTextIsIgnored()
+    {
+        // Given
+        final Note note = rnd.randomObject( Note.class );
+        note.setValue( null );
+        TrackerBundle trackerBundle = mock( TrackerBundle.class );
+        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+
+        when( ctx.getBundle() ).thenReturn( trackerBundle );
+        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, Note.class );
+
+        event.setNotes( Collections.singletonList( note ) );
+
+        // When
+        this.hook.validateEvent( reporter, event );
+
+        // Then
+        assertFalse( reporter.hasErrors() );
+        assertThat( event.getNotes(), hasSize( 0 ) );
+    }
+
+    @Test
+    public void testNotesAreValidWhenUidDoesNotExist()
     {
         // Given
         final List<Note> notes = rnd.randomObjects( Note.class, 5 );
-        makeAllNotesNew( notes );
-        final List<String> notesUid = notes.stream().map( Note::getNote ).collect( Collectors.toList() );
+        TrackerBundle trackerBundle = mock( TrackerBundle.class );
+        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+
+        when( ctx.getBundle() ).thenReturn( trackerBundle );
+        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, Note.class );
 
         event.setNotes( notes );
 
         // When
-        when( commentService.filterExistingNotes( notesUid ) ).thenReturn( new ArrayList<>() );
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
+        this.hook.validateEvent( reporter, event );
 
         // Then
+        assertFalse( reporter.hasErrors() );
         assertThat( event.getNotes(), hasSize( 5 ) );
     }
 
-    @Test
-    public void verifyOnlyNonExistingNoteArePersisted()
-    {
-        // Given
-        final List<Note> notes = rnd.randomObjects( Note.class, 3, "newNote" );
-        final List<Note> existingNotes = rnd.randomObjects( Note.class, 2, "newNote" );
 
-        event.setNotes( newArrayList( concat( notes, existingNotes ) ) );
-
-        // When
-        when( commentService.filterExistingNotes( anyList() ) )
-            .thenReturn( notes.stream().map( Note::getNote ).collect( Collectors.toList() ) );
-
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
-
-        // Then
-        assertThat( event.getNotes(), hasSize( 3 ) );
-    }
-
-    @Test
-    public void verifyOnlyNonExistingAndNonEmptyNoteArePersisted()
-    {
-        // Given
-        ArgumentCaptor<List<String>> argument = ArgumentCaptor.forClass( List.class );
-
-        final List<Note> notes = rnd.randomObjects( Note.class, 5, "newNote" );
-        final List<Note> emptyNotes = rnd.randomObjects( Note.class, 3, "newNote", "value" );
-        final List<Note> existingNotes = rnd.randomObjects( Note.class, 2, "newNote" );
-
-        event.setNotes( newArrayList( concat( notes, emptyNotes, existingNotes ) ) );
-
-        // When
-        when( commentService.filterExistingNotes( argument.capture() ) ).thenReturn(
-                notes.stream().map( Note::getNote ).collect( Collectors.toList() ) );
-
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
-
-        // Then
-        assertThat( event.getNotes(), hasSize( 5 ) );
-        List<String> value = argument.getValue();
-        // make sure that the filterExistingNotes was called only with uid belonging to notes with text
-        assertThat( value, containsInAnyOrder( newArrayList( concat( notes, existingNotes ) ).stream()
-            .map( Note::getNote ).toArray() ) );
-
-    }
-
-    private void makeAllNotesNew( List<Note> notes )
-    {
-        notes.forEach( n -> n.setNewNote( true ) );
-    }
 }


### PR DESCRIPTION
Make sure that a client sending an Enrollment or Event Note with the UID set, will get a proper error message if the Note UID already exist in the database.

ref: TECH-457