### PR TITLE
fix(push-analysis): [2.34] don't render pivot table visualization as img (DHIS2-10166)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/resources/push-analysis-main-html.vm
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/resources/push-analysis-main-html.vm
@@ -51,7 +51,11 @@
                                                 #link ( $itemLink.get( $dashboardItem.getUid() ), "View in Pivot Table app" )
                                             </div>
                                         #else
-                                            #img( $itemHtml.get( $dashboardItem.getUid() ) )
+                                            #if( $dashboardItem.getType() == "PIVOT_TABLE" )
+                                                $itemHtml.get( $dashboardItem.getUid() )
+                                            #else
+                                                #img( $itemHtml.get( $dashboardItem.getUid() ) )
+                                            #end
                                             <div style="padding-top: 10px">
                                                 #if( $dashboardItem.getType() == "MAP" )
                                                     #link ( $itemLink.get( $dashboardItem.getUid() ), "View in Maps  app" )


### PR DESCRIPTION
This prevents push analysis pivot tables from being rendered (incorrectly) as an image:

![Screen Shot 2020-12-21 at 13 53 36](https://user-images.githubusercontent.com/947888/102779623-dbfddb80-4394-11eb-9eb6-439196bfe646.png)

See [DHIS2-10166](https://jira.dhis2.org/browse/DHIS2-10166)

For reference, here is where the HTML generation logic splits - the first branch renders HTML while the second renders the url of a generated image https://github.com/dhis2/dhis2-core/blob/757b281ac024a43da56dc3f6b6bc477fe7f0ca82/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java#L447-L450