### PR TITLE
fix: add report when validation failed

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -132,8 +132,13 @@ public class DefaultTrackerImportService
 
             if ( validationReport.hasErrors() && params.getAtomicMode() == AtomicMode.ALL )
             {
-                return TrackerImportReport.withValidationErrors( validationReport, opsTimer.stopTimer(),
-                    trackerBundle.getBundleSize() );
+                TrackerImportReport trackerImportReport = TrackerImportReport
+                    .withValidationErrors( validationReport, opsTimer.stopTimer(),
+                        trackerBundle.getBundleSize() );
+
+                notifier.endImport( trackerImportReport );
+
+                return trackerImportReport;
             }
             else
             {


### PR DESCRIPTION
When validation was failing and AtomicMode was ALL, not importSummary was present calling `/tracker/jobs/{jobUid}/report` endpoint