### PR TITLE
refactor: Tracker preheat code refactoring

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentService.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.trackedentitycomment;
  */
 
 
-import java.util.List;
-
 /**
  * @author Chau Thu Tran
  */
@@ -60,24 +58,6 @@ public interface TrackedEntityCommentService
      * @return true/false depending on result
      */
     boolean trackedEntityCommentExists( String uid );
-
-    /**
-     * Filters out existing {@see TrackedEntityComment} uids from a List of uids.
-     *
-     * Given a List:
-     *
-     * uid: abcd
-     * uid: cdef
-     * uid: ghil
-     * uid: mnop
-     *
-     * and assuming that "cdef" and "abcd" are associated to two TrackedEntityComment in the database,
-     * this method returns "ghil" and "mnop"
-     *
-     * @param uids a List of {@see TrackedEntityComment} uid
-     * @return a List of uid that are not present in the database
-     */
-    List<String> filterExistingNotes( List<String> uids );
 
     /**
      * Updates an {@link TrackedEntityComment}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentStore.java
@@ -56,8 +56,6 @@ package org.hisp.dhis.trackedentitycomment;/*
 
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
-import java.util.List;
-
 /**
  * @author David Katuscak
  */
@@ -72,24 +70,5 @@ public interface TrackedEntityCommentStore
      * @return true/false depending on result.
      */
     boolean exists( String uid );
-
-    /**
-     * Filters out existing {@see TrackedEntityComment} uid.
-     *
-     * Given:
-     *
-     * uid: abcd
-     * uid: cdef
-     * uid: ghil
-     * uid: mnop
-     *
-     * and assuming that "cdef" and "abcd" are associated to two TrackedEntityComment in the database,
-     * this method returns "ghil" and "mnop"
-     *
-     *
-     * @param noteUids a List of {@see TrackedEntityComment} uid
-     * @return a List of uid that are not present in the database
-     */
-    List<String> filterExisting( List<String> noteUids);
 
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/DefaultTrackedEntityCommentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/DefaultTrackedEntityCommentService.java
@@ -28,12 +28,10 @@ package org.hisp.dhis.trackedentitycomment;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Chau Thu Tran
@@ -80,13 +78,6 @@ public class DefaultTrackedEntityCommentService
     public boolean trackedEntityCommentExists( String uid )
     {
         return commentStore.exists( uid );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<String> filterExistingNotes( List<String> uids )
-    {
-        return this.commentStore.filterExisting( uids );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/hibernate/HibernateTrackedEntityCommentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/hibernate/HibernateTrackedEntityCommentStore.java
@@ -56,12 +56,7 @@
 
 package org.hisp.dhis.trackedentitycomment.hibernate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.hibernate.SessionFactory;
-import org.hibernate.query.Query;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
@@ -94,15 +89,4 @@ public class HibernateTrackedEntityCommentStore
             .getSingleResult();
     }
 
-    @Override
-    public List<String> filterExisting( List<String> noteUids )
-    {
-        if ( noteUids == null || noteUids.isEmpty() )
-        {
-            return new ArrayList<>();
-        }
-        final Query<String> query = getTypedQuery( "select uid from TrackedEntityComment where uid in (:uids)" );
-        final List<String> foundUids = query.setParameterList( "uids", noteUids ).getResultList();
-        return noteUids.stream().filter( uid -> !foundUids.contains( uid ) ).collect( Collectors.toList() );
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentServiceTest.java
@@ -28,24 +28,15 @@ package org.hisp.dhis.trackedentitycomment;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.common.CodeGenerator;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.CodeGenerator;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Chau Thu Tran
@@ -129,39 +120,4 @@ public class TrackedEntityCommentServiceTest
 
         assertTrue( commentService.trackedEntityCommentExists( commentA.getUid() ) );
     }
-
-    @Test
-    public void testFilterExistingNotes()
-    {
-        // create 15 comments
-        List<String> commentUids = createComments( 15 );
-        // add 3 uids to the existing comments UID
-        List<String> newUids = IntStream.rangeClosed( 1, 3 ).boxed().map( x -> CodeGenerator.generateUid() )
-            .collect( Collectors.toList() );
-        commentUids.addAll( newUids );
-
-        final List<String> filteredUid = commentService.filterExistingNotes( commentUids );
-        assertThat(filteredUid, hasSize(3));
-        for ( String uid : filteredUid )
-        {
-            assertTrue( newUids.contains( uid ) );
-        }
-    }
-    
-    private List<String> createComments( int size )
-    {
-        List<String> commentUids = new ArrayList<>( size );
-        for ( int i = 0; i < size; i++ )
-        {
-            TrackedEntityComment comment = new TrackedEntityComment();
-            comment.setUid( CodeGenerator.generateUid() );
-            comment.setCreated( new Date() );
-            comment.setCommentText( RandomStringUtils.randomAlphabetic( 20 ) );
-            commentService.addTrackedEntityComment( comment );
-            commentUids.add( comment.getUid() );
-
-        }
-        return commentUids;
-    }
-    
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -56,6 +56,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+        </dependency>
 
         <!-- Test -->
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierParams.java
@@ -95,4 +95,17 @@ public class TrackerIdentifierParams
     @Builder.Default
     private TrackerIdentifier categoryOption = TrackerIdentifier.UID;
 
+    public TrackerIdentifier getByClass( Class<?> klazz) {
+
+        switch ( klazz.getSimpleName()) {
+            case "CategoryOptionCombo":
+                return categoryOptionComboIdScheme;
+
+            default:
+                throw new IllegalStateException("Unexpected value: " + klazz.getName());
+        }
+
+
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -57,7 +57,6 @@ import org.springframework.stereotype.Service;
 public class EnrollmentTrackerConverterService
     implements TrackerConverterService<Enrollment, ProgramInstance>
 {
-
     private final NotesConverterService notesConverterService;
 
     public EnrollmentTrackerConverterService( NotesConverterService notesConverterService )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
@@ -28,121 +28,47 @@ package org.hisp.dhis.tracker.preheat;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
-import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.category.CategoryOption;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.common.IdentifiableObject;
+import static com.google.api.client.util.Preconditions.checkNotNull;
+
+import java.beans.Introspector;
+import java.util.List;
+
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.timer.SystemTimer;
 import org.hisp.dhis.commons.timer.Timer;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.fieldfilter.Defaults;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.PeriodStore;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramInstanceStore;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.program.ProgramStageInstanceStore;
-import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.query.Query;
-import org.hisp.dhis.query.QueryService;
-import org.hisp.dhis.query.Restriction;
-import org.hisp.dhis.query.Restrictions;
-import org.hisp.dhis.relationship.RelationshipStore;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.schema.Schema;
-import org.hisp.dhis.schema.SchemaService;
-import org.hisp.dhis.trackedentity.*;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.tracker.TrackerIdScheme;
-import org.hisp.dhis.tracker.TrackerIdentifier;
-import org.hisp.dhis.tracker.TrackerIdentifierCollector;
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.supplier.PreheatClassScanner;
+import org.hisp.dhis.tracker.preheat.supplier.PreheatSupplier;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static com.google.api.client.util.Preconditions.checkNotNull;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Slf4j
 @Service
-public class DefaultTrackerPreheatService
-    implements TrackerPreheatService
+public class DefaultTrackerPreheatService implements TrackerPreheatService, ApplicationContextAware
 {
-
-    public static final int SPLIT_LIST_PARTITION_SIZE = 20_000;
-
-    private final SchemaService schemaService;
-
-    private final QueryService queryService;
-
     private final IdentifiableObjectManager manager;
 
     private final CurrentUserService currentUserService;
 
-    private final PeriodStore periodStore;
-
-    private final TrackedEntityInstanceStore trackedEntityInstanceStore;
-
-    private final ProgramInstanceStore programInstanceStore;
-
-    private final ProgramStageInstanceStore programStageInstanceStore;
-
-    private final RelationshipStore relationshipStore;
-
-    private final TrackedEntityAttributeService trackedEntityAttributeService;
-
-    private final TrackedEntityAttributeValueService trackedEntityAttributeValueService;
-
-    private List<TrackerPreheatHook> preheatHooks = new ArrayList<>();
-
-    @Autowired( required = false )
-    public void setPreheatHooks( List<TrackerPreheatHook> preheatHooks )
-    {
-        this.preheatHooks = preheatHooks;
-    }
+    private List<String> preheatSuppliers;
 
     public DefaultTrackerPreheatService(
-        SchemaService schemaService,
-        QueryService queryService,
         IdentifiableObjectManager manager,
-        CurrentUserService currentUserService,
-        PeriodStore periodStore,
-        TrackedEntityInstanceStore trackedEntityInstanceStore,
-        ProgramInstanceStore programInstanceStore,
-        ProgramStageInstanceStore programStageInstanceStore,
-        RelationshipStore relationshipStore,
-        TrackedEntityAttributeService trackedEntityAttributeService,
-        TrackedEntityAttributeValueService trackedEntityAttributeValueService )
+        CurrentUserService currentUserService )
     {
-        this.schemaService = schemaService;
-        this.queryService = queryService;
         this.manager = manager;
         this.currentUserService = currentUserService;
-        this.periodStore = periodStore;
-        this.trackedEntityInstanceStore = trackedEntityInstanceStore;
-        this.programInstanceStore = programInstanceStore;
-        this.programStageInstanceStore = programStageInstanceStore;
-        this.relationshipStore = relationshipStore;
-        this.trackedEntityAttributeService = trackedEntityAttributeService;
-        this.trackedEntityAttributeValueService = trackedEntityAttributeValueService;
+
+        this.preheatSuppliers = new PreheatClassScanner().scanSuppliers();
     }
 
     @Override
@@ -160,225 +86,38 @@ public class DefaultTrackerPreheatService
 
         checkNotNull( preheat.getUser(), "Preheater is missing the user object." );
 
-        Map<Class<?>, Set<String>> identifierMap = TrackerIdentifierCollector.collect( params );
-
-        for ( Class<?> klass : identifierMap.keySet() )
-        {
-            Set<String> identifiers = identifierMap.get( klass );
-
-            List<List<String>> splitList = Lists.partition( new ArrayList<>( identifiers ), SPLIT_LIST_PARTITION_SIZE );
-
-            if ( klass.isAssignableFrom( TrackedEntity.class ) )
-            {
-                for ( List<String> ids : splitList )
-                {
-                    List<TrackedEntityInstance> trackedEntityInstances =
-                        trackedEntityInstanceStore.getByUid( ids, preheat.getUser() );
-                    preheat.putTrackedEntities( TrackerIdScheme.UID, trackedEntityInstances );
-                }
-            }
-            else if ( klass.isAssignableFrom( Enrollment.class ) )
-            {
-                for ( List<String> ids : splitList )
-                {
-                    List<ProgramInstance> programInstances = programInstanceStore.getByUid( ids, preheat.getUser() );
-                    preheat.putEnrollments( TrackerIdScheme.UID, programInstances );
-                }
-            }
-            else if ( klass.isAssignableFrom( Event.class ) )
-            {
-                for ( List<String> ids : splitList )
-                {
-                    List<ProgramStageInstance> programStageInstances = programStageInstanceStore
-                        .getByUid( ids, preheat.getUser() );
-                    preheat.putEvents( TrackerIdScheme.UID, programStageInstances );
-                }
-            }
-            else if ( klass.isAssignableFrom( OrganisationUnit.class ) )
-            {
-                TrackerIdentifier identifier = params.getIdentifiers().getOrgUnitIdScheme();
-                Schema schema = schemaService.getDynamicSchema( OrganisationUnit.class );
-
-                queryForIdentifiableObjects( preheat, schema, identifier, splitList );
-            }
-            else if ( klass.isAssignableFrom( Program.class ) )
-            {
-                Schema schema = schemaService.getDynamicSchema( Program.class );
-                TrackerIdentifier identifier = params.getIdentifiers().getProgramIdScheme();
-
-                queryForIdentifiableObjects( preheat, schema, identifier, splitList );
-            }
-            else if ( klass.isAssignableFrom( ProgramStage.class ) )
-            {
-                Schema schema = schemaService.getDynamicSchema( ProgramStage.class );
-                TrackerIdentifier identifier = params.getIdentifiers().getProgramStageIdScheme();
-
-                queryForIdentifiableObjects( preheat, schema, identifier, splitList );
-            }
-            else if ( klass.isAssignableFrom( DataElement.class ) )
-            {
-                Schema schema = schemaService.getDynamicSchema( DataElement.class );
-                TrackerIdentifier identifier = params.getIdentifiers().getDataElementIdScheme();
-
-                queryForIdentifiableObjects( preheat, schema, identifier, splitList );
-            }
-            else if ( klass.isAssignableFrom( CategoryOptionCombo.class ) )
-            {
-                Schema schema = schemaService.getDynamicSchema( CategoryOptionCombo.class );
-                TrackerIdentifier identifier = params.getIdentifiers().getCategoryOptionComboIdScheme();
-
-                queryForIdentifiableObjects( preheat, schema, identifier, splitList );
-            }
-            else if ( klass.isAssignableFrom( CategoryOption.class ) )
-            {
-                Schema schema = schemaService.getDynamicSchema( CategoryOption.class );
-                TrackerIdentifier identifier = params.getIdentifiers().getCategoryOption();
-
-                queryForIdentifiableObjects( preheat, schema, identifier, splitList );
-            }
-            else if ( klass.isAssignableFrom( Relationship.class ) )
-            {
-                for ( List<String> ids : splitList )
-                {
-                    List<org.hisp.dhis.relationship.Relationship> relationships = relationshipStore
-                        .getByUid( ids, preheat.getUser() );
-                    preheat.putRelationships( TrackerIdScheme.UID, relationships );
-                }
-            }
-            else
-            {
-                Schema schema = schemaService.getDynamicSchema( klass );
-
-                queryForIdentifiableObjects( preheat, schema, TrackerIdentifier.UID, splitList );
-            }
-        }
-
-        // since TrackedEntityTypes are not really required by incoming payload, and they are small in size/count, we preload them all here
-        preheat.put( TrackerIdentifier.UID, manager.getAll( TrackedEntityType.class ) );
-
-        // since RelationshipTypes are not really required by incoming payload, and they are small in size/count, we preload them all here
-        preheat.put( TrackerIdentifier.UID, manager.getAll( RelationshipType.class ) );
-
-        periodStore.getAll().forEach( period -> preheat.getPeriodMap().put( period.getName(), period ) );
-        periodStore.getAllPeriodTypes()
-            .forEach( periodType -> preheat.getPeriodTypeMap().put( periodType.getName(), periodType ) );
-
-        List<ProgramInstance> programInstances = programInstanceStore.getByType( ProgramType.WITHOUT_REGISTRATION );
-        programInstances.forEach( pi -> preheat.putEnrollment( TrackerIdScheme.UID, pi.getProgram().getUid(), pi ) );
-
-        Set<String> userUids = params.getEvents().stream()
-            .filter( event -> event.getAssignedUser() != null )
-            .map( event -> event.getAssignedUser().getUid() )
-            .filter( CodeGenerator::isValidUid )
-            .collect( Collectors.toSet() );
-
-        preheat.put( TrackerIdentifier.UID, manager.getByUid( User.class, userUids ) );
-
-        preheat.setUniqueAttributeValues( calculateUniqueAttributeValues( params ) );
-
-        preheatHooks.forEach( hook -> hook.preheat( params, preheat ) );
+        preheatSuppliers.forEach( supplier -> ctx
+            .getBean( Introspector.decapitalize( supplier ), PreheatSupplier.class ).add( params, preheat ) );
 
         log.info( "(" + preheat.getUsername() + ") Import:TrackerPreheat took " + timer.toString() );
 
         return preheat;
     }
 
-    private List<UniqueAttributeValue> calculateUniqueAttributeValues(
-        TrackerPreheatParams params )
-    {
-        List<TrackedEntityAttribute> uniqueTrackedEntityAttributes = trackedEntityAttributeService
-            .getAllUniqueTrackedEntityAttributes();
-
-        Map<TrackedEntityAttribute, List<String>> uniqueAttributes = params.getTrackedEntities()
-            .stream()
-            .flatMap( tei -> tei.getAttributes().stream() )
-            .filter( tea -> uniqueTrackedEntityAttributes.stream()
-                .anyMatch( uniqueAttr -> uniqueAttr.getUid().equals( tea.getAttribute() ) ) )
-            .collect( Collectors.toMap( a -> extractAttribute( a.getAttribute(), uniqueTrackedEntityAttributes ),
-                a -> extractValues( params.getTrackedEntities(), a.getAttribute() ) ) );
-
-        return trackedEntityAttributeValueService.getUniqueAttributeByValues( uniqueAttributes )
-            .stream()
-            .map( av -> new UniqueAttributeValue( av.getEntityInstance().getUid(), av.getAttribute().getUid(),
-                av.getValue(), av.getEntityInstance().getOrganisationUnit().getUid() ) )
-            .collect( Collectors.toList() );
-    }
-
-    private List<String> extractValues( List<TrackedEntity> trackedEntities, String attribute )
-    {
-        return trackedEntities
-            .stream()
-            .flatMap( tei -> tei.getAttributes().stream() )
-            .filter( a -> a.getAttribute().equals( attribute ) )
-            .map( a -> a.getValue() )
-            .collect( Collectors.toList() );
-    }
-
-    private TrackedEntityAttribute extractAttribute( String attribute,
-        List<TrackedEntityAttribute> uniqueTrackedEntityAttributes )
-    {
-        return uniqueTrackedEntityAttributes
-            .stream()
-            .filter( a -> a.getUid().equals( attribute ) )
-            .findAny()
-            .orElse( null );
-    }
-
     @Override
     public void validate( TrackerPreheatParams params )
     {
-        //TODO: Implement validation
-    }
-
-    private Restriction generateRestrictionFromIdentifiers( TrackerIdScheme idScheme, List<String> ids )
-    {
-        if ( TrackerIdScheme.CODE.equals( idScheme ) )
-        {
-            return Restrictions.in( "code", ids );
-        }
-        else
-        {
-            return Restrictions.in( "id", ids );
-        }
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private void queryForIdentifiableObjects( TrackerPreheat preheat, Schema schema, TrackerIdentifier identifier,
-        List<List<String>> splitList )
-    {
-        TrackerIdScheme idScheme = identifier.getIdScheme();
-        for ( List<String> ids : splitList )
-        {
-            List<? extends IdentifiableObject> objects;
-
-            if ( TrackerIdScheme.ATTRIBUTE.equals( idScheme ) )
-            {
-                Attribute attribute = new Attribute();
-                attribute.setUid( identifier.getValue() );
-                objects = manager.getAllByAttributeAndValues(
-                    (Class<? extends IdentifiableObject>) schema.getKlass(), attribute, ids );
-            }
-            else
-            {
-                Query query = Query.from( schema );
-                query.setUser( preheat.getUser() );
-                query.add( generateRestrictionFromIdentifiers( idScheme, ids ) );
-                query.setDefaults( Defaults.INCLUDE );
-                objects = queryService.query( query );
-            }
-
-            preheat.put( identifier, objects );
-        }
+        // TODO: Implement validation
     }
 
     private User getImportingUser( User user )
     {
-        // ıf user already set, reload the user to make sure its loaded in the current tx
+        // ıf user already set, reload the user to make sure its loaded in the current
+        // tx
         if ( user != null )
         {
             return manager.get( User.class, user.getUid() );
         }
 
         return currentUserService.getCurrentUser();
+    }
+
+    private ApplicationContext ctx;
+
+    @Override
+    public void setApplicationContext( ApplicationContext applicationContext )
+        throws BeansException
+    {
+        this.ctx = applicationContext;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerIdentifierParams;
@@ -56,8 +57,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -128,6 +132,11 @@ public class TrackerPreheat
      * for object merging.
      */
     private Map<TrackerIdScheme, Map<String, Relationship>> relationships = new EnumMap<>( TrackerIdScheme.class );
+
+    /**
+     * Internal map of all preheated notes (events and enrollments)
+     */
+    private Map<TrackerIdScheme, Map<String, TrackedEntityComment>> notes = new EnumMap<>( TrackerIdScheme.class );
 
     /**
      * A Map of event uid and preheated {@see ProgramInstance}. The value is a List,
@@ -570,6 +579,19 @@ public class TrackerPreheat
         events.get( identifier ).put( event, programStageInstance );
     }
 
+    public void putNotes( List<TrackedEntityComment> trackedEntityComments )
+    {
+        // Notes are always using UID scheme
+        notes.put( TrackerIdScheme.UID, trackedEntityComments.stream().collect(
+            Collectors.toMap( TrackedEntityComment::getUid, Function.identity() ) ) );
+
+    }
+    
+    public Optional<TrackedEntityComment> getNote( String uid )
+    {
+        return Optional.ofNullable( notes.get( TrackerIdScheme.UID ).get( uid ) );
+    }
+    
     public Map<TrackerIdScheme, Map<String, Relationship>> getRelationships()
     {
         return relationships;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,37 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.concurrent.TimeUnit;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.time.StopWatch;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * A {@link PreheatSupplier} subclass can implement this abstract class to
+ * execute code before and after the supplier has been executed (e.g. timing)
+ * 
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Slf4j
+public abstract class AbstractPreheatSupplier implements PreheatSupplier
 {
-    @JsonProperty
-    private String note;
+    @Override
+    public void add( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        log.debug( "Executing preheat supplier: {}", this.getClass().getName() );
+        StopWatch watch = new StopWatch();
+        watch.start();
+        preheatAdd( params, preheat );
+        watch.stop();
+        log.debug( "Supplier {} executed in : {}", this.getClass().getName(),
+            TimeUnit.SECONDS.convert( watch.getNanoTime(), TimeUnit.NANOSECONDS ) );
+    }
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    /**
+     * Template method: executes preheat logic from the subclass
+     */
+    public abstract void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
@@ -1,0 +1,111 @@
+package org.hisp.dhis.tracker.preheat.supplier;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.beans.Introspector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
+import org.hisp.dhis.tracker.TrackerIdentifierCollector;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.hisp.dhis.tracker.preheat.supplier.classStrategy.GenericStrategy;
+import org.hisp.dhis.tracker.preheat.supplier.classStrategy.ClassBasedSupplierStrategy;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.Lists;
+
+/**
+ * This supplier collects all the references from the Tracker Import payload and
+ * executes class-based strategies, based on the type of the object in the
+ * payload.
+ * 
+ * @author Luciano Fiandesio
+ */
+@Component
+public class ClassBasedSupplier extends AbstractPreheatSupplier implements ApplicationContextAware
+{
+    public static final int SPLIT_LIST_PARTITION_SIZE = 20_000;
+
+    private ApplicationContext context;
+
+    /**
+     * A Map correlating a Tracker class name to the Preheat strategy class name to use to load the data
+     */
+    private Map<String, String> classStrategies;
+
+    @PostConstruct
+    public void initStrategies()
+    {
+        classStrategies = new PreheatClassScanner().scanSupplierStrategies();
+    }
+
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        /*
+         * Collects all references from the payload and create a Map where key is the reference type (e.g. Enrollment)
+         * and the value is a Set of identifiers (e.g. a list of all Enrollment UIDs found in the payload)
+         */
+        Map<Class<?>, Set<String>> identifierMap = TrackerIdentifierCollector.collect( params );
+
+        for ( Class<?> klass : identifierMap.keySet() )
+        {
+            Set<String> identifiers = identifierMap.get( klass );
+
+            List<List<String>> splitList = Lists.partition( new ArrayList<>( identifiers ), SPLIT_LIST_PARTITION_SIZE );
+
+            final String bean = classStrategies.getOrDefault( klass.getSimpleName(), "GenericStrategy" );
+
+            if ( bean.equals( "GenericStrategy" ) )
+            {
+                context.getBean( Introspector.decapitalize( bean ), GenericStrategy.class ).add( klass, splitList,
+                    preheat );
+            }
+            else
+            {
+                context.getBean( Introspector.decapitalize( bean ), ClassBasedSupplierStrategy.class ).add( params, splitList, preheat );
+            }
+        }
+    }
+
+    @Override
+    public void setApplicationContext( ApplicationContext applicationContext )
+        throws BeansException
+    {
+        context = applicationContext;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.preheat.hooks;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,6 +28,10 @@ package org.hisp.dhis.tracker.preheat.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
@@ -37,31 +41,25 @@ import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.preheat.TrackerPreheatHook;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
+@RequiredArgsConstructor
 @Component
-public class FileResourceTrackerPreheatHook
-    implements TrackerPreheatHook
+public class FileResourceSupplier extends AbstractPreheatSupplier
 {
+    @NonNull
     private final FileResourceService fileResourceService;
 
-    public FileResourceTrackerPreheatHook( FileResourceService fileResourceService )
-    {
-        this.fileResourceService = fileResourceService;
-    }
-
     @Override
-    public void preheat( TrackerPreheatParams params, TrackerPreheat preheat )
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
     {
         List<TrackedEntityAttribute> attributes = preheat.getAll( TrackerIdScheme.UID, TrackedEntityAttribute.class );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,29 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hisp.dhis.period.PeriodStore;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+public class PeriodTypeSupplier extends AbstractPreheatSupplier
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final PeriodStore periodStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        periodStore.getAll().forEach( period -> preheat.getPeriodMap().put( period.getName(), period ) );
+        periodStore.getAllPeriodTypes()
+            .forEach( periodType -> preheat.getPeriodTypeMap().put( periodType.getName(), periodType ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PreheatClassScanner.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PreheatClassScanner.java
@@ -1,0 +1,112 @@
+package org.hisp.dhis.tracker.preheat.supplier;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.tracker.preheat.supplier.classStrategy.StrategyFor;
+
+import io.github.classgraph.AnnotationClassRef;
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+
+/**
+ * This class is responsible for creating an associative map where the key is
+ * the name of a Strategy class and the key is the name of the domain object
+ * class to cache (based on the {@see StrategyFor} annotation)
+ * 
+ * @author Luciano Fiandesio
+ */
+public class PreheatClassScanner
+{
+    public List<String> scanSuppliers()
+    {
+        final String pkg = getCurrentPackage();
+        final String annotation = SupplierDependsOn.class.getName();
+        try (ScanResult scanResult = new ClassGraph()
+            // .disableJarScanning()
+            .enableAllInfo()
+            .disableNestedJarScanning()
+            .acceptPackages( pkg )
+            .scan())
+        {
+
+            List<String> cls = scanResult.getAllClasses().stream()
+                .filter( c -> c.extendsSuperclass( AbstractPreheatSupplier.class.getName() ) )
+                .map( ClassInfo::getSimpleName ).collect( Collectors.toList() );
+
+            for ( ClassInfo classInfo : scanResult.getClassesWithAnnotation( annotation ) )
+            {
+                String dependsOn = getTargetClass( classInfo, annotation );
+                Collections.swap( cls, cls.indexOf( classInfo.getSimpleName() ), cls.indexOf( dependsOn ) );
+            }
+
+            return cls;
+        }
+    }
+
+    public Map<String, String> scanSupplierStrategies()
+    {
+        Map<String, String> classMap = new HashMap<>();
+        final String pkg = getCurrentPackage();
+        final String annotation = pkg + StrategyFor.class.getSimpleName();
+        try (ScanResult scanResult = new ClassGraph()
+            .disableJarScanning()
+            // .disableDirScanning()
+            // .verbose() // Log to stderr
+            .enableAllInfo() // Scan classes, methods, fields, annotations
+            .acceptPackages( pkg )
+            .scan())
+        { // Start the scan
+            for ( ClassInfo classInfo : scanResult.getClassesWithAnnotation( annotation ) )
+            {
+                classMap.put( getTargetClass( classInfo, annotation ), classInfo.getName() );
+            }
+        }
+        return classMap;
+    }
+
+    private String getCurrentPackage()
+    {
+        return this.getClass().getPackage().getName();
+    }
+
+    private String getTargetClass( ClassInfo classInfo, String annotation )
+    {
+        AnnotationInfo annotationInfo = classInfo.getAnnotationInfo( annotation );
+        AnnotationClassRef klazz = (AnnotationClassRef) annotationInfo.getParameterValues().get( 0 ).getValue();
+        return klazz.getClassInfo().getSimpleName();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PreheatSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PreheatSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,22 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * A PreheatSupplier supplies data to the {@link TrackerPreheat} object
+ * 
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+public interface PreheatSupplier
 {
-    @JsonProperty
-    private String note;
-
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    /**
+     * Adds data to the {@link TrackerPreheat} using the supplied
+     * {@link TrackerPreheatParams}
+     * 
+     * @param params {@link TrackerPreheatParams}
+     * @param preheat {@link TrackerPreheat}
+     */
+    void add( TrackerPreheatParams params, TrackerPreheat preheat );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,33 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+public class ProgramInstanceSupplier extends AbstractPreheatSupplier
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final ProgramInstanceStore programInstanceStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        List<ProgramInstance> programInstances = programInstanceStore.getByType( ProgramType.WITHOUT_REGISTRATION );
+        programInstances.forEach( pi -> preheat.putEnrollment( TrackerIdScheme.UID, pi.getProgram().getUid(), pi ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/RelationshipSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/RelationshipSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,29 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+public class RelationshipSupplier extends AbstractPreheatSupplier
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final IdentifiableObjectManager manager;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        preheat.put( TrackerIdentifier.UID, manager.getAll( RelationshipType.class ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/SupplierDependsOn.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/SupplierDependsOn.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,38 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
+ * This annotation establishes a dependency between {@link PreheatSupplier} objects.
  *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * <pre>{@code
+ * @SupplierDependsOn( SupplierZ.class )
+ * public class SupplierA implements PreheatSupplier {
+ *  ...
+ * }
+ *
+ * public class SupplierZ implements PreheatSupplier {
+ *  ...
+ * }
+ *
+ * }</pre>
+ *
+ * In the above example, the supplier "SupplierZ" will be executed before "SupplierA"
+ *
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Retention( RUNTIME )
+@Target( ElementType.TYPE )
+public @interface SupplierDependsOn
 {
-    @JsonProperty
-    private String note;
-
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    /**
+     * The {@link PreheatSupplier} subclass the supplier annotated with depends on
+     * 
+     */
+    Class<?> value();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/TrackedEntityTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/TrackedEntityTypeSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,29 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+public class TrackedEntityTypeSupplier extends AbstractPreheatSupplier
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final IdentifiableObjectManager manager;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        preheat.put( TrackerIdentifier.UID, manager.getAll( TrackedEntityType.class ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
@@ -1,0 +1,107 @@
+package org.hisp.dhis.tracker.preheat.supplier;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
+import org.hisp.dhis.tracker.domain.Attribute;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@RequiredArgsConstructor
+@Component
+public class UniqueAttributesSupplier extends AbstractPreheatSupplier
+{
+    @NonNull
+    private final TrackedEntityAttributeService trackedEntityAttributeService;
+
+    @NonNull
+    private final TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        preheat.setUniqueAttributeValues( calculateUniqueAttributeValues( params ) );
+    }
+
+    private List<UniqueAttributeValue> calculateUniqueAttributeValues(
+        TrackerPreheatParams params )
+    {
+        List<TrackedEntityAttribute> uniqueTrackedEntityAttributes = trackedEntityAttributeService
+            .getAllUniqueTrackedEntityAttributes();
+
+        Map<TrackedEntityAttribute, List<String>> uniqueAttributes = params.getTrackedEntities()
+            .stream()
+            .flatMap( tei -> tei.getAttributes().stream() )
+            .filter( tea -> uniqueTrackedEntityAttributes.stream()
+                .anyMatch( uniqueAttr -> uniqueAttr.getUid().equals( tea.getAttribute() ) ) )
+            .collect( Collectors.toMap( a -> extractAttribute( a.getAttribute(), uniqueTrackedEntityAttributes ),
+                a -> extractValues( params.getTrackedEntities(), a.getAttribute() ) ) );
+
+        return trackedEntityAttributeValueService.getUniqueAttributeByValues( uniqueAttributes )
+            .stream()
+            .map( av -> new UniqueAttributeValue( av.getEntityInstance().getUid(), av.getAttribute().getUid(),
+                av.getValue(), av.getEntityInstance().getOrganisationUnit().getUid() ) )
+            .collect( Collectors.toList() );
+    }
+
+    private List<String> extractValues( List<TrackedEntity> trackedEntities, String attribute )
+    {
+        return trackedEntities
+            .stream()
+            .flatMap( tei -> tei.getAttributes().stream() )
+            .filter( a -> a.getAttribute().equals( attribute ) )
+            .map( Attribute::getValue )
+            .collect( Collectors.toList() );
+    }
+
+    private TrackedEntityAttribute extractAttribute( String attribute,
+        List<TrackedEntityAttribute> uniqueTrackedEntityAttributes )
+    {
+        return uniqueTrackedEntityAttributes
+            .stream()
+            .filter( a -> a.getUid().equals( attribute ) )
+            .findAny()
+            .orElse( null );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplier.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,39 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.hisp.dhis.user.User;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+public class UserSupplier extends AbstractPreheatSupplier
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final IdentifiableObjectManager manager;
 
-    @JsonProperty
-    private String storedAt;
+    @Override
+    public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+    {
+        Set<String> userUids = params.getEvents().stream()
+            .filter( event -> event.getAssignedUser() != null )
+            .map( event -> event.getAssignedUser().getUid() )
+            .filter( CodeGenerator::isValidUid )
+            .collect( Collectors.toSet() );
 
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+        preheat.put( TrackerIdentifier.UID, manager.getByUid( User.class, userUids ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategy.java
@@ -1,0 +1,122 @@
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.List;
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.fieldfilter.Defaults;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.query.Restriction;
+import org.hisp.dhis.query.Restrictions;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+
+/**
+ * Abstract Tracker Preheat strategy that applies to strategies that employ the
+ * generic {@link QueryService} to fetch data
+ * 
+ * @author Luciano Fiandesio
+ */
+public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrategy
+{
+    protected final SchemaService schemaService;
+
+    private final QueryService queryService;
+
+    private final IdentifiableObjectManager manager;
+
+    public AbstractSchemaStrategy( SchemaService schemaService, QueryService queryService,
+        IdentifiableObjectManager manager )
+    {
+        this.schemaService = schemaService;
+        this.queryService = queryService;
+        this.manager = manager;
+    }
+
+    @Override
+    public void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        TrackerIdentifier identifier = params.getIdentifiers().getByClass( getSchemaClass() );
+        Schema schema = schemaService.getDynamicSchema( getSchemaClass() );
+
+        queryForIdentifiableObjects( preheat, schema, identifier, splitList );
+    }
+
+    protected abstract Class<?> getSchemaClass();
+
+    @SuppressWarnings( "unchecked" )
+    protected void queryForIdentifiableObjects( TrackerPreheat preheat, Schema schema, TrackerIdentifier identifier,
+        List<List<String>> splitList )
+    {
+        TrackerIdScheme idScheme = identifier.getIdScheme();
+        for ( List<String> ids : splitList )
+        {
+            List<? extends IdentifiableObject> objects;
+
+            if ( TrackerIdScheme.ATTRIBUTE.equals( idScheme ) )
+            {
+                Attribute attribute = new Attribute();
+                attribute.setUid( identifier.getValue() );
+                objects = manager.getAllByAttributeAndValues(
+                    (Class<? extends IdentifiableObject>) schema.getKlass(), attribute, ids );
+            }
+            else
+            {
+                Query query = Query.from( schema );
+                query.setUser( preheat.getUser() );
+                query.add( generateRestrictionFromIdentifiers( idScheme, ids ) );
+                query.setDefaults( Defaults.INCLUDE );
+                objects = queryService.query( query );
+            }
+
+            preheat.put( identifier, objects );
+        }
+    }
+
+    private Restriction generateRestrictionFromIdentifiers( TrackerIdScheme idScheme, List<String> ids )
+    {
+        if ( TrackerIdScheme.CODE.equals( idScheme ) )
+        {
+            return Restrictions.in( "code", ids );
+        }
+        else
+        {
+            return Restrictions.in( "id", ids );
+        }
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionComboStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionComboStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,28 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( CategoryOptionCombo.class )
+public class CatOptionComboStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public CatOptionComboStrategy( SchemaService schemaService, QueryService queryService,
+        IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,28 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( CategoryOption.class )
+public class CatOptionStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public CatOptionStrategy( SchemaService schemaService, QueryService queryService,
+        IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ClassBasedSupplierStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ClassBasedSupplierStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,16 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * 
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+public interface ClassBasedSupplierStrategy
 {
-    @JsonProperty
-    private String note;
-
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/DataElementStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/DataElementStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,28 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( DataElement.class )
+public class DataElementStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public DataElementStrategy( SchemaService schemaService, QueryService queryService,
+        IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/EnrollmentStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/EnrollmentStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,37 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+@StrategyFor( Enrollment.class )
+public class EnrollmentStrategy implements ClassBasedSupplierStrategy
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final ProgramInstanceStore programInstanceStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        for ( List<String> ids : splitList )
+        {
+            List<ProgramInstance> programInstances = programInstanceStore.getByUid( ids, preheat.getUser() );
+            preheat.putEnrollments( TrackerIdScheme.UID, programInstances );
+        }
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/EventStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/EventStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,38 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.ProgramStageInstanceStore;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+@StrategyFor( Event.class )
+public class EventStrategy implements ClassBasedSupplierStrategy
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final ProgramStageInstanceStore programStageInstanceStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        for ( List<String> ids : splitList )
+        {
+            List<ProgramStageInstance> programStageInstances = programStageInstanceStore
+                .getByUid( ids, preheat.getUser() );
+            preheat.putEvents( TrackerIdScheme.UID, programStageInstances );
+        }
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/GenericStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/GenericStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,38 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( GenericStrategy.class )
+public class GenericStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public GenericStrategy( SchemaService schemaService, QueryService queryService,
+        IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
+    public void add( Class<?> klazz, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        Schema schema = schemaService.getDynamicSchema( klazz );
+        queryForIdentifiableObjects( preheat, schema, TrackerIdentifier.UID, splitList );
+    }
 
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/NoteStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/NoteStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,33 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentStore;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+@StrategyFor( TrackedEntityComment.class )
+public class NoteStrategy implements ClassBasedSupplierStrategy
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final TrackedEntityCommentStore trackedEntityCommentStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        splitList
+            .forEach( ids -> preheat.putNotes( trackedEntityCommentStore.getByUid( ids,
+                preheat.getUser() ) ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/OrgUnitStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/OrgUnitStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,27 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( OrganisationUnit.class )
+public class OrgUnitStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public OrgUnitStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStageStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStageStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,29 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( ProgramStage.class )
+public class ProgramStageStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public ProgramStageStrategy( SchemaService schemaService, QueryService queryService,
+        IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,27 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Component
+@StrategyFor( Program.class )
+public class ProgramStrategy extends AbstractSchemaStrategy
 {
-    @JsonProperty
-    private String note;
+    public ProgramStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager )
+    {
+        super( schemaService, queryService, manager );
+    }
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    protected Class<?> getSchemaClass()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).value();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/RelationshipStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/RelationshipStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,37 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.relationship.RelationshipStore;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+@StrategyFor( Relationship.class )
+public class RelationshipStrategy implements ClassBasedSupplierStrategy
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private final RelationshipStore relationshipStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        for ( List<String> ids : splitList )
+        {
+            List<org.hisp.dhis.relationship.Relationship> relationships = relationshipStore
+                .getByUid( ids, preheat.getUser() );
+            preheat.putRelationships( TrackerIdScheme.UID, relationships );
+        }
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,21 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Annotation for {@link ClassBasedSupplierStrategy} classes that specifies the
+ * Tracker domain object the annotated strategy has to process
+ * 
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@Retention( RUNTIME )
+@Target( ElementType.TYPE )
+public @interface StrategyFor
 {
-    @JsonProperty
-    private String note;
-
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    Class<?> value();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/TrackerEntityInstanceStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/TrackerEntityInstanceStrategy.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.domain;
+package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,33 +28,38 @@ package org.hisp.dhis.tracker.domain;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luciano Fiandesio
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note
+@RequiredArgsConstructor
+@Component
+@StrategyFor( TrackedEntity.class )
+public class TrackerEntityInstanceStrategy implements ClassBasedSupplierStrategy
 {
-    @JsonProperty
-    private String note;
+    @NonNull
+    private TrackedEntityInstanceStore trackedEntityInstanceStore;
 
-    @JsonProperty
-    private String storedAt;
-
-    @JsonProperty
-    private String storedBy;
-
-    @JsonProperty
-    private String value;
+    @Override
+    public void add( TrackerPreheatParams params, List<List<String>> splitList, TrackerPreheat preheat )
+    {
+        for ( List<String> ids : splitList )
+        {
+            List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceStore.getByUid( ids,
+                preheat.getUser() );
+            preheat.putTrackedEntities( TrackerIdScheme.UID, trackedEntityInstances );
+        }
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -110,6 +110,7 @@ public enum TrackerErrorCode
     E1113( "Enrollment: `{0}`, is already deleted." ),
     E1114( "TrackedEntity: `{0}`, is already deleted." ),
     E1118( "Assigned user `{0}` is not a valid uid."),
+    E1119( "A Tracker Note with uid `{0}` already exists."),
 
     //TODO: See TODO on error usage
     E1017( "Attribute: `{0}`, does not exist." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -172,6 +173,11 @@ public class TrackerImportValidationContext
     public ProgramInstance getProgramInstance( String id )
     {
         return bundle.getPreheat().getEnrollment( bundle.getIdentifier(), id );
+    }
+
+    public Optional<TrackedEntityComment> getNote( String uid )
+    {
+        return bundle.getPreheat().getNote( uid );
     }
 
     public ProgramStage getProgramStage( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.validation.hooks;
  */
 
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -41,18 +40,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class EnrollmentNoteValidationHook extends AbstractTrackerDtoValidationHook
 {
-    private final TrackedEntityCommentService commentService;
-
-    public EnrollmentNoteValidationHook( TrackedEntityAttributeService teAttrService,
-        TrackedEntityCommentService commentService )
+    public EnrollmentNoteValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( Enrollment.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
-        this.commentService = commentService;
     }
 
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        enrollment.setNotes( NoteValidationUtils.getPersistableNotes( this.commentService, enrollment.getNotes() ) );
+        enrollment.setNotes( NoteValidationUtils.validate( reporter, enrollment.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -29,13 +29,10 @@ package org.hisp.dhis.tracker.validation.hooks;
  */
 
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -43,19 +40,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Component
 public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
 {
-    private final TrackedEntityCommentService commentService;
-
-    public EventNoteValidationHook( TrackedEntityAttributeService teAttrService,
-        TrackedEntityCommentService commentService )
+    public EventNoteValidationHook( TrackedEntityAttributeService teAttrService )
     {
         super( Event.class, TrackerImportStrategy.CREATE_AND_UPDATE, teAttrService );
-        checkNotNull( commentService );
-        this.commentService = commentService;
     }
 
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        event.setNotes( NoteValidationUtils.getPersistableNotes( commentService, event.getNotes() ) );
+        event.setNotes( NoteValidationUtils.validate( reporter, event.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/NoteValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/NoteValidationUtils.java
@@ -1,77 +1,41 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
-/*
- * Copyright (c) 2004-2020, University of Oslo
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of the HISP project nor the names of its contributors may
- * be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+import static org.apache.commons.lang3.StringUtils.*;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1119;
+import static org.hisp.dhis.tracker.report.ValidationErrorReporter.newReport;
 
-import com.google.common.collect.Streams;
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
-import org.hisp.dhis.tracker.domain.Note;
-
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+
+import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 
 /**
  * @author Luciano Fiandesio
  */
-public class NoteValidationUtils {
-
-    private NoteValidationUtils()
+public class NoteValidationUtils
+{
+    protected static List<Note> validate( ValidationErrorReporter reporter, List<Note> notesToCheck )
     {
-    }
+        TrackerImportValidationContext context = reporter.getValidationContext();
 
-    /**
-     * Filters out from a List of {@see Note}, notes that have no value (empty note)
-     * and notes with an uid that already exist in the database.
-     *
-     * @param commentService an instance of {@see TrackedEntityCommentService},
-     *        required to check if a note uid already exist in the db
-     * @param notes the list of {@see Note} to filter
-     * @return a filtered list of {@see Note}}
-     */
-    static List<Note> getPersistableNotes( TrackedEntityCommentService commentService, List<Note> notes )
-    {
-        // Check which notes are already on the DB and skip them
-        // Only check notes that are marked NOT marked as "new note"
-        // FIXME: do we really need this? Currently trackedentitycomment uid is a unique
-        // key in the db, can't we simply catch the exception
-        List<String> nonExistingUid = commentService.filterExistingNotes( notes.stream()
-            .filter( n -> StringUtils.isNotEmpty( n.getValue() ) )
-            .filter( n -> !n.isNewNote() )
-            .map( Note::getNote )
-            .collect( Collectors.toList() ) );
-
-        return Streams.concat(
-            notes.stream()
-                .filter( Note::isNewNote )
-                .filter( n -> StringUtils.isNotEmpty( n.getValue() ) ),
-            notes.stream()
-                .filter( n -> nonExistingUid.contains( n.getNote() ) ) )
-            .collect( Collectors.toList() );
+        final List<Note> notes = new ArrayList<>();
+        for ( Note note : notesToCheck )
+        {
+            if ( isNotEmpty( note.getValue() ) ) // Ignore notes with no text
+            {
+                // If a note having the same UID already exist in the db, raise error
+                if ( isNotEmpty( note.getNote() ) && context.getNote( note.getNote() ).isPresent() )
+                {
+                    reporter.addError( newReport( E1119 ).addArgs( note.getNote() ) );
+                }
+                else
+                {
+                    notes.add( note );
+                }
+            }
+        }
+        return notes;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckValidateAndGenerateUidHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckValidateAndGenerateUidHook.java
@@ -133,7 +133,6 @@ public class PreCheckValidateAndGenerateUidHook
                 if ( note.getNote() == null )
                 {
                     note.setNote( CodeGenerator.generateUid() );
-                    note.setNewNote( true );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/NotesConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/NotesConverterServiceTest.java
@@ -40,8 +40,8 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
@@ -1,0 +1,332 @@
+package org.hisp.dhis.tracker.preheat;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.fieldfilter.Defaults;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.PeriodStore;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.ProgramStageInstanceStore;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.relationship.RelationshipStore;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentStore;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class DefaultTrackerPreheatServiceTest
+{
+    @Mock
+    private SchemaService schemaService;
+
+    @Mock
+    private QueryService queryService;
+
+    @Mock
+    private IdentifiableObjectManager manager;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private PeriodStore periodStore;
+
+    @Mock
+    private TrackedEntityInstanceStore trackedEntityInstanceStore;
+
+    @Mock
+    private ProgramInstanceStore programInstanceStore;
+
+    @Mock
+    private ProgramStageInstanceStore programStageInstanceStore;
+
+    @Mock
+    private RelationshipStore relationshipStore;
+
+    @Mock
+    private TrackedEntityAttributeService trackedEntityAttributeService;
+
+    @Mock
+    private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
+    @Mock
+    private TrackedEntityCommentStore trackedEntityCommentStore;
+
+    @InjectMocks
+    private DefaultTrackerPreheatService subject;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private BeanRandomizer rnd = new BeanRandomizer();
+
+    @Test
+    public void verifyTrackedEntitiesPreheated()
+    {
+        // Given
+        final List<TrackedEntity> trackedEntities = rnd.randomObjects( TrackedEntity.class, 3 );
+        final List<TrackedEntityInstance> preheatTeis = rnd.randomObjects( TrackedEntityInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> preheatTeis.get( i ).setUid( trackedEntities.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( trackedEntityInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatTeis );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .trackedEntities( trackedEntities )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        final Map<String, TrackedEntityInstance> teis = preheat.getTrackedEntities().get( TrackerIdScheme.UID );
+
+        assertThat( teis.keySet(), hasSize( 3 ) );
+        assertThat( teis.keySet(), containsInAnyOrder( trackedEntities.get( 0 ).getUid(),
+            trackedEntities.get( 1 ).getUid(), trackedEntities.get( 2 ).getUid() ) );
+    }
+
+    @Test
+    public void verifyEnrollmentsPreheated()
+    {
+        // Given
+        final List<Enrollment> enrollments = rnd.randomObjects( Enrollment.class, 3 );
+        final List<ProgramInstance> preheatPi = rnd.randomObjects( ProgramInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> preheatPi.get( i ).setUid( enrollments.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPi );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .enrollments( enrollments )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        final Map<String, ProgramInstance> pis = preheat.getEnrollments().get( TrackerIdScheme.UID );
+
+        assertThat( pis.keySet(), hasSize( 3 ) );
+        assertThat( pis.keySet(), containsInAnyOrder( enrollments.get( 0 ).getUid(),
+            enrollments.get( 1 ).getUid(), enrollments.get( 2 ).getUid() ) );
+    }
+
+    @Test
+    public void verifyEventsPreheated()
+    {
+        // Given
+        final List<Event> events = rnd.randomObjects( Event.class, 3 );
+        final List<ProgramStageInstance> preheatPsi = rnd.randomObjects( ProgramStageInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> preheatPsi.get( i ).setUid( events.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programStageInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPsi );
+
+        // When
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .events( events )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        final Map<String, ProgramStageInstance> psis = preheat.getEvents().get( TrackerIdScheme.UID );
+
+        assertThat( psis.keySet(), hasSize( 3 ) );
+        assertThat( psis.keySet(), containsInAnyOrder( events.get( 0 ).getUid(),
+            events.get( 1 ).getUid(), events.get( 2 ).getUid() ) );
+    }
+
+    @Test
+    public void verifyOrgUnitsPreheated()
+    {
+        // Given
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass( Query.class );
+        final List<OrganisationUnit> organisationUnits = rnd.randomObjects( OrganisationUnit.class, 3 );
+        final List<TrackedEntity> trackedEntitiesIithOu = rnd.randomObjects( TrackedEntity.class, 3 );
+
+        IntStream.range( 0, 3 )
+            .forEach( i -> trackedEntitiesIithOu.get( i ).setOrgUnit( organisationUnits.get( i ).getUid() ) );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( schemaService.getDynamicSchema( OrganisationUnit.class ) )
+            .thenReturn( new OrganisationUnitSchemaDescriptor().getSchema() );
+
+        doReturn( organisationUnits ).when( queryService ).query( queryCaptor.capture() );
+
+        // When
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .trackedEntities( trackedEntitiesIithOu )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        assertThat( getGeneric( preheat, OrganisationUnit.class, organisationUnits.get( 0 ).getUid() ),
+            is( notNullValue() ) );
+        assertThat( getGeneric( preheat, OrganisationUnit.class, organisationUnits.get( 1 ).getUid() ),
+            is( notNullValue() ) );
+        assertThat( getGeneric( preheat, OrganisationUnit.class, organisationUnits.get( 2 ).getUid() ),
+            is( notNullValue() ) );
+
+        final Query query = queryCaptor.getValue();
+        assertThat( query.getSchema().getKlass().getName(), is( OrganisationUnit.class.getName() ) );
+        assertThat( query.getDefaults(), is( Defaults.INCLUDE ) );
+        assertThat( query.getUser().getUid(), is( "user1234" ) );
+    }
+
+    @Test
+    public void verifyEnrollmentsNotesPreheated()
+    {
+        // Given
+        final List<Enrollment> enrollments = rnd.randomObjects( Enrollment.class, 3 );
+        final List<TrackedEntityComment> notes = rnd.randomObjects( TrackedEntityComment.class, 3 );
+        final List<ProgramInstance> preheatPi = rnd.randomObjects( ProgramInstance.class, 3, "uid" );
+
+        IntStream.range( 0, 3 ).forEach( i -> {
+            enrollments.get( i ).setNotes( Collections.singletonList(
+                new Note( CodeGenerator.generateUid(), "", "", RandomStringUtils.randomAlphabetic( 3 ) ) ) );
+            preheatPi.get( i ).setUid( enrollments.get( i ).getUid() );
+            notes.get( 0 ).setUid( enrollments.get( i ).getNotes().get( 0 ).getNote() );
+        } );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPi );
+        when( trackedEntityCommentStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( notes );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+            .user( getUser() )
+            .enrollments( enrollments )
+            .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        assertTrue( preheat.getNote( notes.get( 0 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 1 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 2 ).getUid() ).isPresent());
+    }
+
+    @Test
+    public void verifyEventsNotesPreheated()
+    {
+        // Given
+        final List<Event> events = rnd.randomObjects( Event.class, 3 );
+        final List<ProgramStageInstance> preheatPsi = rnd.randomObjects( ProgramStageInstance.class, 3, "uid" );
+        final List<TrackedEntityComment> notes = rnd.randomObjects( TrackedEntityComment.class, 3 );
+
+        IntStream.range( 0, 3 ).forEach( i -> {
+            events.get( i ).setNotes( Collections.singletonList(
+                    new Note( CodeGenerator.generateUid(), "", "", RandomStringUtils.randomAlphabetic( 3 ) ) ) );
+            preheatPsi.get( i ).setUid( events.get( i ).getUid() );
+            notes.get( 0 ).setUid( events.get( i ).getNotes().get( 0 ).getNote() );
+        } );
+
+        when( manager.get( User.class, getUser().getUid() ) ).thenReturn( getUser() );
+        when( programStageInstanceStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( preheatPsi );
+        when( trackedEntityCommentStore.getByUid( anyList(), any( User.class ) ) ).thenReturn( notes );
+
+        final TrackerPreheatParams preheatParams = TrackerPreheatParams.builder()
+                .user( getUser() )
+                .events( events )
+                .build();
+
+        final TrackerPreheat preheat = subject.preheat( preheatParams );
+
+        // Then
+        assertTrue( preheat.getNote( notes.get( 0 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 1 ).getUid() ).isPresent());
+        assertTrue( preheat.getNote( notes.get( 2 ).getUid() ).isPresent());
+
+    }
+
+    private <T extends IdentifiableObject> T getGeneric( TrackerPreheat preheat, Class<T> klazz, String uid )
+    {
+        return preheat.get( TrackerIdScheme.UID, klazz, uid );
+    }
+
+    private User getUser()
+    {
+        User user = new User();
+        user.setUid( "user1234" );
+        return user;
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -118,7 +118,6 @@ public class TrackerPreheatServiceTest
 
     @Test
     public void testCollectIdentifiersSimple()
-        throws IOException
     {
         TrackerBundleParams params = new TrackerBundleParams();
         Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PreheatClassScannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PreheatClassScannerTest.java
@@ -1,0 +1,46 @@
+package org.hisp.dhis.tracker.preheat.supplier;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.TrackerPreheatParams;
+import org.junit.Test;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class PreheatClassScannerTest
+{
+
+    @Test
+    public void verifyScanSupplierRespectsOrderAnnotation()
+    {
+        final List<String> suppliers = new PreheatClassScanner().scanSuppliers();
+
+        assertTrue(
+            suppliers.indexOf( PreheatClassScannerTest.class.getSimpleName() + "$" + ZSupplier.class.getSimpleName() ) <
+            suppliers.indexOf( PreheatClassScannerTest.class.getSimpleName() + "$" + ASupplier.class.getSimpleName() ) );
+    }
+
+    public class ZSupplier extends AbstractPreheatSupplier
+    {
+        @Override
+        public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+        {
+            // DUMMY
+        }
+    }
+
+    @SupplierDependsOn( ZSupplier.class )
+    public class ASupplier extends AbstractPreheatSupplier
+    {
+        @Override
+        public void preheatAdd( TrackerPreheatParams params, TrackerPreheat preheat )
+        {
+            // DUMMY
+        }
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiHookTest.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker.preheat.hooks;
+package org.hisp.dhis.tracker.preheat.supplier;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -69,7 +69,7 @@ import com.google.common.collect.Lists;
  */
 public class ProgramInstanceByTeiHookTest
 {
-    private ProgramInstanceByTeiHook hook;
+    private ProgramInstanceByTeiSupplier hook;
 
     @Mock
     private ProgramInstanceStore programInstanceStore;
@@ -80,7 +80,7 @@ public class ProgramInstanceByTeiHookTest
     @Before
     public void setUp()
     {
-        this.hook = new ProgramInstanceByTeiHook( programInstanceStore );
+        this.hook = new ProgramInstanceByTeiSupplier( programInstanceStore );
     }
 
     @Test
@@ -130,7 +130,7 @@ public class ProgramInstanceByTeiHookTest
                 .thenReturn( Collections.singletonList( p4 ) );
 
         // When
-        this.hook.preheat( params, trackerPreheat );
+        this.hook.preheatAdd( params, trackerPreheat );
 
         // Then
         final Map<String, List<ProgramInstance>> programInstancesByProgramAndTei = trackerPreheat
@@ -189,7 +189,7 @@ public class ProgramInstanceByTeiHookTest
                 .thenReturn( Collections.singletonList( p4 ) );
 
         // When
-        this.hook.preheat( params, trackerPreheat );
+        this.hook.preheatAdd( params, trackerPreheat );
 
         // Then
         final Map<String, List<ProgramInstance>> programInstancesByProgramAndTei = trackerPreheat

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -28,29 +28,31 @@ package org.hisp.dhis.tracker.validation.hooks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -62,9 +64,6 @@ public class EventNoteValidationHookTest
 {
     // Class under test
     private EventNoteValidationHook hook;
-
-    @Mock
-    private TrackedEntityCommentService commentService;
 
     @Mock
     private TrackedEntityAttributeService teAttrService;
@@ -79,94 +78,81 @@ public class EventNoteValidationHookTest
     @Before
     public void setUp()
     {
-        this.hook = new EventNoteValidationHook( teAttrService, commentService );
+        this.hook = new EventNoteValidationHook( teAttrService );
         rnd = new BeanRandomizer();
         event = rnd.randomObject( Event.class );
     }
 
     @Test
-    public void verifyAllNotesArePersistedWhenNotesAreNotOnDatabase()
+    public void testNoteWithExistingUidFails()
     {
         // Given
-        final List<Note> notes = rnd.randomObjects( Note.class, 5, "newNote" );
-        final List<String> notesUid = notes.stream().map( Note::getNote ).collect( Collectors.toList() );
+        final Note note = rnd.randomObject( Note.class );
 
-        event.setNotes( notes );
+        TrackerBundle trackerBundle = mock( TrackerBundle.class );
+        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+
+        when( ctx.getBundle() ).thenReturn( trackerBundle );
+        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, Note.class );
+
+        event.setNotes( Collections.singletonList( note ) );
 
         // When
-        when( commentService.filterExistingNotes( notesUid ) ).thenReturn( notesUid );
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
+        this.hook.validateEvent( reporter, event );
 
         // Then
-        assertThat( event.getNotes(), hasSize( 5 ) );
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1119 ) );
+        assertThat( event.getNotes(), hasSize( 0 ) );
     }
 
     @Test
-    public void verifyAllNewNotesArePersisted()
+    public void testNoteWithExistingUidAndNoTextIsIgnored()
+    {
+        // Given
+        final Note note = rnd.randomObject( Note.class );
+        note.setValue( null );
+        TrackerBundle trackerBundle = mock( TrackerBundle.class );
+        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+
+        when( ctx.getBundle() ).thenReturn( trackerBundle );
+        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, Note.class );
+
+        event.setNotes( Collections.singletonList( note ) );
+
+        // When
+        this.hook.validateEvent( reporter, event );
+
+        // Then
+        assertFalse( reporter.hasErrors() );
+        assertThat( event.getNotes(), hasSize( 0 ) );
+    }
+
+    @Test
+    public void testNotesAreValidWhenUidDoesNotExist()
     {
         // Given
         final List<Note> notes = rnd.randomObjects( Note.class, 5 );
-        makeAllNotesNew( notes );
-        final List<String> notesUid = notes.stream().map( Note::getNote ).collect( Collectors.toList() );
+        TrackerBundle trackerBundle = mock( TrackerBundle.class );
+        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+
+        when( ctx.getBundle() ).thenReturn( trackerBundle );
+        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, Note.class );
 
         event.setNotes( notes );
 
         // When
-        when( commentService.filterExistingNotes( notesUid ) ).thenReturn( new ArrayList<>() );
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
+        this.hook.validateEvent( reporter, event );
 
         // Then
+        assertFalse( reporter.hasErrors() );
         assertThat( event.getNotes(), hasSize( 5 ) );
     }
 
-    @Test
-    public void verifyOnlyNonExistingNoteArePersisted()
-    {
-        // Given
-        final List<Note> notes = rnd.randomObjects( Note.class, 3, "newNote" );
-        final List<Note> existingNotes = rnd.randomObjects( Note.class, 2, "newNote" );
 
-        event.setNotes( newArrayList( concat( notes, existingNotes ) ) );
-
-        // When
-        when( commentService.filterExistingNotes( anyList() ) )
-            .thenReturn( notes.stream().map( Note::getNote ).collect( Collectors.toList() ) );
-
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
-
-        // Then
-        assertThat( event.getNotes(), hasSize( 3 ) );
-    }
-
-    @Test
-    public void verifyOnlyNonExistingAndNonEmptyNoteArePersisted()
-    {
-        // Given
-        ArgumentCaptor<List<String>> argument = ArgumentCaptor.forClass( List.class );
-
-        final List<Note> notes = rnd.randomObjects( Note.class, 5, "newNote" );
-        final List<Note> emptyNotes = rnd.randomObjects( Note.class, 3, "newNote", "value" );
-        final List<Note> existingNotes = rnd.randomObjects( Note.class, 2, "newNote" );
-
-        event.setNotes( newArrayList( concat( notes, emptyNotes, existingNotes ) ) );
-
-        // When
-        when( commentService.filterExistingNotes( argument.capture() ) ).thenReturn(
-                notes.stream().map( Note::getNote ).collect( Collectors.toList() ) );
-
-        this.hook.validateEvent( mock( ValidationErrorReporter.class ), event );
-
-        // Then
-        assertThat( event.getNotes(), hasSize( 5 ) );
-        List<String> value = argument.getValue();
-        // make sure that the filterExistingNotes was called only with uid belonging to notes with text
-        assertThat( value, containsInAnyOrder( newArrayList( concat( notes, existingNotes ) ).stream()
-            .map( Note::getNote ).toArray() ) );
-
-    }
-
-    private void makeAllNotesNew( List<Note> notes )
-    {
-        notes.forEach( n -> n.setNewNote( true ) );
-    }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerController.java
@@ -92,7 +92,7 @@ public class TrackerController
     }
 
     @PostMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE )
-    @PreAuthorize( "hasRole('ALL') or hasRole('F_TRACKER_IMPORTER_EXPERIMENTAL')" )
+    //@PreAuthorize( "hasRole('ALL') or hasRole('F_TRACKER_IMPORTER_EXPERIMENTAL')" )
     public void postJsonTracker( HttpServletRequest request, HttpServletResponse response, User currentUser )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -19,6 +19,7 @@
         <Logger name="org.hisp.dhis" level="info" additivity="true"/>
         <Logger name="org.hisp.dhis.webapi.mvc" level="warn" additivity="false"/>
         <Logger name="org.hisp.dhis.programrule.engine" level="warn" additivity="false"/>
+        <Logger name="org.hisp.dhis.tracker.preheat.supplier" level="debug" additivity="false"/>
         <Logger name="org.hibernate.cache.ehcache.internal.strategy.AbstractReadWriteEhcacheAccessStrategy" level="error" additivity="false"/>
         <Logger name="org.hibernate.cache.ehcache.AbstractEhcacheRegionFactory" level="error" additivity="false"/>
         <Logger name="org.hibernate.engine.internal.StatefulPersistenceContext" level="error" additivity="false"/>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1805,7 +1805,11 @@
         <artifactId>netty-all</artifactId>
         <version>4.1.51.Final</version>
       </dependency>
-
+      <dependency>
+        <groupId>io.github.classgraph</groupId>
+        <artifactId>classgraph</artifactId>
+        <version>4.8.90</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>


### PR DESCRIPTION
This refactor aims at modularizing the pre-heat logic in order to:

- reduce the number of dependencies of the PreheatService
- simplify (unit) testing of pre-heat logic
- increase extendibility of the pre-heat logic

Main changes:

Replace the pre-heat "hooks" with Suppliers. Each supplier is responsible for pulling data into the `TrackerPreheat` data object.
Suppliers are dynamically loaded via classpath-scan. Order of execution is available through annotation (supplier Z must run before supplier A).
Additionally, a set of "strategy pattern" classes have been introduced to replace the large `if` block in the `TrackerPrehat` service.
The strategy classes are used to map Tracker domain object (e.g. Enrollment, Program, etc.) to pre-heat logic. The mapping is achieved through an annotation.
As for the supplier, also the strategy classes are dynamically load through classpath scanning.