### PR TITLE
fix: Add error handling for cast of non-numeric data during outlier detection

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode
     E2204( "Threshold must be a positive number" ),
     E2205( "Max results must be a positive number" ),
     E2206( "Max results exceeds the allowed max limit: `{0}`" ),
+    E2207( "Non-numeric data values encountered during outlier value detection" ),
 
     /* Security */
     E3000( "User `{0}` is not allowed to create objects of type {1}." ),

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionManager.java
@@ -146,7 +146,7 @@ public class OutlierDetectionManager
         }
         catch ( DataIntegrityViolationException ex )
         {
-            // From casting non-numeric data to double precision, faster than pre-filtering
+            // Casting non-numeric data to double, catching exception is faster than filtering
 
             throw new IllegalQueryException( ErrorCode.E2207 );
         }

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionManager.java
@@ -35,11 +35,15 @@ import java.util.Date;
 import java.util.List;
 
 import org.hisp.dhis.calendar.Calendar;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
 import org.hisp.dhis.outlierdetection.OutlierValue;
 import org.hisp.dhis.period.PeriodType;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -136,8 +140,27 @@ public class OutlierDetectionManager
 
         final Calendar calendar = PeriodType.getCalendar();
 
-        return jdbcTemplate.query( sql, params, ( rs, rowNum ) -> {
+        try
+        {
+            return jdbcTemplate.query( sql, params, getRowMapper( calendar ) );
+        }
+        catch ( DataIntegrityViolationException ex )
+        {
+            // From casting non-numeric data to double precision, faster than pre-filtering
 
+            throw new IllegalQueryException( ErrorCode.E2207 );
+        }
+    }
+
+    /**
+     * Returns a {@link RowMapper} for {@link OutlierValue}.
+     *
+     * @param calendar the {@link Calendar}.
+     * @return a {@link RowMapper}.
+     */
+    private RowMapper<OutlierValue> getRowMapper( final Calendar calendar )
+    {
+        return ( rs, rowNum ) -> {
             final OutlierValue outlier = new OutlierValue();
             outlier.setDe( rs.getString( "de_uid" ) );
             outlier.setDeName( rs.getString( "de_name" ) );
@@ -156,9 +179,8 @@ public class OutlierDetectionManager
             outlier.setLowerBound( rs.getDouble( "lower_bound" ) );
             outlier.setUpperBound( rs.getDouble( "upper_bound" ) );
             return outlier;
-        } );
+        };
     }
-
     /**
      * Returns the ISO period name for the given {@link ResultSet} row.
      *


### PR DESCRIPTION
Catches error from cast of non-numeric data during outlier detection. This approach is faster than filtering out non-numeric data with regexp matching, although might lead to error responses where the filtering approach would return a result.