### PR TITLE
fix: Fix validations when no entities aare linked in a relationship [DHIS2-9995]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -156,6 +156,7 @@ public enum TrackerErrorCode
     E4011(
         "Relationship: `{0}` cannot be persisted because {1} {2} referenced by this relationship is not valid." ),
     E4012( "Could not find `{0}`: `{1}`, linked to Relationship." ),
+    E4013( "Relationship Type `{0}` constraint is missing {1}." ),
     E9999( "N/A" );
 
     private final String message;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -229,7 +229,7 @@ public class RelationshipsValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4013 ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
-            "Relationship Type `from` constraint is missing trackedEntity" ) );
+            "Relationship Type `from` constraint is missing trackedEntity." ) );
     }
 
     @Test


### PR DESCRIPTION
Few things done here:
- Validation to check if there are exactly to null entities in relationship constraint was split and moved away from mandatory validations.
   - Validation to check if there is more than one entity in relationship constraint
   - Validation to check if there is at least one entity in relationship constraint