### PR TITLE
feat: Request/response tracing for Event import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
@@ -28,6 +28,13 @@ package org.hisp.dhis.dxf2.events.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.Grid;
@@ -42,13 +49,6 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.scheduling.JobConfiguration;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -116,6 +116,16 @@ public interface EventService
         throws IOException;
 
     ImportSummaries addEventsJson( InputStream inputStream, ImportOptions importOptions ) throws IOException;
+
+    /**
+     * Initiates the Events import process
+     * 
+     * @param payload a JSON representation of the Events to import
+     * @param importOptions {@link ImportOptions} object
+     * 
+     */
+    ImportSummaries addEventsJson( String payload, ImportOptions importOptions )
+        throws IOException;
 
     ImportSummaries addEventsJson( InputStream inputStream, JobConfiguration jobId, ImportOptions importOptions )
         throws IOException;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
@@ -156,6 +156,11 @@ public class TrackerImportTraceService
     @Scheduled( fixedRate = 60000 )
     public void truncate()
     {
+        if ( !enabled )
+        {
+            return;
+        }
+        
         try
         {
             jdbcTemplate.execute( "DELETE FROM " + TRACE_TABLE + " WHERE id < (SELECT id FROM " + TRACE_TABLE

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
@@ -117,7 +117,7 @@ public class TrackerImportTraceService
         return false;
     }
 
-    public void trace( String request, ImportSummaries importSummaries, Map<String, String> headers, String path, User user )
+    public void trace( long elapsed, String request, ImportSummaries importSummaries, Map<String, String> headers, String path, User user )
     {
         if ( !enabled )
         {
@@ -125,12 +125,12 @@ public class TrackerImportTraceService
         }
 
         final String sql = "INSERT INTO " + TRACE_TABLE
-            + " (USERNAME, PAYLOAD, RESPONSE, IMPORT_STATUS, PATH, HEADERS) VALUES(?,?,?,?,?,?)";
+            + " (ELAPSED, USERNAME, PAYLOAD, RESPONSE, IMPORT_STATUS, PATH, HEADERS) VALUES(?,?,?,?,?,?,?)";
 
         CompletableFuture.runAsync( () -> {
             try
             {
-                jdbcTemplate.update( sql, user.getUsername(), request, renderService.toJsonAsString( importSummaries ),
+                jdbcTemplate.update( sql, elapsed, user.getUsername(), request, renderService.toJsonAsString( importSummaries ),
                     importSummaries.getStatus().name(), StringUtils.left( path, 2000 ),
                     renderService.toJsonAsString( headers ) );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
@@ -117,7 +117,18 @@ public class TrackerImportTraceService
         return false;
     }
 
-    public void trace( long elapsed, String request, ImportSummaries importSummaries, Map<String, String> headers, String path, User user )
+    /**
+     * Dump the request/response data to the database
+     * 
+     * @param elapsed request/response elapsed time (ms.)
+     * @param request the JSON representation of the request payload
+     * @param importSummaries the result of the Tracker Import
+     * @param headers a Map containing the request headers
+     * @param path the request path
+     * @param user the current user
+     */
+    public void trace( long elapsed, String request, ImportSummaries importSummaries, Map<String, String> headers,
+        String path, User user )
     {
         if ( !enabled )
         {
@@ -130,9 +141,9 @@ public class TrackerImportTraceService
         CompletableFuture.runAsync( () -> {
             try
             {
-                jdbcTemplate.update( sql, elapsed, user.getUsername(), request, renderService.toJsonAsString( importSummaries ),
-                    importSummaries.getStatus().name(), StringUtils.left( path, 2000 ),
-                    renderService.toJsonAsString( headers ) );
+                jdbcTemplate.update( sql, elapsed, user.getUsername(), request,
+                    renderService.toJsonAsString( importSummaries ), importSummaries.getStatus().name(),
+                    StringUtils.left( path, 2000 ), renderService.toJsonAsString( headers ) );
             }
             catch ( Exception e )
             {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/trace/TrackerImportTraceService.java
@@ -1,0 +1,164 @@
+package org.hisp.dhis.dxf2.trace;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.hisp.dhis.external.conf.ConfigurationKey.TRACKER_IMPORT_TRACING_ENABLED;
+import static org.hisp.dhis.external.conf.ConfigurationKey.TRACKER_IMPORT_TRACING_LOG_SIZE;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.user.User;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This service writes to a database table request and response information of a
+ * Tracker Import operation. The write operation is async.
+ * 
+ * Upon initialization, the service checks if the target log table exists. If
+ * the table is missing, the service shuts itself down.
+ * 
+ * The service also shuts itself down if an error occurs during persistence.
+ * 
+ * The service periodically checks the size of the log table and truncates older
+ * entries. The default table size is 1000 entries. This value can be configured
+ * using the 'tracker.import.tracing.log.size' configuration key.
+ * 
+ * The service must be enabled using the 'tracker.import.tracing.enabled'
+ * configuration key.
+ * 
+ *
+ * @author Luciano Fiandesio
+ */
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class TrackerImportTraceService
+{
+    private final JdbcTemplate jdbcTemplate;
+
+    private final RenderService renderService;
+
+    private final DhisConfigurationProvider config;
+
+    private boolean enabled = false;
+
+    private int logSize = 1000;
+
+    private final static String TRACE_TABLE = "tracker_trace";
+
+    @PostConstruct
+    public void init()
+    {
+        this.enabled = config.isEnabled( TRACKER_IMPORT_TRACING_ENABLED ) && traceTableExists();
+        try
+        {
+            this.logSize = Integer.parseInt( config.getProperty( TRACKER_IMPORT_TRACING_LOG_SIZE ) );
+        }
+        catch ( NumberFormatException e )
+        {
+        }
+    }
+
+    public boolean traceTableExists()
+    {
+        try
+        {
+            Integer cnt = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM information_schema.tables WHERE  table_name = '" + TRACE_TABLE + "'",
+                Integer.class );
+
+            return cnt != null && cnt == 1;
+
+        }
+        catch ( Exception e )
+        {
+            log.warn( ":::: An error occurred trying to determine if the table " + TRACE_TABLE
+                + " exists. Tracker Tracing is disabled.", e );
+            enabled = false;
+        }
+        return false;
+    }
+
+    public void trace( String request, ImportSummaries importSummaries, Map<String, String> headers, String path, User user )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        final String sql = "INSERT INTO " + TRACE_TABLE
+            + " (USERNAME, PAYLOAD, RESPONSE, IMPORT_STATUS, PATH, HEADERS) VALUES(?,?,?,?,?,?)";
+
+        CompletableFuture.runAsync( () -> {
+            try
+            {
+                jdbcTemplate.update( sql, user.getUsername(), request, renderService.toJsonAsString( importSummaries ),
+                    importSummaries.getStatus().name(), StringUtils.left( path, 2000 ),
+                    renderService.toJsonAsString( headers ) );
+            }
+            catch ( Exception e )
+            {
+                log.error( ":::: Tracker tracing failed. Service will be disabled.", e );
+                enabled = false;
+            }
+        } );
+    }
+
+    @Scheduled( fixedRate = 60000 )
+    public void truncate()
+    {
+        try
+        {
+            jdbcTemplate.execute( "DELETE FROM " + TRACE_TABLE + " WHERE id < (SELECT id FROM " + TRACE_TABLE
+                + " ORDER BY id DESC LIMIT 1 OFFSET " + logSize + " )" );
+        }
+        catch ( Exception e )
+        {
+            log.error( ":::: Tracker tracing failed during table clean-up. Service will be disabled.", e );
+            enabled = false;
+        }
+    }
+
+    public void toggle()
+    {
+        this.enabled = !enabled;
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -109,7 +109,9 @@ public enum ConfigurationKey
     AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "off" ),
     AUDIT_METADATA_MATRIX( "audit.metadata", "", false ),
     AUDIT_TRACKER_MATRIX( "audit.tracker", "", false ),
-    AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false );
+    AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false ),
+    TRACKER_IMPORT_TRACING_ENABLED( "tracker.import.tracing.enabled", "off", false ),
+    TRACKER_IMPORT_TRACING_LOG_SIZE( "tracker.import.tracing.log.size", "1000", false );
 
     private final String key;
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -969,6 +969,8 @@ public class EventController
     public void postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions ) throws Exception
     {
+        long start = System.currentTimeMillis();
+
         importOptions.setImportStrategy( strategy );
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
         importOptions.setIdSchemes( getIdSchemesFromParameters( importOptions.getIdSchemes(), contextService.getParameterValuesMap() ) );
@@ -976,7 +978,6 @@ public class EventController
         if ( !importOptions.isAsync() )
         {
             final String payload = org.springframework.util.StreamUtils.copyToString( inputStream, StandardCharsets.UTF_8 );
-
             ImportSummaries importSummaries = eventService.addEventsJson( payload, importOptions );
             importSummaries.setImportOptions( importOptions );
 
@@ -1002,7 +1003,8 @@ public class EventController
                     }
                 }
             }
-            traceService.trace( payload, importSummaries, getReqHeaders( request ),
+            
+            traceService.trace( System.currentTimeMillis() - start, payload, importSummaries, getReqHeaders( request ),
                 getPath( request ), currentUserService.getCurrentUser() );
 
             webMessageService.send( WebMessageUtils.importSummaries( importSummaries ), response, request );


### PR DESCRIPTION
Adds a configurable HTTP Request/Response tracing service for the Tracker Event import process..
The service writes to a database table request and response information for each REST call to the `/events/` endpoint.
The write operation is async and does not open a transaction.

Each log entry contains:

- id
- timestamp
- elapsed (milliseconds)
- json request
- json reponse
- path
- user name
- http req headers (minus security sensible headers)
- import status

Upon initialization, the service checks if the target log table exists. If
the table is missing, the service shuts itself down.

The service also shuts itself down if an error occurs during persistence.

The service periodically checks the size of the log table and truncates older
entries. The default table size is 1000 entries. This value can be configured
using the `tracker.import.tracing.log.size` configuration key.

The service must be enabled using the `tracker.import.tracing.enabled`
configuration key.

NOTE: the tracing service requires a table named `tracker_trace`. The table is not automatically generated by Flyway and has to be manually created using the following command:

```
create table tracker_trace
(
	id serial not null
		constraint tracker_trace_pk
			primary key,
	event_timestamp timestamp default CURRENT_TIMESTAMP not null,
	username varchar(150) not null,
	payload text,
	import_status varchar(50),
	response text,
	headers text,
	path varchar(2000),
	elapsed integer
);

create unique index tracker_trace_id_uindex
	on tracker_trace (id);

```