### PR TITLE
fix: Import report ignore values on stats objects

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/RelationshipPersister.java
@@ -63,50 +63,6 @@ public class RelationshipPersister
     }
 
     @Override
-    public TrackerTypeReport persist( Session session, TrackerBundle bundle )
-    {
-        List<Relationship> relationships = bundle.getRelationships();
-        TrackerTypeReport typeReport = new TrackerTypeReport( TrackerType.RELATIONSHIP );
-
-        relationships.forEach( o -> bundleHooks.forEach( hook -> hook.preCreate( Relationship.class, o, bundle ) ) );
-
-        for ( int idx = 0; idx < relationships.size(); idx++ )
-        {
-            org.hisp.dhis.relationship.Relationship relationship = relationshipConverter
-                .from( bundle.getPreheat(), relationships.get( idx ) );
-            Date now = new Date();
-            relationship.setLastUpdated( now );
-            relationship.setLastUpdatedBy( bundle.getUser() );
-
-            TrackerObjectReport objectReport = new TrackerObjectReport( TrackerType.RELATIONSHIP, relationship.getUid(),
-                idx );
-            typeReport.addObjectReport( objectReport );
-
-            if ( relationship.getId() == 0 )
-            {
-                typeReport.getStats().incCreated();
-            }
-            else
-            {
-                typeReport.getStats().incUpdated();
-            }
-
-            session.persist( relationship );
-
-            if ( FlushMode.OBJECT == bundle.getFlushMode() )
-            {
-                session.flush();
-            }
-        }
-
-        session.flush();
-
-        relationships.forEach( o -> bundleHooks.forEach( hook -> hook.postCreate( Relationship.class, o, bundle ) ) );
-
-        return typeReport;
-    }
-
-    @Override
     protected void runPreCreateHooks( TrackerBundle bundle )
     {
         bundle.getRelationships()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReport.java
@@ -28,7 +28,10 @@ package org.hisp.dhis.tracker.report;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.Map;
+
 import org.hisp.dhis.tracker.TrackerBundleReportMode;
+import org.hisp.dhis.tracker.TrackerType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -109,8 +112,8 @@ public class TrackerImportReport
      *
      */
     public static TrackerImportReport withValidationErrors(
-            TrackerValidationReport validationReport,
-            TrackerTimingsStats timingsStats, int bundleSize )
+        TrackerValidationReport validationReport,
+        TrackerTimingsStats timingsStats, int bundleSize )
     {
         TrackerImportReport report = new TrackerImportReport();
         report.status = TrackerStatus.ERROR;
@@ -139,7 +142,7 @@ public class TrackerImportReport
      *
      */
     public static TrackerImportReport withError( String message, TrackerValidationReport validationReport,
-                                                 TrackerTimingsStats timingsStats )
+        TrackerTimingsStats timingsStats )
     {
         TrackerImportReport report = new TrackerImportReport();
         report.status = TrackerStatus.ERROR;
@@ -157,24 +160,25 @@ public class TrackerImportReport
      *
      * Import statistics are calculated based on the {@link TrackerBundleReport} and
      * {@link TrackerValidationReport}.
-     *
+     * 
      * @param status The outcome of the process
      * @param bundleReport The report containing how many bundle objects were
      *        successfully persisted
      * @param validationReport The validation report if available
      * @param timingsStats The timing stats if available
-     *
+     * @param bundleSize a map containing the size of each entity type in the Bundle
+     *        - before the validation
      */
     public static TrackerImportReport withImportCompleted( TrackerStatus status, TrackerBundleReport bundleReport,
-                                                           TrackerValidationReport validationReport,
-                                                           TrackerTimingsStats timingsStats )
+        TrackerValidationReport validationReport,
+        TrackerTimingsStats timingsStats, Map<TrackerType, Integer> bundleSize )
     {
-
         TrackerImportReport report = new TrackerImportReport();
         report.status = status;
         report.validationReport = validationReport;
         report.timingsStats = timingsStats;
-        report.bundleReport = bundleReport;
+
+        report.bundleReport = processBundleReport( bundleReport, bundleSize );
 
         TrackerStats stats = new TrackerStats();
         stats.merge( bundleReport.getStats() );
@@ -182,6 +186,33 @@ public class TrackerImportReport
         report.stats = stats;
 
         return report;
+    }
+
+    /**
+     * Calculates the 'ignored' value for each type of entity in the
+     * {@link TrackerBundleReport}.
+     * 
+     * The 'ignored' value is calculated by subtracting the sum of all processed
+     * entities from the TrackerBundleReport (by type) from the bundle size
+     * specified in the 'bundleSize' map.
+     */
+    private static TrackerBundleReport processBundleReport( TrackerBundleReport bundleReport,
+        Map<TrackerType, Integer> bundleSize )
+    {
+        for ( final TrackerType value : TrackerType.values() )
+        {
+            final TrackerTypeReport trackerTypeReport = bundleReport.getTypeReportMap().get( value );
+            if ( trackerTypeReport != null )
+            {
+                final TrackerStats stats = trackerTypeReport.getStats();
+                if ( stats != null )
+                {
+                    int statsSize = stats.getDeleted() + stats.getCreated() + stats.getUpdated();
+                    stats.setIgnored( bundleSize.getOrDefault( value,  statsSize) - statsSize );
+                }
+            }
+        }
+        return bundleReport;
     }
 
     /**
@@ -208,17 +239,17 @@ public class TrackerImportReport
 
         switch ( reportMode )
         {
-            case ERRORS:
-                trackerImportReport.getValidationReport().setPerformanceReport( null );
-                trackerImportReport.getValidationReport().setWarningReports( null );
-                trackerImportReport.timingsStats = null;
-                break;
-            case WARNINGS:
-                trackerImportReport.getValidationReport().setPerformanceReport( null );
-                trackerImportReport.timingsStats = null;
-                break;
-            case FULL:
-                break;
+        case ERRORS:
+            trackerImportReport.getValidationReport().setPerformanceReport( null );
+            trackerImportReport.getValidationReport().setWarningReports( null );
+            trackerImportReport.timingsStats = null;
+            break;
+        case WARNINGS:
+            trackerImportReport.getValidationReport().setPerformanceReport( null );
+            trackerImportReport.timingsStats = null;
+            break;
+        case FULL:
+            break;
         }
 
         return trackerImportReport;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -48,8 +48,6 @@ import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.tracker.TrackerBundleReportMode;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerTimingsStats;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -174,8 +172,10 @@ public class TrackerBundleImportReportTest extends DhisSpringTest
         //
         // BUILD TRACKER IMPORT REPORT
         //
+        final Map<TrackerType, Integer> bundleSize = new HashMap<>();
+        bundleSize.put( TrackerType.TRACKED_ENTITY, 1 );
         TrackerImportReport toSerializeReport = TrackerImportReport.withImportCompleted( TrackerStatus.ERROR,
-            bundleReport, tvr, timingsStats );
+            bundleReport, tvr, timingsStats, bundleSize);
 
         String jsonString = jsonMapper.writeValueAsString( toSerializeReport );
 
@@ -241,8 +241,10 @@ public class TrackerBundleImportReportTest extends DhisSpringTest
 
     private TrackerImportReport createImportReport()
     {
+        final Map<TrackerType, Integer> bundleSize = new HashMap<>();
+        bundleSize.put( TrackerType.TRACKED_ENTITY, 1 );
         return TrackerImportReport.withImportCompleted( TrackerStatus.OK, createBundleReport(),
-            createValidationReport(), createTimingStats() );
+            createValidationReport(), createTimingStats(), bundleSize );
     }
 
     private TrackerTimingsStats createTimingStats()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerImportReportTest.java
@@ -1,0 +1,80 @@
+package org.hisp.dhis.tracker.report;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.tracker.TrackerType;
+import org.junit.Test;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class TrackerImportReportTest
+{
+
+    private BeanRandomizer rnd = new BeanRandomizer();
+
+    @Test
+    public void testImportCalculatesIgnoredValues()
+    {
+        // Create Bundle report for tei and enrollment
+        final Map<TrackerType, TrackerTypeReport> trackerTypeReportMap = new HashMap<>();
+        trackerTypeReportMap.put( TrackerType.TRACKED_ENTITY, createTypeReport( TrackerType.TRACKED_ENTITY, 5, 3, 0 ) );
+        trackerTypeReportMap.put( TrackerType.ENROLLMENT, createTypeReport( TrackerType.ENROLLMENT, 3, 3, 0 ) );
+        TrackerBundleReport bundleReport = new TrackerBundleReport( TrackerStatus.OK, trackerTypeReportMap );
+
+        // Create validation report with 3 objects
+        TrackerValidationReport validationReport = TrackerValidationReport.builder()
+            .errorReports( rnd.randomObjects( TrackerErrorReport.class, 3 ) )
+            .build();
+
+        // Create empty Timing Stats report
+        TrackerTimingsStats timingsStats = new TrackerTimingsStats();
+
+        // Create payload map
+        Map<TrackerType, Integer> originalPayload = new HashMap<>();
+        originalPayload.put( TrackerType.TRACKED_ENTITY, 10 );
+        originalPayload.put( TrackerType.ENROLLMENT, 8 );
+
+        // Method under test
+        TrackerImportReport rep = TrackerImportReport.withImportCompleted( TrackerStatus.OK, bundleReport,
+            validationReport, timingsStats, originalPayload );
+
+        assertThat( rep.getStats().getCreated(), is( 8 ) );
+        assertThat( rep.getStats().getUpdated(), is( 6 ) );
+        assertThat( rep.getStats().getIgnored(), is( 3 ) );
+        assertThat( rep.getStats().getDeleted(), is( 0 ) );
+
+        assertThat( getBundleReportStats( rep, TrackerType.TRACKED_ENTITY ).getCreated(), is( 5 ) );
+        assertThat( getBundleReportStats( rep, TrackerType.TRACKED_ENTITY ).getUpdated(), is( 3 ) );
+        assertThat( getBundleReportStats( rep, TrackerType.TRACKED_ENTITY ).getDeleted(), is( 0 ) );
+        assertThat( getBundleReportStats( rep, TrackerType.TRACKED_ENTITY ).getIgnored(), is( 2 ) );
+
+        assertThat( getBundleReportStats( rep, TrackerType.ENROLLMENT ).getCreated(), is( 3 ) );
+        assertThat( getBundleReportStats( rep, TrackerType.ENROLLMENT ).getUpdated(), is( 3 ) );
+        assertThat( getBundleReportStats( rep, TrackerType.ENROLLMENT ).getDeleted(), is( 0 ) );
+        assertThat( getBundleReportStats( rep, TrackerType.ENROLLMENT ).getIgnored(), is( 2 ) );
+    }
+
+    private TrackerStats getBundleReportStats( TrackerImportReport importReport, TrackerType type )
+    {
+        return importReport.getBundleReport().getTypeReportMap().get( type ).getStats();
+
+    }
+
+    private TrackerTypeReport createTypeReport( TrackerType type, int created, int updated, int deleted )
+    {
+        final Map<TrackerType, TrackerTypeReport> map = new HashMap<>();
+        final TrackerStats teiStats = new TrackerStats();
+        teiStats.setCreated( created );
+        teiStats.setUpdated( updated );
+        teiStats.setDeleted( deleted );
+
+        return new TrackerTypeReport( type, teiStats, new ArrayList<>(), new ArrayList<>() );
+    }
+}


### PR DESCRIPTION
This PR fixes several problems with the Tracker Import report and specifically with the "Stats" objects, attached to the report.

The `ignore` value is now calculated correctly on both the global stats and the Bundle Report stats.

ref: DHIS2-9991, DHIS2-9981