### PR TITLE
fix: correct validation rule for Event's TEI value

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
@@ -121,7 +121,7 @@ public class ProgramInstanceByTeiSupplier extends AbstractPreheatSupplier
             {
                 final List<ProgramInstance> programInstances = result.getOrDefault( event.getUid(), new ArrayList<>() );
                 programInstances.add( pi );
-                result.put( event.getUid(), programInstances );
+                result.put( event.getEvent(), programInstances );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BundlePreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BundlePreProcessor.java
@@ -28,55 +28,14 @@ package org.hisp.dhis.tracker.preprocess;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.programrule.RuleActionApplier;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
- * @author Enrico Colasante
+ * 
+ *
+ * @author Luciano Fiandesio
  */
-@Slf4j
-@Service
-public class DefaultTrackerPreprocessService
-    implements TrackerPreprocessService
+public interface BundlePreProcessor
 {
-    private List<RuleActionApplier> appliers = new ArrayList<>();
-
-    private List<BundlePreProcessor> preProcessors = new ArrayList<>();
-
-    @Autowired( required = false )
-    public void setAppliers( List<RuleActionApplier> appliers )
-    {
-        this.appliers = appliers;
-    }
-
-    @Autowired( required = false )
-    public void setPreProcessors( List<BundlePreProcessor> preProcessors )
-    {
-        this.preProcessors = preProcessors;
-    }
-
-    @Override
-    public TrackerBundle preprocess( TrackerBundle bundle )
-    {
-        // TODO we may consider "merging" the BundlePreProcessor with the RuleActionApplier, since
-        // they share an identical interface.
-        for ( BundlePreProcessor preProcessor : preProcessors )
-        {
-            preProcessor.process( bundle );
-        }
-
-        for ( RuleActionApplier applier : appliers )
-        {
-            bundle = applier.executeActions( bundle );
-        }
-
-        return bundle;
-    }
+    void process( TrackerBundle bundle );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BundlePreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BundlePreProcessor.java
@@ -31,7 +31,13 @@ package org.hisp.dhis.tracker.preprocess;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 
 /**
- * 
+ * Interface for classes responsible of preprocessing the payload prior to
+ * validation.
+ *
+ * The validation stage is not supposed to change the payload. A pre-processor
+ * can modify the payload content and add data to the preheat if needed. Note
+ * that the pre-processing stage takes place after the preheat and before the
+ * validation.
  *
  * @author Luciano Fiandesio
  */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
@@ -1,6 +1,33 @@
 package org.hisp.dhis.tracker.preprocess;
 
-import java.util.Collections;
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import java.util.List;
 import java.util.Optional;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
@@ -1,0 +1,63 @@
+package org.hisp.dhis.tracker.preprocess;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.ReferenceTrackerEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.springframework.stereotype.Component;
+
+/**
+ * This preprocessor is responsible for setting the TrackedEntityInstance UID on
+ * an Event, inferring it from the Event's parent enrollment. If the Event
+ * already has a TrackedEntityInstance UID set, this preprocessor does not
+ * process the Event
+ *
+ * @author Luciano Fiandesio
+ */
+@Component
+public class EventDefaultEnrollmentPreProcessor implements BundlePreProcessor
+{
+    @Override
+    public void process( TrackerBundle bundle )
+    {
+        for ( Event event : bundle.getEvents() )
+        {
+            // If the event enrollment is missing, it will be captured later by validation
+            if ( StringUtils.isEmpty( event.getTrackedEntity() ) && StringUtils.isNotEmpty( event.getEnrollment() ) )
+            {
+                event.setTrackedEntity(
+                    getFromPreheat( bundle.getPreheat(), event )
+                        .orElseGet( () -> getFromRef( bundle, event ) ) );
+            }
+        }
+    }
+
+    private String getFromRef( TrackerBundle bundle, Event event )
+    {
+        final Optional<ReferenceTrackerEntity> ref = bundle.getPreheat().getReference( event.getEvent() );
+
+        return ref
+            .map( rte -> getTrackedEntityFromEnrollment( bundle.getEnrollments(), rte.getParentUid() ) )
+            .orElse( null );
+    }
+
+    private Optional<String> getFromPreheat( TrackerPreheat preheat, Event event )
+    {
+        return Optional.ofNullable( preheat.getEnrollment( TrackerIdScheme.UID, event.getEnrollment() ) )
+            .map( e -> e.getEntityInstance().getUid() );
+    }
+
+    private String getTrackedEntityFromEnrollment( List<Enrollment> enrollments, String enrollment )
+    {
+        return enrollments.stream().filter( e -> e.getEnrollment().equals( enrollment ) ).findFirst()
+            .map( Enrollment::getTrackedEntity ).orElse( null );
+
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
@@ -13,6 +13,8 @@ import org.hisp.dhis.tracker.preheat.ReferenceTrackerEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.springframework.stereotype.Component;
 
+import static java.util.Collections.*;
+
 /**
  * This preprocessor is responsible for setting the TrackedEntityInstance UID on
  * an Event, inferring it from the Event's parent enrollment. If the Event
@@ -54,8 +56,8 @@ public class EventDefaultEnrollmentPreProcessor implements BundlePreProcessor
             .map( e -> {
                 if ( e.getEntityInstance() != null )
                 {
-                    preheat.putTrackedEntities( TrackerIdScheme.UID,
-                        Collections.singletonList( e.getEntityInstance() ) );
+                    // The Tracked Entity has to be added to the preheat, otherwise validation will fail downstream
+                    preheat.putTrackedEntities( TrackerIdScheme.UID, singletonList( e.getEntityInstance() ) );
                     return e.getEntityInstance().getUid();
                 }
                 return null;
@@ -66,7 +68,6 @@ public class EventDefaultEnrollmentPreProcessor implements BundlePreProcessor
     {
         return enrollments.stream().filter( e -> e.getEnrollment().equals( enrollment ) ).findFirst()
             .map( Enrollment::getTrackedEntity ).orElse( null );
-
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessor.java
@@ -1,5 +1,6 @@
 package org.hisp.dhis.tracker.preprocess;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,7 +51,15 @@ public class EventDefaultEnrollmentPreProcessor implements BundlePreProcessor
     private Optional<String> getFromPreheat( TrackerPreheat preheat, Event event )
     {
         return Optional.ofNullable( preheat.getEnrollment( TrackerIdScheme.UID, event.getEnrollment() ) )
-            .map( e -> e.getEntityInstance().getUid() );
+            .map( e -> {
+                if ( e.getEntityInstance() != null )
+                {
+                    preheat.putTrackedEntities( TrackerIdScheme.UID,
+                        Collections.singletonList( e.getEntityInstance() ) );
+                    return e.getEntityInstance().getUid();
+                }
+                return null;
+            } );
     }
 
     private String getTrackedEntityFromEnrollment( List<Enrollment> enrollments, String enrollment )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionApplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionApplier.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.tracker.programrule;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 
 /**
- * @Author Enrico Colasante
+ * @author Enrico Colasante
  */
 public interface RuleActionApplier extends RuleActionImplementer
 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionImplementer.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.rules.models.RuleEffect;
 
 /**
- * @Author Enrico Colasante
+ * @author Enrico Colasante
  */
 public interface RuleActionImplementer<T>
 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/hooks/ProgramInstanceByTeiHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/hooks/ProgramInstanceByTeiHookTest.java
@@ -204,6 +204,7 @@ public class ProgramInstanceByTeiHookTest
     {
         Event event = new Event();
         event.setUid( CodeGenerator.generateUid() );
+        event.setEvent( event.getUid() );
         event.setEnrollment( programInstance == null ? null : programInstance.getUid() );
         event.setTrackedEntity( trackedEntityInstance == null ? null : trackedEntityInstance.getUid() );
         event.setProgram( program == null ? null : program.getUid() );
@@ -214,6 +215,7 @@ public class ProgramInstanceByTeiHookTest
     {
         Event event = new Event();
         event.setUid( CodeGenerator.generateUid() );
+        event.setEvent( event.getUid() );
         event.setEnrollment( programInstance == null ? null : programInstance.getUid() );
         event.setTrackedEntity( trackedEntityInstance == null ? null : trackedEntityInstance.getUid() );
         event.setProgram( programInstance == null ? null : programInstance.getProgram().getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessorTest.java
@@ -1,0 +1,118 @@
+package org.hisp.dhis.tracker.preprocess;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class EventDefaultEnrollmentPreProcessorTest
+{
+    private EventDefaultEnrollmentPreProcessor preProcessor;
+
+    private BeanRandomizer rnd = new BeanRandomizer();
+
+    @Before
+    public void setUp()
+    {
+        preProcessor = new EventDefaultEnrollmentPreProcessor();
+    }
+
+    @Test
+    public void verifyTrackedEntityValueIsNotModifiedWhenPresent()
+    {
+        Event event = new Event();
+        event.setTrackedEntity( CodeGenerator.generateUid() );
+        TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
+
+        preProcessor.process( bundle );
+        assertThat( event.getTrackedEntity(), is( bundle.getEvents().get( 0 ).getTrackedEntity() ) );
+    }
+
+    @Test
+    public void verifyTrackedEntityValueIsNotModifiedWhenTrackedEntityValueAndEnrollmentValueAreMissing()
+    {
+        Event event = new Event();
+        TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
+
+        preProcessor.process( bundle );
+
+        assertThat( event.getTrackedEntity(), is( nullValue() ) );
+    }
+
+    @Test
+    public void verifyTrackedEntityValueIsSetToParentEnrollmentTeiValue()
+    {
+        String enrollmentUid = CodeGenerator.generateUid();
+        String teiUid = CodeGenerator.generateUid();
+
+        ProgramInstance programInstance = rnd.randomObject( ProgramInstance.class );
+        programInstance.setUid( enrollmentUid );
+        TrackedEntityInstance trackedEntityInstance = rnd.randomObject( TrackedEntityInstance.class );
+        trackedEntityInstance.setUid( teiUid );
+        programInstance.setEntityInstance( trackedEntityInstance );
+
+        TrackerPreheat preheat = new TrackerPreheat();
+        preheat.setEnrollments( ImmutableMap.of( TrackerIdScheme.UID, ImmutableMap.of( enrollmentUid, programInstance)));
+
+        Event event = new Event();
+        event.setEnrollment( enrollmentUid );
+
+        TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( preheat )
+            .events( Collections.singletonList( event ) ).build();
+
+        preProcessor.process( bundle );
+
+        assertThat( event.getTrackedEntity(), is( teiUid ) );
+    }
+
+    @Test
+    public void verifyTrackedEntityValueIsSetToParentEnrollmentTeiValueFromRef()
+    {
+        String teiUid = CodeGenerator.generateUid();
+
+        // Create an enrollment with a reference to a parent tei
+        Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
+        enrollment.setTrackedEntity( teiUid );
+
+        // create an event without a tei reference
+        Event event = new Event();
+        event.setEnrollment( enrollment.getEnrollment() );
+
+        // Add to preheat and make sure the enrollment and event uid are added to the reference tree
+        TrackerPreheat preheat = new TrackerPreheat();
+        preheat.putEnrollments( TrackerIdScheme.UID, new ArrayList<>(), Collections.singletonList( enrollment ) );
+        preheat.putEvents( TrackerIdScheme.UID, new ArrayList<>(), Collections.singletonList( event ) );
+
+        TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( preheat )
+            .enrollments( Collections.singletonList( enrollment ))
+            .events( Collections.singletonList( event ) )
+            .build();
+
+        preProcessor.process( bundle );
+
+        assertThat( event.getTrackedEntity(), is( teiUid ) );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessorTest.java
@@ -1,6 +1,35 @@
 package org.hisp.dhis.tracker.preprocess;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -71,7 +100,8 @@ public class EventDefaultEnrollmentPreProcessorTest
         programInstance.setEntityInstance( trackedEntityInstance );
 
         TrackerPreheat preheat = new TrackerPreheat();
-        preheat.setEnrollments( ImmutableMap.of( TrackerIdScheme.UID, ImmutableMap.of( enrollmentUid, programInstance)));
+        preheat.setEnrollments(
+            ImmutableMap.of( TrackerIdScheme.UID, ImmutableMap.of( enrollmentUid, programInstance ) ) );
 
         Event event = new Event();
         event.setEnrollment( enrollmentUid );
@@ -83,6 +113,8 @@ public class EventDefaultEnrollmentPreProcessorTest
         preProcessor.process( bundle );
 
         assertThat( event.getTrackedEntity(), is( teiUid ) );
+
+        assertThat( preheat.getTrackedEntity( TrackerIdScheme.UID, teiUid ), is( notNullValue() ) );
     }
 
     @Test
@@ -99,14 +131,15 @@ public class EventDefaultEnrollmentPreProcessorTest
         Event event = new Event();
         event.setEnrollment( enrollment.getEnrollment() );
 
-        // Add to preheat and make sure the enrollment and event uid are added to the reference tree
+        // Add to preheat and make sure the enrollment and event uid are added to the
+        // reference tree
         TrackerPreheat preheat = new TrackerPreheat();
         preheat.putEnrollments( TrackerIdScheme.UID, new ArrayList<>(), Collections.singletonList( enrollment ) );
         preheat.putEvents( TrackerIdScheme.UID, new ArrayList<>(), Collections.singletonList( event ) );
 
         TrackerBundle bundle = TrackerBundle.builder()
             .preheat( preheat )
-            .enrollments( Collections.singletonList( enrollment ))
+            .enrollments( Collections.singletonList( enrollment ) )
             .events( Collections.singletonList( event ) )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -123,7 +123,7 @@ public class EnrollmentImportValidationTest
             "tracker/validations/enrollments_te_te-data.json" );
 
         TrackerBundle trackerBundle = trackerBundleService.create( trackerBundleParams );
-        assertEquals( 4, trackerBundle.getTrackedEntities().size() );
+        assertEquals( 5, trackerBundle.getTrackedEntities().size() );
 
         TrackerValidationReport report = trackerValidationService.validate( trackerBundle );
         assertEquals( 0, report.getErrorReports().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -244,7 +244,7 @@ public class EnrollmentSecurityImportValidationTest
         trackerBundleParams.setUser( user );
 
         TrackerBundle trackerBundle = trackerBundleService.create( trackerBundleParams );
-        assertEquals( 4, trackerBundle.getTrackedEntities().size() );
+        assertEquals( 5, trackerBundle.getTrackedEntities().size() );
 
         TrackerValidationReport report = trackerValidationService.validate( trackerBundle );
         assertEquals( 0, report.getErrorReports().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -588,6 +588,7 @@ public class EventImportValidationTest
     }
 
     @Test
+    @Ignore
     public void testTeiNotEnrolled()
         throws IOException
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -127,7 +127,7 @@ public class EventImportValidationTest
         trackerBundleParams.setUser( user );
 
         TrackerBundle trackerBundle = trackerBundleService.create( trackerBundleParams );
-        assertEquals( 4, trackerBundle.getTrackedEntities().size() );
+        assertEquals( 5, trackerBundle.getTrackedEntities().size() );
 
         TrackerValidationReport report = trackerValidationService.validate( trackerBundle );
         assertEquals( 0, report.getErrorReports().size() );
@@ -588,7 +588,6 @@ public class EventImportValidationTest
     }
 
     @Test
-    @Ignore
     public void testTeiNotEnrolled()
         throws IOException
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -189,7 +189,7 @@ public class EventSecurityImportValidationTest
         trackerBundleParams.setUser( user );
 
         TrackerBundle trackerBundle = trackerBundleService.create( trackerBundleParams );
-        assertEquals( 4, trackerBundle.getTrackedEntities().size() );
+        assertEquals( 5, trackerBundle.getTrackedEntities().size() );
 
         TrackerValidationReport report = trackerValidationService.validate( trackerBundle );
         assertEquals( 0, report.getErrorReports().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
@@ -493,7 +493,7 @@ public class TrackedEntityImportValidationTest
 
         params.setImportStrategy( TrackerImportStrategy.DELETE );
         TrackerBundle trackerBundle = trackerBundleService.create( params );
-        assertEquals( 4, trackerBundle.getTrackedEntities().size() );
+        assertEquals( 5, trackerBundle.getTrackedEntities().size() );
 
         report = trackerValidationService.validate( trackerBundle );
         printReport( report );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_te-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_te-data.json
@@ -107,6 +107,33 @@
           "value": "AddressX"
         }
       ]
+    },
+    {
+      "trackedEntityType": "bPJ0FMtcnEh",
+      "trackedEntity": "YYYYj6vYdes",
+      "orgUnit": "QfUVllTs6cS",
+      "updatedAt": "2019-08-19T13:59:13.706",
+      "featureType": "POLYGON",
+      "programOwners": [
+        {
+          "ownerOrgUnit": "QfUVllTs6cS",
+          "program": "E8o1E9tAppy",
+          "trackedEntity": "Kj6vYde4LHh"
+        }
+      ],
+      "relationships": [],
+      "attributes": [
+        {
+          "storedBy": "admin",
+          "attribute": "fmBIpOStKkF",
+          "value": "PersonX"
+        },
+        {
+          "storedBy": "admin",
+          "attribute": "sTJvSLN7Kcb",
+          "value": "AddressX"
+        }
+      ]
     }
   ]
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_tei-not-enrolled.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_tei-not-enrolled.json
@@ -7,7 +7,7 @@
       "event": "ZwwuwNp6gVd",
       "programStage": "Qmqxq907VNz",
       "orgUnit": "QfUVllTs6cS",
-      "trackedEntity": "KKKKj6vYdes",
+      "trackedEntity": "YYYYj6vYdes",
       "enrollmentStatus": "ACTIVE",
       "status": "ACTIVE",
       "orgUnitName": "TA org_unit lvl2",


### PR DESCRIPTION
Fixes an issue with validating the `trackedEntity` value of an incoming Event.

Additionally, this PR introduces a `BundlePreProcessor` interface to alter the payload prior to validation.
A new PreProcessor is created to infer the `trackedEntity` value of an Event from the parent Enrollment.

ref: DHIS2-9958