### PR TITLE
fix: add config key to disable Audit scheduler

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfig.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfig.java
@@ -28,6 +28,15 @@ package org.hisp.dhis.artemis.config;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static org.hisp.dhis.artemis.ProducerConfiguration.ProducerConfigurationBuilder;
+import static org.hisp.dhis.external.conf.ConfigurationKey.AUDIT_USE_INMEMORY_QUEUE_ENABLED;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
@@ -48,13 +57,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.core.JmsTemplate;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.DeliveryMode;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.hisp.dhis.artemis.ProducerConfiguration.ProducerConfigurationBuilder;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -210,7 +212,6 @@ public class ArtemisConfig
     public ProducerConfiguration producerConfiguration()
     {
         return ProducerConfigurationBuilder.aProducerConfiguration()
-            .withUseQueue( true ) // TODO this should come from configuration
-            .build();
+            .withUseQueue( this.dhisConfig.isEnabled( AUDIT_USE_INMEMORY_QUEUE_ENABLED ) ).build();
     }
 }

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -84,6 +84,7 @@ public enum ConfigurationKey
     ARTEMIS_PASSWORD( "artemis.password", "guest", true ),
     ARTEMIS_EMBEDDED_SECURITY( "artemis.embedded.security", "false" ),
     ARTEMIS_EMBEDDED_PERSISTENCE( "artemis.embedded.persistence", "false" ),
+    AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", "off", false ),
     LOGGING_FILE_MAX_SIZE( "logging.file.max_size", "100MB" ),
     LOGGING_FILE_MAX_ARCHIVES( "logging.file.max_archives", "0" ),
     SERVER_BASE_URL( "server.base.url", "", false ),


### PR DESCRIPTION
Adds a new config key `audit.inmemory-queue.enabled` that enable/disable the Audit Scheduler.
The default value is "off".
This config key already exists in 2.34 and 2.35.