### PR TITLE
org.apache.catalina.startup.ContextConfig 

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
@@ -36,7 +36,9 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.external.util.LogOnceLogger;
@@ -57,22 +59,26 @@ public class DefaultLocationManager extends LogOnceLogger
 
     private static final String DEFAULT_ENV_VAR = "DHIS2_HOME";
     private static final String DEFAULT_SYS_PROP = "dhis2.home";
-
+    private static final String DEFAULT_CTX_VAR = "dhis2.home";
+    
     private String externalDir;
 
     private String environmentVariable;
 
     private String systemProperty;
+    
+    private String contextVariable;
 
-    public DefaultLocationManager( String environmentVariable, String systemProperty )
+    public DefaultLocationManager( String environmentVariable, String systemProperty, String contextVariable )
     {
         this.environmentVariable = environmentVariable;
         this.systemProperty = systemProperty;
+        this.contextVariable = contextVariable;
     }
 
     public static DefaultLocationManager getDefault()
     {
-        return new DefaultLocationManager( DEFAULT_ENV_VAR, DEFAULT_SYS_PROP );
+        return new DefaultLocationManager( DEFAULT_ENV_VAR, DEFAULT_SYS_PROP, DEFAULT_CTX_VAR );
     }
 
     // -------------------------------------------------------------------------
@@ -82,6 +88,10 @@ public class DefaultLocationManager extends LogOnceLogger
     @PostConstruct
     public void init()
     {
+        
+        
+        
+        
         String path = System.getProperty( systemProperty );
 
         if ( path != null )
@@ -95,13 +105,18 @@ public class DefaultLocationManager extends LogOnceLogger
         }
         else
         {
-            log( log, Level.INFO, "System property " + systemProperty + " not set" );
+            try 
+            {
+                Context initCtx = new InitialContext();
+                Context envCtx = ( Context ) initCtx.lookup( "java:comp/env" );
+                path = ( String ) envCtx.lookup( this.contextVariable );
+            }catch ( NamingException e ) 
+            {
 
-            path = System.getenv( environmentVariable );
-
+            }
             if ( path != null )
             {
-                log( log, Level.INFO, "Environment variable " + environmentVariable + " points to " + path );
+                log( log, Level.INFO, "Context variable " + contextVariable + " points to " + path );
 
                 if ( directoryIsValid( new File( path ) ) )
                 {
@@ -110,15 +125,31 @@ public class DefaultLocationManager extends LogOnceLogger
             }
             else
             {
-                log( log, Level.INFO, "Environment variable " + environmentVariable + " not set" );
+                log( log, Level.INFO, "System property " + systemProperty + " not set" );
 
-                path = DEFAULT_DHIS2_HOME;
+                path = System.getenv( environmentVariable );
 
-                if ( directoryIsValid( new File( path ) ) )
+                if ( path != null )
                 {
-                    externalDir = path;
-                    log( log, Level.INFO, "Home directory set to " + DEFAULT_DHIS2_HOME );
+                    log( log, Level.INFO, "Environment variable " + environmentVariable + " points to " + path );
 
+                    if ( directoryIsValid( new File( path ) ) )
+                    {
+                        externalDir = path;
+                    }
+                }
+                else
+                {
+                    log( log, Level.INFO, "Environment variable " + environmentVariable + " not set" );
+
+                    path = DEFAULT_DHIS2_HOME;
+
+                    if ( directoryIsValid( new File( path ) ) )
+                    {
+                        externalDir = path;
+                        log( log, Level.INFO, "Home directory set to " + DEFAULT_DHIS2_HOME );
+
+                    }
                 }
             }
         }

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
@@ -59,7 +59,7 @@ public class DefaultLocationManager extends LogOnceLogger
 
     private static final String DEFAULT_ENV_VAR = "DHIS2_HOME";
     private static final String DEFAULT_SYS_PROP = "dhis2.home";
-    private static final String DEFAULT_CTX_VAR = "dhis2.home";
+    private static final String DEFAULT_CTX_VAR = "dhis2-home";
     
     private String externalDir;
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/location/DefaultLocationManager.java
@@ -105,6 +105,7 @@ public class DefaultLocationManager extends LogOnceLogger
         }
         else
         {
+            log( log, Level.INFO, "System property " + systemProperty + " not set" );
             try 
             {
                 Context initCtx = new InitialContext();
@@ -125,7 +126,7 @@ public class DefaultLocationManager extends LogOnceLogger
             }
             else
             {
-                log( log, Level.INFO, "System property " + systemProperty + " not set" );
+                log( log, Level.INFO, "Context variable " + contextVariable + " not set" );
 
                 path = System.getenv( environmentVariable );
 


### PR DESCRIPTION
To be able to set the dhis2 home from a context var instead of system property so one can have multiple DHIS2 running without messing the env variable (and running multiple tomcat)

Solution inspired from https://stackoverflow.com/questions/372686/how-can-i-specify-system-properties-in-tomcat-configuration-on-startup

Example of context file to put on TOMCAT_HOME/conf/Catalina/localhost/<warname>.xml when using Catalina engine and no specific host configured


```
<Context>

  <Environment name="dhis2-home" value="/home/dhis/config-2"
         type="java.lang.String" override="false"/>

</Context>
```

I tested the solution, DHIS2 detect the right value
