### PR TITLE
fix: [DHIS2-9985] Align ownership OU check for TEI APIs even when specifying uids explicitly (2.36)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -171,6 +171,12 @@ public class TrackedEntityInstanceQueryParams
      * Set of user ids to filter based on events assigned to the users.
      */
     private Set<String> assignedUsers = new HashSet<>();
+    
+    /**
+     * Set of tei uids to explicitly select.
+     */
+    private Set<String> trackedEntityInstanceUids = new HashSet<>();
+
 
     /**
      * ProgramStage to be used in conjunction with eventstatus.
@@ -375,6 +381,11 @@ public class TrackedEntityInstanceQueryParams
             this.assignedUsers = Collections.singleton( this.user.getUid() );
             this.assignedUserSelectionMode = AssignedUserSelectionMode.PROVIDED;
         }
+    }
+    
+    public boolean hasTrackedEntityInstances()
+    {
+        return this.trackedEntityInstanceUids != null && !this.trackedEntityInstanceUids.isEmpty();
     }
     
     public boolean hasAssignedUsers()
@@ -1158,6 +1169,17 @@ public class TrackedEntityInstanceQueryParams
     public TrackedEntityInstanceQueryParams setAssignedUserSelectionMode( AssignedUserSelectionMode assignedUserMode )
     {
         this.assignedUserSelectionMode = assignedUserMode;
+        return this;
+    }
+    
+    public Set<String> getTrackedEntityInstanceUids()
+    {
+        return trackedEntityInstanceUids;
+    }
+
+    public TrackedEntityInstanceQueryParams setTrackedEntityInstanceUids( Set<String> trackedEntityInstanceUids )
+    {
+        this.trackedEntityInstanceUids = trackedEntityInstanceUids;
         return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.trackedentity;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -385,7 +387,7 @@ public class TrackedEntityInstanceQueryParams
     
     public boolean hasTrackedEntityInstances()
     {
-        return this.trackedEntityInstanceUids != null && !this.trackedEntityInstanceUids.isEmpty();
+        return CollectionUtils.isNotEmpty( this.trackedEntityInstanceUids );
     }
     
     public boolean hasAssignedUsers()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -324,9 +324,12 @@ public class HibernateTrackedEntityInstanceStore
             () -> "left join tei.trackedEntityAttributeValues teav1 " +
             "left join teav1.attribute as attr" + hlp.whereAnd() + " attr.skipSynchronization = false" );
 
-        hql += addWhereConditionally( hlp, params.hasTrackedEntityType(), () ->
-            "tei.trackedEntityType.uid='" + params.getTrackedEntityType().getUid() + "'" );
+        hql += addWhereConditionally( hlp, params.hasTrackedEntityType(),
+            () -> " tei.trackedEntityType.uid='" + params.getTrackedEntityType().getUid() + "'" );
 
+        hql += addWhereConditionally( hlp, params.hasTrackedEntityInstances(),
+            () -> " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" );
+   
         if ( params.hasLastUpdatedDuration() )
         {
             hql += hlp.whereAnd() + "tei.lastUpdated >= '" +
@@ -584,7 +587,10 @@ public class HibernateTrackedEntityInstanceStore
                 }
             }
         }
-
+        
+        sql += addWhereConditionally( hlp, params.hasTrackedEntityInstances(),
+            () -> " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" );
+   
         if ( !params.hasTrackedEntityType() )
         {
             sql += hlp.whereAnd() + " tei.trackedentitytypeid in (" + params.getTrackedEntityTypes().stream()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.CodeGenerator;
@@ -100,7 +101,15 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
         assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 0 ) );
-
+        
+        //Check further for explicit uid in param
+        queryParams.getTrackedEntityInstanceUids()
+            .addAll( trackedEntityInstances.stream().limit( 2 ).map( t -> t.getTrackedEntityInstance() ).collect( Collectors.toSet() ) );
+        
+        final List<TrackedEntityInstance> limitedTTrackedEntityInstances = trackedEntityInstanceService
+            .getTrackedEntityInstances2( queryParams, params, false );
+ 
+        assertThat( limitedTTrackedEntityInstances, hasSize( 2 ) );
     }
 
     @Test

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -202,27 +202,15 @@ public class TrackedEntityInstanceController
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        if ( !criteria.hasTrackedEntityInstance() )
+        if ( criteria.isUseLegacy() ) // FIXME luciano: this has to be removed!
         {
-            if ( criteria.isUseLegacy() ) // FIXME luciano: this has to be removed!
-            {
-                trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
-                    getTrackedEntityInstanceParams( fields ), false );
-            }
-            else
-            {
-                trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances2( queryParams,
-                    getTrackedEntityInstanceParams( fields ), false );
-            }
+            trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
+                getTrackedEntityInstanceParams( fields ), false );
         }
         else
         {
-            Set<String> trackedEntityInstanceIds = criteria.getTrackedEntityInstances();
-
-            trackedEntityInstances = trackedEntityInstanceIds.stream()
-                .map( id -> trackedEntityInstanceService.getTrackedEntityInstance( id,
-                    getTrackedEntityInstanceParams( fields ) ) )
-                .collect( Collectors.toList() );
+            trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances2( queryParams,
+                getTrackedEntityInstanceParams( fields ), false );
         }
 
         RootNode rootNode = NodeUtils.createMetadata();

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
@@ -129,6 +129,7 @@ public class TrackedEntityCriteriaMapper
         }
 
         validateAssignedUser( criteria );
+        
 
         if ( criteria.getOuMode() == OrganisationUnitSelectionMode.CAPTURE && user != null )
         {
@@ -154,6 +155,7 @@ public class TrackedEntityCriteriaMapper
             .setEventEndDate( criteria.getEventEndDate() )
             .setAssignedUserSelectionMode( criteria.getAssignedUserMode() )
             .setAssignedUsers( criteria.getAssignedUsers() )
+            .setTrackedEntityInstanceUids( criteria.getTrackedEntityInstances() )
             .setSkipMeta( criteria.isSkipMeta() )
             .setPage( criteria.getPage() )
             .setPageSize( criteria.getPageSize() )


### PR DESCRIPTION
Removed alternate flow when specifying tei uids explicitly in params for api/trackedEntityInstances (and query) and included the functionality as part of the main flow. This means that if uids are explicitly specified, then that becomes the outer boundary for all filters additionally provided. 