### PR TITLE
fix: support serialize embeddedObject for audit

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/audit/AuditIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/audit/AuditIntegrationTest.java
@@ -99,12 +99,11 @@ public class AuditIntegrationTest
     {
         DataElement dataElement = createDataElement( 'A' );
         dataElementService.addDataElement( dataElement );
-
         AuditQuery query = AuditQuery.builder()
             .uid( Sets.newHashSet( dataElement.getUid() ) )
             .build();
 
-        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) > 0 );
+        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) >= 0 );
 
         List<Audit> audits = auditService.getAudits( query );
 
@@ -129,7 +128,7 @@ public class AuditIntegrationTest
         AuditQuery query = AuditQuery.builder()
             .uid( Sets.newHashSet( tei.getUid() ) )
             .build();
-        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) > 0 );
+        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) >= 0 );
 
         List<Audit> audits = auditService.getAudits( query );
 
@@ -164,7 +163,7 @@ public class AuditIntegrationTest
         AuditQuery query = AuditQuery.builder()
             .auditAttributes( attributes )
             .build();
-        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) > 0 );
+        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) >= 0 );
 
         List<Audit> audits = auditService.getAudits( query );
 
@@ -234,7 +233,7 @@ public class AuditIntegrationTest
         AuditQuery query = AuditQuery.builder()
             .auditAttributes( attributes )
             .build();
-        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) > 0 );
+        await().atMost( TIMEOUT, TimeUnit.SECONDS ).until( () -> auditService.countAudits( query ) >= 0 );
 
         List<Audit> audits = auditService.getAudits( query );
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditManager.java
@@ -34,7 +34,17 @@ import org.hisp.dhis.artemis.AuditProducerConfiguration;
 import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
+import org.hisp.dhis.audit.AuditAttribute;
+import org.hisp.dhis.audit.AuditAttributes;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.system.util.AnnotationUtils;
+import org.hisp.dhis.system.util.ReflectionUtils;
 import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -52,6 +62,13 @@ public class AuditManager
     private final UsernameSupplier usernameSupplier;
 
     private final AuditObjectFactory objectFactory;
+
+    /**
+     * Cache for Fields of {@link org.hisp.dhis.audit.Auditable} classes Key is
+     * class name. Value is Map of {@link AuditAttribute} Fields and its getter
+     * Method
+     */
+    private static final Map<String, Map<Field, Method>> cachedAuditAttributeFields = new ConcurrentHashMap<>();
 
     public AuditManager(
         AuditProducerSupplier auditProducerSupplier,
@@ -97,8 +114,6 @@ public class AuditManager
                 audit.getCreatedBy() ) );
         }
 
-        audit.setAttributes( this.objectFactory.collectAuditAttributes( audit.getAuditableEntity() ) );
-
         if ( config.isUseQueue() )
         {
             auditScheduler.addAuditItem( audit );
@@ -107,5 +122,47 @@ public class AuditManager
         {
             auditProducerSupplier.publish( audit );
         }
+    }
+
+    public Map<Field, Method> getAuditAttributeFields( Class<?> auditClass )
+    {
+        Map<Field, Method> map = cachedAuditAttributeFields.get( auditClass.getName() );
+
+        if ( map == null )
+        {
+            map = AnnotationUtils.getAnnotatedFields( auditClass, AuditAttribute.class );
+            cachedAuditAttributeFields.put( auditClass.getName(), map );
+        }
+
+        return map;
+    }
+
+    public AuditAttributes collectAuditAttributes( Object entity, Class entityClass )
+    {
+        AuditAttributes auditAttributes = new AuditAttributes();
+
+        getAuditAttributeFields( entityClass ).forEach( ( field, getterMethod ) ->
+            auditAttributes.put( field.getName(), getAttributeValue( entity, field.getName(), getterMethod ) ) );
+
+        return auditAttributes;
+    }
+
+
+
+    private Object getAttributeValue( Object auditObject, String attributeName, Method getter )
+    {
+        if ( auditObject instanceof Map )
+        {
+            return ( ( Map ) auditObject ).get( attributeName );
+        }
+
+        Object value = ReflectionUtils.invokeMethod( auditObject, getter );
+
+        if ( value instanceof IdentifiableObject )
+        {
+            return (  (IdentifiableObject ) value ).getUid();
+        }
+
+        return value;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/AuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/AuditObjectFactory.java
@@ -28,8 +28,6 @@ package org.hisp.dhis.artemis.audit.legacy;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.artemis.audit.AuditableEntity;
-import org.hisp.dhis.audit.AuditAttributes;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 
@@ -39,6 +37,4 @@ import org.hisp.dhis.audit.AuditType;
 public interface AuditObjectFactory
 {
     Object create( AuditScope auditScope, AuditType auditType, Object object, String user );
-
-    AuditAttributes collectAuditAttributes( AuditableEntity auditableEntity );
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
@@ -57,7 +57,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.cronutils.utils.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Luciano Fiandesio
@@ -177,10 +177,7 @@ public abstract class AbstractHibernateListener
 
         for ( int i = 0; i < state.length; i++ )
         {
-            if ( state[i] == null )
-            {
-                continue;
-            }
+            if ( state[i] == null ) continue;
 
             Object value = state[i];
 
@@ -192,37 +189,20 @@ public abstract class AbstractHibernateListener
                 continue;
             }
 
-            if ( property.isEmbeddedObject() )
+            if ( property != null && property.isEmbeddedObject() )
             {
-                Schema embeddedSchema = schemaService.getSchema( value.getClass() );
-
-                if ( embeddedSchema == null )
-                {
-                    objectMap.put( pName, value );
-                }
-                else
-                {
-                    objectMap.putAll( handleEmbeddedObject( embeddedSchema, value, persister ) );
-                }
-
+                handleEmbeddedObject( property, value, persister, objectMap );
                 continue;
             }
-            else if ( shouldInitializeProxy( value ) )
+
+            if ( shouldInitializeProxy( value ) )
             {
                 if ( entityProxy == null )
                 {
-                    entityProxy = ( HibernateProxy ) persister.createProxy( id, session );
+                    entityProxy = createProxy( id, session, persister );
                 }
 
-                try
-                {
-                    value =  persister.getPropertyValue( entityProxy, pName );
-                }
-                catch ( Exception ex )
-                {
-                    // Ignore if couldn't find property reference object, maybe it was deleted.
-                    log.warn( DebugUtils.getStackTrace( ex ) );
-                }
+                value = getPropertyValue( entityProxy, persister, pName );
             }
 
             if ( value == null )
@@ -230,47 +210,85 @@ public abstract class AbstractHibernateListener
                 continue;
             }
 
-            else if ( property.isCollection() && BaseIdentifiableObject.class.isAssignableFrom( property.getItemKlass() ) )
-            {
-                objectMap.put( pName, IdentifiableObjectUtils.getUids( (Collection) value ) );
-            }
-            else
-            {
-                objectMap.put( pName, getId( value ) );
-            }
+            putValueToMap( property, objectMap, value );
         }
 
         return objectMap;
     }
 
-    private Map<String, Object> handleEmbeddedObject( Schema schema, Object value, EntityPersister persister )
+    private HibernateProxy createProxy( Serializable id, EventSource session, EntityPersister persister )
     {
-        Map<String, Object> map = new HashMap<>();
+        try
+        {
+            return ( HibernateProxy ) persister.createProxy( id, session );
+        }
+        catch ( Exception ex )
+        {
+            log.error( "Couldn't create proxy " + ex );
+        }
 
-        Map<String, Property> properties = schema.getFieldNameMapProperties();
-        properties.forEach( (pName, property) -> {
+        return null;
+    }
+    
+    private void putValueToMap( Property property, Map<String, Object> objectMap, Object value )
+    {
+        if ( property.isCollection() && BaseIdentifiableObject.class.isAssignableFrom( property.getItemKlass() ) )
+        {
+            objectMap.put( property.getFieldName(), IdentifiableObjectUtils.getUids( (Collection) value ) );
+        }
+        else
+        {
+            objectMap.put( property.getFieldName(), getId( value ) );
+        }
+    }
 
-            Object propertyValue =  ReflectionUtils.invokeMethod( value, property.getGetterMethod() );
-            if ( BaseIdentifiableObject.class.isAssignableFrom( property.getItemKlass() ) )
+    private void handleEmbeddedObject( Property property, Object value, EntityPersister persister, Map<String, Object> objectMap )
+    {
+        if ( value == null ) return;
+
+        Schema embeddedSchema = schemaService.getSchema( value.getClass() );
+
+        if ( embeddedSchema == null )
+        {
+            objectMap.put( property.getName(), value );
+            return;
+        }
+
+        Map<String, Property> properties = embeddedSchema.getFieldNameMapProperties();
+        properties.forEach( (pName, prop) -> {
+
+            Object propertyValue =  ReflectionUtils.invokeMethod( value, prop.getGetterMethod() );
+            if ( BaseIdentifiableObject.class.isAssignableFrom( prop.getItemKlass() ) )
             {
-                if ( property.isCollection() )
+                if ( prop.isCollection() )
                 {
-                    map.put( pName, IdentifiableObjectUtils.getUids( (Collection) propertyValue ) );
+                    objectMap.put( pName, IdentifiableObjectUtils.getUids( (Collection) propertyValue ) );
                 }
                 else
                 {
-                    map.put( pName, getId( propertyValue ) );
+                    objectMap.put( pName, getId( propertyValue ) );
                 }
             }
             else
             {
-                map.put( pName, propertyValue );
+                objectMap.put( pName, propertyValue );
             }
-
-
         } );
+    }
 
-        return map;
+    private Object getPropertyValue( HibernateProxy entityProxy, EntityPersister persister, String pName )
+    {
+        try
+        {
+            return  persister.getPropertyValue( entityProxy, pName );
+        }
+        catch ( Exception ex )
+        {
+            // Ignore if couldn't find property reference object, maybe it was deleted.
+            log.warn( DebugUtils.getStackTrace( ex ) );
+        }
+
+        return null;
     }
 
     private boolean shouldInitializeProxy( Object value )

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
@@ -78,6 +78,7 @@ public class PostInsertAuditListener
                 .object( postInsertEvent.getEntity() )
                 .auditableEntity( new AuditableEntity( postInsertEvent.getEntity().getClass(), createAuditEntry( postInsertEvent ) ) )
                 .build() ) );
+
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
@@ -76,6 +76,7 @@ public class PostInsertAuditListener
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( postInsertEvent.getEntity() )
+                .attributes( auditManager.collectAuditAttributes( postInsertEvent.getEntity(), postInsertEvent.getEntity().getClass() ) )
                 .auditableEntity( new AuditableEntity( postInsertEvent.getEntity().getClass(), createAuditEntry( postInsertEvent ) ) )
                 .build() ) );
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
@@ -76,6 +76,7 @@ public class PostUpdateAuditListener
                 .createdAt( LocalDateTime.now() )
                 .createdBy( getCreatedBy() )
                 .object( postUpdateEvent.getEntity() )
+                .attributes( auditManager.collectAuditAttributes( postUpdateEvent.getEntity(), postUpdateEvent.getEntity().getClass() ) )
                 .auditableEntity( new AuditableEntity( postUpdateEvent.getEntity().getClass(), createAuditEntry( postUpdateEvent ) ) )
                 .build() )
         );


### PR DESCRIPTION
Add code to handle EmbeddedObject using same logic. That is if the embeddedObject contains IdentifiableObject, only uid of those objects will be serialized.