### PR TITLE
feat: Tracker Import metadata cache

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -169,6 +169,11 @@ public class DefaultTrackerImportService
     private TrackerValidationReport execRuleEngine( TrackerTimingsStats opsTimer, TrackerBundle trackerBundle,
         TrackerValidationReport report, ImportNotifier notifier )
     {
+        if ( trackerBundle.isSkipRuleEngine() )
+        {
+            return report;
+        }
+
         //
         // rule engine
         //

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -160,11 +160,6 @@ public class DefaultTrackerBundleService
     @Override
     public TrackerBundle runRuleEngine( TrackerBundle trackerBundle )
     {
-        if ( trackerBundle.isSkipRuleEngine() )
-        {
-            return trackerBundle;
-        }
-
         Map<String, List<RuleEffect>> enrollmentRuleEffects = trackerProgramRuleService
             .calculateEnrollmentRuleEffects( trackerBundle.getEnrollments(), trackerBundle );
         Map<String, List<RuleEffect>> eventRuleEffects = trackerProgramRuleService

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
@@ -1,0 +1,152 @@
+package org.hisp.dhis.tracker.preheat.cache;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Pre-heat cache implementation for metadata objects.
+ *
+ * @author Luciano Fiandesio
+ */
+@RequiredArgsConstructor
+@Service
+public class DefaultPreheatCacheService implements PreheatCacheService
+{
+    private final DhisConfigurationProvider config;
+
+    private final Environment environment;
+
+    /**
+     * Data structure to hold the metadata cache:
+     *
+     * - the key is the full class name of the metadata class getting cached (e.g.
+     * "org.hisp.dhis.program.Program")
+     * 
+     * - the value is a Cache2K cache holding the objects to cache
+     *
+     * Caveat: this data structure may reference multiple times the same objects, if
+     * different {@link TrackerIdScheme} are used during different imports.
+     */
+    private static Map<String, Cache<String, IdentifiableObject>> cache = new HashMap<>();
+
+    @Override
+    public Optional<IdentifiableObject> get( final String cacheKey, final String id )
+    {
+        if ( isCacheEnabled() && cache.containsKey( cacheKey ) )
+        {
+            return Optional.ofNullable( cache.get( cacheKey ).get( id ) );
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean hasKey( String cacheKey )
+    {
+        return cache.containsKey( cacheKey );
+    }
+
+    public List<IdentifiableObject> getAll( String cacheKey )
+    {
+        List<IdentifiableObject> res = new ArrayList<>();
+        if ( hasKey( cacheKey ) )
+        {
+            cache.get( cacheKey ).keys().forEach( k -> {
+                res.add( cache.get( cacheKey ).get( k ) );
+            } );
+        }
+        return res;
+
+    }
+
+    @Override
+    public void put( final String cacheKey, final String id, IdentifiableObject object,
+        final int cacheTTL, final long capacity )
+    {
+        if ( isCacheEnabled() )
+        {
+            if ( object == null )
+            {
+                return;
+            }
+            if ( cache.containsKey( cacheKey ) )
+            {
+                cache.get( cacheKey ).put( id, object );
+            }
+            else
+            {
+                Cache<String, IdentifiableObject> c = new Cache2kBuilder<String, IdentifiableObject>()
+                {
+                }
+                    .expireAfterWrite( cacheTTL, TimeUnit.MINUTES )
+                    .name( cacheKey )
+                    .permitNullValues( false )
+                    .entryCapacity( capacity == -1 ? Long.MAX_VALUE : capacity )
+                    .resilienceDuration( 30, TimeUnit.SECONDS ) // cope with at most 30 seconds
+                    // outage before propagating exceptions
+                    .build();
+
+                c.put( id, object );
+
+                cache.put( cacheKey, c );
+            }
+        }
+    }
+
+    public void invalidateCache()
+    {
+        cache.keySet().forEach( k -> cache.get( k ).removeAll() );
+    }
+
+    private boolean isCacheEnabled()
+    {
+
+        return !isTestRun( this.environment.getActiveProfiles() )
+            && config.isEnabled( ConfigurationKey.TRACKER_IMPORT_PREHEAT_CACHE_ENABLED );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapper.java
@@ -29,11 +29,14 @@ package org.hisp.dhis.tracker.preheat.mappers;
  */
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+
+import java.util.Set;
 
 @Mapper( )
 public interface OrganisationUnitMapper

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
@@ -28,11 +28,15 @@ package org.hisp.dhis.tracker.preheat.supplier;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.time.StopWatch;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,6 +49,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class AbstractPreheatSupplier implements PreheatSupplier
 {
+    private final int CACHE_TTL = 60;
+
+    private final long CACHE_CAPACITY = 1000;
+
     @Override
     public void add( TrackerImportParams params, TrackerPreheat preheat )
     {
@@ -73,4 +81,20 @@ public abstract class AbstractPreheatSupplier implements PreheatSupplier
      * Template method: executes preheat logic from the subclass
      */
     public abstract void preheatAdd( TrackerImportParams params, TrackerPreheat preheat );
+
+    protected void addToPreheat( TrackerPreheat preheat, List<? extends IdentifiableObject> relationshipTypes )
+    {
+        preheat.put( TrackerIdentifier.UID, relationshipTypes );
+    }
+
+    protected void addToCache( PreheatCacheService cache, List<? extends IdentifiableObject> objects, int ttl,
+        long capacity )
+    {
+        objects.forEach( rt -> cache.put( rt.getClass().getName(), rt.getUid(), rt, ttl, capacity ) );
+    }
+
+    protected void addToCache( PreheatCacheService cache, List<? extends IdentifiableObject> objects )
+    {
+        objects.forEach( rt -> cache.put( rt.getClass().getName(), rt.getUid(), rt, CACHE_TTL, CACHE_CAPACITY ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplier.java
@@ -32,21 +32,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-
-import org.hisp.dhis.tracker.TrackerIdentifier;
-import org.hisp.dhis.tracker.domain.Attribute;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 /**
  * @author Abyot Asalefew Gizaw <abyota@gmail.com>
@@ -60,7 +59,7 @@ public class OrgUnitValueTypeSupplier extends AbstractPreheatSupplier
     private final IdentifiableObjectManager manager;
 
     @Override
-    public void preheatAdd(TrackerImportParams params, TrackerPreheat preheat )
+    public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
         List<TrackedEntityAttribute> attributes = preheat.getAll( TrackedEntityAttribute.class );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategy.java
@@ -28,7 +28,9 @@ package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.attribute.Attribute;
@@ -45,8 +47,10 @@ import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.CopyMapper;
 import org.hisp.dhis.tracker.preheat.mappers.PreheatMapper;
+import org.hisp.dhis.user.User;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -63,12 +67,15 @@ public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrate
 
     private final IdentifiableObjectManager manager;
 
+    private final PreheatCacheService cache;
+
     public AbstractSchemaStrategy( SchemaService schemaService, QueryService queryService,
-        IdentifiableObjectManager manager )
+        IdentifiableObjectManager manager, PreheatCacheService preheatCacheService )
     {
         this.schemaService = schemaService;
         this.queryService = queryService;
         this.manager = manager;
+        this.cache = preheatCacheService;
     }
 
     @Override
@@ -78,11 +85,6 @@ public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrate
         Schema schema = schemaService.getDynamicSchema( getSchemaClass() );
 
         queryForIdentifiableObjects( preheat, schema, identifier, splitList, mapper() );
-    }
-
-    private Class<? extends PreheatMapper> mapper()
-    {
-        return getClass().getAnnotation( StrategyFor.class ).mapper();
     }
 
     protected Class<?> getSchemaClass()
@@ -109,24 +111,99 @@ public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrate
             }
             else
             {
-                Query query = Query.from( schema );
-                query.setUser( preheat.getUser() );
-                query.add( generateRestrictionFromIdentifiers( idScheme, ids ) );
-                query.setDefaults( Defaults.INCLUDE );
-                if ( mapper.isAssignableFrom( CopyMapper.class ) )
-                {
-                    objects = queryService.query( query );
-                }
-                else
-                {
-                    objects = queryService.query( query ).stream().map( o -> Mappers.getMapper( mapper ).map( o ) )
-                        .map( IdentifiableObject.class::cast ).collect( Collectors.toList() );
-                }
-
+                objects = cacheAwareFetch( preheat.getUser(), schema, identifier, ids, mapper );
             }
 
             preheat.put( identifier, objects );
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<IdentifiableObject> cacheAwareFetch( User user, Schema schema, TrackerIdentifier identifier, List<String> ids, Class<? extends PreheatMapper> mapper )
+    {
+        TrackerIdScheme idScheme = identifier.getIdScheme();
+        
+        List<IdentifiableObject> objects;
+        final String cacheKey = schema.getKlass().getSimpleName();
+        
+        if ( canCache() ) // check if this strategy requires caching
+        {
+            List<String> toRemove = new ArrayList<>();
+            List<IdentifiableObject> cachedObjects = new ArrayList<>();
+
+            for ( String id : ids )
+            {
+                // is the object reference by the given id in cache?
+                Optional<IdentifiableObject> o = cache.get( cacheKey, id );
+                if ( o.isPresent()  )
+                {
+                    // add to objects to set into preheat
+                    cachedObjects.add( o.get() );
+                    // remove this id from list of id to fetch from db
+                    toRemove.add( id );
+                }
+            }
+            // is there any object which was not found in cache?
+            if ( ids.size() > toRemove.size() )
+            {
+                // remove from the list of ids the ids found in cache
+                ids.removeAll( toRemove );
+                
+                // execute the query
+                objects = map((List<IdentifiableObject>) queryService.query( buildQuery( schema, user, idScheme, ids ) ), mapper );
+
+                // put objects in query based on given scheme
+                if ( idScheme.equals( TrackerIdScheme.UID ) )
+                {
+                    objects.forEach( o -> cache.put( cacheKey, o.getUid(), o, getCacheTTL(), getCapacity() ) );
+                }
+                else if ( idScheme.equals( TrackerIdScheme.CODE ) )
+                {
+                    objects.forEach( o -> cache.put( cacheKey, o.getCode(), o, getCacheTTL(), getCapacity() ) );
+                }
+                else if ( idScheme.equals( TrackerIdScheme.ATTRIBUTE ) )
+                {
+                    // TODO
+                }
+                // add back the cached objects to the final list
+                objects.addAll( cachedObjects );
+            }
+            else
+            {
+                objects = cachedObjects;
+            }
+        }
+        else
+        {
+            objects = map((List<IdentifiableObject>) queryService.query( buildQuery( schema, user, idScheme, ids ) ), mapper );
+        }
+            
+        return objects;
+    }
+    
+    private List<IdentifiableObject> map( List<IdentifiableObject> objects, Class<? extends PreheatMapper> mapper )
+    {
+
+        if ( mapper.isAssignableFrom( CopyMapper.class ) )
+        {
+            return objects;
+        }
+        else
+        {
+            return objects.stream().map( o -> Mappers.getMapper( mapper ).map( o ) )
+                .map( IdentifiableObject.class::cast ).collect( Collectors.toList() );
+        }
+    }
+    
+
+    private Query buildQuery( Schema schema, User user, TrackerIdScheme idScheme, List<String> ids )
+    {
+        Query query = Query.from( schema );
+        query.setUser( user );
+        query.add( generateRestrictionFromIdentifiers( idScheme, ids ) );
+        query.setDefaults( Defaults.INCLUDE );
+
+        return query;
     }
 
     private Restriction generateRestrictionFromIdentifiers( TrackerIdScheme idScheme, List<String> ids )
@@ -143,5 +220,25 @@ public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrate
         {
             return Restrictions.in( "id", ids );
         }
+    }
+
+    private Class<? extends PreheatMapper> mapper()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).mapper();
+    }
+
+    private boolean canCache()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).cache();
+    }
+
+    private int getCacheTTL()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).ttl();
+    }
+
+    private long getCapacity()
+    {
+        return getClass().getAnnotation( StrategyFor.class ).capacity();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionComboStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionComboStrategy.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.CategoryOptionComboMapper;
 import org.springframework.stereotype.Component;
 
@@ -39,12 +40,12 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = CategoryOptionCombo.class, mapper = CategoryOptionComboMapper.class )
+@StrategyFor( value = CategoryOptionCombo.class, mapper = CategoryOptionComboMapper.class, cache = true, ttl = 30 )
 public class CatOptionComboStrategy extends AbstractSchemaStrategy
 {
     public CatOptionComboStrategy( SchemaService schemaService, QueryService queryService,
-        IdentifiableObjectManager manager )
+        IdentifiableObjectManager manager, PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionStrategy.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.CategoryOptionMapper;
 import org.springframework.stereotype.Component;
 
@@ -39,12 +40,12 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = CategoryOption.class, mapper = CategoryOptionMapper.class)
+@StrategyFor( value = CategoryOption.class, mapper = CategoryOptionMapper.class, cache = true, ttl = 30 )
 public class CatOptionStrategy extends AbstractSchemaStrategy
 {
     public CatOptionStrategy( SchemaService schemaService, QueryService queryService,
-        IdentifiableObjectManager manager )
+        IdentifiableObjectManager manager, PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/DataElementStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/DataElementStrategy.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.DataElementMapper;
 import org.springframework.stereotype.Component;
 
@@ -43,8 +44,8 @@ import org.springframework.stereotype.Component;
 public class DataElementStrategy extends AbstractSchemaStrategy
 {
     public DataElementStrategy( SchemaService schemaService, QueryService queryService,
-        IdentifiableObjectManager manager )
+        IdentifiableObjectManager manager, PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/GenericStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/GenericStrategy.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.CopyMapper;
 import org.springframework.stereotype.Component;
 
@@ -47,9 +48,9 @@ import org.springframework.stereotype.Component;
 public class GenericStrategy extends AbstractSchemaStrategy
 {
     public GenericStrategy( SchemaService schemaService, QueryService queryService,
-        IdentifiableObjectManager manager )
+        IdentifiableObjectManager manager, PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 
     public void add( Class<?> klazz, List<List<String>> splitList, TrackerPreheat preheat )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/OrgUnitStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/OrgUnitStrategy.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.OrganisationUnitMapper;
 import org.springframework.stereotype.Component;
 
@@ -39,11 +40,12 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = OrganisationUnit.class, mapper = OrganisationUnitMapper.class )
+@StrategyFor( value = OrganisationUnit.class, mapper = OrganisationUnitMapper.class, cache = true, ttl = 30, capacity = 2000 )
 public class OrgUnitStrategy extends AbstractSchemaStrategy
 {
-    public OrgUnitStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager )
+    public OrgUnitStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager,
+        PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStageStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStageStrategy.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.ProgramStageMapper;
 import org.springframework.stereotype.Component;
 
@@ -39,12 +40,12 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = ProgramStage.class, mapper = ProgramStageMapper.class )
+@StrategyFor( value = ProgramStage.class, mapper = ProgramStageMapper.class, cache = true, ttl = 20  )
 public class ProgramStageStrategy extends AbstractSchemaStrategy
 {
     public ProgramStageStrategy( SchemaService schemaService, QueryService queryService,
-        IdentifiableObjectManager manager )
+        IdentifiableObjectManager manager, PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStrategy.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.ProgramMapper;
 import org.springframework.stereotype.Component;
 
@@ -39,11 +40,12 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = Program.class, mapper = ProgramMapper.class )
+@StrategyFor( value = Program.class, mapper = ProgramMapper.class, cache = true, ttl = 20 )
 public class ProgramStrategy extends AbstractSchemaStrategy
 {
-    public ProgramStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager )
+    public ProgramStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager,
+        PreheatCacheService cacheService )
     {
-        super( schemaService, queryService, manager );
+        super( schemaService, queryService, manager, cacheService );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
@@ -28,13 +28,13 @@ package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.tracker.preheat.mappers.PreheatMapper;
-
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import org.hisp.dhis.tracker.preheat.mappers.PreheatMapper;
 
 /**
  * Annotation for {@link ClassBasedSupplierStrategy} classes that specifies the
@@ -47,5 +47,22 @@ import java.lang.annotation.Target;
 public @interface StrategyFor
 {
     Class<?> value();
+
     Class<? extends PreheatMapper> mapper();
+
+    /**
+     * Whether the object used in this Strategy can be cached
+     */
+    boolean cache() default false;
+
+    /**
+     * The time-to-live for the type of object being cached The value is in
+     * **minutes**. Defaults to 5 minutes
+     */
+    int ttl() default 5;
+
+    /**
+     * The maximum number of entries hold by the cache. Defaults to Long.MAX_VALUE
+     */
+    long capacity() default Long.MAX_VALUE;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -70,7 +70,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class PreCheckMetaValidationHook
-    extends AbstractTrackerDtoValidationHook
+        extends AbstractTrackerDtoValidationHook
 {
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity tei )
@@ -133,7 +133,7 @@ public class PreCheckMetaValidationHook
         if ( program != null )
         {
             addErrorIf( () -> program.isRegistration() && StringUtils.isEmpty( event.getEnrollment() ), reporter, E1033,
-                event.getEvent() );
+                    event.getEvent() );
         }
         validateEventProgramAndProgramStage( reporter, event, context, strategy, bundle, program, programStage );
         validateDataElementForDataValues( reporter, event, context );
@@ -164,8 +164,8 @@ public class PreCheckMetaValidationHook
     }
 
     private void validateEventProgramAndProgramStage( ValidationErrorReporter reporter, Event event,
-        TrackerImportValidationContext context, TrackerImportStrategy strategy, TrackerBundle bundle, Program program,
-        ProgramStage programStage )
+                                                      TrackerImportValidationContext context, TrackerImportStrategy strategy, TrackerBundle bundle, Program program,
+                                                      ProgramStage programStage )
     {
         if ( program == null && programStage == null )
         {
@@ -199,7 +199,7 @@ public class PreCheckMetaValidationHook
     }
 
     private void validateNotChangingProgram( ValidationErrorReporter reporter, Event event,
-        TrackerImportValidationContext context, Program program )
+                                             TrackerImportValidationContext context, Program program )
     {
         ProgramStageInstance psi = context.getProgramStageInstance( event.getEvent() );
         Program existingProgram = psi.getProgramStage().getProgram();
@@ -207,8 +207,8 @@ public class PreCheckMetaValidationHook
         if ( !existingProgram.getUid().equals( program.getUid() ) )
         {
             reporter.addError( newReport( TrackerErrorCode.E1110 )
-                .addArg( psi )
-                .addArg( existingProgram ) );
+                    .addArg( psi )
+                    .addArg( existingProgram ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplierTest.java
@@ -6,10 +6,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodStore;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.cache.DefaultPreheatCacheService;
@@ -17,7 +17,6 @@ import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -26,18 +25,18 @@ import org.springframework.core.env.Environment;
 /**
  * @author Luciano Fiandesio
  */
-public class TrackedEntityTypeSupplierTest {
+public class PeriodTypeSupplierTest
+{
+    private PeriodTypeSupplier supplier;
 
-    private TrackedEntityTypeSupplier supplier;
+    @Mock
+    private PeriodStore periodStore;
 
     @Mock
     private DhisConfigurationProvider conf;
 
     @Mock
     private Environment env;
-
-    @Mock
-    private IdentifiableObjectManager manager;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -47,21 +46,22 @@ public class TrackedEntityTypeSupplierTest {
     @Before
     public void setUp()
     {
-        final PreheatCacheService cache = new DefaultPreheatCacheService( conf,  env );
-        supplier = new TrackedEntityTypeSupplier( manager, cache );
+        final PreheatCacheService cache = new DefaultPreheatCacheService( conf, env );
+        supplier = new PeriodTypeSupplier( periodStore, cache );
         when( env.getActiveProfiles() ).thenReturn( new String[] {} );
     }
+
     @Test
     public void verifySupplier()
     {
-        final List<TrackedEntityType> trackedEntityTypes = rnd.randomObjects( TrackedEntityType.class, 5 );
-        when( manager.getAll( TrackedEntityType.class  ) ).thenReturn( trackedEntityTypes );
+        final List<Period> periods = rnd.randomObjects( Period.class, 20 );
+        when( periodStore.getAll() ).thenReturn( periods );
 
         final TrackerImportParams params = TrackerImportParams.builder().build();
 
         TrackerPreheat preheat = new TrackerPreheat();
         this.supplier.preheatAdd( params, preheat );
 
-        assertThat( preheat.getAll( TrackedEntityType.class ), hasSize( 5 ) );
+        assertThat( preheat.getPeriodMap().values(), hasSize( 20 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/RelationshipTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/RelationshipTypeSupplierTest.java
@@ -7,32 +7,49 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.cache.DefaultPreheatCacheService;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.springframework.core.env.Environment;
 
 /**
  * @author Luciano Fiandesio
  */
 public class RelationshipTypeSupplierTest
 {
-    @InjectMocks
     private RelationshipTypeSupplier supplier;
 
     @Mock
     private IdentifiableObjectManager manager;
 
+    @Mock
+    private DhisConfigurationProvider conf;
+
+    @Mock
+    private Environment env;
+
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private BeanRandomizer rnd = new BeanRandomizer();
+
+    @Before
+    public void setUp()
+    {
+        final PreheatCacheService cache = new DefaultPreheatCacheService( conf,  env );
+        supplier = new RelationshipTypeSupplier( manager, cache );
+        when( env.getActiveProfiles() ).thenReturn( new String[] {} );
+    }
 
     @Test
     public void verifySupplier()

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -127,7 +127,8 @@ public enum ConfigurationKey
     OIDC_PROVIDER_WSO2_MAPPING_CLAIM( "oidc.provider.wso2.mapping_claim", "email", false ),
     OIDC_PROVIDER_WSO2_SERVER_URL( "oidc.provider.wso2.server_url", "", false ),
     OIDC_PROVIDER_WSO2_DISPLAY_ALIAS( "oidc.provider.wso2.display_alias", "", false ),
-    OIDC_PROVIDER_WSO2_ENABLE_LOGOUT( "oidc.provider.wso2.enable_logout", Constants.TRUE, false );
+    OIDC_PROVIDER_WSO2_ENABLE_LOGOUT( "oidc.provider.wso2.enable_logout", Constants.TRUE, false ),
+    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false );
 
     private final String key;
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1909,12 +1909,12 @@
       <dependency>
         <groupId>org.cache2k</groupId>
         <artifactId>cache2k-api</artifactId>
-        <version>1.2.4.Final</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>org.cache2k</groupId>
         <artifactId>cache2k-core</artifactId>
-        <version>1.2.4.Final</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.jsmpp</groupId>


### PR DESCRIPTION
This PR introduces a Cache2K-based cache for caching metadata objects accessed during the Preheat stage of the the Tracker Import process.

Notable changes:

- Introduced a `cache` property to the `@StrategyFor` annotation used to pre-load metadata. The property signals if the Metadata fetching class should cache the results
- Introduced a `PreheatCacheService` in the `preheat` package that is responsible for instantiating the caches for the metadata objects.
- Introduced a new global property `tracker.import.preheat.cache.enabled` to disable the Tracker Import cache.
- Bumped version of cache2K to `1.6.0.Final`