### PR TITLE
perf: replace expensive "Program has OrgUnit" call with faster SQL

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -373,6 +373,10 @@ public class Program
         return programStages != null && programStages.size() == 1;
     }
 
+    /**
+     * @deprecated use {@link ProgramService.hasOrgUnit()} instead.
+     */
+    @Deprecated
     public boolean hasOrganisationUnit( OrganisationUnit unit )
     {
         return organisationUnits.contains( unit );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -172,4 +172,10 @@ public interface ProgramService
      * @return a list of program data elements.
      */
     List<ProgramDataElementDimensionItem> getGeneratedProgramDataElements( String programUid );
+
+    /**
+     * Checks whether the given {@link OrganisationUnit} belongs to the specified
+     * {@link Program}
+     */
+    boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit  );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStore.java
@@ -75,4 +75,10 @@ public interface ProgramStore
      * @return a list of {@link Program}
      */
     List<Program> getByDataEntryForm( DataEntryForm dataEntryForm );
+
+    /**
+     * Checks whether the given {@link OrganisationUnit} belongs to the specified
+     * {@link Program}
+     */
+    boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.program;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -47,11 +49,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * @author Abyot Asalefew
  */
+@RequiredArgsConstructor
 @Service( "org.hisp.dhis.program.ProgramService" )
 public class DefaultProgramService
     implements ProgramService
@@ -60,23 +61,11 @@ public class DefaultProgramService
     // Dependencies
     // -------------------------------------------------------------------------
 
-    private final ProgramStore programStore;
+    @NonNull private final ProgramStore programStore;
 
-    private final CurrentUserService currentUserService;
+    @NonNull private final CurrentUserService currentUserService;
 
-    private final OrganisationUnitService organisationUnitService;
-
-    public DefaultProgramService( ProgramStore programStore, CurrentUserService currentUserService,
-        OrganisationUnitService organisationUnitService )
-    {
-        checkNotNull( programStore );
-        checkNotNull( currentUserService );
-        checkNotNull( organisationUnitService );
-
-        this.programStore = programStore;
-        this.currentUserService = currentUserService;
-        this.organisationUnitService = organisationUnitService;
-    }
+    @NonNull private final OrganisationUnitService organisationUnitService;
 
     // -------------------------------------------------------------------------
     // Implementation methods
@@ -224,5 +213,11 @@ public class DefaultProgramService
         Collections.sort( programDataElements );
 
         return programDataElements;
+    }
+
+    @Override
+    public boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit )
+    {
+        return this.programStore.hasOrgUnit( program, organisationUnit );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
@@ -33,6 +33,7 @@ import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -104,5 +105,15 @@ public class HibernateProgramStore
         final String hql = "from Program p where p.dataEntryForm = :dataEntryForm";
 
         return getQuery( hql ).setParameter( "dataEntryForm", dataEntryForm ).list();
+    }
+
+    public boolean hasOrgUnit( Program program, OrganisationUnit organisationUnit )
+    {
+        NativeQuery<Long> query = getSession().createNativeQuery(
+            "select programid from program_organisationunits where programid = :pid and organisationunitid = :ouid" );
+        query.setParameter( "pid", program.getId() );
+        query.setParameter( "ouid", organisationUnit.getId() );
+
+        return query.getResultList().size() == 1;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -139,7 +139,7 @@ public class EnrollmentSMSListener
             throw new SMSProcessingException( SmsResponse.INVALID_TETYPE.set( tetid ) );
         }
 
-        if ( !program.hasOrganisationUnit( orgUnit ) )
+        if ( !programService.hasOrgUnit( program, orgUnit )  )
         {
             throw new SMSProcessingException( SmsResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -111,7 +111,7 @@ public class SimpleEventSMSListener
             throw new SMSProcessingException( SmsResponse.INVALID_AOC.set( aocid ) );
         }
 
-        if ( !program.hasOrganisationUnit( orgUnit ) )
+        if ( !programService.hasOrgUnit( program, orgUnit ) )
         {
             throw new SMSProcessingException( SmsResponse.OU_NOTIN_PROGRAM.set( ouid, progid ) );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -82,13 +83,15 @@ public class TrackedEntityRegistrationSMSListener
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     private final ProgramInstanceService programInstanceService;
+    
+    private final ProgramService programService;
 
-    public TrackedEntityRegistrationSMSListener( ProgramInstanceService programInstanceService,
+    public TrackedEntityRegistrationSMSListener( ProgramService programService,
+        ProgramInstanceService programInstanceService,
         CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
-        TrackedEntityTypeService trackedEntityTypeService, TrackedEntityInstanceService trackedEntityInstanceService,
-        ProgramInstanceService programInstanceService1 )
+        TrackedEntityTypeService trackedEntityTypeService, TrackedEntityInstanceService trackedEntityInstanceService )
     {
         super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
             currentUserService, incomingSmsService, smsSender );
@@ -101,7 +104,8 @@ public class TrackedEntityRegistrationSMSListener
         this.smsCommandService = smsCommandService;
         this.trackedEntityTypeService = trackedEntityTypeService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
-        this.programInstanceService = programInstanceService1;
+        this.programInstanceService = programInstanceService;
+        this.programService = programService;
     }
 
     // -------------------------------------------------------------------------
@@ -121,7 +125,7 @@ public class TrackedEntityRegistrationSMSListener
 
         OrganisationUnit orgUnit = SmsUtils.selectOrganisationUnit( orgUnits, parsedMessage, smsCommand );
 
-        if ( !program.hasOrganisationUnit( orgUnit ) )
+        if ( !programService.hasOrgUnit( program, orgUnit ) )
         {
             sendFeedback( SMSCommand.NO_OU_FOR_PROGRAM, senderPhoneNumber, WARNING );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramServiceTest.java
@@ -184,4 +184,18 @@ public class ProgramServiceTest
         assertEquals( programA, programService.getProgram( "UID-A" ) );
         assertEquals( programB, programService.getProgram( "UID-B" ) );
     }
+
+    @Test
+    public void testProgramHasOrgUnit()
+    {
+        programService.addProgram( programA );
+
+        Program p = programService.getProgram( programA.getUid() );
+        OrganisationUnit ou = organisationUnitService.getOrganisationUnit( organisationUnitA.getUid() );
+
+        //sessionFactory.getCurrentSession().flush();
+
+        assertTrue( programService.hasOrgUnit( p, ou ) );
+
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -28,6 +28,20 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -74,21 +88,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-
 import com.google.common.collect.Sets;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class EnrollmentSMSListenerTest
     extends
@@ -186,8 +186,6 @@ public class EnrollmentSMSListenerTest
 
     private TrackedEntityAttributeValue trackedEntityAttributeValue;
 
-    private ProgramTrackedEntityAttribute programTrackedEntityAttribute;
-
     private TrackedEntityType trackedEntityType;
 
     private TrackedEntityInstance trackedEntityInstance;
@@ -216,14 +214,10 @@ public class EnrollmentSMSListenerTest
 
         when( organisationUnitService.getOrganisationUnit( anyString() ) ).thenReturn( organisationUnit );
         when( programService.getProgram( anyString() ) ).thenReturn( program );
-        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
-        when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
-        when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );
         when( trackedEntityTypeService.getTrackedEntityType( anyString() ) ).thenReturn( trackedEntityType );
-        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
-            .thenReturn( trackedEntityAttribute );
         when( programInstanceService.enrollTrackedEntityInstance( any(), any(), any(), any(), any(), any() ) )
             .thenReturn( programInstance );
+        when( programService.hasOrgUnit( any( Program.class ), any( OrganisationUnit.class ) ) ).thenReturn( true );
 
         doAnswer( invocation -> {
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];
@@ -234,6 +228,9 @@ public class EnrollmentSMSListenerTest
     @Test
     public void testEnrollmentNoEvents()
     {
+        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
+            .thenReturn( trackedEntityAttribute );
+
         subject.receive( incomingSmsEnrollmentNoEvents );
 
         assertNotNull( updatedIncomingSms );
@@ -246,6 +243,12 @@ public class EnrollmentSMSListenerTest
     @Test
     public void testEnrollmentWithEvents()
     {
+        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
+        when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
+        when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );
+        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
+            .thenReturn( trackedEntityAttribute );
+
         subject.receive( incomingSmsEnrollmentWithEvents );
 
         assertNotNull( updatedIncomingSms );
@@ -258,6 +261,12 @@ public class EnrollmentSMSListenerTest
     @Test
     public void testEnrollmentWithEventsRepeat()
     {
+        when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
+        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
+        when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );
+        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
+            .thenReturn( trackedEntityAttribute );
+
         subject.receive( incomingSmsEnrollmentWithEvents );
         subject.receive( incomingSmsEnrollmentWithEvents );
 
@@ -271,6 +280,9 @@ public class EnrollmentSMSListenerTest
     @Test
     public void testEnrollmentWithNulls()
     {
+        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
+            .thenReturn( trackedEntityAttribute );
+
         subject.receive( incomingSmsEnrollmentWithNulls );
 
         assertNotNull( updatedIncomingSms );
@@ -295,6 +307,12 @@ public class EnrollmentSMSListenerTest
     @Test
     public void testEnrollmentEventWithNulls()
     {
+        when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
+        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
+        when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );
+        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
+            .thenReturn( trackedEntityAttribute );
+
         subject.receive( incomingSmsEnrollmentEventWithNulls );
 
         assertNotNull( updatedIncomingSms );
@@ -309,6 +327,11 @@ public class EnrollmentSMSListenerTest
     @Test
     public void testEnrollmentEventNoValues()
     {
+        when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
+        when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );
+        when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
+            .thenReturn( trackedEntityAttribute );
+
         subject.receive( incomingSmsEnrollmentEventNoValues );
 
         assertNotNull( updatedIncomingSms );
@@ -331,8 +354,8 @@ public class EnrollmentSMSListenerTest
         user.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
 
         trackedEntityAttribute = createTrackedEntityAttribute( 'A', ValueType.TEXT );
-        programTrackedEntityAttribute = createProgramTrackedEntityAttribute( program, trackedEntityAttribute );
-        program.getProgramAttributes().add( programTrackedEntityAttribute );
+        final ProgramTrackedEntityAttribute programTrackedEntityAttribute = createProgramTrackedEntityAttribute(program, trackedEntityAttribute);
+        program.getProgramAttributes().add(programTrackedEntityAttribute);
         program.getOrganisationUnits().add( organisationUnit );
         program.setTrackedEntityType( trackedEntityType );
         HashSet<ProgramStage> stages = new HashSet<>();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -178,6 +178,8 @@ public class SimpleEventSMSListenerTest
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];
             return updatedIncomingSms;
         } ).when( incomingSmsService ).update( any() );
+
+        when( programService.hasOrgUnit( any( Program.class ), any( OrganisationUnit.class ) ) ).thenReturn( true );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -178,7 +178,8 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
         // Mock for trackedEntityInstanceService
         when( trackedEntityInstanceService.createTrackedEntityInstance( any(), any() ) ).thenReturn( 1L );
         when( trackedEntityInstanceService.getTrackedEntityInstance( anyLong() ) ).thenReturn( trackedEntityInstance );
-
+        when( programService.hasOrgUnit( program, organisationUnit ) ).thenReturn( true );
+        
         // Mock for incomingSmsService
         doAnswer( invocation -> {
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -28,14 +28,29 @@ package org.hisp.dhis.sms.listener;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.common.collect.Sets;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
-import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.code.SMSCode;
@@ -43,7 +58,11 @@ import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.sms.parse.SMSParserException;
-import org.hisp.dhis.trackedentity.*;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -55,9 +74,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.google.common.collect.Sets;
 
 /**
  * @author Zubair Asghar.
@@ -103,6 +120,8 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     @Mock
     private TrackedEntityInstanceService trackedEntityInstanceService;
 
+    @Mock
+    private ProgramService programService;
 
     private TrackedEntityRegistrationSMSListener subject;
 
@@ -128,9 +147,11 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     @Before
     public void initTest()
     {
-        subject = new TrackedEntityRegistrationSMSListener( programInstanceService, dataElementCategoryService,
-                programStageInstanceService, userService, currentUserService, incomingSmsService, smsSender, smsCommandService,
-                trackedEntityTypeService, trackedEntityInstanceService, programInstanceService);
+        subject = new TrackedEntityRegistrationSMSListener( programService, programInstanceService,
+            dataElementCategoryService,
+            programStageInstanceService, userService, currentUserService, incomingSmsService, smsSender,
+            smsCommandService,
+            trackedEntityTypeService, trackedEntityInstanceService );
 
         setUpInstances();
 
@@ -146,7 +167,9 @@ public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
         when( smsSender.sendMessage( any(), any(), anyString() ) ).thenAnswer( invocation -> {
             message = (String) invocation.getArguments()[1];
             return response;
-        });
+        } );
+
+        when( programService.hasOrgUnit( program, organisationUnit ) ).thenReturn( false );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
@@ -63,4 +63,17 @@ public class AuditMatrix
     {
         return matrix.get( auditScope ).getOrDefault( auditType, false );
     }
+
+    public boolean isReadEnabled()
+    {
+        final AuditScope[] auditScopes = AuditScope.values();
+        for ( AuditScope auditScope : auditScopes )
+        {
+            if ( isEnabled( auditScope, AuditType.READ ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Deprecated the method `Program.hasOrganisationUnit()` and replaced with SQL method on the `ProgramService`.

All calls to `Program.hasOrganisationUnit()` have been replaced with a call to `ProgramService.hasOrgUnit`, which uses a fast JDBC-based query against the `program_organisationunits` table.

Additionally, added a check to disable the `LOAD` Hibernate listener, if ON_LOAD auditing is disabled by the user.

cherry-picked from: 291d62e36f5d37ee76f0584bc3a618407ddb3ed3