### PR TITLE
fix: Close files used by Apps

### DIFF
--- a/dhis-2/dhis-support/dhis-support-commons/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-commons/pom.xml
@@ -24,6 +24,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/StreamUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/StreamUtils.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.commons.util;
 
 /*
- * Copyright (c) 2004-2019, University of Oslo
+ * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,9 +35,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -270,4 +272,56 @@ public class StreamUtils
             throw new RuntimeException( "Failed to finish the content of the ZipOutputStream", ex );
         }
     }
+
+    /**
+     * Closes an {@link InputStream} unconditionally without throwing exceptions.
+     *
+     * @param input the input stream.
+     */
+    public static void closeQuietly( InputStream input )
+    {
+        try
+        {
+            if ( input != null )
+            {
+                input.close();
+            }
+        }
+        catch ( final IOException ioe )
+        {
+            // Ignore
+        }
+    }
+
+    /**
+     * Copies the input stream into the output stream, then finally closes the input stream only.
+     *
+     * @param in  stream to copy from
+     * @param out stream to copy to
+     * @return the number of bytes copied
+     * @throws IOException in case of I/O errors
+     */
+    public static int copyThenCloseInputStream( InputStream in, OutputStream out )
+        throws IOException
+    {
+        Objects.requireNonNull( in, "InputStream must not be null" );
+        Objects.requireNonNull( out, "OutputStream must not be null" );
+
+        try
+        {
+            return org.springframework.util.StreamUtils.copy( in, out );
+        }
+        finally
+        {
+            try
+            {
+                in.close();
+            }
+            catch ( IOException ex )
+            {
+                //ignore
+            }
+        }
+    }
+
 }

--- a/dhis-2/dhis-web/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-api/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>dhis-service-tracker</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -66,13 +70,9 @@
       <artifactId>jasperreports-fonts</artifactId>
     </dependency>
     <dependency>
-	  <groupId>org.javassist</groupId>
+      <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-web-api-mobile</artifactId>
-    </dependency> <!-- remove this -->
 
     <!-- Batik -->
 
@@ -88,6 +88,11 @@
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>fop</artifactId>
     </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.projectlombok</groupId>-->
+<!--      <artifactId>lombok</artifactId>-->
+<!--      <scope>provided</scope>-->
+<!--    </dependency>-->
 
     <!-- Test -->
 
@@ -111,7 +116,15 @@
       <artifactId>json-path</artifactId>
       <scope>test</scope>
     </dependency>
+
+
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+    </dependency>
+
   </dependencies>
+
 
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.appmanager.AppStatus;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
@@ -63,7 +64,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -238,7 +238,8 @@ public class AppController
 
             response.setContentLength( (int) resource.contentLength() );
             response.setHeader( "Last-Modified", DateUtils.getHttpDateString( new Date( resource.lastModified() ) ) );
-            StreamUtils.copy( resource.getInputStream(), response.getOutputStream() );
+
+            StreamUtils.copyThenCloseInputStream( resource.getInputStream(), response.getOutputStream() );
         }
     }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IconController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IconController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 
 import com.google.common.net.MediaType;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.icon.Icon;
@@ -42,7 +43,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -126,6 +126,6 @@ public class IconController
         response.setHeader( "Cache-Control", CacheControl.maxAge( TTL, TimeUnit.DAYS ).getHeaderValue() );
         response.setContentType( MediaType.SVG_UTF_8.toString() );
 
-        StreamUtils.copy( icon.get().getInputStream(), response.getOutputStream() );
+        StreamUtils.copyThenCloseInputStream( icon.get().getInputStream(), response.getOutputStream() );
     }
 }


### PR DESCRIPTION
* Close file descriptors to prevent leak for app resources that leads to unusable DHIS 2 instance.

Issue:[DHIS2-9939]
Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>