### PR TITLE
ci: run api tests with github action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,7 +33,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
@@ -76,6 +76,7 @@ jobs:
 
 
     - uses: actions/upload-artifact@v2
+      if: failure()
       with:
         name: "logs"
         path: '~/logs.txt'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,12 +19,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
     steps:
     - uses: actions/checkout@v2
-    - uses: satackey/action-docker-layer-caching@v0.0.8
-      continue-on-error: true
-      with:
-        key: dhis2-docker-cache-{hash}
-        restore-keys: |
-          dhis2-docker-cache-
     - name: Build core image
       run: |
         docker build . -t $CORE_IMAGE_NAME
@@ -37,4 +31,11 @@ jobs:
         IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up -d
         docker build -t $TEST_IMAGE_NAME .
         IMAGE_NAME=$TEST_IMAGE_NAME docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
+
+    - name: Upload logs
+      run: |
+        docker-compose logs web > logs.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          path: logs.txt
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,7 +33,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
@@ -47,3 +47,18 @@ jobs:
     - name: Run integration tests
       run: mvn clean install -Pintegration -f ./dhis-2/pom.xml
     
+  api-test:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'some-defined-label')
+    steps:
+    - uses: actions/checkout@v2
+    - name: build docker
+      run: |
+        docker build . -t dhis2/core-dev:local
+        ./docker/extract-artifacts.sh dhis2/core-dev:local
+        ONLY_DEFAULT=1 ./docker/build-containers.sh dhis2/core-dev:local dhis2/core-dev:local
+        cd dhis-2/dhis-e2e-test
+        IMAGE_NAME=dhis2/core-dev:local docker-compose up -d
+        docker build -t dhis2/tests:local .
+        IMAGE_NAME=dhis2/tests:local docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
+

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         cd dhis-2/dhis-e2e-test
         docker-compose logs web > ~/logs.txt
-      uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2
       with:
         path: '~/logs.txt'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,43 +10,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-      
-  unit-test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Test core
-      run: mvn clean install -DskipTests=false --update-snapshots -q -f ./dhis-2/pom.xml
-    - name: Test dhis-web
-      run: mvn clean install -DskipTests=false --update-snapshots -q -f ./dhis-2/dhis-web/pom.xml
-  
-  integration-test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Run integration tests
-      run: mvn clean install -Pintegration -f ./dhis-2/pom.xml
-    
+
   api-test:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'some-defined-label')

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,6 +11,42 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
       
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Test core
+      run: mvn clean install -DskipTests=false --update-snapshots -q -f ./dhis-2/pom.xml
+    - name: Test dhis-web
+      run: mvn clean install -DskipTests=false --update-snapshots -q -f ./dhis-2/dhis-web/pom.xml
+  
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Run integration tests
+      run: mvn clean install -Pintegration -f ./dhis-2/pom.xml
+    
   api-test:
     env:
       CORE_IMAGE_NAME: "dhis2/core-dev:local"
@@ -35,7 +71,7 @@ jobs:
     - name: Upload logs
       run: |
         docker-compose logs web > logs.txt
-      - uses: actions/upload-artifact@v2
-        with:
-          path: logs.txt
+    - uses: actions/upload-artifact@v2
+      with:
+        path: logs.txt
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,7 +73,8 @@ jobs:
       run: |
         cd dhis-2/dhis-e2e-test
         docker-compose logs web > ~/logs.txt
-    - uses: actions/upload-artifact@v2
-      with:
-        path: '~/logs.txt'
 
+      uses: actions/upload-artifact@v2
+      with:
+        name: "logs"
+        path: '~/logs.txt'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: satackey/action-docker-layer-caching@v0.0.8
+      continue-on-error: true
+      with:
+        key: dhis2-docker-cache-{hash}
+        restore-keys: |
+          dhis2-docker-cache-
     - name: Run API tests
       env:
         CORE_IMAGE_NAME: "dhis2/core-dev:local"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
   api-test:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'some-defined-label')
+    if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
     steps:
     - uses: actions/checkout@v2
     - name: build docker

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,5 +28,5 @@ jobs:
         cd dhis-2/dhis-e2e-test
         IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up -d
         docker build -t $TEST_IMAGE_NAME .
-        IMAGE_NAME=$TEST_IMAGE_NAME:local docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
+        IMAGE_NAME=$TEST_IMAGE_NAME docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,6 +71,7 @@ jobs:
     - name: Upload logs
       if: failure()
       run: |
+        cd dhis-2/dhis-e2e-test
         docker-compose logs web > logs.txt
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,7 +74,8 @@ jobs:
         cd dhis-2/dhis-e2e-test
         docker-compose logs web > ~/logs.txt
 
-      uses: actions/upload-artifact@v2
+
+    - uses: actions/upload-artifact@v2
       with:
         name: "logs"
         path: '~/logs.txt'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,7 +72,6 @@ jobs:
         cd dhis-2/dhis-e2e-test
         docker-compose logs web > ~/logs.txt
 
-
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,13 +16,16 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
     steps:
     - uses: actions/checkout@v2
-    - name: build docker
+    - name: Run API tests
+      env:
+        CORE_IMAGE_NAME: "dhis2/core-dev:local"
+        TEST_IMAGE_NAME: "dhis2/tests:local"
       run: |
-        docker build . -t dhis2/core-dev:local
-        ./docker/extract-artifacts.sh dhis2/core-dev:local
-        ONLY_DEFAULT=1 ./docker/build-containers.sh dhis2/core-dev:local dhis2/core-dev:local
+        docker build . -t $CORE_IMAGE_NAME
+        ./docker/extract-artifacts.sh $CORE_IMAGE_NAME
+        ONLY_DEFAULT=1 ./docker/build-containers.sh $CORE_IMAGE_NAME $CORE_IMAGE_NAME
         cd dhis-2/dhis-e2e-test
-        IMAGE_NAME=dhis2/core-dev:local docker-compose up -d
-        docker build -t dhis2/tests:local .
-        IMAGE_NAME=dhis2/tests:local docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
+        IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up -d
+        docker build -t $TEST_IMAGE_NAME .
+        IMAGE_NAME=$TEST_IMAGE_NAME:local docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,6 +12,9 @@ jobs:
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
       
   api-test:
+    env:
+      CORE_IMAGE_NAME: "dhis2/core-dev:local"
+      TEST_IMAGE_NAME: "dhis2/tests:local"
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
     steps:
@@ -22,14 +25,14 @@ jobs:
         key: dhis2-docker-cache-{hash}
         restore-keys: |
           dhis2-docker-cache-
-    - name: Run API tests
-      env:
-        CORE_IMAGE_NAME: "dhis2/core-dev:local"
-        TEST_IMAGE_NAME: "dhis2/tests:local"
+    - name: Build core image
       run: |
         docker build . -t $CORE_IMAGE_NAME
         ./docker/extract-artifacts.sh $CORE_IMAGE_NAME
         ONLY_DEFAULT=1 ./docker/build-containers.sh $CORE_IMAGE_NAME $CORE_IMAGE_NAME
+
+    - name: Run tests
+      run: |
         cd dhis-2/dhis-e2e-test
         IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up -d
         docker build -t $TEST_IMAGE_NAME .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,7 +49,7 @@ jobs:
     
   api-test:
     env:
-      CORE_IMAGE_NAME: "dhis2/core-dev:local"
+      CORE_IMAGE_NAME: "dhis2/core:local"
       TEST_IMAGE_NAME: "dhis2/tests:local"
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
@@ -57,9 +57,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build core image
       run: |
-        docker build . -t $CORE_IMAGE_NAME
-        ./docker/extract-artifacts.sh $CORE_IMAGE_NAME
-        ONLY_DEFAULT=1 ./docker/build-containers.sh $CORE_IMAGE_NAME $CORE_IMAGE_NAME
+        bash ./dhis-2/build-dev.sh
 
     - name: Run tests
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,12 +10,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-
+      
   api-test:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
     steps:
     - uses: actions/checkout@v2
+    - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Run API tests
       env:
         CORE_IMAGE_NAME: "dhis2/core-dev:local"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,8 +72,8 @@ jobs:
       if: failure()
       run: |
         cd dhis-2/dhis-e2e-test
-        docker-compose logs web > logs.txt
-    - uses: actions/upload-artifact@v2
+        docker-compose logs web > ~/logs.txt
+      uses: actions/upload-artifact@v2
       with:
-        path: logs.txt
+        path: '~/logs.txt'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,6 +69,7 @@ jobs:
         IMAGE_NAME=$TEST_IMAGE_NAME docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
 
     - name: Upload logs
+      if: failure()
       run: |
         docker-compose logs web > logs.txt
     - uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /src
 COPY dhis-2 .
 
 # TODO: We should be able to achieve much faster incremental builds and cached dependencies using
-RUN mvn clean install -T1C -f pom.xml -DskipTests
-RUN mvn clean install -T1C -U -f dhis-web/pom.xml -DskipTests
+RUN mvn clean install -f pom.xml -DskipTests
+RUN mvn clean install -U -f dhis-web/pom.xml -DskipTests
 
 RUN cp dhis-web/dhis-web-portal/target/dhis.war /dhis.war && \
     cd / && \


### PR DESCRIPTION
Adds another GitHub action that will run the API tests. The job run takes around 15 minutes because we need to build a war and set up an environment, so for now, we will trigger it only for PRs that need that. 

Label `run-api-tests` will trigger an API test run. If tests fail, logs from the server will be added as a job artifact.

The tests are failing, because they are failing on master. 