### PR TITLE
fix: (2.34) No transaction error while importing Events [DHIS2-9936]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.cache.HibernateCacheManager;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -386,6 +387,7 @@ public class HibernateDbmsManager
     }
 
     @Override
+    @Transactional //TODO need to be fixed as this reduces performance
     public void clearSession()
     {
         sessionFactory.getCurrentSession().flush();


### PR DESCRIPTION
Fix no transaction exception while importing events. 
Resolved it by adding `@Transactional` annotation so it has to be tested for performance.


standard 2.34
![image](https://user-images.githubusercontent.com/13900328/99037632-5d877000-2584-11eb-96e4-cd230e13000f.png)



2.34 feature branch 
![image](https://user-images.githubusercontent.com/13900328/99037681-7d1e9880-2584-11eb-8454-b6c4145262cd.png)


