### PR TITLE
fix: [DHIS2-9601] Header vs rows mismatch on event data items as filter

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
@@ -154,6 +154,13 @@ public interface Grid
     Grid addEmptyHeaders( int number );
 
     /**
+     * Replaces the list of headers.
+     *
+     * @param headers list of headers.
+     */
+    Grid replaceHeaders( List<GridHeader> headers );
+
+    /**
      * Returns the current height / number of rows in the grid.
      */
     int getHeight();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
@@ -366,6 +366,28 @@ public class DataHandler
             Grid eventGrid = eventAnalyticsService.getAggregatedEventData( eventQueryParams );
 
             grid.addRows( eventGrid );
+
+            replaceGridIfNeeded( grid, eventGrid );
+        }
+    }
+
+    /**
+     * This method will replace the headers in the current grid by the event grid
+     * IF, and only IF, there is a mismatch between the current grid and the event
+     * grid headers.
+     *
+     * @param grid the current/actual grid
+     * @param eventGrid the event grid
+     */
+    private void replaceGridIfNeeded( final Grid grid, final Grid eventGrid )
+    {
+        final boolean eventGridHasAdditionalHeaders = grid.getHeaderWidth() < eventGrid.getHeaderWidth();
+        final boolean eventHeaderSizeIsSameAsGridColumns = eventGrid.getHeaderWidth() == eventGrid.getWidth();
+
+        // Replacing the current grid headers by the actual event grid headers.
+        if ( eventGridHasAdditionalHeaders && eventHeaderSizeIsSameAsGridColumns )
+        {
+            grid.replaceHeaders( eventGrid.getHeaders() );
         }
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -245,6 +245,22 @@ public class ListGrid
     }
 
     @Override
+    public Grid replaceHeaders( List<GridHeader> gridHeaders )
+    {
+        if ( gridHeaders == null || gridHeaders.isEmpty() )
+        {
+            return this;
+        }
+
+        headers.clear();
+        headers.addAll( gridHeaders );
+
+        updateColumnIndexMap();
+
+        return this;
+    }
+
+    @Override
     @JsonProperty
     public List<GridHeader> getHeaders()
     {


### PR DESCRIPTION
Backport to 2.35, from master