### PR TITLE
fix: remove validation for event date fields

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -137,8 +137,6 @@ public enum TrackerErrorCode
 
     E1200( "Rule engine error: `{0}`" ),
 
-    E1300( "Data value: CreatedAt date `{0}` is not valid" ),
-    E1301( "Data value: UpdatedAt date `{0}` is not valid" ),
     E1302( "DataElement `{0}` is not valid: `{1}`" ),
     E1303( "Mandatory DataElement `{0}` is not present" ),
     E1304( "DataElement `{0}` is not a valid data element" ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -68,15 +68,11 @@ public class EventDataValuesValidationHook
 
         for ( DataValue dataValue : event.getDataValues() )
         {
-            addErrorIf( () -> !isValidDateStringAndNotNull( dataValue.getCreatedAt() ),
-                reporter, TrackerErrorCode.E1300, dataValue.getCreatedAt() );
-            addErrorIf( () -> !isValidDateStringAndNotNull( dataValue.getUpdatedAt() ),
-                reporter, TrackerErrorCode.E1301, dataValue.getUpdatedAt() );
-
+            // event dates (createdAt, updatedAt) are ignored and set by the system
             validateDataElement( reporter, context, dataValue );
         }
         validateMandatoryDataValue( reporter, context, event );
-        validateDataValueDataElementIsConnectedToProgramStage(reporter, context, event);
+        validateDataValueDataElementIsConnectedToProgramStage( reporter, context, event );
     }
 
     private void validateDataElement( ValidationErrorReporter reporter, TrackerImportValidationContext ctx,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -86,10 +86,9 @@ public class EventDataValuesValidationHookTest
         DataElement validDataElement = new DataElement();
         validDataElement.setValueType( ValueType.TEXT );
 
-        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerBundle bundle = TrackerBundle.builder().build();
 
         when( validationContext.getBundle() ).thenReturn( bundle );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
         when( validationContext.getDataElement( VALID_DATA_ELEMENT ) ).thenReturn( validDataElement );
     }
 
@@ -108,7 +107,7 @@ public class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenCreatedAtIsNull()
+    public void successValidationWhenCreatedAtIsNull()
     {
         // Given
         DataValue validDataValue = validDataValue();
@@ -120,12 +119,11 @@ public class EventDataValuesValidationHookTest
         hookToTest.validateEvent( reporter, event );
 
         // Then
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1300, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
 
     @Test
-    public void failValidationWhenCreatedAtIsInvalid()
+    public void successValidationWhenCreatedAtIsInvalid()
     {
         // Given
         DataValue validDataValue = validDataValue();
@@ -137,8 +135,7 @@ public class EventDataValuesValidationHookTest
         hookToTest.validateEvent( reporter, event );
 
         // Then
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1300, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
 
     @Test
@@ -154,12 +151,11 @@ public class EventDataValuesValidationHookTest
         hookToTest.validateEvent( reporter, event );
 
         // Then
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1301, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
 
     @Test
-    public void failValidationWhenUpdatedAtIsInvalid()
+    public void successValidationWhenUpdatedAtIsInvalid()
     {
         // Given
         DataValue validDataValue = validDataValue();
@@ -171,8 +167,7 @@ public class EventDataValuesValidationHookTest
         hookToTest.validateEvent( reporter, event );
 
         // Then
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1301, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
 
     @Test
@@ -196,6 +191,7 @@ public class EventDataValuesValidationHookTest
     public void failValidationWhenMandatoryDataElementIsNotPresent()
     {
         // Given
+
         ProgramStage programStage = new ProgramStage();
         ProgramStageDataElement mandatoryStageDataElement = new ProgramStageDataElement();
         DataElement dataElement = new DataElement();


### PR DESCRIPTION
The Event values `occurredAt` and `updatedAt` are no longer validated.
The client values are ignored and set by the system.

ref: DHIS2-9951