### PR TITLE
refactor: Tracker Import params creation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerImportService.java
@@ -48,14 +48,6 @@ public interface TrackerImportService
     TrackerImportReport importTracker( TrackerImportParams params );
 
     /**
-     * Parses, and creates a TrackerImportParams instance based on given map of parameters.
-     *
-     * @param parameters Key-Value map of wanted parameters
-     * @return MetadataImportParams instance created based on input parameters
-     */
-    TrackerImportParams getParamsFromMap( Map<String, List<String>> parameters );
-
-    /**
      * Build the report based on the mode selected by the client.
      *
      * @param importReport report with all the data collected during import

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerController.java
@@ -100,7 +100,7 @@ public class TrackerController
         throws IOException
     {
         // Set the Import Parameters
-        TrackerImportParams params = trackerImportService.getParamsFromMap( contextService.getParameterValuesMap() );
+        TrackerImportParams params = TrackerImportParamsBuilder.build( contextService.getParameterValuesMap() );
 
         // Set the actual objects to import
         TrackerBundleParams trackerBundleParams = renderService.fromJson( request.getInputStream(), TrackerBundleParams.class );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilder.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilder.java
@@ -1,0 +1,125 @@
+package org.hisp.dhis.webapi.controller.tracker;
+
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.tracker.AtomicMode;
+import org.hisp.dhis.tracker.FlushMode;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.TrackerIdentifierParams;
+import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.bundle.TrackerBundleMode;
+
+import com.google.common.base.Enums;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class TrackerImportParamsBuilder
+{
+    public static String VALIDATION_MODE_KEY = "validationMode";
+
+    public static String IMPORT_MODE_KEY = "importMode";
+
+    public static String IMPORT_STRATEGY_KEY = "importStrategy";
+
+    public static String ATOMIC_MODE_KEY = "atomicMode";
+
+    public static String FLUSH_MODE_KEY = "flushMode";
+
+    public static TrackerImportParams build( Map<String, List<String>> parameters )
+    {
+        TrackerImportParams params = new TrackerImportParams();
+
+        params.setValidationMode( getEnumWithDefault( ValidationMode.class, parameters, VALIDATION_MODE_KEY,
+            ValidationMode.FULL ) );
+        params.setImportMode(
+            getEnumWithDefault( TrackerBundleMode.class, parameters, IMPORT_MODE_KEY, TrackerBundleMode.COMMIT ) );
+        params.setIdentifiers( getTrackerIdentifiers( parameters ) );
+        params.setImportStrategy( getEnumWithDefault( TrackerImportStrategy.class, parameters, IMPORT_STRATEGY_KEY,
+            TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        params.setAtomicMode( getEnumWithDefault( AtomicMode.class, parameters, ATOMIC_MODE_KEY, AtomicMode.ALL ) );
+        params.setFlushMode( getEnumWithDefault( FlushMode.class, parameters, FLUSH_MODE_KEY, FlushMode.AUTO ) );
+
+        return params;
+
+    }
+
+    private static <T extends Enum<T>> T getEnumWithDefault( Class<T> enumKlass, Map<String, List<String>> parameters,
+        String key, T defaultValue )
+    {
+        if ( parameters == null || parameters.get( key ) == null || parameters.get( key ).isEmpty() )
+        {
+            return defaultValue;
+        }
+
+        if ( TrackerIdScheme.class.equals( enumKlass ) && IdScheme.isAttribute( parameters.get( key ).get( 0 ) ) )
+        {
+            return Enums.getIfPresent( enumKlass, "ATTRIBUTE" ).orNull();
+        }
+
+        String value = String.valueOf( parameters.get( key ).get( 0 ) );
+
+        return Enums.getIfPresent( enumKlass, value ).or( defaultValue );
+    }
+
+    private static TrackerIdentifierParams getTrackerIdentifiers( Map<String, List<String>> parameters )
+    {
+        TrackerIdScheme idScheme = getEnumWithDefault( TrackerIdScheme.class, parameters, "idScheme",
+            TrackerIdScheme.UID );
+        TrackerIdScheme orgUnitIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters, "orgUnitIdScheme",
+            idScheme );
+        TrackerIdScheme programIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters, "programIdScheme",
+            idScheme );
+        TrackerIdScheme programStageIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters,
+            "programStageIdScheme", idScheme );
+        TrackerIdScheme dataElementIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters,
+            "dataElementIdScheme", idScheme );
+
+        return TrackerIdentifierParams.builder()
+            .idScheme( TrackerIdentifier.builder().idScheme( idScheme )
+                .value( getAttributeUidOrNull( parameters, "idScheme" ) ).build() )
+            .orgUnitIdScheme( TrackerIdentifier.builder().idScheme( orgUnitIdScheme )
+                .value( getAttributeUidOrNull( parameters, "orgUnitIdScheme" ) ).build() )
+            .programIdScheme( TrackerIdentifier.builder().idScheme( programIdScheme )
+                .value( getAttributeUidOrNull( parameters, "programIdScheme" ) ).build() )
+            .programStageIdScheme( TrackerIdentifier.builder().idScheme( programStageIdScheme )
+                .value( getAttributeUidOrNull( parameters, "programStageIdScheme" ) ).build() )
+            .dataElementIdScheme( TrackerIdentifier.builder().idScheme( dataElementIdScheme )
+                .value( getAttributeUidOrNull( parameters, "dataElementIdScheme" ) ).build() )
+            .build();
+    }
+
+    private static String getAttributeUidOrNull( Map<String, List<String>> parameters, String key )
+    {
+        if ( parameters == null || parameters.get( key ) == null || parameters.get( key ).isEmpty() )
+        {
+            return null;
+        }
+
+        if ( IdScheme.isAttribute( parameters.get( key ).get( 0 ) ) )
+        {
+            String uid = "";
+
+            // Get second half of string, separated by ':'
+            String[] splitParam = parameters.get( key ).get( 0 ).split( ":" );
+
+            if ( splitParam.length > 1 )
+            {
+                uid = splitParam[1];
+            }
+
+            if ( CodeGenerator.isValidUid( uid ) )
+            {
+                return uid;
+            }
+        }
+
+        return null;
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilderTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilderTest.java
@@ -1,0 +1,150 @@
+package org.hisp.dhis.webapi.controller.tracker;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.ATOMIC_MODE_KEY;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.FLUSH_MODE_KEY;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.IMPORT_MODE_KEY;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.IMPORT_STRATEGY_KEY;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.VALIDATION_MODE_KEY;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.tracker.AtomicMode;
+import org.hisp.dhis.tracker.FlushMode;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.TrackerIdentifierParams;
+import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.bundle.TrackerBundleMode;
+import org.junit.Test;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class TrackerImportParamsBuilderTest
+{
+    private Map<String, List<String>> paramMap = new HashMap<>();
+
+    @Test
+    public void testDefaultParams()
+    {
+        final TrackerImportParams params = TrackerImportParamsBuilder.build( null );
+        assertDefaultParams( params );
+    }
+
+    @Test
+    public void testValidationMode()
+    {
+        Arrays.stream( ValidationMode.values() ).forEach( e -> {
+            paramMap.put( VALIDATION_MODE_KEY, Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getValidationMode(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testImportMode()
+    {
+        Arrays.stream( TrackerBundleMode.values() ).forEach( e -> {
+            paramMap.put( IMPORT_MODE_KEY, Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getImportMode(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testAtomicMode()
+    {
+        Arrays.stream( AtomicMode.values() ).forEach( e -> {
+            paramMap.put( ATOMIC_MODE_KEY, Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getAtomicMode(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testFlushMode()
+    {
+        Arrays.stream( FlushMode.values() ).forEach( e -> {
+            paramMap.put( FLUSH_MODE_KEY, Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getFlushMode(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testImportStrategy()
+    {
+        Arrays.stream( TrackerImportStrategy.values() ).forEach( e -> {
+            paramMap.put( IMPORT_STRATEGY_KEY, Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getImportStrategy(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testOrgUnitIdentifier()
+    {
+        Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
+            paramMap.put( "orgUnitIdScheme", Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getIdentifiers().getOrgUnitIdScheme().getIdScheme(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testProgramIdentifier()
+    {
+        Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
+            paramMap.put( "programIdScheme", Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getIdentifiers().getProgramIdScheme().getIdScheme(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testProgramStageIdentifier()
+    {
+        Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
+            paramMap.put( "programStageIdScheme", Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getIdentifiers().getProgramStageIdScheme().getIdScheme(), is( e ) );
+        } );
+    }
+
+    @Test
+    public void testDataElementIdentifier()
+    {
+        Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
+            paramMap.put( "dataElementIdScheme", Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getIdentifiers().getDataElementIdScheme().getIdScheme(), is( e ) );
+        } );
+    }
+
+    private void assertDefaultParams( TrackerImportParams params )
+    {
+        assertThat( params.getValidationMode(), is( ValidationMode.FULL ) );
+        assertThat( params.getImportMode(), is( TrackerBundleMode.COMMIT ) );
+        assertThat( params.getImportStrategy(), is( TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        assertThat( params.getAtomicMode(), is( AtomicMode.ALL ) );
+        assertThat( params.getFlushMode(), is( FlushMode.AUTO ) );
+
+        TrackerIdentifierParams identifiers = params.getIdentifiers();
+        assertThat( identifiers.getOrgUnitIdScheme(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getProgramIdScheme(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getCategoryOptionComboIdScheme(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getCategoryOption(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getDataElementIdScheme(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getProgramStageIdScheme(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getIdScheme(), is( TrackerIdentifier.UID ) );
+    }
+
+}


### PR DESCRIPTION
Moved the logic to map HTTP request params to the `TrackerImportParams` object
from the Service layer to the front layer.
Added unit tests