### PR TITLE
fix: Adding Transactional annotation in rule engine call

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,7 @@ public class DefaultTrackerProgramRuleService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, List<RuleEffect>> calculateEnrollmentRuleEffects( List<Enrollment> enrollments,
         TrackerBundle bundle )
     {
@@ -90,6 +92,7 @@ public class DefaultTrackerProgramRuleService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, List<RuleEffect>> calculateEventRuleEffects( List<Event> events, TrackerBundle bundle )
     {
         return events


### PR DESCRIPTION
The Transactional annotation is needed to make sure all the lazy collections in the
creation of the rule engine context ar correctly loaded correctly