### PR TITLE
fix: DHIS2-9914: Filter all items in /dataItems endpoint not working

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacade.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacade.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.webapi.controller.dataitem;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.containsDimensionTypeFilter;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntitiesFromInFilter;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntityFromEqualFilter;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.OrderingHelper.sort;
@@ -145,7 +146,7 @@ public class DataItemServiceFacade
     {
         final Set<Class<? extends BaseDimensionalItemObject>> targetedEntities = new HashSet<>( 0 );
 
-        if ( isNotEmpty( filters ) )
+        if ( containsDimensionTypeFilter( filters ) )
         {
             final Iterator<String> iterator = filters.iterator();
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelper.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelper.java
@@ -40,8 +40,10 @@ import static org.hisp.dhis.webapi.controller.dataitem.DataItemServiceFacade.DAT
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.feedback.ErrorMessage;
@@ -109,7 +111,7 @@ public class FilteringHelper
         final byte DIMENSION_TYPE = 2;
         Class<? extends BaseDimensionalItemObject> entity = null;
 
-        if ( trimToEmpty( filter ).contains( DIMENSION_TYPE_EQUAL_FILTER_PREFIX ) )
+        if ( hasEqualsDimensionTypeFilter( filter ) )
         {
             final String[] array = filter.split( ":" );
             final boolean hasDimensionType = array.length == 3;
@@ -125,6 +127,38 @@ public class FilteringHelper
         }
 
         return entity;
+    }
+
+    /**
+     * Simply checks if the given list of filters contains a dimension type filter.
+     *
+     * @param filters
+     * @return true if a dimension type filter is found, false otherwise.
+     */
+    public static boolean containsDimensionTypeFilter( final List<String> filters )
+    {
+        if ( CollectionUtils.isNotEmpty( filters ) )
+        {
+            for ( final String filter : filters )
+            {
+                if ( hasEqualsDimensionTypeFilter( filter ) || hasInDimensionTypeFilter( filter ) )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean hasEqualsDimensionTypeFilter( final String filter )
+    {
+        return trimToEmpty( filter ).contains( DIMENSION_TYPE_EQUAL_FILTER_PREFIX );
+    }
+
+    private static boolean hasInDimensionTypeFilter( final String filter )
+    {
+        return trimToEmpty( filter ).contains( DIMENSION_TYPE_IN_FILTER_PREFIX );
     }
 
     private static Class<? extends BaseDimensionalItemObject> entityClassFromString( final String entityType )

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelperTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelperTest.java
@@ -28,18 +28,21 @@ package org.hisp.dhis.webapi.controller.dataitem.helper;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hisp.dhis.webapi.controller.dataitem.DataItemServiceFacade.DATA_TYPE_ENTITY_MAP;
+import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.containsDimensionTypeFilter;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntitiesFromInFilter;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntityFromEqualFilter;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import org.hisp.dhis.common.BaseDimensionalItemObject;
@@ -146,6 +149,48 @@ public class FilteringHelperTest
 
         // When
         extractEntityFromEqualFilter( filtersWithInvalidType );
+    }
+
+    @Test
+    public void testContainsDimensionTypeFilterUsingEqualsQuery()
+    {
+        // Given
+        final List<String> anyFilters = singletonList( "dimensionItemType:eq:DATA_SET" );
+        final boolean expectedTrueResult = true;
+
+        // When
+        final boolean actualResult = containsDimensionTypeFilter( anyFilters );
+
+        // Then
+        assertThat( actualResult, is( expectedTrueResult ) );
+    }
+
+    @Test
+    public void testContainsDimensionTypeFilterUsingInQuery()
+    {
+        // Given
+        final List<String> anyFilters = singletonList( "dimensionItemType:in:[DATA_SET,INDICATOR]" );
+        final boolean expectedTrueResult = true;
+
+        // When
+        final boolean actualResult = containsDimensionTypeFilter( anyFilters );
+
+        // Then
+        assertThat( actualResult, is( expectedTrueResult ) );
+    }
+
+    @Test
+    public void testContainsDimensionTypeFilterWhenThereDimensionItemTypeFilterIsNotSet()
+    {
+        // Given
+        final List<String> anyFilters = singletonList( "displayName:ilike:anc" );
+        final boolean expectedFalseResult = false;
+
+        // When
+        final boolean actualResult = containsDimensionTypeFilter( anyFilters );
+
+        // Then
+        assertThat( actualResult, is( expectedFalseResult ) );
     }
 
     @Test


### PR DESCRIPTION
Backporting to 2.35, from master