### PR TITLE
fix: [DHIS2-9886] [DHIS2-9890] deserialization of primitive and null check for datavalue dates

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -609,17 +609,7 @@ public class DefaultTrackerBundleService
             eventDataValue.setValue( dv.getValue() );
             eventDataValue.setStoredBy( dv.getStoredBy() );
 
-            try
-            {
-                eventDataValue.setCreated( dv.getCreatedAt() == null ? new Date() : new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getCreatedAt() ) );
-                eventDataValue.setLastUpdated( dv.getUpdatedAt() == null ? new Date() : new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getUpdatedAt() ) );
-            }
-            catch ( ParseException e )
-            {
-                // Created and updated dates are already validated.
-                // This catch should never be reached
-                e.printStackTrace();
-            }
+            handleDataValueCreatedUpdatedDates( dv, eventDataValue );
 
             if ( StringUtils.isEmpty( eventDataValue.getValue() ) )
             {
@@ -637,6 +627,21 @@ public class DefaultTrackerBundleService
                 }
                 psi.getEventDataValues().add( eventDataValue );
             }
+        }
+    }
+
+    private void handleDataValueCreatedUpdatedDates( DataValue dv, EventDataValue eventDataValue )
+    {
+        try
+        {
+            eventDataValue.setCreated( dv.getCreatedAt() == null ? new Date() : new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getCreatedAt() ) );
+            eventDataValue.setLastUpdated( dv.getUpdatedAt() == null ? new Date() : new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getUpdatedAt() ) );
+        }
+        catch ( ParseException e )
+        {
+            // Created and updated dates are already validated.
+            // This catch should never be reached
+            e.printStackTrace();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -611,8 +611,8 @@ public class DefaultTrackerBundleService
 
             try
             {
-                eventDataValue.setCreated( new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getCreatedAt() ) );
-                eventDataValue.setLastUpdated( new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getUpdatedAt() ) );
+                eventDataValue.setCreated( dv.getCreatedAt() == null ? new Date() : new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getCreatedAt() ) );
+                eventDataValue.setLastUpdated( dv.getUpdatedAt() == null ? new Date() : new SimpleDateFormat( "yyyy-MM-dd" ).parse( dv.getUpdatedAt() ) );
             }
             catch ( ParseException e )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
@@ -71,7 +71,7 @@ public class TrackerObjectReport
         this.trackerType = trackerType;
     }
 
-    public TrackerObjectReport( TrackerType trackerType, String uid, int index )
+    public TrackerObjectReport( TrackerType trackerType, String uid, Integer index )
     {
         this.trackerType = trackerType;
         this.uid = uid;
@@ -79,7 +79,7 @@ public class TrackerObjectReport
     }
     
     @JsonCreator
-    public TrackerObjectReport( @JsonProperty( "trackerType" ) TrackerType trackerType, @JsonProperty( "uid" ) String uid, @JsonProperty( "index" ) int index,
+    public TrackerObjectReport( @JsonProperty( "trackerType" ) TrackerType trackerType, @JsonProperty( "uid" ) String uid, @JsonProperty( "index" ) Integer index,
         @JsonProperty( "errorReports" ) List<TrackerErrorReport> errorReports )
     {
         this.trackerType = trackerType;


### PR DESCRIPTION
1. Default to current date in case of DataValue.createdAt and DataValue.updatedAt is null during creation.
2. Change primitive int to wrapper Integer to support null values in ImportReport.