### PR TITLE
fix: [DHIS2-9601] Header vs rows mismatch on event data items as filter

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
@@ -154,6 +154,13 @@ public interface Grid
     Grid addEmptyHeaders( int number );
 
     /**
+     * Replaces the list of headers.
+     *
+     * @param headers list of headers.
+     */
+    Grid replaceHeaders( List<GridHeader> headers );
+
+    /**
      * Returns the current height / number of rows in the grid.
      */
     int getHeight();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
@@ -366,6 +366,28 @@ public class DataHandler
             Grid eventGrid = eventAnalyticsService.getAggregatedEventData( eventQueryParams );
 
             grid.addRows( eventGrid );
+
+            replaceGridIfNeeded( grid, eventGrid );
+        }
+    }
+
+    /**
+     * This method will replace the headers in the current grid by the event grid
+     * IF, and only IF, there is a mismatch between the current grid and the event
+     * grid headers.
+     * 
+     * @param grid the current/actual grid
+     * @param eventGrid the event grid
+     */
+    private void replaceGridIfNeeded( final Grid grid, final Grid eventGrid )
+    {
+        final boolean eventGridHasAdditionalHeaders = grid.getHeaderWidth() < eventGrid.getHeaderWidth();
+        final boolean eventHeaderSizeIsSameAsGridColumns = eventGrid.getHeaderWidth() == eventGrid.getWidth();
+
+        // Replacing the current grid headers by the actual event grid headers.
+        if ( eventGridHasAdditionalHeaders && eventHeaderSizeIsSameAsGridColumns )
+        {
+            grid.replaceHeaders( eventGrid.getHeaders() );
         }
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -28,24 +28,6 @@ package org.hisp.dhis.system.grid;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.Iterables;
-
-import net.sf.jasperreports.engine.JRException;
-import net.sf.jasperreports.engine.JRField;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
-import org.apache.commons.math3.stat.regression.SimpleRegression;
-import org.apache.commons.math3.util.Precision;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.adapter.JacksonRowDataSerializer;
-import org.hisp.dhis.system.util.MathUtils;
-import org.springframework.jdbc.support.rowset.SqlRowSet;
-import org.springframework.jdbc.support.rowset.SqlRowSetMetaData;
-
 import java.io.Serializable;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -59,6 +41,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.apache.commons.math3.util.Precision;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.adapter.JacksonRowDataSerializer;
+import org.hisp.dhis.system.util.MathUtils;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.jdbc.support.rowset.SqlRowSetMetaData;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Iterables;
+
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRField;
 
 /**
  * @author Lars Helge Overland
@@ -238,6 +239,22 @@ public class ListGrid
         {
             headers.add( new GridHeader( "", false, false ) );
         }
+
+        updateColumnIndexMap();
+
+        return this;
+    }
+
+    @Override
+    public Grid replaceHeaders( List<GridHeader> gridHeaders )
+    {
+        if ( gridHeaders == null || gridHeaders.isEmpty() )
+        {
+            return this;
+        }
+
+        headers.clear();
+        headers.addAll( gridHeaders );
 
         updateColumnIndexMap();
 


### PR DESCRIPTION
This happens only when we have event data items.

Current response (mismatch):

```
{
  "headers": [
    {
      "name": "ou",
      "column": "Organisation unit",
      "valueType": "TEXT",
      "type": "java.lang.String",
      "hidden": false,
      "meta": true
    },
    {
      "name": "pe",
      "column": "Period",
      "valueType": "TEXT",
      "type": "java.lang.String",
      "hidden": false,
      "meta": true
    },
    {
      "name": "value",
      "column": "Value",
      "valueType": "NUMBER",
      "type": "java.lang.Double",
      "hidden": false,
      "meta": false
    }
  ],
  "metaData": {},
  "rows": [
    [
      "kla3mAPgvCH.HrJmqlBqTFG",
      "ImspTQPwCqd",
      "202001",
      "567.0"
    ],
    [
      "kla3mAPgvCH.HrJmqlBqTFG",
      "ImspTQPwCqd",
      "202010",
      "136.0"
    ]
  ],
  "height": 2,
  "width": 4,
  "headerWidth": 3
}
```
Response after this fix:
```
{
  "headers": [
    {
      "name": "dy",
      "column": "Data",
      "valueType": "TEXT",
      "type": "java.lang.String",
      "hidden": false,
      "meta": true
    },
    {
      "name": "ou",
      "valueType": "TEXT",
      "type": "java.lang.String",
      "hidden": false,
      "meta": true
    },
    {
      "name": "pe",
      "valueType": "TEXT",
      "type": "java.lang.String",
      "hidden": false,
      "meta": true
    },
    {
      "name": "value",
      "column": "Value",
      "valueType": "NUMBER",
      "type": "java.lang.Double",
      "hidden": false,
      "meta": false
    }
  ],
  "metaData": {},
  "rows": [
    [
      "kla3mAPgvCH.HrJmqlBqTFG",
      "ImspTQPwCqd",
      "202010",
      "136.0"
    ],
    [
      "kla3mAPgvCH.HrJmqlBqTFG",
      "ImspTQPwCqd",
      "202001",
      "567.0"
    ]
  ],
  "width": 4,
  "height": 2,
  "headerWidth": 4
}
```