### PR TITLE
perf: replace expensive "Program has OrgUnit" call with faster SQL

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -373,6 +373,10 @@ public class Program
         return programStages != null && programStages.size() == 1;
     }
 
+    /**
+     * @deprecated use {@link ProgramService.hasOrgUnit()} instead.
+     */
+    @Deprecated
     public boolean hasOrganisationUnit( OrganisationUnit unit )
     {
         return organisationUnits.contains( unit );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -46,19 +46,12 @@ public interface ProgramService
     String ID = ProgramService.class.getName();
 
     Pattern INPUT_PATTERN = Pattern.compile( "(<input.*?/>)", Pattern.DOTALL );
-
     Pattern DYNAMIC_ATTRIBUTE_PATTERN = Pattern.compile( "attributeid=\"(\\w+)\"" );
-
     Pattern PROGRAM_PATTERN = Pattern.compile( "programid=\"(\\w+)\"" );
-
     Pattern VALUE_TAG_PATTERN = Pattern.compile( "value=\"(.*?)\"", Pattern.DOTALL );
-
     Pattern TITLE_TAG_PATTERN = Pattern.compile( "title=\"(.*?)\"", Pattern.DOTALL );
-
     Pattern SUGGESTED_VALUE_PATTERN = Pattern.compile( "suggested=('|\")(\\w*)('|\")" );
-
     Pattern CLASS_PATTERN = Pattern.compile( "class=('|\")(\\w*)('|\")" );
-
     Pattern STYLE_PATTERN = Pattern.compile( "style=('|\")([\\w|\\d\\:\\;]+)('|\")" );
 
     /**
@@ -77,8 +70,9 @@ public interface ProgramService
     void updateProgram( Program program );
 
     /**
-     * Deletes a {@link Program}. All {@link ProgramStage}, {@link ProgramInstance}
-     * and {@link ProgramStageInstance} belong to this program are removed
+     * Deletes a {@link Program}. All {@link ProgramStage},
+     * {@link ProgramInstance} and {@link ProgramStageInstance} belong to this
+     * program are removed
      *
      * @param program the Program to delete.
      */
@@ -95,8 +89,8 @@ public interface ProgramService
     /**
      * Returns all {@link Program}.
      *
-     * @return a collection of all Program, or an empty collection if there are no
-     *         Programs.
+     * @return a collection of all Program, or an empty collection if there are
+     *         no Programs.
      */
     List<Program> getAllPrograms();
 
@@ -111,9 +105,9 @@ public interface ProgramService
     /**
      * Get {@link Program} by a type
      *
-     * @param type The type of program. There are three types, include Multi events
-     *        with registration, Single event with registration and Single event
-     *        without registration
+     * @param type The type of program. There are three types, include Multi
+     *        events with registration, Single event with registration and
+     *        Single event without registration
      * @return Program list by a type specified
      */
     List<Program> getPrograms( ProgramType type );
@@ -142,8 +136,8 @@ public interface ProgramService
     List<Program> getProgramsByDataEntryForm( DataEntryForm dataEntryForm );
 
     /**
-     * Get {@link Program} by the current user. Returns all programs if current user
-     * is superuser. Returns an empty list if there is no current user.
+     * Get {@link Program} by the current user. Returns all programs if current
+     * user is superuser. Returns an empty list if there is no current user.
      *
      * @return Immutable set of programs associated with the current user.
      */
@@ -155,15 +149,15 @@ public interface ProgramService
      * Get {@link Program} by the current user and a certain type
      *
      * @param programType The type of program. There are three types, include Multi
-     *        events with registration, Single event with registration and Single
-     *        event without registration.
+     *        events with registration, Single event with registration and
+     *        Single event without registration.
      * @return Immutable set of programs associated with the current user.
      */
     Set<Program> getUserPrograms( ProgramType programType );
 
     /**
-     * Sets the given merge organisation units on the given programs. Only the
-     * sub-hierarchy of the current user is modified.
+     * Sets the given merge organisation units on the given programs. Only
+     * the sub-hierarchy of the current user is modified.
      *
      * @param program the program.
      * @param mergeOrganisationUnits the merge organisation units.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -46,12 +46,19 @@ public interface ProgramService
     String ID = ProgramService.class.getName();
 
     Pattern INPUT_PATTERN = Pattern.compile( "(<input.*?/>)", Pattern.DOTALL );
+
     Pattern DYNAMIC_ATTRIBUTE_PATTERN = Pattern.compile( "attributeid=\"(\\w+)\"" );
+
     Pattern PROGRAM_PATTERN = Pattern.compile( "programid=\"(\\w+)\"" );
+
     Pattern VALUE_TAG_PATTERN = Pattern.compile( "value=\"(.*?)\"", Pattern.DOTALL );
+
     Pattern TITLE_TAG_PATTERN = Pattern.compile( "title=\"(.*?)\"", Pattern.DOTALL );
+
     Pattern SUGGESTED_VALUE_PATTERN = Pattern.compile( "suggested=('|\")(\\w*)('|\")" );
+
     Pattern CLASS_PATTERN = Pattern.compile( "class=('|\")(\\w*)('|\")" );
+
     Pattern STYLE_PATTERN = Pattern.compile( "style=('|\")([\\w|\\d\\:\\;]+)('|\")" );
 
     /**
@@ -70,9 +77,8 @@ public interface ProgramService
     void updateProgram( Program program );
 
     /**
-     * Deletes a {@link Program}. All {@link ProgramStage},
-     * {@link ProgramInstance} and {@link ProgramStageInstance} belong to this
-     * program are removed
+     * Deletes a {@link Program}. All {@link ProgramStage}, {@link ProgramInstance}
+     * and {@link ProgramStageInstance} belong to this program are removed
      *
      * @param program the Program to delete.
      */
@@ -89,8 +95,8 @@ public interface ProgramService
     /**
      * Returns all {@link Program}.
      *
-     * @return a collection of all Program, or an empty collection if there are
-     *         no Programs.
+     * @return a collection of all Program, or an empty collection if there are no
+     *         Programs.
      */
     List<Program> getAllPrograms();
 
@@ -105,9 +111,9 @@ public interface ProgramService
     /**
      * Get {@link Program} by a type
      *
-     * @param type The type of program. There are three types, include Multi
-     *        events with registration, Single event with registration and
-     *        Single event without registration
+     * @param type The type of program. There are three types, include Multi events
+     *        with registration, Single event with registration and Single event
+     *        without registration
      * @return Program list by a type specified
      */
     List<Program> getPrograms( ProgramType type );
@@ -136,8 +142,8 @@ public interface ProgramService
     List<Program> getProgramsByDataEntryForm( DataEntryForm dataEntryForm );
 
     /**
-     * Get {@link Program} by the current user. Returns all programs if current
-     * user is superuser. Returns an empty list if there is no current user.
+     * Get {@link Program} by the current user. Returns all programs if current user
+     * is superuser. Returns an empty list if there is no current user.
      *
      * @return Immutable set of programs associated with the current user.
      */
@@ -149,15 +155,15 @@ public interface ProgramService
      * Get {@link Program} by the current user and a certain type
      *
      * @param programType The type of program. There are three types, include Multi
-     *        events with registration, Single event with registration and
-     *        Single event without registration.
+     *        events with registration, Single event with registration and Single
+     *        event without registration.
      * @return Immutable set of programs associated with the current user.
      */
     Set<Program> getUserPrograms( ProgramType programType );
 
     /**
-     * Sets the given merge organisation units on the given programs. Only
-     * the sub-hierarchy of the current user is modified.
+     * Sets the given merge organisation units on the given programs. Only the
+     * sub-hierarchy of the current user is modified.
      *
      * @param program the program.
      * @param mergeOrganisationUnits the merge organisation units.
@@ -172,4 +178,10 @@ public interface ProgramService
      * @return a list of program data elements.
      */
     List<ProgramDataElementDimensionItem> getGeneratedProgramDataElements( String programUid );
+
+    /**
+     * Checks whether the given {@link OrganisationUnit} belongs to the specified
+     * {@link Program}
+     */
+    boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit  );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStore.java
@@ -63,6 +63,12 @@ public interface ProgramStore
     List<Program> get( OrganisationUnit organisationUnit );
 
     /**
+     * Checks whether the given {@link OrganisationUnit} belongs to the specified
+     * {@link Program}
+     */
+    boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit );
+
+    /**
      * Get {@link Program} by TrackedEntityType
      *
      * @param trackedEntityType {@link TrackedEntityType}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
@@ -28,8 +28,14 @@ package org.hisp.dhis.program;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -41,13 +47,8 @@ import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Abyot Asalefew
@@ -224,5 +225,11 @@ public class DefaultProgramService
         Collections.sort( programDataElements );
 
         return programDataElements;
+    }
+
+    @Override
+    public boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit )
+    {
+        return this.programStore.hasOrgUnit( program, organisationUnit );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.program.hibernate;
  */
 
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.criteria.CriteriaBuilder;
 
@@ -88,9 +89,9 @@ public class HibernateProgramStore
 
     public boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit )
     {
-        return jdbcTemplate.queryForObject(
+        return jdbcTemplate.queryForList(
             "select programid from program_organisationunits where programid = ? and organisationunitid = ?",
-            Long.class, program.getId(), organisationUnit.getId() ) != null;
+            program.getId(), organisationUnit.getId() ).size() == 1;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
@@ -28,7 +28,10 @@ package org.hisp.dhis.program.hibernate;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Lists;
+import java.util.List;
+
+import javax.persistence.criteria.CriteriaBuilder;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.dataentryform.DataEntryForm;
@@ -44,8 +47,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import java.util.List;
+import com.google.common.collect.Lists;
 
 /**
  * @author Chau Thu Tran
@@ -82,6 +84,13 @@ public class HibernateProgramStore
 
         return getList( builder, newJpaParameters()
             .addPredicate( root -> builder.equal( root.join( "organisationUnits" ).get( "id" ), organisationUnit.getId() ) ) );
+    }
+
+    public boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit )
+    {
+        return jdbcTemplate.queryForObject(
+            "select programid from program_organisationunits where programid = ? and organisationunitid = ?",
+            Long.class, program.getId(), organisationUnit.getId() ) != null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -140,7 +140,7 @@ public class EnrollmentSMSListener
             throw new SMSProcessingException( SmsResponse.INVALID_TETYPE.set( tetid ) );
         }
 
-        if ( !program.hasOrganisationUnit( orgUnit ) )
+        if ( !programService.hasOrgUnit( program, orgUnit ) )
         {
             throw new SMSProcessingException( SmsResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -111,7 +111,7 @@ public class SimpleEventSMSListener
             throw new SMSProcessingException( SmsResponse.INVALID_AOC.set( aocid ) );
         }
 
-        if ( !program.hasOrganisationUnit( orgUnit ) )
+        if ( !programService.hasOrgUnit( program, orgUnit ) )
         {
             throw new SMSProcessingException( SmsResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -82,13 +83,15 @@ public class TrackedEntityRegistrationSMSListener
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     private final ProgramInstanceService programInstanceService;
+    
+    private final ProgramService programService;
 
     public TrackedEntityRegistrationSMSListener( ProgramInstanceService programInstanceService,
         CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityInstanceService trackedEntityInstanceService,
-        ProgramInstanceService programInstanceService1 )
+        ProgramService programService )
     {
         super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
             currentUserService, incomingSmsService, smsSender );
@@ -97,11 +100,13 @@ public class TrackedEntityRegistrationSMSListener
         checkNotNull( trackedEntityTypeService );
         checkNotNull( trackedEntityInstanceService );
         checkNotNull( programInstanceService );
+        checkNotNull( programService );
 
         this.smsCommandService = smsCommandService;
         this.trackedEntityTypeService = trackedEntityTypeService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
-        this.programInstanceService = programInstanceService1;
+        this.programInstanceService = programInstanceService;
+        this.programService = programService;
     }
 
     // -------------------------------------------------------------------------
@@ -121,7 +126,7 @@ public class TrackedEntityRegistrationSMSListener
 
         OrganisationUnit orgUnit = SmsUtils.selectOrganisationUnit( orgUnits, parsedMessage, smsCommand );
 
-        if ( !program.hasOrganisationUnit( orgUnit ) )
+        if ( !programService.hasOrgUnit( program, orgUnit ) )
         {
             sendFeedback( SMSCommand.NO_OU_FOR_PROGRAM, senderPhoneNumber, WARNING );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramServiceTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashSet;
 import java.util.List;
 
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -53,6 +54,9 @@ public class ProgramServiceTest
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
+
+    @Autowired
+    private SessionFactory sessionFactory;
 
     private OrganisationUnit organisationUnitA;
 
@@ -81,6 +85,8 @@ public class ProgramServiceTest
 
         programC = createProgram( 'C', new HashSet<>(), organisationUnitB );
         programC.setUid( "UID-C" );
+
+
     }
 
     @Test
@@ -183,5 +189,19 @@ public class ProgramServiceTest
 
         assertEquals( programA, programService.getProgram( "UID-A" ) );
         assertEquals( programB, programService.getProgram( "UID-B" ) );
+    }
+
+    @Test
+    public void testProgramHasOrgUnit()
+    {
+        programService.addProgram( programA );
+
+        Program p = programService.getProgram( programA.getUid() );
+        OrganisationUnit ou = organisationUnitService.getOrganisationUnit( organisationUnitA.getUid() );
+
+        sessionFactory.getCurrentSession().flush();
+
+        assertTrue( programService.hasOrgUnit( p, ou ) );
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -28,6 +28,20 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -74,21 +88,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-
 import com.google.common.collect.Sets;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class EnrollmentSMSListenerTest
     extends
@@ -216,6 +216,7 @@ public class EnrollmentSMSListenerTest
 
         when( organisationUnitService.getOrganisationUnit( anyString() ) ).thenReturn( organisationUnit );
         when( programService.getProgram( anyString() ) ).thenReturn( program );
+        when( programService.hasOrgUnit( any( Program.class ), any( OrganisationUnit.class ) ) ).thenReturn( true );
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
         when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
         when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -28,6 +28,20 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -61,21 +75,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-
 import com.google.common.collect.Sets;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class SimpleEventSMSListenerTest
     extends
@@ -178,6 +178,9 @@ public class SimpleEventSMSListenerTest
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];
             return updatedIncomingSms;
         } ).when( incomingSmsService ).update( any() );
+
+        when( programService.hasOrgUnit( any( Program.class ), any( OrganisationUnit.class ) ) ).thenReturn( true );
+
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -28,14 +28,29 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Sets;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
-import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.code.SMSCode;
@@ -43,7 +58,11 @@ import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.sms.parse.SMSParserException;
-import org.hisp.dhis.trackedentity.*;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -55,9 +74,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.google.common.collect.Sets;
 
 /**
  * @author Zubair Asghar.
@@ -81,6 +98,9 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
 
     @Mock
     private ProgramStageInstanceService programStageInstanceService;
+
+    @Mock
+    private ProgramService  programService;
 
     @Mock
     private UserService userService;
@@ -130,7 +150,7 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     {
         subject = new TrackedEntityRegistrationSMSListener( programInstanceService, dataElementCategoryService,
                 programStageInstanceService, userService, currentUserService, incomingSmsService, smsSender, smsCommandService,
-                trackedEntityTypeService, trackedEntityInstanceService, programInstanceService);
+                trackedEntityTypeService, trackedEntityInstanceService, programService );
 
         setUpInstances();
 
@@ -161,6 +181,8 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];
             return updatedIncomingSms;
         }).when( incomingSmsService ).update( any() );
+
+        when( programService.hasOrgUnit( program, organisationUnit ) ).thenReturn( true );
 
         subject.receive( incomingSms );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -28,10 +28,45 @@ package org.hisp.dhis.dxf2.events.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import lombok.extern.slf4j.Slf4j;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_BY_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_DATE_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_CREATED_BY_USER_INFO_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_CREATED_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_DELETED;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_DUE_DATE_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ENROLLMENT_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_EXECUTION_DATE_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_GEOMETRY;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_LAST_UPDATED_BY_USER_INFO_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_LAST_UPDATED_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ORG_UNIT_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ORG_UNIT_NAME;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_PROGRAM_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_PROGRAM_STAGE_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_STATUS_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_STORED_BY_ID;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.PAGER_META_KEY;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.SimpleCacheBuilder;
@@ -94,10 +129,10 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.notification.event.ProgramStageCompletionNotificationEvent;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.engine.DataValueUpdatedEvent;
@@ -132,25 +167,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -646,10 +667,11 @@ public abstract class AbstractEventService
             programStage = programStageInstance.getProgramStage();
         }
 
-        if ( !programInstance.getProgram().hasOrganisationUnit( organisationUnit ) )
+        if ( !programService.hasOrgUnit( programInstance.getProgram(), organisationUnit ) )
         {
-            return new ImportSummary( ImportStatus.ERROR, "Program is not assigned to this organisation unit: " + event.getOrgUnit() )
-                .setReference( event.getEvent() ).incrementIgnored();
+            return new ImportSummary( ImportStatus.ERROR,
+                "Program is not assigned to this organisation unit: " + event.getOrgUnit() )
+                    .setReference( event.getEvent() ).incrementIgnored();
         }
 
         validateExpiryDays( importOptions, event, program, programStageInstance );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -28,45 +28,10 @@ package org.hisp.dhis.dxf2.events.event;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_BY_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_DATE_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_CREATED_BY_USER_INFO_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_CREATED_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_DELETED;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_DUE_DATE_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ENROLLMENT_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_EXECUTION_DATE_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_GEOMETRY;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_LAST_UPDATED_BY_USER_INFO_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_LAST_UPDATED_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ORG_UNIT_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ORG_UNIT_NAME;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_PROGRAM_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_PROGRAM_STAGE_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_STATUS_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_STORED_BY_ID;
-import static org.hisp.dhis.dxf2.events.event.EventSearchParams.PAGER_META_KEY;
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.SimpleCacheBuilder;
@@ -129,10 +94,10 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.notification.event.ProgramStageCompletionNotificationEvent;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.engine.DataValueUpdatedEvent;
@@ -167,11 +132,25 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import lombok.extern.slf4j.Slf4j;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.events.event.EventSearchParams.*;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
@@ -28,15 +28,15 @@ package org.hisp.dhis.artemis.audit.configuration;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Luciano Fiandesio
@@ -62,5 +62,18 @@ public class AuditMatrix
     public boolean isEnabled( AuditScope auditScope, AuditType auditType )
     {
         return matrix.get( auditScope ).getOrDefault( auditType, false );
+    }
+
+    public boolean isReadEnabled()
+    {
+        final AuditScope[] auditScopes = AuditScope.values();
+        for ( AuditScope auditScope : auditScopes )
+        {
+            if ( isEnabled( auditScope, AuditType.READ ) )
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Deprecated the method `Program.hasOrganisationUnit()` and replaced with SQL method on the `ProgramService`.

All calls to `Program.hasOrganisationUnit()` have been replaced with a call to `ProgramService.hasOrgUnit`, which uses a fast JDBC-based query against the `program_organisationunits` table.

Additionally, added a check to disable the `LOAD` Hibernate listener, if ON_LOAD auditing is disabled by the user.