### PR TITLE
fix: Tracker Identifiers resolution during Tracker import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <properties>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
@@ -113,7 +113,7 @@ public class DefaultTrackerProgramRuleService
     {
         return events
             .stream()
-            .filter( e -> isEventInRegistrationProgram( e, bundle.getPreheat(), bundle.getIdentifier() ) )
+            .filter( e -> isEventInRegistrationProgram( e, bundle.getPreheat() ) )
             .collect( Collectors.toMap( Event::getEvent, event -> {
                 ProgramInstance enrollment = getEnrollment( bundle, event );
                 try
@@ -137,14 +137,13 @@ public class DefaultTrackerProgramRuleService
             } ) );
     }
 
-    private boolean isEventInRegistrationProgram( Event e, TrackerPreheat preheat,
-        TrackerIdScheme identifier )
+    private boolean isEventInRegistrationProgram( Event e, TrackerPreheat preheat )
     {
         if ( e.getProgram() == null )
         {
             return false;
         }
-        Program program = preheat.get( identifier, Program.class, e.getProgram() );
+        Program program = preheat.get( Program.class, e.getProgram() );
         if ( program == null )
         {
             return false;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifier.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.tracker;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -52,9 +53,11 @@ public class TrackerIdentifier
 
     public final static TrackerIdentifier AUTO = builder().idScheme( TrackerIdScheme.AUTO ).build();
 
+    @JsonProperty
     @Builder.Default
     private TrackerIdScheme idScheme = TrackerIdScheme.UID;
 
+    @JsonProperty
     @Builder.Default
     private String value = null;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -136,7 +136,7 @@ public class TrackerIdentifierCollector
             Stream
                 .of( MoreObjects.firstNonNull( event.getAttributeCategoryOptions(), "" ).split( TextUtils.SEMICOLON ) )
                 .forEach(
-                    s -> addIdentifier( map, CategoryOption.class, params.getCategoryOption().getIdScheme(), s ) );
+                    s -> addIdentifier( map, CategoryOption.class, params.getCategoryOptionComboIdScheme().getIdScheme(), s ) );
 
             addIdentifier( map, CategoryOptionCombo.class, params.getCategoryOptionComboIdScheme().getIdScheme(),
                 event.getAttributeOptionCombo() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierParams.java
@@ -95,7 +95,7 @@ public class TrackerIdentifierParams
      */
     @JsonProperty
     @Builder.Default
-    private TrackerIdentifier categoryOption = TrackerIdentifier.UID;
+    private TrackerIdentifier categoryOptionIdScheme = TrackerIdentifier.UID;
 
     public TrackerIdentifier getByClass( Class<?> klazz )
     {
@@ -106,7 +106,7 @@ public class TrackerIdentifierParams
         case "OrganisationUnit":
             return orgUnitIdScheme;
         case "CategoryOption":
-            return categoryOption;
+            return categoryOptionIdScheme;
         case "DataElement":
             return dataElementIdScheme;
         case "Program":

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -33,12 +33,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.FlushMode;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -33,14 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.FlushMode;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.FlushMode;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.bundle.TrackerBundleHook;
@@ -301,7 +300,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
 
     private void assignFileResource( Session session, TrackerPreheat preheat, String fr, boolean isAssign )
     {
-        FileResource fileResource = preheat.get( TrackerIdScheme.UID, FileResource.class, fr );
+        FileResource fileResource = preheat.get( FileResource.class, fr );
 
         if ( fileResource == null )
         {
@@ -323,8 +322,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
         for ( Attribute at : payloadAttributes )
         {
             boolean isNew = false;
-            TrackedEntityAttribute attribute = preheat.get( TrackerIdScheme.UID, TrackedEntityAttribute.class,
-                at.getAttribute() );
+            TrackedEntityAttribute attribute = preheat.get( TrackedEntityAttribute.class, at.getAttribute() );
 
             checkNotNull( attribute,
                 "Attribute should never be NULL here if validation is enforced before commit." );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
@@ -177,7 +177,7 @@ public class EventPersister extends AbstractTrackerPersister<Event, ProgramStage
 
         for ( DataValue dv : payloadDataValues )
         {
-            DataElement dateElement = preheat.get( TrackerIdScheme.UID, DataElement.class, dv.getDataElement() );
+            DataElement dateElement = preheat.get( DataElement.class, dv.getDataElement() );
 
             checkNotNull( dateElement,
                 "Data element should never be NULL here if validation is enforced before commit." );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -116,11 +116,11 @@ public class EnrollmentTrackerConverterService
     private ProgramInstance from( TrackerPreheat preheat, Enrollment enrollment, ProgramInstance programInstance )
     {
         OrganisationUnit organisationUnit = preheat
-            .get( TrackerIdScheme.UID, OrganisationUnit.class, enrollment.getOrgUnit() );
+            .get( OrganisationUnit.class, enrollment.getOrgUnit() );
 
         checkNotNull( organisationUnit, TrackerImporterAssertErrors.ORGANISATION_UNIT_CANT_BE_NULL );
 
-        Program program = preheat.get( TrackerIdScheme.UID, Program.class, enrollment.getProgram() );
+        Program program = preheat.get( Program.class, enrollment.getProgram() );
 
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -176,9 +176,9 @@ public class EventTrackerConverterService
 
     private ProgramStageInstance from( TrackerPreheat preheat, Event event, ProgramStageInstance programStageInstance )
     {
-        ProgramStage programStage = preheat.get( TrackerIdScheme.UID, ProgramStage.class, event.getProgramStage() );
+        ProgramStage programStage = preheat.get( ProgramStage.class, event.getProgramStage() );
         OrganisationUnit organisationUnit = preheat
-            .get( TrackerIdScheme.UID, OrganisationUnit.class, event.getOrgUnit() );
+            .get( OrganisationUnit.class, event.getOrgUnit() );
 
         if ( isNewEntity( programStageInstance ) )
         {
@@ -204,7 +204,7 @@ public class EventTrackerConverterService
         if ( attributeOptionCombo != null )
         {
             programStageInstance.setAttributeOptionCombo(
-                preheat.get( TrackerIdScheme.UID, CategoryOptionCombo.class, event.getAttributeOptionCombo() ) );
+                preheat.get( CategoryOptionCombo.class, event.getAttributeOptionCombo() ) );
         }
         else
         {
@@ -234,7 +234,7 @@ public class EventTrackerConverterService
 
         if ( programStage.isEnableUserAssignment() )
         {
-            User assignedUser = preheat.get( TrackerIdScheme.UID, User.class, event.getAssignedUser() );
+            User assignedUser = preheat.get( User.class, event.getAssignedUser() );
             programStageInstance.setAssignedUser( assignedUser );
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -123,7 +123,7 @@ public class RelationshipTrackerConverterService
         org.hisp.dhis.relationship.Relationship toRelationship )
     {
         org.hisp.dhis.relationship.RelationshipType relationshipType = preheat
-            .get( TrackerIdScheme.UID, RelationshipType.class, fromRelationship.getRelationshipType() );
+            .get( RelationshipType.class, fromRelationship.getRelationshipType() );
         org.hisp.dhis.relationship.RelationshipItem fromItem = new org.hisp.dhis.relationship.RelationshipItem();
         org.hisp.dhis.relationship.RelationshipItem toItem = new org.hisp.dhis.relationship.RelationshipItem();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/TrackedEntityTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/TrackedEntityTrackerConverterService.java
@@ -101,9 +101,9 @@ public class TrackedEntityTrackerConverterService
 
     private TrackedEntityInstance from( TrackerPreheat preheat, TrackedEntity te, TrackedEntityInstance tei )
     {
-        OrganisationUnit organisationUnit = preheat.get( TrackerIdScheme.UID, OrganisationUnit.class,
+        OrganisationUnit organisationUnit = preheat.get( OrganisationUnit.class,
             te.getOrgUnit() );
-        TrackedEntityType trackedEntityType = preheat.get( TrackerIdScheme.UID, TrackedEntityType.class,
+        TrackedEntityType trackedEntityType = preheat.get( TrackedEntityType.class,
             te.getTrackedEntityType() );
 
         if ( isNewEntity( tei ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -84,10 +84,11 @@ public class TrackerPreheat
     private User user;
 
     /**
-     * Internal map of all objects mapped by identifier => class type => uid.
+     * Internal map of all metadata objects mapped by class type => [id] The value
+     * of each id can be either the metadata uid, code or attribute value
      */
     @Getter
-    private Map<TrackerIdScheme, Map<Class<? extends IdentifiableObject>, Map<String, IdentifiableObject>>> map = new HashMap<>();
+    private Map<Class<? extends IdentifiableObject>, Map<String, IdentifiableObject>> map = new HashMap<>();
 
     /**
      * Internal tree of all payload references which are not present in the
@@ -225,113 +226,65 @@ public class TrackerPreheat
         return User.username( user );
     }
 
-    public <T extends IdentifiableObject> T get( TrackerIdentifier identifier,
-        Class<? extends IdentifiableObject> klass, IdentifiableObject object )
-    {
-        return get( identifier.getIdScheme(), klass, identifier.getIdentifier( object ) );
-    }
-
+    /**
+     * Fetch a metadata object from the pre-heat, based on the type of the object
+     * and the cached identifier.
+     *
+     * @param klass The metadata class to fetch
+     * @param key The key used during the pre-heat creation
+     * @return A metadata object or null
+     */
     @SuppressWarnings( "unchecked" )
-    public <T extends IdentifiableObject> T get( TrackerIdScheme identifier, Class<? extends IdentifiableObject> klass,
+    public <T extends IdentifiableObject> T get( Class<? extends IdentifiableObject> klass,
         String key )
     {
-        if ( !containsKey( identifier, klass, key ) )
-        {
-            return null;
-        }
-
-        return (T) map.get( identifier ).get( klass ).get( key );
+        return (T) map.getOrDefault( klass, new HashMap<>() ).get( key );
     }
 
-    public <T extends IdentifiableObject> List<T> getAll( TrackerIdentifier identifier, List<T> keys )
-    {
-        List<T> objects = new ArrayList<>();
-
-        for ( T key : keys )
-        {
-            T identifiableObject = get( identifier, key );
-
-            if ( identifiableObject != null )
-            {
-                objects.add( identifiableObject );
-            }
-        }
-
-        return objects;
-    }
-
+    /**
+     * Fetch all the metadata objects from the pre-heat, by object type
+     * 
+     * @param klass The metadata class to fetch
+     *
+     * @return a List of pre-heated object or empty list
+     */
     @SuppressWarnings( "unchecked" )
-    public <T extends IdentifiableObject> List<T> getAll( TrackerIdScheme identifier, Class<T> klass )
+    public <T extends IdentifiableObject> List<T> getAll( Class<T> klass )
     {
-        if ( !map.containsKey( identifier ) || !map.get( identifier ).containsKey( klass ) )
-        {
-            return new ArrayList<>();
-        }
-
-        return new ArrayList<>( (Collection<? extends T>) map.get( identifier ).get( klass ).values() );
-    }
-
-    @SuppressWarnings( "unchecked" )
-    public <T extends IdentifiableObject> T get( TrackerIdentifier identifier, T object )
-    {
-        if ( object == null )
-        {
-            return null;
-        }
-
-        Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) getRealClass(
-            object.getClass() );
-
-        return get( identifier.getIdScheme(), klass, identifier.getIdentifier( object ) );
-    }
-
-    public boolean containsKey( TrackerIdScheme identifier, Class<? extends IdentifiableObject> klass, String key )
-    {
-        return !(isEmpty() || isEmpty( identifier ) || isEmpty( identifier, klass )) &&
-            map.get( identifier ).get( klass ).containsKey( key );
-    }
+        return new ArrayList<>( (Collection<? extends T>) map.getOrDefault( klass, new HashMap<>() ).values() );
+    }    
 
     public boolean isEmpty()
     {
         return map.isEmpty();
     }
 
-    public boolean isEmpty( TrackerIdScheme identifier )
-    {
-        return !map.containsKey( identifier ) || map.get( identifier ).isEmpty();
-    }
-
-    public boolean isEmpty( TrackerIdScheme identifier, Class<? extends IdentifiableObject> klass )
-    {
-        return isEmpty( identifier ) || !map.get( identifier ).containsKey( klass ) ||
-            map.get( identifier ).get( klass ).isEmpty();
-    }
-
     @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> TrackerPreheat put( TrackerIdentifier identifier, T object )
     {
-        TrackerIdScheme idScheme = identifier.getIdScheme();
         if ( object == null )
+        {
             return this;
+        }
 
         Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) getRealClass(
             object.getClass() );
 
-        if ( !map.containsKey( idScheme ) )
-            map.put( idScheme, new HashMap<>() );
-        if ( !map.get( idScheme ).containsKey( klass ) )
-            map.get( idScheme ).put( klass, new HashMap<>() );
+        if ( !map.containsKey( klass ) )
+        {
+            map.put( klass, new HashMap<>() );
+        }
 
         if ( User.class.isAssignableFrom( klass ) )
         {
-            if ( !map.get( idScheme ).containsKey( UserCredentials.class ) )
+            if ( !map.containsKey( UserCredentials.class ) )
             {
-                map.get( idScheme ).put( UserCredentials.class, new HashMap<>() );
+                map.put( UserCredentials.class, new HashMap<>() );
             }
 
             User user = (User) object;
 
-            Map<String, IdentifiableObject> identifierMap = map.get( idScheme ).get( UserCredentials.class );
+            Map<String, IdentifiableObject> identifierMap = map.get( UserCredentials.class );
 
             if ( !StringUtils.isEmpty( identifier.getIdentifier( user ) ) &&
                 !identifierMap.containsKey( identifier.getIdentifier( user ) ) )
@@ -340,57 +293,7 @@ public class TrackerPreheat
             }
         }
 
-        Map<String, IdentifiableObject> identifierMap = map.get( idScheme ).get( klass );
-        String key = identifier.getIdentifier( object );
-
-        if ( !StringUtils.isEmpty( key ) && !identifierMap.containsKey( key ) )
-        {
-            identifierMap.put( key, object );
-        }
-
-        return this;
-    }
-
-    @SuppressWarnings( "unchecked" )
-    public <T extends IdentifiableObject> TrackerPreheat replace( TrackerIdentifier identifier, T object )
-    {
-        TrackerIdScheme idScheme = identifier.getIdScheme();
-        if ( object == null )
-            return this;
-
-        Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) getRealClass(
-            object.getClass() );
-
-        if ( !map.containsKey( idScheme ) )
-            map.put( idScheme, new HashMap<>() );
-        if ( !map.get( idScheme ).containsKey( klass ) )
-            map.get( idScheme ).put( klass, new HashMap<>() );
-
-        if ( User.class.isAssignableFrom( klass ) )
-        {
-            if ( !map.get( idScheme ).containsKey( UserCredentials.class ) )
-            {
-                map.get( idScheme ).put( UserCredentials.class, new HashMap<>() );
-            }
-
-            User user = (User) object;
-
-            Map<String, IdentifiableObject> identifierMap = map.get( idScheme ).get( UserCredentials.class );
-
-            if ( !StringUtils.isEmpty( identifier.getIdentifier( user ) ) &&
-                !identifierMap.containsKey( identifier.getIdentifier( user ) ) )
-            {
-                identifierMap.put( identifier.getIdentifier( user ), user.getUserCredentials() );
-            }
-        }
-
-        Map<String, IdentifiableObject> identifierMap = map.get( idScheme ).get( klass );
-        String key = identifier.getIdentifier( object );
-
-        if ( !StringUtils.isEmpty( key ) )
-        {
-            identifierMap.put( key, object );
-        }
+        resolveKey( identifier, object ).ifPresent( k -> map.get( klass ).put( k, object ) );
 
         return this;
     }
@@ -400,44 +303,6 @@ public class TrackerPreheat
         for ( T object : objects )
         {
             put( identifier, object );
-        }
-
-        return this;
-    }
-
-    public TrackerPreheat remove( TrackerIdScheme identifier, Class<? extends IdentifiableObject> klass, String key )
-    {
-        if ( containsKey( identifier, klass, key ) )
-        {
-            map.get( identifier ).get( klass ).remove( key );
-        }
-
-        return this;
-    }
-
-    @SuppressWarnings( "unchecked" )
-    public TrackerPreheat remove( TrackerIdentifier identifier, IdentifiableObject object )
-    {
-        TrackerIdScheme idScheme = identifier.getIdScheme();
-        Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) getRealClass(
-            object.getClass() );
-
-        String key = identifier.getIdentifier( object );
-
-        if ( containsKey( idScheme, klass, key ) )
-        {
-            map.get( idScheme ).get( klass ).remove( key );
-        }
-
-        return this;
-    }
-
-    public TrackerPreheat remove( TrackerIdScheme identifier, Class<? extends IdentifiableObject> klass,
-        Collection<String> keys )
-    {
-        for ( String key : keys )
-        {
-            remove( identifier, klass, key );
         }
 
         return this;
@@ -685,6 +550,26 @@ public class TrackerPreheat
         return new StringJoiner( ", ", TrackerPreheat.class.getSimpleName() + "[", "]" )
             .add( "map=" + map )
             .toString();
+    }
+
+    private <T extends IdentifiableObject> Optional<String> resolveKey( TrackerIdentifier identifier, T object )
+    {
+        if ( identifier.getIdScheme().equals( TrackerIdScheme.UID ) )
+        {
+            return Optional.ofNullable( object.getUid() );
+        }
+        else if ( identifier.getIdScheme().equals( TrackerIdScheme.CODE ) )
+        {
+            return Optional.ofNullable( object.getCode() );
+        }
+        else if ( identifier.getIdScheme().equals( TrackerIdScheme.ATTRIBUTE ) )
+        {
+            return Optional.ofNullable( identifier.getIdentifier( object ) );
+        }
+        // TODO TrackerIdScheme.AUTO ??
+
+        return Optional.empty();
+
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplier.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Attribute;
@@ -61,7 +60,7 @@ public class FileResourceSupplier extends AbstractPreheatSupplier
     @Override
     public void preheatAdd(TrackerImportParams params, TrackerPreheat preheat )
     {
-        List<TrackedEntityAttribute> attributes = preheat.getAll( TrackerIdScheme.UID, TrackedEntityAttribute.class );
+        List<TrackedEntityAttribute> attributes = preheat.getAll( TrackedEntityAttribute.class );
 
         List<String> fileResourceAttributes = attributes.stream()
             .filter( at -> at.getValueType() == ValueType.FILE_RESOURCE )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplier.java
@@ -40,7 +40,6 @@ import org.springframework.util.StringUtils;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -63,7 +62,7 @@ public class OrgUnitValueTypeSupplier extends AbstractPreheatSupplier
     @Override
     public void preheatAdd(TrackerImportParams params, TrackerPreheat preheat )
     {
-        List<TrackedEntityAttribute> attributes = preheat.getAll( TrackerIdScheme.UID, TrackedEntityAttribute.class );
+        List<TrackedEntityAttribute> attributes = preheat.getAll( TrackedEntityAttribute.class );
 
         List<String> orgUnitAttributes = attributes.stream()
             .filter( at -> at.getValueType() == ValueType.ORGANISATION_UNIT )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
@@ -132,7 +132,7 @@ public class ProgramInstanceByTeiSupplier extends AbstractPreheatSupplier
 
     private Program getProgram( TrackerPreheat preheat, String uid )
     {
-        return preheat.get( TrackerIdScheme.UID, Program.class, uid );
+        return preheat.get( Program.class, uid );
     }
 
     private TrackedEntityInstance getTrackedEntityInstance( TrackerPreheat preheat, String uid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UsernameValueTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UsernameValueTypeSupplier.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -62,7 +61,7 @@ public class UsernameValueTypeSupplier extends AbstractPreheatSupplier
     @Override
     public void preheatAdd(TrackerImportParams params, TrackerPreheat preheat )
     {
-        List<TrackedEntityAttribute> attributes = preheat.getAll( TrackerIdScheme.UID, TrackedEntityAttribute.class );
+        List<TrackedEntityAttribute> attributes = preheat.getAll( TrackedEntityAttribute.class );
 
         List<String> usernameAttributes = attributes.stream()
             .filter( at -> at.getValueType() == ValueType.USERNAME )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BidirectionalRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BidirectionalRelationshipsPreProcessor.java
@@ -28,18 +28,9 @@ package org.hisp.dhis.tracker.preprocess;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.commons.collections4.BidiMap;
-import org.apache.commons.collections4.bidimap.DualHashBidiMap;
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Relationship;
 import org.springframework.stereotype.Component;
-
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This preprocessor is responsible for populating the bidirectional field
@@ -58,7 +49,7 @@ public class BidirectionalRelationshipsPreProcessor
         bundle.getRelationships()
             .forEach( rel -> {
                 RelationshipType relType = bundle.getPreheat()
-                    .get( bundle.getIdentifier(), RelationshipType.class, rel.getRelationshipType() );
+                    .get( RelationshipType.class, rel.getRelationshipType() );
                 if (relType != null)
                 {
                     rel.setBidirectional( relType.isBidirectional() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
@@ -160,7 +160,7 @@ public class TrackerImportValidationContext
 
     public OrganisationUnit getOrganisationUnit( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), OrganisationUnit.class, id );
+        return bundle.getPreheat().get( OrganisationUnit.class, id );
     }
 
     public TrackedEntityInstance getTrackedEntityInstance( String id )
@@ -170,27 +170,27 @@ public class TrackerImportValidationContext
 
     public TrackedEntityAttribute getTrackedEntityAttribute( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), TrackedEntityAttribute.class, id );
+        return bundle.getPreheat().get( TrackedEntityAttribute.class, id );
     }
 
     public DataElement getDataElement( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), DataElement.class, id );
+        return bundle.getPreheat().get( DataElement.class, id );
     }
 
     public TrackedEntityType getTrackedEntityType( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), TrackedEntityType.class, id );
+        return bundle.getPreheat().get( TrackedEntityType.class, id );
     }
 
     public RelationshipType getRelationShipType(String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), RelationshipType.class, id );
+        return bundle.getPreheat().get( RelationshipType.class, id );
     }
 
     public Program getProgram( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), Program.class, id );
+        return bundle.getPreheat().get( Program.class, id );
     }
 
     public ProgramInstance getProgramInstance( String id )
@@ -215,7 +215,7 @@ public class TrackerImportValidationContext
 
     public ProgramStage getProgramStage( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), ProgramStage.class, id );
+        return bundle.getPreheat().get( ProgramStage.class, id );
     }
 
     public ProgramStageInstance getProgramStageInstance( String event )
@@ -225,12 +225,12 @@ public class TrackerImportValidationContext
 
     public CategoryOptionCombo getCategoryOptionCombo( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), CategoryOptionCombo.class, id );
+        return bundle.getPreheat().get( CategoryOptionCombo.class, id );
     }
 
     public CategoryOption getCategoryOption( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), CategoryOption.class, id );
+        return bundle.getPreheat().get( CategoryOption.class, id );
     }
 
     public Map<String, List<ProgramInstance>> getEventToProgramInstancesMap()
@@ -245,7 +245,7 @@ public class TrackerImportValidationContext
 
     public FileResource getFileResource( String id )
     {
-        return bundle.getPreheat().get( bundle.getIdentifier(), FileResource.class, id );
+        return bundle.getPreheat().get( FileResource.class, id );
     }
 
     public Optional<ReferenceTrackerEntity> getReference( String uid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
 import java.util.Optional;
 
 import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -74,7 +73,7 @@ public class AssignedUserValidationHook
 
     private boolean assignedUserNotPresentInPreheat(ValidationErrorReporter reporter, Event event )
     {
-        return reporter.getValidationContext().getBundle().getPreheat().get( TrackerIdScheme.UID, User.class,
+        return reporter.getValidationContext().getBundle().getPreheat().get( User.class,
             event.getAssignedUser() ) == null;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -159,12 +158,8 @@ public class PreCheckMetaValidationHook
             .stream()
             .map( DataValue::getDataElement )
             .forEach( de -> {
-                DataElement dataElement = context.getBundle().getPreheat().get( TrackerIdScheme.UID, DataElement.class,
-                    de );
-                if ( dataElement == null )
-                {
-                    addError( reporter, E1087, event.getEvent(), de );
-                }
+                DataElement dataElement = context.getBundle().getPreheat().get( DataElement.class, de );
+                addErrorIfNull( dataElement,  reporter, E1087, event.getEvent(), de );
             } );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -52,7 +52,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -84,7 +83,7 @@ public class RelationshipsValidationHook
         }
 
         boolean isValid = validateMandatoryData( reporter, relationship,
-                bundle.getPreheat().getAll( TrackerIdScheme.UID, RelationshipType.class ) );
+                bundle.getPreheat().getAll( RelationshipType.class ) );
 
         // No need to check additional data if there are missing information on the
         // Relationship
@@ -116,7 +115,7 @@ public class RelationshipsValidationHook
     private void validateRelationshipConstraint( ValidationErrorReporter reporter, Relationship relationship,
                                                  TrackerBundle bundle )
     {
-        getRelationshipType( bundle.getPreheat().getAll( TrackerIdScheme.UID, RelationshipType.class ),
+        getRelationshipType( bundle.getPreheat().getAll( RelationshipType.class ),
                 relationship.getRelationshipType() ).ifPresent( relationshipType -> {
 
                 validateRelationshipConstraint( "from", relationship.getFrom(), relationshipType.getFromConstraint(),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
@@ -250,7 +249,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
         }
 
         FileResource fileResource = reporter.getValidationContext().getBundle().getPreheat()
-            .get( TrackerIdScheme.UID, FileResource.class, attr.getValue() );
+            .get( FileResource.class, attr.getValue() );
         
         addErrorIfNull( fileResource, reporter, E1084, attr.getValue() );
         addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, E1009, attr.getValue() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
@@ -30,41 +30,23 @@ package org.hisp.dhis.tracker.bundle;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
-import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.render.RenderFormat;
-import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.tracker.ParamsConverter;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.UserService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -99,12 +81,12 @@ public class TrackedEntityAttributeTest
 
         TrackerPreheat preheat = trackerPreheatService.preheat( trackerImportParams );
 
-        assertNotNull( preheat.get( TrackerIdScheme.UID, OrganisationUnit.class, "cNEZTkdAvmg" ) );
-        assertNotNull( preheat.get( TrackerIdScheme.UID, TrackedEntityType.class, "KrYIdvLxkMb" ) );
+        assertNotNull( preheat.get( OrganisationUnit.class, "cNEZTkdAvmg" ) );
+        assertNotNull( preheat.get( TrackedEntityType.class, "KrYIdvLxkMb" ) );
 
-        assertNotNull( preheat.get( TrackerIdScheme.UID, TrackedEntityAttribute.class, "sYn3tkL3XKa" ) );
-        assertNotNull( preheat.get( TrackerIdScheme.UID, TrackedEntityAttribute.class, "TsfP85GKsU5" ) );
-        assertNotNull( preheat.get( TrackerIdScheme.UID, TrackedEntityAttribute.class, "sTGqP5JNy6E" ) );
+        assertNotNull( preheat.get( TrackedEntityAttribute.class, "sYn3tkL3XKa" ) );
+        assertNotNull( preheat.get( TrackedEntityAttribute.class, "TsfP85GKsU5" ) );
+        assertNotNull( preheat.get( TrackedEntityAttribute.class, "sTGqP5JNy6E" ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -38,9 +38,6 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
-import org.hisp.dhis.tracker.converter.EventTrackerConverterService;
-import org.hisp.dhis.tracker.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.Before;
@@ -85,10 +82,8 @@ public class EventTrackerConverterServiceTest
 
         programStage.setProgram( program );
 
-        when( preheat.get( TrackerIdScheme.UID, ProgramStage.class, programStage.getUid() ) )
-            .thenReturn( programStage );
-        when( preheat.get( TrackerIdScheme.UID, OrganisationUnit.class, organisationUnit.getUid() ) )
-            .thenReturn( organisationUnit );
+        when( preheat.get( ProgramStage.class, programStage.getUid() ) ).thenReturn( programStage );
+        when( preheat.get( OrganisationUnit.class, organisationUnit.getUid() ) ).thenReturn( organisationUnit );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerImportParamsSerdeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerImportParamsSerdeTest.java
@@ -1,0 +1,129 @@
+package org.hisp.dhis.tracker.job;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+
+import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.tracker.AtomicMode;
+import org.hisp.dhis.tracker.FlushMode;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.TrackerIdentifierParams;
+import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.bundle.TrackerBundleMode;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class TrackerImportParamsSerdeTest extends TrackerTest
+{
+
+    @Autowired
+    private RenderService renderService;
+
+    @Override
+    protected void initTest()
+    {
+
+    }
+
+    @Test
+    public void testJsonSerialization()
+        throws JSONException
+    {
+        TrackerIdentifierParams identifierParams = TrackerIdentifierParams.builder().idScheme( TrackerIdentifier.CODE )
+            .programIdScheme(
+                TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( "aaaa" ).build() )
+            .build();
+
+        TrackerImportParams trackerImportParams = TrackerImportParams.builder()
+            .identifiers( identifierParams )
+            .atomicMode( AtomicMode.OBJECT )
+            .flushMode( FlushMode.OBJECT )
+            .skipRuleEngine( true )
+            .importStrategy( TrackerImportStrategy.DELETE )
+            .validationMode( ValidationMode.SKIP )
+            .build();
+
+        String json = renderService.toJsonAsString( trackerImportParams );
+        JSONAssert.assertEquals( "" +
+            "{\"importMode\":\"COMMIT\"," +
+            "\"identifiers\":{\"dataElementIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"orgUnitIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"programIdScheme\":{\"idScheme\":\"ATTRIBUTE\",\"value\":\"aaaa\"}," +
+            "\"programStageIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"idScheme\":{\"idScheme\":\"CODE\"}," +
+            "\"categoryOptionComboIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"categoryOptionIdScheme\":{\"idScheme\":\"UID\"}}," +
+            "\"importStrategy\":\"DELETE\"," +
+            "\"atomicMode\":\"OBJECT\"," +
+            "\"flushMode\":\"OBJECT\"," +
+            "\"validationMode\":\"SKIP\"," +
+            "\"skipPatternValidation\":false," +
+            "\"skipSideEffects\":false," +
+            "\"skipRuleEngine\":true," +
+            "\"trackedEntities\":[]," +
+            "\"enrollments\":[]," +
+            "\"events\":[]," +
+            "\"relationships\":[]," +
+            "\"username\":\"system-process\"}", json, JSONCompareMode.LENIENT );
+    }
+
+    @Test
+    public void testJsonDeserialization()
+        throws IOException
+    {
+
+        final String json = "" +
+            "{\"importMode\":\"COMMIT\"," +
+            "\"identifiers\":{\"dataElementIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"orgUnitIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"programIdScheme\":{\"idScheme\":\"ATTRIBUTE\",\"value\":\"aaaa\"}," +
+            "\"programStageIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"idScheme\":{\"idScheme\":\"CODE\"}," +
+            "\"categoryOptionComboIdScheme\":{\"idScheme\":\"UID\"}," +
+            "\"categoryOptionIdScheme\":{\"idScheme\":\"UID\"}}," +
+            "\"importStrategy\":\"DELETE\"," +
+            "\"atomicMode\":\"OBJECT\"," +
+            "\"flushMode\":\"OBJECT\"," +
+            "\"validationMode\":\"SKIP\"," +
+            "\"skipPatternValidation\":true," +
+            "\"skipSideEffects\":true," +
+            "\"skipRuleEngine\":true," +
+            "\"trackedEntities\":[]," +
+            "\"enrollments\":[]," +
+            "\"events\":[]," +
+            "\"relationships\":[]," +
+            "\"username\":\"system-process\"}";
+
+        final TrackerImportParams trackerImportParams = renderService.fromJson( json, TrackerImportParams.class );
+
+        assertThat( trackerImportParams.getImportMode(), is( TrackerBundleMode.COMMIT ) );
+        assertThat( trackerImportParams.getImportStrategy(), is( TrackerImportStrategy.DELETE ) );
+        assertThat( trackerImportParams.getAtomicMode(), is( AtomicMode.OBJECT ) );
+        assertThat( trackerImportParams.getFlushMode(), is( FlushMode.OBJECT ) );
+        assertThat( trackerImportParams.getValidationMode(), is( ValidationMode.SKIP ) );
+        assertThat( trackerImportParams.isSkipPatternValidation(), is( true ) );
+        assertThat( trackerImportParams.isSkipSideEffects(), is( true ) );
+        assertThat( trackerImportParams.isSkipRuleEngine(), is( true ) );
+        assertThat( trackerImportParams.getUser(), is( nullValue() ) );
+
+        TrackerIdentifierParams identifiers = trackerImportParams.getIdentifiers();
+        assertThat( identifiers.getIdScheme(), is( TrackerIdentifier.CODE ) );
+        assertThat( identifiers.getProgramIdScheme().getIdScheme(), is( TrackerIdScheme.ATTRIBUTE ) );
+        assertThat( identifiers.getProgramIdScheme().getValue(), is( "aaaa" ) );
+
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
@@ -322,7 +322,7 @@ public class DefaultTrackerPreheatServiceTest
 
     private <T extends IdentifiableObject> T getGeneric( TrackerPreheat preheat, Class<T> klazz, String uid )
     {
-        return preheat.get( TrackerIdScheme.UID, klazz, uid );
+        return preheat.get( klazz, uid );
     }
 
     private User getUser()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -186,14 +186,13 @@ public class TrackerPreheatServiceTest extends TrackerTest
 
         assertNotNull( preheat );
         assertNotNull( preheat.getMap() );
-        assertNotNull( preheat.getMap().get( TrackerIdScheme.UID ) );
-        assertNotNull( preheat.getMap().get( TrackerIdScheme.UID ).get( DataElement.class ) );
-        assertNotNull( preheat.getMap().get( TrackerIdScheme.UID ).get( OrganisationUnit.class ) );
-        assertNotNull( preheat.getMap().get( TrackerIdScheme.UID ).get( Program.class ) );
-        assertNotNull( preheat.getMap().get( TrackerIdScheme.UID ).get( ProgramStage.class ) );
-        assertNotNull( preheat.getMap().get( TrackerIdScheme.UID ).get( CategoryOptionCombo.class ) );
+        assertNotNull( preheat.getMap().get( DataElement.class ) );
+        assertNotNull( preheat.getMap().get( OrganisationUnit.class ) );
+        assertNotNull( preheat.getMap().get( Program.class ) );
+        assertNotNull( preheat.getMap().get( ProgramStage.class ) );
+        assertNotNull( preheat.getMap().get( CategoryOptionCombo.class ) );
 
-        assertNotNull( preheat.get( TrackerIdScheme.UID, CategoryOptionCombo.class, "XXXvX50cXC0" ) );
-        assertNotNull( preheat.get( TrackerIdScheme.UID, CategoryOption.class, "XXXrKDKCefk" ) );
+        assertNotNull( preheat.get( CategoryOptionCombo.class, "XXXvX50cXC0" ) );
+        assertNotNull( preheat.get( CategoryOption.class, "XXXrKDKCefk" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -29,17 +29,22 @@ package org.hisp.dhis.tracker.preheat;
  */
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -62,8 +67,66 @@ public class TrackerPreheatTest
         TrackerPreheat preheat = new TrackerPreheat();
 
         assertTrue( preheat.isEmpty() );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.UID ) );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.CODE ) );
+        assertTrue( preheat.getAll( Program.class ).isEmpty() );
+
+    }
+
+    @Test
+    public void testPutAndGetByUid()
+    {
+        TrackerPreheat preheat = new TrackerPreheat();
+
+        assertTrue( preheat.getAll( Program.class ).isEmpty() );
+        assertTrue( preheat.isEmpty() );
+
+        DataElement de1 = new DataElement( "dataElementA" );
+        de1.setUid( CodeGenerator.generateUid() );
+        DataElement de2 = new DataElement( "dataElementB" );
+        de2.setUid( CodeGenerator.generateUid() );
+
+        preheat.put( TrackerIdentifier.UID, de1 );
+        preheat.put( TrackerIdentifier.UID, de2 );
+
+        assertEquals( 2, preheat.getAll( DataElement.class ).size() );
+    }
+
+    @Test
+    public void testPutAndGetByCode()
+    {
+        TrackerPreheat preheat = new TrackerPreheat();
+
+        DataElement de1 = new DataElement( "dataElementA" );
+        de1.setCode( "CODE1" );
+        DataElement de2 = new DataElement( "dataElementB" );
+        de2.setCode( "CODE12" );
+
+        preheat.put( TrackerIdentifier.CODE, de1 );
+        preheat.put( TrackerIdentifier.CODE, de2 );
+
+        assertEquals( 2, preheat.getAll( DataElement.class ).size() );
+        assertThat( preheat.get( DataElement.class, de1.getCode() ), is( notNullValue() ) );
+        assertThat( preheat.get( DataElement.class, de2.getCode() ), is( notNullValue() ) );
+    }
+
+    @Test
+    public void testPutAndGetByAttribute()
+    {
+        TrackerPreheat preheat = new TrackerPreheat();
+        Attribute attribute = new Attribute();
+        attribute.setAutoFields();
+
+        AttributeValue attributeValue = new AttributeValue( "value1" );
+        attributeValue.setAttribute( attribute );
+        DataElement de1 = new DataElement( "dataElementA" );
+        de1.setAttributeValues( Collections.singleton( attributeValue ) );
+
+        preheat.put( TrackerIdentifier.builder()
+            .idScheme( TrackerIdScheme.ATTRIBUTE )
+            .value( attribute.getUid() )
+            .build(), de1 );
+
+        assertEquals( 1, preheat.getAll( DataElement.class ).size() );
+        assertThat( preheat.get( DataElement.class, "value1" ), is( notNullValue() ) );
     }
 
     @Test
@@ -84,16 +147,11 @@ public class TrackerPreheatTest
         preheat.put( TrackerIdentifier.UID, de3 );
 
         assertFalse( preheat.isEmpty() );
-        assertFalse( preheat.isEmpty( TrackerIdScheme.UID ) );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.CODE ) );
 
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de1.getUid() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de2.getUid() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de3.getUid() ) );
 
-        assertEquals( de1.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de1.getUid() ).getUid() );
-        assertEquals( de2.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de2.getUid() ).getUid() );
-        assertEquals( de3.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de3.getUid() ).getUid() );
+        assertEquals( de1.getUid(), preheat.get( DataElement.class, de1.getUid() ).getUid() );
+        assertEquals( de2.getUid(), preheat.get( DataElement.class, de2.getUid() ).getUid() );
+        assertEquals( de3.getUid(), preheat.get( DataElement.class, de3.getUid() ).getUid() );
     }
 
     @Test
@@ -117,16 +175,10 @@ public class TrackerPreheatTest
         preheat.put( TrackerIdentifier.CODE, de3 );
 
         assertFalse( preheat.isEmpty() );
-        assertFalse( preheat.isEmpty( TrackerIdScheme.CODE ) );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.UID ) );
 
-        assertTrue( preheat.containsKey( TrackerIdScheme.CODE, DataElement.class, de1.getCode() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.CODE, DataElement.class, de2.getCode() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.CODE, DataElement.class, de3.getCode() ) );
-
-        assertEquals( de1.getCode(), preheat.get( TrackerIdScheme.CODE, DataElement.class, de1.getCode() ).getCode() );
-        assertEquals( de2.getCode(), preheat.get( TrackerIdScheme.CODE, DataElement.class, de2.getCode() ).getCode() );
-        assertEquals( de3.getCode(), preheat.get( TrackerIdScheme.CODE, DataElement.class, de3.getCode() ).getCode() );
+        assertEquals( de1.getCode(), preheat.get( DataElement.class, de1.getCode() ).getCode() );
+        assertEquals( de2.getCode(), preheat.get( DataElement.class, de2.getCode() ).getCode() );
+        assertEquals( de3.getCode(), preheat.get( DataElement.class, de3.getCode() ).getCode() );
     }
 
     @Test
@@ -145,72 +197,10 @@ public class TrackerPreheatTest
         preheat.put( TrackerIdentifier.UID, Lists.newArrayList( de1, de2, de3 ) );
 
         assertFalse( preheat.isEmpty() );
-        assertFalse( preheat.isEmpty( TrackerIdScheme.UID ) );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.CODE ) );
 
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de1.getUid() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de2.getUid() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de3.getUid() ) );
-
-        assertEquals( de1.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de1.getUid() ).getUid() );
-        assertEquals( de2.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de2.getUid() ).getUid() );
-        assertEquals( de3.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de3.getUid() ).getUid() );
-    }
-
-    @Test
-    public void testPutCollectionRemoveOneUid()
-    {
-        TrackerPreheat preheat = new TrackerPreheat();
-
-        DataElement de1 = new DataElement( "dataElementA" );
-        DataElement de2 = new DataElement( "dataElementB" );
-        DataElement de3 = new DataElement( "dataElementC" );
-
-        de1.setAutoFields();
-        de2.setAutoFields();
-        de3.setAutoFields();
-
-        preheat.put( TrackerIdentifier.UID, Lists.newArrayList( de1, de2, de3 ) );
-
-        assertFalse( preheat.isEmpty() );
-        assertFalse( preheat.isEmpty( TrackerIdScheme.UID ) );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.CODE ) );
-
-        preheat.remove( TrackerIdScheme.UID, DataElement.class, de2.getUid() );
-
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de1.getUid() ) );
-        assertFalse( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de2.getUid() ) );
-        assertTrue( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de3.getUid() ) );
-
-        assertEquals( de1.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de1.getUid() ).getUid() );
-        assertEquals( de3.getUid(), preheat.get( TrackerIdScheme.UID, DataElement.class, de3.getUid() ).getUid() );
-    }
-
-    @Test
-    public void testPutCollectionRemoveAllUid()
-    {
-        TrackerPreheat preheat = new TrackerPreheat();
-
-        DataElement de1 = new DataElement( "dataElementA" );
-        DataElement de2 = new DataElement( "dataElementB" );
-        DataElement de3 = new DataElement( "dataElementC" );
-
-        de1.setAutoFields();
-        de2.setAutoFields();
-        de3.setAutoFields();
-
-        preheat.put( TrackerIdentifier.UID, Lists.newArrayList( de1, de2, de3 ) );
-
-        assertFalse( preheat.isEmpty() );
-        assertFalse( preheat.isEmpty( TrackerIdScheme.UID ) );
-        assertTrue( preheat.isEmpty( TrackerIdScheme.CODE ) );
-
-        preheat.remove( TrackerIdScheme.UID, DataElement.class,
-            Lists.newArrayList( de1.getUid(), de2.getUid(), de3.getUid() ) );
-
-        assertFalse( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de1.getUid() ) );
-        assertFalse( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de2.getUid() ) );
-        assertFalse( preheat.containsKey( TrackerIdScheme.UID, DataElement.class, de3.getUid() ) );
+        assertEquals( de1.getUid(), preheat.get( DataElement.class, de1.getUid() ).getUid() );
+        assertEquals( de2.getUid(), preheat.get( DataElement.class, de2.getUid() ).getUid() );
+        assertEquals( de3.getUid(), preheat.get( DataElement.class, de3.getUid() ).getUid() );
     }
     
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/RelationshipTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/RelationshipTypeSupplierTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.Rule;
@@ -46,6 +45,6 @@ public class RelationshipTypeSupplierTest
         TrackerPreheat preheat = new TrackerPreheat();
         this.supplier.preheatAdd( params, preheat );
 
-        assertThat( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ), hasSize( 5 ) );
+        assertThat( preheat.getAll( RelationshipType.class ), hasSize( 5 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/TrackedEntityTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/TrackedEntityTypeSupplierTest.java
@@ -1,9 +1,14 @@
 package org.hisp.dhis.tracker.preheat.supplier;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.Rule;
@@ -12,11 +17,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.util.List;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Luciano Fiandesio
@@ -45,6 +45,6 @@ public class TrackedEntityTypeSupplierTest {
         TrackerPreheat preheat = new TrackerPreheat();
         this.supplier.preheatAdd( params, preheat );
 
-        assertThat( preheat.getAll( TrackerIdScheme.UID, TrackedEntityType.class ), hasSize( 5 ) );
+        assertThat( preheat.getAll( TrackedEntityType.class ), hasSize( 5 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplierTest.java
@@ -15,7 +15,6 @@ import java.util.stream.IntStream;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -68,9 +67,9 @@ public class UserSupplierTest
 
         for ( String userUid : userIds )
         {
-            assertThat( preheat.get( TrackerIdScheme.UID, User.class, userUid ), is( notNullValue() ) );
+            assertThat( preheat.get( User.class, userUid ), is( notNullValue() ) );
         }
         // Make sure also User Credentials object are cached in the pre-heat
-        assertThat( preheat.getAll( TrackerIdScheme.UID, UserCredentials.class ), hasSize( 5 ) );
+        assertThat( preheat.getAll( UserCredentials.class ), hasSize( 5 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/RelationshipImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/RelationshipImportValidationTest.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -81,7 +80,7 @@ public class RelationshipImportValidationTest
         when( context.getBundle() ).thenReturn( trackerBundle );
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( trackerBundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) ).thenReturn( getRelationshipTypes() );
+        when( preheat.getAll( RelationshipType.class ) ).thenReturn( getRelationshipTypes() );
         when( trackerBundle.getImportStrategy() ).thenReturn( TrackerImportStrategy.CREATE );
 
         validatorToTest = new RelationshipsValidationHook();
@@ -111,7 +110,7 @@ public class RelationshipImportValidationTest
     @Test
     public void validateRelationshipShouldFailForMissingRelationshipType()
     {
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) ).thenReturn( Lists.newArrayList() );
+        when( preheat.getAll( RelationshipType.class ) ).thenReturn( Lists.newArrayList() );
 
         Relationship rel = getValidRelationship();
         reporter = new ValidationErrorReporter( context, rel );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -135,7 +135,7 @@ public class RelationshipsValidationHookTest
 
         RelationshipType relationshipType = new RelationshipType();
         relationshipType.setUid( relationship.getRelationshipType() );
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -159,7 +159,7 @@ public class RelationshipsValidationHookTest
 
         RelationshipType relationshipType = new RelationshipType();
         relationshipType.setUid( relationship.getRelationshipType() );
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -191,7 +191,7 @@ public class RelationshipsValidationHookTest
         constraint.setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
         relationshipType.setFromConstraint( constraint );
         relationshipType.setToConstraint( constraint );
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -223,7 +223,7 @@ public class RelationshipsValidationHookTest
         constraint.setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
         relationshipType.setFromConstraint( constraint );
         relationshipType.setToConstraint( constraint );
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -257,7 +257,7 @@ public class RelationshipsValidationHookTest
         constraint.setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
         relationshipType.setFromConstraint( constraint );
         relationshipType.setToConstraint( constraint );
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -305,7 +305,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -333,7 +333,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );
@@ -366,7 +366,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         TrackedEntityType teiTrackedEntityType = new TrackedEntityType();
@@ -409,7 +409,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         List<TrackedEntity> trackedEntities = new ArrayList<>();
@@ -449,7 +449,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         TrackedEntity tei = new TrackedEntity();
@@ -491,7 +491,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         TrackedEntity tei = new TrackedEntity();
@@ -526,7 +526,7 @@ public class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
 
-        when( preheat.getAll( TrackerIdScheme.UID, RelationshipType.class ) )
+        when( preheat.getAll(  RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( ctx, relationship );

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilderTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilderTest.java
@@ -141,7 +141,7 @@ public class TrackerImportParamsBuilderTest
         assertThat( identifiers.getOrgUnitIdScheme(), is( TrackerIdentifier.UID ) );
         assertThat( identifiers.getProgramIdScheme(), is( TrackerIdentifier.UID ) );
         assertThat( identifiers.getCategoryOptionComboIdScheme(), is( TrackerIdentifier.UID ) );
-        assertThat( identifiers.getCategoryOption(), is( TrackerIdentifier.UID ) );
+        assertThat( identifiers.getCategoryOptionIdScheme(), is( TrackerIdentifier.UID ) );
         assertThat( identifiers.getDataElementIdScheme(), is( TrackerIdentifier.UID ) );
         assertThat( identifiers.getProgramStageIdScheme(), is( TrackerIdentifier.UID ) );
         assertThat( identifiers.getIdScheme(), is( TrackerIdentifier.UID ) );


### PR DESCRIPTION
This PR simplifies the way the `TrackerPreheat` object keeps track of metadata objects during the Tracker Import.
Rather than keeping track of the `TrackerIdScheme` associated to each class of object, the system now simply uses a `Map` where the key is the class type (e.g. `Program`) and the value is a `Map` of object key and pre-heated object.

Assuming that IdScheme `CODE` is used for `Program`, the data is structred like so:

```
Program.class -->  CODE_1 -> Program 1
                   CODE_2 -> Program 2
                   CODE_3 -> Program 3

```

By using this simplified data structure, the pre-heated object can be simply fetched by using the `id` used in the payload (`uid`, `code`, etc.), without having to specify the `TrackerIdScheme` on `TrackerPreheat.get()`.

Additionally, this PR fixes a serialization issue with the `TrackerIdentifierParams`, which was not serialized correctly to Json and "broke" the propagation of IdScheme to the Import Service.

ref: DHIS2-9895