### PR TITLE
perf: reduce number of Org Units fetched from DB on Tracker Import

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplier.java
@@ -1,0 +1,114 @@
+package org.hisp.dhis.dxf2.events.importer.context;
+
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.NotImplementedException;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.events.event.Event;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Component( "workContextProgramOrgUnitsSupplier" )
+public class ProgramOrgUnitSupplier extends AbstractSupplier<Map<Long, List<Long>>>
+{
+    public ProgramOrgUnitSupplier( NamedParameterJdbcTemplate jdbcTemplate )
+    {
+        super( jdbcTemplate );
+    }
+
+    public Map<Long, List<Long>> get( ImportOptions importOptions, List<Event> events,
+        Map<String, OrganisationUnit> orgUniMap )
+    {
+        if ( events == null )
+        {
+            return new HashMap<>();
+        }
+
+        //
+        // Collect all the org unit IDs to pass as SQL query
+        // argument
+        //
+        final Set<Long> orgUnitIds = orgUniMap.values().stream().map( BaseIdentifiableObject::getId )
+            .collect( Collectors.toSet() );
+
+        if ( isEmpty( orgUnitIds ) )
+        {
+            return new HashMap<>();
+        }
+
+        final String sql = "select programid, organisationunitid from program_organisationunits where organisationunitid in ( :ids )";
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue( "ids", orgUnitIds );
+
+        return jdbcTemplate.query( sql, parameters, rs -> {
+
+            Map<Long, List<Long>> map = new HashMap<>();
+            while ( rs.next() )
+            {
+                final Long pid = rs.getLong( "programid" );
+                final Long ouid = rs.getLong( "organisationunitid" );
+
+                if ( map.containsKey( pid ) )
+                {
+                    map.get( pid ).add( ouid );
+                }
+                else
+                {
+                    map.put( pid, ImmutableList.of( ouid ));
+                }
+            }
+
+            return map;
+        } );
+
+    }
+
+    @Override
+    public Map<Long, List<Long>> get( ImportOptions importOptions, List<Event> events )
+    {
+        throw new NotImplementedException( "Use other get method" );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplier.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.dxf2.common.ImportOptions;
@@ -46,6 +45,8 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * @author Luciano Fiandesio
@@ -97,7 +98,9 @@ public class ProgramOrgUnitSupplier extends AbstractSupplier<Map<Long, List<Long
                 }
                 else
                 {
-                    map.put( pid, ImmutableList.of( ouid ));
+                    List<Long> ouids = new ArrayList<>();
+                    ouids.add( ouid );
+                    map.put( pid, ouids );
                 }
             }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
@@ -147,13 +147,13 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
 
     // Caches the entire Program hierarchy, including Program Stages and ACL data
     private final Cache<String, Map<String, Program>> programsCache = new Cache2kBuilder<String, Map<String, Program>>() {}
-        .name( "eventImportProgramCache" + RandomStringUtils.randomAlphabetic( 5 ) )
+        .name( "eventImportProgramCache_" + RandomStringUtils.randomAlphabetic( 5 ) )
         .expireAfterWrite( 1, TimeUnit.MINUTES )
         .build();
 
     // Caches the User Groups and the Users belonging to each group
     private final Cache<Long, Set<User>> userGroupCache = new Cache2kBuilder<Long, Set<User>>() {}
-        .name( "eventImportUserGroupCache" + RandomStringUtils.randomAlphabetic( 5 ) )
+        .name( "eventImportUserGroupCache_" + RandomStringUtils.randomAlphabetic( 5 ) )
         .expireAfterWrite( 5, TimeUnit.MINUTES )
         .permitNullValues( true )
         .loader( new CacheLoader<Long, Set<User>>()
@@ -213,7 +213,7 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
             Map<Long, Set<UserGroupAccess>> programStageUserGroupAccessMap = loadGroupUserAccessesForProgramStages();
             Map<Long, Set<UserGroupAccess>> tetUserGroupAccessMap = loadGroupUserAccessesForTrackedEntityTypes();
 
-            aggregateProgramAndAclData( programMap, loadOrgUnits(), programUserAccessMap, programUserGroupAccessMap,
+            aggregateProgramAndAclData( programMap, programUserAccessMap, programUserGroupAccessMap,
                 tetUserAccessMap, tetUserGroupAccessMap,
                 programStageUserAccessMap, programStageUserGroupAccessMap,
                 loadProgramStageDataElementSets() );
@@ -224,7 +224,7 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
         return programMap;
     }
 
-    private void aggregateProgramAndAclData( Map<String, Program> programMap, Map<Long, Set<OrganisationUnit>> ouMap,
+    private void aggregateProgramAndAclData( Map<String, Program> programMap,
         Map<Long, Set<UserAccess>> programUserAccessMap,
         Map<Long, Set<UserGroupAccess>> programUserGroupAccessMap, Map<Long, Set<UserAccess>> tetUserAccessMap,
         Map<Long, Set<UserGroupAccess>> tetUserGroupAccessMap, Map<Long, Set<UserAccess>> programStageUserAccessMap,
@@ -234,7 +234,6 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
 
         for ( Program program : programMap.values() )
         {
-            program.setOrganisationUnits( ouMap.getOrDefault( program.getId(), new HashSet<>() ) );
             program.setUserAccesses( programUserAccessMap.getOrDefault( program.getId(), new HashSet<>() ) );
             program
                 .setUserGroupAccesses( programUserGroupAccessMap.getOrDefault( program.getId(), new HashSet<>() ) );
@@ -280,37 +279,6 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
         return Optional.ofNullable( dataElementSet )
             .orElse( Collections.emptySet() )
             .stream();
-    }
-
-    //
-    // Load a Map of OrgUnits belonging to a Program (key: program id, value: Set of
-    // OrgUnits)
-    //
-    private Map<Long, Set<OrganisationUnit>> loadOrgUnits()
-    {
-        final String sql = "select p.programid, ou.organisationunitid, ou.uid, ou.code, ou.name, ou.attributevalues "
-            + "from program_organisationunits p "
-            + "join organisationunit ou on p.organisationunitid = ou.organisationunitid order by programid";
-
-        return jdbcTemplate.query( sql, ( ResultSet rs ) -> {
-            Map<Long, Set<OrganisationUnit>> results = new HashMap<>();
-            long programId = 0;
-            while ( rs.next() )
-            {
-                if ( programId != rs.getLong( PROGRAM_ID ) )
-                {
-                    Set<OrganisationUnit> ouSet = new HashSet<>();
-                    ouSet.add( toOrganisationUnit( rs ) );
-                    results.put( rs.getLong( PROGRAM_ID ), ouSet );
-                    programId = rs.getLong( PROGRAM_ID );
-                }
-                else
-                {
-                    results.get( rs.getLong( PROGRAM_ID ) ).add( toOrganisationUnit( rs ) );
-                }
-            }
-            return results;
-        } );
     }
 
     private Map<Long, Set<UserAccess>> loadUserAccessesForPrograms()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContext.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.events.importer.context;
 
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifierBasedOnIdScheme;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -134,6 +135,13 @@ public class WorkContext
     private final Map<String, User> assignedUserMap;
 
     private final Map<String, Note> notesMap;
+
+    /**
+     * Holds a Map of Program ID (primary key) and List of Org Unit ID associated to
+     * each program. Note that the List only contains the Org Unit ID of org units
+     * that are specified in the payload.
+     */
+    private final Map<Long, List<Long>> programWithOrgUnitsMap;
 
     /**
      * Services / components

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplierTest.java
@@ -1,0 +1,75 @@
+package org.hisp.dhis.dxf2.events.importer.context;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.events.event.Event;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.junit.Before;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Luciano Fiandesio
+ */
+public class ProgramOrgUnitSupplierTest extends AbstractSupplierTest<Long>
+{
+    private ProgramOrgUnitSupplier subject;
+
+    @Before
+    public void setUp()
+    {
+        this.subject = new ProgramOrgUnitSupplier( jdbcTemplate );
+    }
+
+    @Override
+    public void verifySupplier()
+        throws SQLException
+    {
+        // Org Unit //
+        OrganisationUnit ou1 = new OrganisationUnit();
+        ou1.setId( 1 );
+        ou1.setUid( "abcded" );
+
+        OrganisationUnit ou2 = new OrganisationUnit();
+        ou2.setId( 2 );
+        ou2.setUid( "fgfgfg" );
+
+        // create 2 events to import - each one pointing to a different org unit
+        Event event = new Event();
+        event.setUid( CodeGenerator.generateUid() );
+        event.setOrgUnit( "abcded" );
+
+        Event event2 = new Event();
+        event2.setUid( CodeGenerator.generateUid() );
+        event2.setOrgUnit( "fgfgfg" );
+
+        Map<String, OrganisationUnit> organisationUnitMap = new HashMap<>();
+        organisationUnitMap.put( event.getOrgUnit(), ou1 );
+        organisationUnitMap.put( event.getOrgUnit(), ou2 );
+
+        when( mockResultSet.next() ).thenReturn( true ).thenReturn( true ).thenReturn( false );
+
+        when( mockResultSet.getLong( "programid" ) ).thenReturn( 100L );
+        when( mockResultSet.getLong( "organisationunitid" ) ).thenReturn( 1L, 2L );
+
+        // mock result-set extraction
+        mockResultSetExtractor( mockResultSet );
+
+        final Map<Long, List<Long>> longListMap = subject.get( ImportOptions.getDefaultImportOptions(),
+            ImmutableList.of( event, event2 ), organisationUnitMap );
+
+        assertThat( longListMap.keySet(), hasSize( 1 ) );
+        assertThat( longListMap.get( 100L ), hasSize( 2 ) );
+        assertThat( longListMap.get( 100L ), containsInAnyOrder( 1L, 2L ) );
+    }
+}


### PR DESCRIPTION
This PR modifies the Event import code that was refactored in version 2.35 and optimmizes the check to verify if an Event's Org Unit is part of the Event's Program Org Units List.
Programs are now stored in the `WorkContext` without the "link" to Organization Units.
A new, dedicated data structure is created to map Program to Org Units - using only Org Units effectively specified in the payload.

This change is required to minimize memory allocation and SQL exec time when a Program has a very large (> 10.000) Org Units associated to it.

ref: DHIS2-10139