### PR TITLE
fix: [DHIS2-9985] Align ownership OU check for TEI APIs even when specifying uids explicitly (2.34-ksoidc)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.trackedentity;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -171,6 +173,11 @@ public class TrackedEntityInstanceQueryParams
      * Set of user ids to filter based on events assigned to the users.
      */
     private Set<String> assignedUsers = new HashSet<>();
+    
+    /**
+     * Set of tei uids to explicitly select.
+     */
+    private Set<String> trackedEntityInstanceUids = new HashSet<>();
     
     /**
      * ProgramStage to be used in conjunction with eventstatus.
@@ -375,6 +382,11 @@ public class TrackedEntityInstanceQueryParams
             this.assignedUsers = Collections.singleton( this.user.getUid() );
             this.assignedUserSelectionMode = AssignedUserSelectionMode.PROVIDED;
         }
+    }
+    
+    public boolean hasTrackedEntityInstances()
+    {
+        return CollectionUtils.isNotEmpty( this.trackedEntityInstanceUids );
     }
     
     public boolean hasAssignedUsers()
@@ -1158,6 +1170,17 @@ public class TrackedEntityInstanceQueryParams
     public TrackedEntityInstanceQueryParams setAssignedUserSelectionMode( AssignedUserSelectionMode assignedUserMode )
     {
         this.assignedUserSelectionMode = assignedUserMode;
+        return this;
+    }
+    
+    public Set<String> getTrackedEntityInstanceUids()
+    {
+        return trackedEntityInstanceUids;
+    }
+
+    public TrackedEntityInstanceQueryParams setTrackedEntityInstanceUids( Set<String> trackedEntityInstanceUids )
+    {
+        this.trackedEntityInstanceUids = trackedEntityInstanceUids;
         return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
@@ -151,6 +151,7 @@ public interface TrackedEntityInstanceService
      * @param eventEndDate               the event end date for the given Program.
      * @param assignedUserMode           the selection mode for assigned users of events.
      * @param assignedUsers              list of userids for events assigned.
+     * @param trackedEntityInstanceUids  list of tei uids for defining the outer boundary of the query.
      * @param skipMeta                   indicates whether to include meta data in the response.
      * @param page                       the page number.
      * @param pageSize                   the page size.
@@ -166,7 +167,7 @@ public interface TrackedEntityInstanceService
         Boolean followUp, Date lastUpdatedStart, Date lastUpdatedEndDate, String lastUpdatedDuration,
         Date programEnrollmentStartDate, Date programEnrollmentEndDate, Date programIncidentStartDate,
         Date programIncidentEndDate, String trackedEntityType, String programStage, EventStatus eventStatus, Date eventStartDate,
-        Date eventEndDate, AssignedUserSelectionMode assignedUserMode, Set<String> assignedUsers,
+        Date eventEndDate, AssignedUserSelectionMode assignedUserMode, Set<String> assignedUsers, Set<String> trackedEntityInstanceUids,
         boolean skipMeta, Integer page, Integer pageSize, boolean totalPages, boolean skipPaging,
         boolean includeDeleted, boolean includeAllAttributes, List<String> orders );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -675,7 +675,7 @@ public class DefaultTrackedEntityInstanceService
         Boolean followUp, Date lastUpdatedStartDate, Date lastUpdatedEndDate, String lastUpdatedDuration,
         Date programEnrollmentStartDate, Date programEnrollmentEndDate, Date programIncidentStartDate,
         Date programIncidentEndDate, String trackedEntityType, String programStage, EventStatus eventStatus, Date eventStartDate,
-        Date eventEndDate, AssignedUserSelectionMode assignedUserSelectionMode, Set<String> assignedUsers,
+        Date eventEndDate, AssignedUserSelectionMode assignedUserSelectionMode, Set<String> assignedUsers, Set<String> trackedEntityInstanceUids,
         boolean skipMeta, Integer page, Integer pageSize, boolean totalPages, boolean skipPaging,
         boolean includeDeleted, boolean includeAllAttributes, List<String> orders )
     {
@@ -771,6 +771,13 @@ public class DefaultTrackedEntityInstanceService
                 .collect( Collectors.toSet() );
         }
 
+        if ( trackedEntityInstanceUids != null )
+        {
+            trackedEntityInstanceUids = trackedEntityInstanceUids.stream()
+                .filter( CodeGenerator::isValidUid )
+                .collect( Collectors.toSet() );
+        }
+        
         params.setQuery( queryFilter )
             .setProgram( pr )
             .setProgramStatus( programStatus )
@@ -790,6 +797,7 @@ public class DefaultTrackedEntityInstanceService
             .setEventEndDate( eventEndDate )
             .setAssignedUserSelectionMode( assignedUserSelectionMode )
             .setAssignedUsers( assignedUsers )
+            .setTrackedEntityInstanceUids( trackedEntityInstanceUids )
             .setSkipMeta( skipMeta )
             .setPage( page )
             .setPageSize( pageSize )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -257,6 +257,11 @@ public class HibernateTrackedEntityInstanceStore
         {
             hql += hlp.whereAnd() + "tei.trackedEntityType.uid='" + params.getTrackedEntityType().getUid() + "'";
         }
+        
+        if ( params.hasTrackedEntityInstances() )
+        {
+            hql += hlp.whereAnd() + " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")";
+        }
 
         if ( params.hasLastUpdatedDuration() )
         {
@@ -604,6 +609,11 @@ public class HibernateTrackedEntityInstanceStore
                         + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
                 }
             }
+        }
+        
+        if ( params.hasTrackedEntityInstances() )
+        {
+            sql += hlp.whereAnd() + " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" ;
         }
 
         if ( !params.hasTrackedEntityType() )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -313,6 +313,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user1111111", "user2222222" ),
+            newHashSet( "tei11111111", "tei22222222" ),
             true,
             1,
             50,
@@ -359,6 +360,9 @@ public class TrackedEntityInstanceServiceTest
         assertThat( queryParams.getAssignedUserSelectionMode(), is( AssignedUserSelectionMode.PROVIDED ) );
         assertTrue( queryParams.getAssignedUsers().stream().anyMatch( u -> u.equals( "user1111111" ) ) );
         assertTrue( queryParams.getAssignedUsers().stream().anyMatch( u -> u.equals( "user2222222" ) ) );
+        
+        assertTrue( queryParams.getTrackedEntityInstanceUids().stream().anyMatch( t -> t.equals( "tei11111111" ) ) );
+        assertTrue( queryParams.getTrackedEntityInstanceUids().stream().anyMatch( t -> t.equals( "tei22222222" ) ) );
 
         assertThat( queryParams.isIncludeDeleted(), is( true ) );
         assertThat( queryParams.isIncludeAllAttributes(), is( false ) );
@@ -395,6 +399,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -434,6 +439,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -473,6 +479,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -512,6 +519,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -551,6 +559,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -590,6 +599,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -633,6 +643,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.PROVIDED,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,
@@ -672,6 +683,7 @@ public class TrackedEntityInstanceServiceTest
             getDate( 2020, 7, 7 ),
             AssignedUserSelectionMode.CURRENT,
             newHashSet( "user-1", "user-2" ),
+            null,
             true,
             1,
             50,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
@@ -287,6 +287,32 @@ public class TrackedEntityInstanceStoreTest
         assertEquals( 2, teis.size() );
         assertTrue( teis.contains( teiB ) );
         assertTrue( teis.contains( teiE ) );
+        
+     // Filter explicitly by uids
+        params = new TrackedEntityInstanceQueryParams();
+        params.getTrackedEntityInstanceUids().add( teiC.getUid() );
+        params.getTrackedEntityInstanceUids().add( teiB.getUid() );
+        params.getTrackedEntityInstanceUids().add( teiD.getUid() );
+
+        teis = teiStore.getTrackedEntityInstances( params );
+
+        assertEquals( 3, teis.size() );
+
+        assertTrue( teis.contains( teiC ) );
+        assertTrue( teis.contains( teiB ) );
+        assertTrue( teis.contains( teiD ) );
+
+        // Filter explicitly by uids and an additional filter (program in this case)
+        params = new TrackedEntityInstanceQueryParams();
+        params.getTrackedEntityInstanceUids().add( teiC.getUid() );
+        params.getTrackedEntityInstanceUids().add( teiB.getUid() );
+        params.getTrackedEntityInstanceUids().add( teiD.getUid() );
+        params.setProgram( prA );
+
+        teis = teiStore.getTrackedEntityInstances( params );
+
+        assertEquals( 1, teis.size() );
+        assertTrue( teis.contains( teiB ) );
     }
 
     @Test

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -221,6 +221,8 @@ public class TrackedEntityInstanceController
 
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
 
+        Set<String> trackedEntityInstanceUids = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
+
         RootNode rootNode = NodeUtils.createMetadata();
 
         List<TrackedEntityInstance> trackedEntityInstances;
@@ -230,22 +232,11 @@ public class TrackedEntityInstanceController
         TrackedEntityInstanceQueryParams queryParams = instanceService.getFromUrl( query, attribute, filter, orgUnits,
             ouMode, program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, lastUpdatedDuration,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
-            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
+            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, trackedEntityInstanceUids, skipMeta,
             page, pageSize, totalPages, skipPaging, includeDeleted, includeAllAttributes, getOrderParams( order ) );
 
-        if ( trackedEntityInstance == null )
-        {
-            trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
-                getTrackedEntityInstanceParams( fields ), false );
-        }
-        else
-        {
-            Set<String> trackedEntityInstanceIds = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
-
-            trackedEntityInstances = trackedEntityInstanceIds != null ? trackedEntityInstanceIds.stream()
-                .map( id -> trackedEntityInstanceService.getTrackedEntityInstance( id, getTrackedEntityInstanceParams( fields ) ) )
-                .collect( Collectors.toList() ) : null;
-        }
+        trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
+            getTrackedEntityInstanceParams( fields ), false );
 
         if ( queryParams.isPaging() && queryParams.isTotalPages() )
         {
@@ -409,6 +400,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) String trackedEntityType,
         @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
         @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) String trackedEntityInstance,
         @RequestParam( required = false ) String programStage,
         @RequestParam( required = false ) EventStatus eventStatus,
         @RequestParam( required = false ) Date eventStartDate,
@@ -428,13 +420,14 @@ public class TrackedEntityInstanceController
         programEnrollmentEndDate = ObjectUtils.firstNonNull( programEnrollmentEndDate, programEndDate );
         Set<String> orgUnits = TextUtils.splitToArray( ou, TextUtils.SEMICOLON );
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
+        Set<String> trackedEntityInstanceUids = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
         TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
-            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
+            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, trackedEntityInstanceUids, skipMeta,
             page, pageSize, totalPages, skipPaging, includeDeleted, false, getOrderParams( order ) );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON, CacheStrategy.NO_CACHE );
@@ -462,6 +455,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) String trackedEntityType,
         @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
         @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) String trackedEntityInstance,
         @RequestParam( required = false ) String programStage,
         @RequestParam( required = false ) EventStatus eventStatus,
         @RequestParam( required = false ) Date eventStartDate,
@@ -480,13 +474,14 @@ public class TrackedEntityInstanceController
         programEnrollmentEndDate = ObjectUtils.firstNonNull( programEnrollmentEndDate, programEndDate );
         Set<String> orgUnits = TextUtils.splitToArray( ou, TextUtils.SEMICOLON );
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
+        Set<String> trackedEntityInstanceUids = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
         TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
-            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
+            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, trackedEntityInstanceUids, skipMeta,
             page, pageSize, totalPages, skipPaging, includeDeleted, false, getOrderParams( order ) );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.NO_CACHE );
@@ -515,6 +510,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) String trackedEntityType,
         @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
         @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) String trackedEntityInstance,
         @RequestParam( required = false ) String programStage,
         @RequestParam( required = false ) EventStatus eventStatus,
         @RequestParam( required = false ) Date eventStartDate,
@@ -533,13 +529,14 @@ public class TrackedEntityInstanceController
         programEnrollmentEndDate = ObjectUtils.firstNonNull( programEnrollmentEndDate, programEndDate );
         Set<String> orgUnits = TextUtils.splitToArray( ou, TextUtils.SEMICOLON );
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
+        Set<String> trackedEntityInstanceUids = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
         TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
-            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
+            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, trackedEntityInstanceUids, skipMeta,
             page, pageSize, totalPages, skipPaging, includeDeleted, false, getOrderParams( order ) );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_EXCEL, CacheStrategy.NO_CACHE );
@@ -568,6 +565,7 @@ public class TrackedEntityInstanceController
         @RequestParam( required = false ) String trackedEntityType,
         @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
         @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) String trackedEntityInstance,
         @RequestParam( required = false ) String programStage,
         @RequestParam( required = false ) EventStatus eventStatus,
         @RequestParam( required = false ) Date eventStartDate,
@@ -586,13 +584,14 @@ public class TrackedEntityInstanceController
         programEnrollmentEndDate = ObjectUtils.firstNonNull( programEnrollmentEndDate, programEndDate );
         Set<String> orgUnits = TextUtils.splitToArray( ou, TextUtils.SEMICOLON );
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
+        Set<String> trackedEntityInstanceUids = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
 
         skipPaging = PagerUtils.isSkipPaging( skipPaging, paging );
 
         TrackedEntityInstanceQueryParams params = instanceService.getFromUrl( query, attribute, filter, orgUnits, ouMode,
             program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, null,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
-            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, skipMeta,
+            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, trackedEntityInstanceUids, skipMeta,
             page, pageSize, totalPages, skipPaging, includeDeleted, false, getOrderParams( order ) );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.NO_CACHE );
@@ -640,11 +639,12 @@ public class TrackedEntityInstanceController
 
         Set<String> orgUnits = TextUtils.splitToArray( ou, TextUtils.SEMICOLON );
         Set<String> assignedUsers = TextUtils.splitToArray( assignedUser, TextUtils.SEMICOLON );
+        Set<String> trackedEntityInstanceUids = TextUtils.splitToArray( trackedEntityInstance, TextUtils.SEMICOLON );
 
         TrackedEntityInstanceQueryParams queryParams = instanceService.getFromUrl( query, attribute, filter, orgUnits,
             ouMode, program, programStatus, followUp, lastUpdatedStartDate, lastUpdatedEndDate, lastUpdatedDuration,
             programEnrollmentStartDate, programEnrollmentEndDate, programIncidentStartDate, programIncidentEndDate,
-            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, true,
+            trackedEntityType, programStage, eventStatus, eventStartDate, eventEndDate, assignedUserMode, assignedUsers, trackedEntityInstanceUids, true,
             TrackedEntityInstanceQueryParams.DEFAULT_PAGE, Pager.DEFAULT_PAGE_SIZE, true, true,
             includeDeleted, false, null );
 


### PR DESCRIPTION
Backport that has already been merged to 2.33 till 2.36