### PR TITLE
fix: Leading decimal number data entry DHIS2-2510

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.js
@@ -207,7 +207,14 @@ function saveVal( dataElementId, optionComboId, fieldId, feedbackId )
             }
             if ( type == 'NUMBER' && !dhis2.validation.isNumber( value ) )
             {
-                return dhis2.de.alertField( fieldId, i18n_value_must_number + '\n\n' + dataElementName );
+                if ( dhis2.validation.isNumber( '0' + value ) )
+                {
+                    value = '0' + value; // Prepend '0' to a leading decimal point
+                }
+                else
+                {
+                    return dhis2.de.alertField(fieldId, i18n_value_must_number + '\n\n' + dataElementName);
+                }
             }
             if ( type == 'INTEGER' && !dhis2.validation.isInt( value ) )
             {


### PR DESCRIPTION
In the data entry app, prepends a '0' to the stored value sent to the backend if the user enters a number starting with a '.' instead of telling the user they entered an illegal number.

For example: .1 -> 0.1, .33 -> 0.33, etc.

Note: This is similar to what Excel and Google Sheets do. They add a leading zero if the user enters a number starting with a '.'