### PR TITLE
fix: [DHIS2-7310] Move rule engine call and validations after bundle validation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerProgramRuleService.java
@@ -67,9 +67,6 @@ public class DefaultTrackerProgramRuleService
 
     private final TrackerConverterService<Event, ProgramStageInstance> eventTrackerConverterService;
 
-    private final String WARN_MESSAGE = "An error occurred during a Program Rule engine call for %s.\n" +
-        " Please check the response payload for additional information";
-
     public DefaultTrackerProgramRuleService(
         @Qualifier( "serviceTrackerRuleEngine" ) ProgramRuleEngine programRuleEngine,
         TrackerConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService,
@@ -89,22 +86,7 @@ public class DefaultTrackerProgramRuleService
             .collect( Collectors.toMap( Enrollment::getEnrollment, e -> {
                 ProgramInstance enrollment = enrollmentTrackerConverterService.fromForRuleEngine( bundle.getPreheat(),
                     e );
-                try
-                {
-                    return programRuleEngine.evaluate( enrollment, Sets.newHashSet() );
-                }
-                catch ( Exception ex )
-                {
-                    if ( log.isDebugEnabled() )
-                    {
-                        log.debug( String.format( WARN_MESSAGE, "enrollment" ), e );
-                    }
-                    else
-                    {
-                        log.warn( String.format( WARN_MESSAGE, "enrollment" ) );
-                    }
-                    return Lists.newArrayList();
-                }
+                return programRuleEngine.evaluate( enrollment, Sets.newHashSet() );
             } ) );
     }
 
@@ -116,24 +98,9 @@ public class DefaultTrackerProgramRuleService
             .filter( e -> isEventInRegistrationProgram( e, bundle.getPreheat() ) )
             .collect( Collectors.toMap( Event::getEvent, event -> {
                 ProgramInstance enrollment = getEnrollment( bundle, event );
-                try
-                {
-                    return programRuleEngine.evaluate( enrollment,
-                        eventTrackerConverterService.from( bundle.getPreheat(), event ),
-                        getEventsFromEnrollment( enrollment.getUid(), bundle, events ) );
-                }
-                catch ( Exception e )
-                {
-                    if ( log.isDebugEnabled() )
-                    {
-                        log.debug( String.format( WARN_MESSAGE, "event" ), e );
-                    }
-                    else
-                    {
-                        log.warn( String.format( WARN_MESSAGE, "event" ) );
-                    }
-                    return Lists.newArrayList();
-                }
+                return programRuleEngine.evaluate( enrollment,
+                    eventTrackerConverterService.from( bundle.getPreheat(), event ),
+                    getEventsFromEnrollment( enrollment.getUid(), bundle, events ) );
             } ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.tracker.bundle.persister.CommitService;
 import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
+import org.hisp.dhis.tracker.programrule.RuleActionApplier;
 import org.hisp.dhis.tracker.report.TrackerBundleReport;
 import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.sideeffect.SideEffectHandlerService;
@@ -86,6 +87,14 @@ public class DefaultTrackerBundleService
     private List<TrackerBundleHook> bundleHooks = new ArrayList<>();
 
     private List<SideEffectHandlerService> sideEffectHandlers = new ArrayList<>();
+
+    private List<RuleActionApplier> appliers = new ArrayList<>();
+
+    @Autowired( required = false )
+    public void setAppliers( List<RuleActionApplier> appliers )
+    {
+        this.appliers = appliers;
+    }
 
     @Autowired( required = false )
     public void setBundleHooks( List<TrackerBundleHook> bundleHooks )
@@ -159,23 +168,16 @@ public class DefaultTrackerBundleService
             return trackerBundle;
         }
 
-        try
+        Map<String, List<RuleEffect>> enrollmentRuleEffects = trackerProgramRuleService
+            .calculateEnrollmentRuleEffects( trackerBundle.getEnrollments(), trackerBundle );
+        Map<String, List<RuleEffect>> eventRuleEffects = trackerProgramRuleService
+            .calculateEventRuleEffects( trackerBundle.getEvents(), trackerBundle );
+        trackerBundle.setEnrollmentRuleEffects( enrollmentRuleEffects );
+        trackerBundle.setEventRuleEffects( eventRuleEffects );
+        
+        for ( RuleActionApplier applier : appliers )
         {
-            Map<String, List<RuleEffect>> enrollmentRuleEffects = trackerProgramRuleService
-                .calculateEnrollmentRuleEffects( trackerBundle.getEnrollments(), trackerBundle );
-            Map<String, List<RuleEffect>> eventRuleEffects = trackerProgramRuleService
-                .calculateEventRuleEffects( trackerBundle.getEvents(), trackerBundle );
-            trackerBundle.setEnrollmentRuleEffects( enrollmentRuleEffects );
-            trackerBundle.setEventRuleEffects( eventRuleEffects );
-        }
-        catch ( Exception e )
-        {
-            // TODO: Report that rule engine has failed
-            // Rule engine can fail because of validation errors in the payload that
-            // were not discovered yet.
-            // If rule engine fails and the validation pass, a 500 code should be returned
-            log.warn( "An error occured during a Program Rule engine call. " +
-                "Please check the response payload for additional information" );
+            trackerBundle = applier.executeActions( trackerBundle );
         }
         return trackerBundle;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -28,32 +28,21 @@ package org.hisp.dhis.tracker.bundle;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.tracker.AtomicMode;
-import org.hisp.dhis.tracker.FlushMode;
-import org.hisp.dhis.tracker.TrackerIdScheme;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.*;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -164,8 +164,6 @@ public class TrackerBundle
     @Builder.Default
     private Map<String, List<RuleEffect>> eventRuleEffects = new HashMap<>();
 
-    private TrackerImportValidationContext trackerImportValidationContext;
-
     @JsonProperty
     public String getUsername()
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -138,8 +138,11 @@ public class EnrollmentTrackerConverterService
             programInstance.setLastUpdated( now );
             programInstance.setLastUpdatedAtClient( now );
 
-            programInstance.setEnrollmentDate( DateUtils.parseDate( enrollment.getEnrolledAt() ) );
-            programInstance.setIncidentDate( DateUtils.parseDate( enrollment.getOccurredAt() ) );
+            Date enrollmentDate = DateUtils.parseDate( enrollment.getEnrolledAt() );
+            Date incidentDate = DateUtils.parseDate( enrollment.getOccurredAt() );
+
+            programInstance.setEnrollmentDate( enrollmentDate );
+            programInstance.setIncidentDate( incidentDate != null ? incidentDate : enrollmentDate );
             programInstance.setOrganisationUnit( organisationUnit );
             programInstance.setProgram( program );
             programInstance.setEntityInstance( trackedEntityInstance );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DefaultTrackerPreprocessService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DefaultTrackerPreprocessService.java
@@ -28,15 +28,13 @@ package org.hisp.dhis.tracker.preprocess;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.ArrayList;
-import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.programrule.RuleActionApplier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Enrico Colasante

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DefaultTrackerPreprocessService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DefaultTrackerPreprocessService.java
@@ -46,15 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DefaultTrackerPreprocessService
     implements TrackerPreprocessService
 {
-    private List<RuleActionApplier> appliers = new ArrayList<>();
-
     private List<BundlePreProcessor> preProcessors = new ArrayList<>();
-
-    @Autowired( required = false )
-    public void setAppliers( List<RuleActionApplier> appliers )
-    {
-        this.appliers = appliers;
-    }
 
     @Autowired( required = false )
     public void setPreProcessors( List<BundlePreProcessor> preProcessors )
@@ -65,16 +57,9 @@ public class DefaultTrackerPreprocessService
     @Override
     public TrackerBundle preprocess( TrackerBundle bundle )
     {
-        // TODO we may consider "merging" the BundlePreProcessor with the RuleActionApplier, since
-        // they share an identical interface.
         for ( BundlePreProcessor preProcessor : preProcessors )
         {
             preProcessor.process( bundle );
-        }
-
-        for ( RuleActionApplier applier : appliers )
-        {
-            bundle = applier.executeActions( bundle );
         }
 
         return bundle;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tracker;
+package org.hisp.dhis.tracker.programrule;
 
 /*
  * Copyright (c) 2004-2020, University of Oslo
@@ -28,18 +28,15 @@ package org.hisp.dhis.tracker;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import com.google.api.client.util.Sets;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerProgramRuleService;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -48,10 +45,12 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import com.google.api.client.util.Sets;
-import com.google.common.collect.Lists;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Enrico Colasante

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidator.java
@@ -37,10 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.rules.models.RuleActionSetMandatoryField;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Attribute;
-import org.hisp.dhis.tracker.domain.DataValue;
-import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.domain.*;
 import org.springframework.stereotype.Component;
 
 import com.google.api.client.util.Lists;
@@ -66,7 +63,7 @@ public class SetMandatoryFieldValidator
         Map<String, List<RuleEffect>> effects = getEffects( bundle.getEnrollmentRuleEffects() );
 
         return effects.entrySet().stream()
-            .collect( Collectors.toMap( e -> e.getKey(),
+            .collect( Collectors.toMap( Map.Entry::getKey,
                 e -> getTrackedEntityFromEnrollment( bundle, e.getKey() )
                     .map( tei -> checkMandatoryTeiAttribute( tei, e.getValue() ) ).orElse( Lists.newArrayList() ) ) );
     }
@@ -77,7 +74,7 @@ public class SetMandatoryFieldValidator
         Map<String, List<RuleEffect>> effects = getEffects( bundle.getEventRuleEffects() );
 
         return effects.entrySet().stream()
-            .collect( Collectors.toMap( e -> e.getKey(),
+            .collect( Collectors.toMap( Map.Entry::getKey,
                 e -> getEvent( bundle, e.getKey() )
                     .map( tei -> checkMandatoryDataElement( tei, e.getValue() ) ).orElse( Lists.newArrayList() ) ) );
     }
@@ -153,7 +150,7 @@ public class SetMandatoryFieldValidator
         return bundle.getEnrollments()
             .stream()
             .filter( e -> e.getEnrollment().equals( enrollmentUid ) )
-            .map( e -> e.getTrackedEntity() )
+            .map( Enrollment::getTrackedEntity )
             .findAny()
             .flatMap( tei -> getTrackedEntity( bundle, tei ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidator.java
@@ -51,7 +51,7 @@ import com.google.api.client.util.Lists;
  * @Author Enrico Colasante
  */
 @Component
-public class SetMandatoryFieldImplementer
+public class SetMandatoryFieldValidator
     implements RuleActionValidator
 {
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowErrorOnCompleteValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowErrorOnCompleteValidator.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component;
  * @Author Enrico Colasante
  */
 @Component
-public class ShowErrorOnCompleteImplementer
+public class ShowErrorOnCompleteValidator
     extends ErrorWarningImplementer
 {
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowErrorValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowErrorValidator.java
@@ -28,27 +28,27 @@
 
 package org.hisp.dhis.tracker.programrule;
 
-import org.hisp.dhis.rules.models.RuleActionShowWarning;
+import org.hisp.dhis.rules.models.RuleActionShowError;
 import org.springframework.stereotype.Component;
 
 /**
- * This implementer show warnings calculated by Rule Engine.
+ * This implementer show errors calculated by Rule Engine.
  *
  * @Author Enrico Colasante
  */
 @Component
-public class ShowWarningImplementer
+public class ShowErrorValidator
     extends ErrorWarningImplementer
 {
     @Override
-    public Class<RuleActionShowWarning> getActionClass()
+    public Class<RuleActionShowError> getActionClass()
     {
-        return RuleActionShowWarning.class;
+        return RuleActionShowError.class;
     }
 
     @Override
     public boolean isWarning()
     {
-        return true;
+        return false;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowWarningOnCompleteValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowWarningOnCompleteValidator.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component;
  * @Author Enrico Colasante
  */
 @Component
-public class ShowWarningOnCompleteImplementer
+public class ShowWarningOnCompleteValidator
     extends ErrorWarningImplementer
 {
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowWarningValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/ShowWarningValidator.java
@@ -28,27 +28,27 @@
 
 package org.hisp.dhis.tracker.programrule;
 
-import org.hisp.dhis.rules.models.RuleActionShowError;
+import org.hisp.dhis.rules.models.RuleActionShowWarning;
 import org.springframework.stereotype.Component;
 
 /**
- * This implementer show errors calculated by Rule Engine.
+ * This implementer show warnings calculated by Rule Engine.
  *
  * @Author Enrico Colasante
  */
 @Component
-public class ShowErrorImplementer
+public class ShowWarningValidator
     extends ErrorWarningImplementer
 {
     @Override
-    public Class<RuleActionShowError> getActionClass()
+    public Class<RuleActionShowWarning> getActionClass()
     {
-        return RuleActionShowError.class;
+        return RuleActionShowWarning.class;
     }
 
     @Override
     public boolean isWarning()
     {
-        return false;
+        return true;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerTimingsStats.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerTimingsStats.java
@@ -51,11 +51,15 @@ public class TrackerTimingsStats
 {
     public static final String PREHEAT_OPS = "preheat";
 
-    public static final String PROGRAMRULE_OPS = "programrule";
+    public static final String PREPROCESS_OPS = "preprocess";
 
     public static final String COMMIT_OPS = "commit";
 
     public static final String VALIDATION_OPS = "validation";
+
+    public static final String PROGRAMRULE_OPS = "programrule";
+
+    public static final String VALIDATE_PROGRAMRULE_OPS = "programruleValidation";
 
     public static final String TOTAL_OPS = "totalImport";
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
@@ -67,14 +67,14 @@ public class TrackerValidationReport
     public void add( TrackerValidationReport validationReport )
     {
         add( validationReport.getErrorReports() );
-        this.warningReports.addAll( validationReport.getWarningReports() );
+        addWarnings( validationReport.getWarningReports() );
         addPerfReports( validationReport.getPerformanceReport() );
     }
 
     public void add( ValidationErrorReporter validationReporter )
     {
         add( validationReporter.getReportList() );
-        this.warningReports.addAll( validationReporter.getWarningsReportList() );
+        addWarnings( validationReporter.getWarningsReportList() );
     }
 
     public void add( List<TrackerErrorReport> errorReports )
@@ -82,6 +82,14 @@ public class TrackerValidationReport
         for ( TrackerErrorReport errorReport : errorReports )
         {
             addErrorIfNotExisting( errorReport );
+        }
+    }
+
+    public void addWarnings( List<TrackerWarningReport> warningReportsReports )
+    {
+        for ( TrackerWarningReport warningReport : warningReportsReports )
+        {
+            addWarningIfNotExisting( warningReport );
         }
     }
 
@@ -103,16 +111,25 @@ public class TrackerValidationReport
     /**
      * Returns the size of all the Tracker DTO that did not pass validation
      */
-    public long size() {
-        
+    public long size()
+    {
+
         return this.getErrorReports().stream().map( TrackerErrorReport::getUid ).distinct().count();
     }
-    
+
     private void addErrorIfNotExisting( TrackerErrorReport report )
     {
         if ( !this.errorReports.contains( report ) )
         {
             this.errorReports.add( report );
+        }
+    }
+
+    private void addWarningIfNotExisting( TrackerWarningReport report )
+    {
+        if ( !this.warningReports.contains( report ) )
+        {
+            this.warningReports.add( report );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationConfig.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.hisp.dhis.tracker.validation.hooks.*;
@@ -53,6 +54,12 @@ public class TrackerImportValidationConfig
     {
         // EMPTY
     }
+
+    protected static final List<Class<? extends TrackerValidationHook>> RULE_ENGINE_VALIDATION_HOOKS = ImmutableList.of(
+
+        EnrollmentRuleValidationHook.class,
+        EventRuleValidationHook.class
+    );
 
     protected static final List<Class<? extends TrackerValidationHook>> VALIDATION_ORDER = ImmutableList.of(
 
@@ -79,9 +86,6 @@ public class TrackerImportValidationConfig
 
         RelationshipsValidationHook.class,
 
-        EnrollmentRuleValidationHook.class,
-        EventRuleValidationHook.class,
-
         AssignedUserValidationHook.class,
 
         RepeatedEventsValidationHook.class // This validation must be run after all the Event validations
@@ -102,9 +106,25 @@ public class TrackerImportValidationConfig
      *
      * @param hooks list to sort
      */
-    public static void sortHooks( List<TrackerValidationHook> hooks )
+    public static List<TrackerValidationHook> sortValidationHooks( List<TrackerValidationHook> hooks )
     {
         //TODO: Make some tests to check this is correctly configured
-        hooks.sort( Comparator.comparingInt( o -> VALIDATION_ORDER_MAP.get( o.getClass() ) ) );
+        return hooks
+            .stream().filter( h -> VALIDATION_ORDER.contains( h.getClass() ) )
+            .sorted( Comparator.comparingInt( o -> VALIDATION_ORDER_MAP.get( o.getClass() ) ) )
+            .collect( Collectors.toList() );
+    }
+
+    /**
+     * Get just rule engine validation hooks.
+     *
+     * @param hooks list to filter
+     */
+    public static List<TrackerValidationHook> getRuleEngineValidationHooks( List<TrackerValidationHook> hooks )
+    {
+        return hooks
+            .stream()
+            .filter( h -> RULE_ENGINE_VALIDATION_HOOKS.contains( h.getClass() ) )
+            .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerValidationService.java
@@ -42,4 +42,11 @@ public interface TrackerValidationService
      * @param bundle Bundle to validate
      */
     TrackerValidationReport validate( TrackerBundle bundle );
+
+    /**
+     * Validate tracker bundle with validations created by rule engine
+     *
+     * @param bundle Bundle to validate
+     */
+    TrackerValidationReport validateRuleEngine( TrackerBundle bundle );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -124,21 +124,21 @@ public class ProgramRuleIntegrationTest
         ProgramRule programRule = createProgramRule( 'A', program );
         programRuleService.addProgramRule( programRule );
 
-        ProgramRuleAction programRuleActionSendMessage = createProgramRuleAction( 'A', programRule );
-        programRuleActionSendMessage.setProgramRuleActionType( ProgramRuleActionType.SENDMESSAGE );
-        programRuleActionSendMessage.setContent( "WARNING" );
-        programRuleActionSendMessage.setTemplateUid( "M4zQapPyTZI" );
-        programRuleActionService.addProgramRuleAction( programRuleActionSendMessage );
+        ProgramRuleAction programRuleActionShowWarning = createProgramRuleAction( 'A', programRule );
+        programRuleActionShowWarning.setProgramRuleActionType( ProgramRuleActionType.SHOWWARNING );
+        programRuleActionShowWarning.setContent( "WARNING" );
+        programRuleActionService.addProgramRuleAction( programRuleActionShowWarning );
 
-        programRule.getProgramRuleActions().add( programRuleActionSendMessage );
+        programRule.getProgramRuleActions().add( programRuleActionShowWarning );
         programRuleService.updateProgramRule( programRule );
 
         userA = userService.getUser( "M5zQapPyTZI" );
     }
 
     @Test
-    public void testImportSuccessWithWaringRaised() throws IOException {
-
+    public void testImportSuccessWithWarningRaised()
+        throws IOException
+    {
         InputStream inputStream = new ClassPathResource( "tracker/single_tei.json" ).getInputStream();
 
         TrackerImportParams params = renderService.fromJson( inputStream, TrackerImportParams.class );
@@ -147,7 +147,7 @@ public class ProgramRuleIntegrationTest
 
         TrackerImportParams enrollmentParams = renderService
             .fromJson( new ClassPathResource( "tracker/single_enrollment.json" ).getInputStream(),
-                    TrackerImportParams.class );
+                TrackerImportParams.class );
         enrollmentParams.setUserId( userA.getUid() );
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService
             .importTracker( enrollmentParams );
@@ -157,6 +157,6 @@ public class ProgramRuleIntegrationTest
 
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getWarningReports().isEmpty() );
+        assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getWarningReports().size() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -66,7 +66,8 @@ import com.google.common.collect.Sets;
 
 import static org.junit.Assert.*;
 
-public class SetMandatoryFieldImplementerTest extends AbstractImportValidationTest
+public class SetMandatoryFieldValidatorTest
+    extends AbstractImportValidationTest
 {
 
     @Autowired
@@ -94,7 +95,7 @@ public class SetMandatoryFieldImplementerTest extends AbstractImportValidationTe
     private ProgramRuleVariableService programRuleVariableService;
 
     @Autowired
-    private SetMandatoryFieldImplementer implementerToTest;
+    private SetMandatoryFieldValidator implementerToTest;
 
     @Override
     protected void setUpTest()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -189,6 +189,6 @@ public class SetMandatoryFieldValidatorTest
 
         errors.entrySet().stream()
             .filter( e -> e.getKey().equals( "D9PbzJY8bJO" ) )
-            .forEach( e -> assertTrue( e.getValue().size() == 1 ) );
+            .forEach( e -> assertEquals( 1, e.getValue().size() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -93,16 +93,16 @@ public class ShowErrorWarningImplementerTest
     private ProgramRuleActionService programRuleActionService;
 
     @Autowired
-    private ShowWarningOnCompleteImplementer warningOnCompleteImplementer;
+    private ShowWarningOnCompleteValidator warningOnCompleteImplementer;
 
     @Autowired
-    private ShowErrorOnCompleteImplementer errorOnCompleteImplementer;
+    private ShowErrorOnCompleteValidator errorOnCompleteImplementer;
 
     @Autowired
-    private ShowErrorImplementer errorImplementer;
+    private ShowErrorValidator errorImplementer;
 
     @Autowired
-    private ShowWarningImplementer warningImplementer;
+    private ShowWarningValidator warningImplementer;
 
     private TrackerBundle trackerBundle;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTests.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTests.java
@@ -95,7 +95,6 @@ public class EnrollmentAttrValidationTests
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_attr-missing-uuid.json" );
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( params, TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
@@ -114,7 +113,6 @@ public class EnrollmentAttrValidationTests
             "tracker/validations/enrollments_te_attr-missing-value.json" );
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( params, TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
@@ -158,7 +156,6 @@ public class EnrollmentAttrValidationTests
             "tracker/validations/enrollments_te_attr-missing-mandatory.json" );
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( params, TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
@@ -177,7 +174,6 @@ public class EnrollmentAttrValidationTests
             "tracker/validations/enrollments_te_attr-only-program-attr.json" );
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( params, TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -354,7 +354,6 @@ public class EnrollmentImportValidationTest
             "tracker/validations/enrollments_error_non_program_attr.json" );
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( params, TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
@@ -484,7 +483,6 @@ insert into programinstance (uid, created, lastUpdated, createdAtClient, lastUpd
             "tracker/validations/enrollments_bad-geo-missing-geotype.json" );
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( params, TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
 
         TrackerValidationReport validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
@@ -511,7 +509,7 @@ insert into programinstance (uid, created, lastUpdated, createdAtClient, lastUpd
 
         createAndUpdate = validateAndCommit(
             "tracker/validations/enrollments_double-tei-enrollment_part2.json", TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEnrollments().size() );
+
         validationReport = createAndUpdate.getValidationReport();
         printReport( validationReport );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -396,7 +396,7 @@ public class EventImportValidationTest
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams,
             TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEvents().size() );
+
         TrackerValidationReport report = createAndUpdate.getValidationReport();
         printReport( report );
 
@@ -487,7 +487,7 @@ public class EventImportValidationTest
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams,
             TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEvents().size() );
+
         TrackerValidationReport report = createAndUpdate.getValidationReport();
         printReport( report );
 
@@ -524,7 +524,7 @@ public class EventImportValidationTest
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams,
             TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEvents().size() );
+
         TrackerValidationReport report = createAndUpdate.getValidationReport();
         printReport( report );
 
@@ -550,7 +550,7 @@ public class EventImportValidationTest
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams,
             TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEvents().size() );
+
         TrackerValidationReport report = createAndUpdate.getValidationReport();
         printReport( report );
 
@@ -623,7 +623,7 @@ public class EventImportValidationTest
 
         ValidateAndCommitTestUnit createAndUpdate = validateAndCommit( trackerBundleParams,
             TrackerImportStrategy.CREATE );
-        assertEquals( 1, createAndUpdate.getTrackerBundle().getEvents().size() );
+
         TrackerValidationReport report = createAndUpdate.getValidationReport();
         printReport( report );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
@@ -165,15 +165,7 @@ public class TeTaValidationTest
         trackerBundleService.commit( trackerBundle );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
-        assertEquals( 1, trackedEntityInstances.size() );
-
-        TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
-
-        List<TrackedEntityAttributeValue> attributeValues = trackedEntityAttributeValueService
-            .getTrackedEntityAttributeValues(
-                trackedEntityInstance );
-
-        assertEquals( 1, attributeValues.size() );
+        assertEquals( 0, trackedEntityInstances.size() );
     }
 
     @Test
@@ -196,15 +188,7 @@ public class TeTaValidationTest
         trackerBundleService.commit( trackerBundle );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
-        assertEquals( 1, trackedEntityInstances.size() );
-
-        TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
-
-        List<TrackedEntityAttributeValue> attributeValues = trackedEntityAttributeValueService
-            .getTrackedEntityAttributeValues(
-                trackedEntityInstance );
-
-        assertEquals( 1, attributeValues.size() );
+        assertEquals( 0, trackedEntityInstances.size() );
     }
 
     @Test


### PR DESCRIPTION
The primary goal of this commit is moving rule engine call after bundle validation
so there are no unexpected problems building the context to call rule engine.
Other issues solved by this commit are:
    - Put a default value for occuredAt date in the enrollment converter
    - Remove the invalid entities from the bundle after validation, to avoid
        errors in the persistence phase