### PR TITLE
fix: relationship should not be imported when invalid

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -260,4 +260,9 @@ public class RelationshipsValidationHook
             .filter( t -> t.getTrackedEntity().equals( uid ) ).findFirst();
         return payloadTei.map( TrackedEntity::getTrackedEntityType );
     }
+
+    public boolean removeOnError()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Make sure that the an invalid Relationship is not persisted during Tracker Import.
The PR simply adds a super method to the Relationship validation that removes the failed Relationship from the payload.

ref: DHIS2-9991