### PR TITLE
fix: prevent changes to a deleted event

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
@@ -234,6 +234,8 @@ public interface IdentifiableObjectStore<T>
 
     /**
      * Retrieves a list of objects referenced by the given collection of uids.
+     * 
+     * Objects which are soft-deleted (deleted=true) are filtered out
      *
      * @param uids a collection of uids.
      * @return a list of objects.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceStore.java
@@ -102,9 +102,18 @@ public interface ProgramStageInstanceStore
      * Returns UIDs of existing ProgramStageInstances (including deleted) from the provided UIDs
      *
      * @param uids PSI UIDs to check
-     * @return Set containing UIDs of existing PSIs (including deleted)
+     * @return List containing UIDs of existing PSIs (including deleted)
      */
     List<String> getUidsIncludingDeleted( List<String> uids );
+
+    /**
+     * Fetches ProgramStageInstance matching the given list of UIDs
+     * 
+     * @param uids a List of UID
+     * @return a List containing the ProgramStageInstance matching the given
+     *         parameters list
+     */
+    List<ProgramStageInstance> getIncludingDeleted( List<String> uids );
 
     /**
      * Get all ProgramStageInstances which have notifications with the given ProgramNotificationTemplate scheduled on the given date.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageInstanceStore.java
@@ -68,6 +68,8 @@ public class HibernateProgramStageInstanceStore
     extends SoftDeleteHibernateObjectStore<ProgramStageInstance>
     implements ProgramStageInstanceStore
 {
+    private final static String PSI_HQL_BY_UIDS = "from ProgramStageInstance as psi where psi.uid in (:uids)";
+
     private final static Set<NotificationTrigger> SCHEDULED_PROGRAM_STAGE_INSTANCE_TRIGGERS =
         Sets.intersection(
             NotificationTrigger.getAllApplicableToProgramStageInstance(),
@@ -158,7 +160,7 @@ public class HibernateProgramStageInstanceStore
     @Override
     public List<String> getUidsIncludingDeleted( List<String> uids )
     {
-        String hql = "select psi.uid from ProgramStageInstance as psi where psi.uid in (:uids)";
+        final String hql = "select psi.uid " + PSI_HQL_BY_UIDS;
         List<String> resultUids = new ArrayList<>();
         List<List<String>> uidsPartitions = Lists.partition( Lists.newArrayList( uids ), 20000 );
 
@@ -172,6 +174,25 @@ public class HibernateProgramStageInstanceStore
 
         return resultUids;
     }
+
+    @Override
+    public List<ProgramStageInstance> getIncludingDeleted( List<String> uids )
+    {
+        List<ProgramStageInstance> programStageInstances = new ArrayList<>();
+        List<List<String>> uidsPartitions = Lists.partition( Lists.newArrayList( uids ), 20000 );
+
+        for ( List<String> uidsPartition : uidsPartitions )
+        {
+            if ( !uidsPartition.isEmpty() )
+            {
+                programStageInstances.addAll( getSession().createQuery( PSI_HQL_BY_UIDS, ProgramStageInstance.class )
+                    .setParameter( "uids", uidsPartition ).list() );
+            }
+        }
+
+        return programStageInstances;
+    }
+
 
     @Override
     public void updateProgramStageInstancesSyncTimestamp( List<String> programStageInstanceUIDs, Date lastSynchronized )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
@@ -58,9 +58,10 @@ public interface ProgramInstanceMapper extends PreheatMapper<ProgramInstance>
     @Mapping( target = "entityInstance" )
     @Mapping( target = "organisationUnit" )
     @Mapping( target = "created" )
+    @Mapping( target = "incidentDate" )
     @Mapping( target = "enrollmentDate" )
     @Mapping( target = "comments" )
-
+    @Mapping( target = "deleted" )
     ProgramInstance map( ProgramInstance programInstance );
 
     @Named( "userGroupAccessesPi" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageInstanceMapper.java
@@ -60,6 +60,11 @@ public interface ProgramStageInstanceMapper extends PreheatMapper<ProgramStageIn
     @Mapping( target = "programInstance" )
     @Mapping( target = "eventDataValues" )
     @Mapping( target = "comments" )
+    @Mapping( target = "dueDate" )
+    @Mapping( target = "executionDate" )
+    @Mapping( target = "completedDate" )
+    @Mapping( target = "completedBy" )
+    @Mapping( target = "deleted" )
     ProgramStageInstance map( ProgramStageInstance programStageInstance );
 
     Set<UserGroupAccess> mapUserGroupAccessPsi( Set<UserGroupAccess> userGroupAccesses );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/EventStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/EventStrategy.java
@@ -60,8 +60,7 @@ public class EventStrategy implements ClassBasedSupplierStrategy
     {
         for ( List<String> ids : splitList )
         {
-            List<ProgramStageInstance> programStageInstances = programStageInstanceStore
-                .getByUid( ids, preheat.getUser() );
+            List<ProgramStageInstance> programStageInstances = programStageInstanceStore.getIncludingDeleted( ids );
 
             final List<String> rootEntities = params.getEvents().stream().map( Event::getEvent )
                 .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -110,7 +110,7 @@ public enum TrackerErrorCode
     E1048( "Object: `{0}`, uid: `{1}`, has an invalid uid format." ),
     E1049( "Could not find OrganisationUnit: `{0}`, linked to Tracked Entity." ),
     // TODO: Delete not working yet
-    E1082( "Event: `{0}`, is already deleted." ),
+    E1082( "Event: `{0}`, is already deleted and can't be modified." ),
     E1113( "Enrollment: `{0}`, is already deleted." ),
     E1114( "TrackedEntity: `{0}`, is already deleted." ),
     E1118( "Assigned user `{0}` is not a valid uid."),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -145,6 +145,13 @@ public class PreCheckExistenceValidationHook
 
         ProgramStageInstance existingPsi = context.getProgramStageInstance( event.getEvent() );
 
+        // If the event is soft-deleted no operation is allowed
+        if ( existingPsi != null && existingPsi.isDeleted() )
+        {
+            addError( reporter, E1082, event.getEvent() );
+            return;
+        }
+
         if ( importStrategy.isCreateAndUpdate() )
         {
             if ( existingPsi == null )
@@ -159,10 +166,6 @@ public class PreCheckExistenceValidationHook
         else if ( existingPsi != null && importStrategy.isCreate() )
         {
             addError( reporter, E1030, event.getEvent() );
-        }
-        else if ( existingPsi != null && existingPsi.isDeleted() && importStrategy.isDelete() )
-        {
-            addError( reporter, E1082, event.getEvent() );
         }
         else if ( existingPsi == null && importStrategy.isUpdateOrDelete() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -885,6 +886,58 @@ public class EventImportValidationTest
             assertNull( comment.getCreator() );
             assertNull( comment.getLastUpdatedBy() );
         } );
+    }
+
+    @Test
+    public void testUpdateDeleteEventFails()
+        throws IOException
+    {
+        // Given -> Creates an event
+        createEvent( "tracker/validations/events-with-notes-data.json" );
+
+        // When -> Soft-delete the event
+        programStageServiceInstance
+            .deleteProgramStageInstance( programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" ) );
+
+        TrackerImportParams trackerBundleParams = createBundleFromJson(
+            "tracker/validations/events-with-notes-data.json" );
+
+        // Then
+        ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams, CREATE );
+
+        assertEquals( 0, createAndUpdate.getTrackerBundle().getEvents().size() );
+        TrackerValidationReport report = createAndUpdate.getValidationReport();
+        printReport( report );
+        assertEquals( 1, report.getErrorReports().size() );
+        assertThat( report.getErrorReports(),
+            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1082 ) ) ) );
+
+    }
+
+    @Test
+    public void testInserDeleteEventFails()
+            throws IOException
+    {
+        // Given -> Creates an event
+        createEvent( "tracker/validations/events-with-notes-data.json" );
+
+        // When -> Soft-delete the event
+        programStageServiceInstance
+                .deleteProgramStageInstance( programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" ) );
+
+        TrackerImportParams trackerBundleParams = createBundleFromJson(
+                "tracker/validations/events-with-notes-data.json" );
+
+        // Then
+        ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams, CREATE );
+
+        assertEquals( 0, createAndUpdate.getTrackerBundle().getEvents().size() );
+        TrackerValidationReport report = createAndUpdate.getValidationReport();
+        printReport( report );
+        assertEquals( 1, report.getErrorReports().size() );
+        assertThat( report.getErrorReports(),
+                everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1082 ) ) ) );
+
     }
 
     private ValidateAndCommitTestUnit createEvent( String jsonPayload )


### PR DESCRIPTION
Validates that a soft-deleted event cannot be Deleted or Updated.
Trying to insert an event that has a UID matching the UID of an existing, soft-deleted event, will also fail the validation.

ref: DHIS2-9888