### PR TITLE
fix: Add into Preheat also default values for CategoryOption (DHIS2-9975)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -362,12 +362,6 @@ public class TrackerPreheat
     {
         for ( T object : objects )
         {
-            boolean isDefault = isDefault( object );
-            if ( isDefault )
-            {
-                continue;
-            }
-
             put( identifier, object );
         }
 


### PR DESCRIPTION
If default CategoryOption is used in the payload, an error is shown because the CategoryOption is not loaded into the Preheat. DHIS2-9975