### PR TITLE
fix: extract payload size prior to validation in Tracker Import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -115,6 +115,10 @@ public class DefaultTrackerImportService
             TrackerBundle trackerBundle = opsTimer.exec( PREHEAT_OPS,
                 () -> preheatBundle( params ) );
 
+            // cache the bundle size because the objects in the bundle may get removed
+            // during validation
+            int bundleSize = trackerBundle.getBundleSize();
+
             //
             // preprocess
             //
@@ -133,8 +137,7 @@ public class DefaultTrackerImportService
             if ( validationReport.hasErrors() && params.getAtomicMode() == AtomicMode.ALL )
             {
                 TrackerImportReport trackerImportReport = TrackerImportReport
-                    .withValidationErrors( validationReport, opsTimer.stopTimer(),
-                        trackerBundle.getBundleSize() );
+                    .withValidationErrors( validationReport, opsTimer.stopTimer(), bundleSize );
 
                 notifier.endImport( trackerImportReport );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.AtomicMode;


### PR DESCRIPTION
Extract the payload size from the request object prior to validation:
this makes sure that the Tracker Report object always shows the correct
number of ignored objects, since the Validation stage may remove objects from the payload.