### PR TITLE
fix: [DHIS2-6642] delete relationships associated with soft deleted events (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -275,4 +275,50 @@ public class MaintenanceServiceTest
 
         assertFalse( programStageInstanceService.programStageInstanceExistsIncludingDeleted( programStageInstanceA.getUid() ) );
     }
+    
+    @Test
+    public void testDeleteSoftDeletedProgramInstanceLinkedToARelationshipItem()
+    {
+
+        RelationshipType rType= createRelationshipType( 'A' );
+        rType.getFromConstraint().setRelationshipEntity( RelationshipEntity.PROGRAM_INSTANCE );
+        rType.getFromConstraint().setProgram( program );
+
+        rType.getToConstraint().setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+        rType.getFromConstraint().setTrackedEntityType( entityInstance.getTrackedEntityType() );
+
+        relationshipTypeService.addRelationshipType( rType );
+
+
+        Relationship r = new Relationship();
+        RelationshipItem rItem1 = new RelationshipItem();
+        rItem1.setProgramInstance( programInstance );
+
+
+        RelationshipItem rItem2 = new RelationshipItem();
+        rItem2.setTrackedEntityInstance( entityInstance );
+
+        r.setFrom( rItem1 );
+        r.setTo( rItem2 );
+        r.setRelationshipType( rType );
+
+        relationshipService.addRelationship( r );
+
+        assertNotNull( programInstanceService.getProgramInstance( programInstance.getId() ) );
+
+        assertNotNull(relationshipService.getRelationship( r.getId() )) ;
+
+
+        programInstanceService.deleteProgramInstance( programInstance );
+
+        assertNull( programInstanceService.getProgramInstance( programInstance.getId() ) );
+
+        assertNull(relationshipService.getRelationship( r.getId() )) ;
+
+        assertTrue( programInstanceService.programInstanceExistsIncludingDeleted( programInstance.getUid() ) );
+
+        maintenanceService.deleteSoftDeletedProgramInstances();
+
+        assertFalse( programInstanceService.programInstanceExistsIncludingDeleted( programInstance.getUid() ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -40,6 +40,12 @@ import org.hisp.dhis.program.*;
 import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageRecipients;
 import org.hisp.dhis.program.message.ProgramMessageService;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipEntity;
+import org.hisp.dhis.relationship.RelationshipItem;
+import org.hisp.dhis.relationship.RelationshipService;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
@@ -84,6 +90,12 @@ public class MaintenanceServiceTest
 
     @Autowired
     private ProgramStageInstanceService programStageInstanceService;
+    
+    @Autowired
+    private RelationshipService relationshipService;
+    
+    @Autowired
+    private RelationshipTypeService relationshipTypeService;
 
     @Autowired
     private MaintenanceService maintenanceService;
@@ -209,5 +221,58 @@ public class MaintenanceServiceTest
         maintenanceService.deleteSoftDeletedProgramInstances();
 
         assertFalse( programInstanceService.programInstanceExistsIncludingDeleted( programInstance.getUid() ) );
+    }
+    
+    @Test
+    public void testDeleteSoftDeletedProgramStageInstanceLinkedToARelationshipItem()
+    {
+       
+        RelationshipType rType= createRelationshipType( 'A' );
+        rType.getFromConstraint().setRelationshipEntity( RelationshipEntity.PROGRAM_STAGE_INSTANCE );
+        rType.getFromConstraint().setProgram( program );
+        rType.getFromConstraint().setProgramStage( program.getProgramStageByStage( 1 ) );
+        
+        rType.getToConstraint().setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+        rType.getFromConstraint().setTrackedEntityType( entityInstance.getTrackedEntityType() );
+        
+        relationshipTypeService.addRelationshipType( rType );
+        
+        ProgramStageInstance programStageInstanceA = new ProgramStageInstance( programInstance,
+            program.getProgramStageByStage( 1 ) );
+        programStageInstanceA.setDueDate( enrollmentDate );
+        programStageInstanceA.setUid( "UID-A" );
+
+        long idA = programStageInstanceService.addProgramStageInstance( programStageInstanceA );
+        
+        Relationship r = new Relationship();
+        RelationshipItem rItem1 = new RelationshipItem();
+        rItem1.setProgramStageInstance( programStageInstanceA );
+      
+        
+        RelationshipItem rItem2 = new RelationshipItem();
+        rItem2.setTrackedEntityInstance( entityInstance );
+        
+        r.setFrom( rItem1 );
+        r.setTo( rItem2 );
+        r.setRelationshipType( rType );
+        
+        relationshipService.addRelationship( r );
+
+        assertNotNull( programStageInstanceService.getProgramStageInstance( idA ) );
+        
+        assertNotNull(relationshipService.getRelationship( r.getId() )) ;
+
+
+        programStageInstanceService.deleteProgramStageInstance( programStageInstanceA );
+
+        assertNull( programStageInstanceService.getProgramStageInstance( idA ) );
+        
+        assertNull(relationshipService.getRelationship( r.getId() )) ;
+        
+        assertTrue( programStageInstanceService.programStageInstanceExistsIncludingDeleted( programStageInstanceA.getUid() ) );
+
+        maintenanceService.deleteSoftDeletedProgramStageInstances();
+
+        assertFalse( programStageInstanceService.programStageInstanceExistsIncludingDeleted( programStageInstanceA.getUid() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.relationship;
 
 import java.util.Collection;
 
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.springframework.stereotype.Component;
@@ -67,6 +68,21 @@ public class RelationshipDeletionHandler
     {
         Collection<Relationship> relationships = relationshipService
             .getRelationshipsByTrackedEntityInstance( entityInstance, false );
+
+        if ( relationships != null )
+        {
+            for ( Relationship relationship : relationships )
+            {
+                relationshipService.deleteRelationship( relationship );
+            }
+        }
+    }
+    
+    @Override
+    public void deleteProgramStageInstance( ProgramStageInstance programStageInstance )
+    {
+        Collection<Relationship> relationships = relationshipService
+            .getRelationshipsByProgramStageInstance( programStageInstance, false );
 
         if ( relationships != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.relationship;
 
 import java.util.Collection;
 
+import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -92,6 +93,22 @@ public class RelationshipDeletionHandler
             }
         }
     }
+    
+    @Override
+    public void deleteProgramInstance( ProgramInstance programInstance )
+    {
+        Collection<Relationship> relationships = relationshipService
+            .getRelationshipsByProgramInstance( programInstance, false );
+
+        if ( relationships != null )
+        {
+            for ( Relationship relationship : relationships )
+            {
+                relationshipService.deleteRelationship( relationship );
+            }
+        }
+    }
+
 
     @Override
     public String allowDeleteRelationshipType( RelationshipType relationshipType )

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_17__Remove_referenced_relationships_from_soft_deleted_events_and_enrollments.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_17__Remove_referenced_relationships_from_soft_deleted_events_and_enrollments.sql
@@ -1,0 +1,23 @@
+update relationship
+	set from_relationshipitemid = null, 
+		to_relationshipitemid = null
+	where from_relationshipitemid in (select relationshipitemid from relationshipitem ri 
+										left join programstageinstance psi on ri.programstageinstanceid = psi.programstageinstanceid 
+										where psi.deleted=true  )
+		or to_relationshipitemid in (select relationshipitemid from relationshipitem ri 
+										left join programstageinstance psi on ri.programstageinstanceid = psi.programstageinstanceid 
+										where psi.deleted=true  );
+
+update relationship 
+	set from_relationshipitemid = null,
+		to_relationshipitemid = null 
+	where from_relationshipitemid in (select relationshipitemid from relationshipitem ri 
+										left join programinstance pi on ri.programinstanceid = pi.programinstanceid 
+										where pi.deleted=true  )
+		or to_relationshipitemid in (select relationshipitemid from relationshipitem ri 
+										left join programinstance pi on ri.programinstanceid = pi.programinstanceid 
+										where pi.deleted=true );
+
+delete from relationshipitem where relationshipid in (select relationshipid from relationship where from_relationshipitemid is null or to_relationshipitemid is null );
+
+delete from relationship where from_relationshipitemid is null or to_relationshipitemid is null;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
@@ -479,7 +479,7 @@ public class HibernateDbmsManager
     {
         try
         {
-            jdbcTemplate.update( "update relationshipitem set relationshipid = null; delete from relationship; delete from relationshipitem" );
+            jdbcTemplate.update( "update relationshipitem set relationshipid = null; delete from relationship; delete from relationshipitem; update relationshiptype set from_relationshipconstraintid = null,to_relationshipconstraintid = null; delete from relationshipconstraint; delete from relationshiptype;" );
         }
         catch ( BadSqlGrammarException ex )
         {


### PR DESCRIPTION
Remove associated relationships when soft deleting events/enrollments to avoid constraint issues when hard deleting them. Also added a flyway script to remove historically soft deleted events/enrollments