### PR TITLE
[2.34] fix: use non static cache for DataElements on Event fetching

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageInstanceService.java
@@ -33,12 +33,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.user.User;
 
 /**
  * @author Abyot Asalefew
@@ -173,7 +171,8 @@ public interface ProgramStageInstanceService
      */
     void auditDataValuesChangesAndHandleFileDataValues( Set<EventDataValue> newDataValues,
         Set<EventDataValue> updatedDataValues, Set<EventDataValue> removedDataValues,
-        Cache<DataElement> dataElementsCache, Set<String> nonAccessibleDataElements, ProgramStageInstance programStageInstance, boolean singleValue );
+        Map<String, DataElement> dataElementsCache, Set<String> nonAccessibleDataElements,
+        ProgramStageInstance programStageInstance, boolean singleValue );
 
     /**
      * Validates EventDataValues, handles files for File EventDataValues and creates audit logs for the upcoming create/save changes.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
@@ -287,7 +287,7 @@ public class DefaultProgramStageInstanceService
     @Transactional
     public void auditDataValuesChangesAndHandleFileDataValues( Set<EventDataValue> newDataValues,
         Set<EventDataValue> updatedDataValues, Set<EventDataValue> removedDataValues,
-        Cache<DataElement> dataElementsCache, Set<String> nonAccessibleDataElements, ProgramStageInstance programStageInstance, boolean singleValue )
+        Map<String, DataElement> dataElementsCache, Set<String> nonAccessibleDataElements, ProgramStageInstance programStageInstance, boolean singleValue )
     {
         Set<EventDataValue> updatedOrNewDataValues = Sets.union( newDataValues, updatedDataValues );
 
@@ -377,14 +377,14 @@ public class DefaultProgramStageInstanceService
     // ---- Audit ----
 
     private void auditDataValuesChanges( Set<EventDataValue> newDataValues, Set<EventDataValue> updatedDataValues,
-        Set<EventDataValue> removedDataValues, Cache<DataElement> dataElementsCache,
+        Set<EventDataValue> removedDataValues, Map<String, DataElement> dataElementsCache,
         ProgramStageInstance programStageInstance )
     {
-        newDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ),
+        newDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ),
             programStageInstance, AuditType.CREATE ) );
-        updatedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ),
+        updatedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ),
             programStageInstance, AuditType.UPDATE ) );
-        removedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ),
+        removedDataValues.forEach( dv -> createAndAddAudit( dv, dataElementsCache.get( dv.getDataElement() ),
             programStageInstance, AuditType.DELETE ) );
     }
 
@@ -403,13 +403,13 @@ public class DefaultProgramStageInstanceService
 
     // ---- File Data Values Handling ----
     private void handleFileDataValueChanges( Set<EventDataValue> newDataValues, Set<EventDataValue> updatedDataValues,
-        Set<EventDataValue> removedDataValues, Cache<DataElement> dataElementsCache )
+        Set<EventDataValue> removedDataValues, Map<String, DataElement> dataElementsCache )
     {
         removedDataValues
-            .forEach( dv -> handleFileDataValueDelete( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ) ) );
+            .forEach( dv -> handleFileDataValueDelete( dv, dataElementsCache.get( dv.getDataElement() ) ) );
         updatedDataValues
-            .forEach( dv -> handleFileDataValueUpdate( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ) ) );
-        newDataValues.forEach( dv -> handleFileDataValueSave( dv, dataElementsCache.get( dv.getDataElement() ).orElse( null ) ) );
+            .forEach( dv -> handleFileDataValueUpdate( dv, dataElementsCache.get( dv.getDataElement() ) ) );
+        newDataValues.forEach( dv -> handleFileDataValueSave( dv, dataElementsCache.get( dv.getDataElement() ) ) );
     }
 
     private void handleFileDataValueUpdate( EventDataValue dataValue, DataElement dataElement )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -31,19 +31,20 @@ package org.hisp.dhis.program;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.audit.UserInfoTestHelper;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.TestCache;
 import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
@@ -99,64 +100,22 @@ public class ProgramStageInstanceServiceTest
     @Autowired
     private TrackedEntityAttributeValueService attributeValueService;
 
-//    @Autowired
-//    private EventDataValueService eventDataValueService;
-
     @Autowired
     private TrackedEntityDataValueAuditService dataValueAuditService;
-
-    private OrganisationUnit organisationUnitA;
-
-    private OrganisationUnit organisationUnitB;
 
     private ProgramStage stageA;
 
     private ProgramStage stageB;
 
-    private ProgramStage stageC;
-
-    private ProgramStage stageD;
-
-    private DataElement dataElementA;
-
     private DataElement dataElementB;
 
     private DataElement dataElementC;
 
-    private DataElement dataElementD;
-
-
-    private ProgramStageDataElement stageDataElementA;
-
-    private ProgramStageDataElement stageDataElementB;
-
-    private ProgramStageDataElement stageDataElementC;
-
-    private ProgramStageDataElement stageDataElementD;
-
-    private Date incidenDate;
-
-    private Date enrollmentDate;
-
     private ProgramInstance programInstanceA;
-
-    private ProgramInstance programInstanceB;
 
     private ProgramStageInstance programStageInstanceA;
 
     private ProgramStageInstance programStageInstanceB;
-
-    private ProgramStageInstance programStageInstanceC;
-
-    private ProgramStageInstance programStageInstanceD1;
-
-    private ProgramStageInstance programStageInstanceD2;
-
-    private TrackedEntityInstance entityInstanceA;
-
-    private TrackedEntityInstance entityInstanceB;
-
-    private Program programA;
 
     private MockI18nFormat mockFormat;
 
@@ -165,7 +124,7 @@ public class ProgramStageInstanceServiceTest
     private EventDataValue eventDataValueC;
     private EventDataValue eventDataValueD;
 
-    private Cache<DataElement> dataElementMap = new TestCache<>();
+    private Map<String, DataElement> dataElementMap = new HashMap<>();
 
     private List<DataElement> dataElements;
 
@@ -174,17 +133,17 @@ public class ProgramStageInstanceServiceTest
     {
         mockFormat = new MockI18nFormat();
 
-        organisationUnitA = createOrganisationUnit( 'A' );
-        organisationUnitService.addOrganisationUnit( organisationUnitA );
+        final OrganisationUnit organisationUnitA = createOrganisationUnit('A');
+        organisationUnitService.addOrganisationUnit(organisationUnitA);
 
-        organisationUnitB = createOrganisationUnit( 'B' );
-        organisationUnitService.addOrganisationUnit( organisationUnitB );
+        final OrganisationUnit organisationUnitB = createOrganisationUnit('B');
+        organisationUnitService.addOrganisationUnit(organisationUnitB);
 
-        entityInstanceA = createTrackedEntityInstance( organisationUnitA );
-        entityInstanceService.addTrackedEntityInstance( entityInstanceA );
+        final TrackedEntityInstance entityInstanceA = createTrackedEntityInstance(organisationUnitA);
+        entityInstanceService.addTrackedEntityInstance(entityInstanceA);
 
-        entityInstanceB = createTrackedEntityInstance( organisationUnitB );
-        entityInstanceService.addTrackedEntityInstance( entityInstanceB );
+        final TrackedEntityInstance entityInstanceB = createTrackedEntityInstance(organisationUnitB);
+        entityInstanceService.addTrackedEntityInstance(entityInstanceB);
 
         TrackedEntityAttribute attribute = createTrackedEntityAttribute( 'A' );
         attribute.setValueType( ValueType.PHONE_NUMBER );
@@ -195,21 +154,21 @@ public class ProgramStageInstanceServiceTest
         attributeValueService.addTrackedEntityAttributeValue( attributeValue );
 
         entityInstanceA.getTrackedEntityAttributeValues().add( attributeValue );
-        entityInstanceService.updateTrackedEntityInstance( entityInstanceA );
+        entityInstanceService.updateTrackedEntityInstance(entityInstanceA);
 
-        /**
+        /*
          * Program A
          */
-        programA = createProgram( 'A', new HashSet<>(), organisationUnitA );
-        programService.addProgram( programA );
+        final Program programA = createProgram('A', new HashSet<>(), organisationUnitA);
+        programService.addProgram(programA);
 
         stageA = createProgramStage( 'A', 0 );
-        stageA.setProgram( programA );
+        stageA.setProgram(programA);
         stageA.setSortOrder( 1 );
 
         programStageService.saveProgramStage( stageA );
 
-        stageB = new ProgramStage( "B", programA );
+        stageB = new ProgramStage( "B", programA);
         stageB.setSortOrder( 2 );
 
         programStageService.saveProgramStage( stageB );
@@ -218,88 +177,88 @@ public class ProgramStageInstanceServiceTest
         programStages.add( stageA );
         programStages.add( stageB );
         programA.setProgramStages( programStages );
-        programService.updateProgram( programA );
+        programService.updateProgram(programA);
 
-        dataElementA = createDataElement( 'A' );
+        final DataElement dataElementA = createDataElement('A');
         dataElementB = createDataElement( 'B' );
         dataElementC = createDataElement( 'C' );
-        dataElementD = createDataElement( 'D' );
+        final DataElement dataElementD = createDataElement('D');
 
-        dataElementService.addDataElement( dataElementA );
+        dataElementService.addDataElement(dataElementA);
         dataElementService.addDataElement( dataElementB );
         dataElementService.addDataElement( dataElementC );
-        dataElementService.addDataElement( dataElementD );
+        dataElementService.addDataElement(dataElementD);
 
-        stageDataElementA = new ProgramStageDataElement( stageA, dataElementA, false, 1 );
-        stageDataElementB = new ProgramStageDataElement( stageA, dataElementB, false, 2 );
-        stageDataElementC = new ProgramStageDataElement( stageB, dataElementA, false, 1 );
-        stageDataElementD = new ProgramStageDataElement( stageB, dataElementB, false, 2 );
+        final ProgramStageDataElement stageDataElementA = new ProgramStageDataElement(stageA, dataElementA, false, 1);
+        final ProgramStageDataElement stageDataElementB = new ProgramStageDataElement(stageA, dataElementB, false, 2);
+        final ProgramStageDataElement stageDataElementC = new ProgramStageDataElement(stageB, dataElementA, false, 1);
+        final ProgramStageDataElement stageDataElementD = new ProgramStageDataElement(stageB, dataElementB, false, 2);
 
-        programStageDataElementService.addProgramStageDataElement( stageDataElementA );
-        programStageDataElementService.addProgramStageDataElement( stageDataElementB );
-        programStageDataElementService.addProgramStageDataElement( stageDataElementC );
-        programStageDataElementService.addProgramStageDataElement( stageDataElementD );
+        programStageDataElementService.addProgramStageDataElement(stageDataElementA);
+        programStageDataElementService.addProgramStageDataElement(stageDataElementB);
+        programStageDataElementService.addProgramStageDataElement(stageDataElementC);
+        programStageDataElementService.addProgramStageDataElement(stageDataElementD);
 
         /*
          * Program B
          */
 
-        Program programB = createProgram( 'B', new HashSet<>(), organisationUnitB );
+        Program programB = createProgram( 'B', new HashSet<>(), organisationUnitB);
         programService.addProgram( programB );
 
-        stageC = new ProgramStage( "C", programB );
+        final ProgramStage stageC = new ProgramStage("C", programB);
         stageC.setSortOrder( 1 );
-        programStageService.saveProgramStage( stageC );
+        programStageService.saveProgramStage(stageC);
 
-        stageD = new ProgramStage( "D", programB );
+        final ProgramStage stageD = new ProgramStage("D", programB);
         stageB.setSortOrder( 2 );
         stageC.setRepeatable( true );
-        programStageService.saveProgramStage( stageD );
+        programStageService.saveProgramStage(stageD);
 
         programStages = new HashSet<>();
-        programStages.add( stageC );
-        programStages.add( stageD );
+        programStages.add(stageC);
+        programStages.add(stageD);
         programB.setProgramStages( programStages );
         programService.updateProgram( programB );
 
-        /**
+        /*
          * Program Instance and Program Stage Instance
          */
 
         DateTime testDate1 = DateTime.now();
         testDate1.withTimeAtStartOfDay();
         testDate1 = testDate1.minusDays( 70 );
-        incidenDate = testDate1.toDate();
+        final Date incidenDate = testDate1.toDate();
 
         DateTime testDate2 = DateTime.now();
         testDate2.withTimeAtStartOfDay();
-        enrollmentDate = testDate2.toDate();
+        final Date enrollmentDate = testDate2.toDate();
 
-        programInstanceA = new ProgramInstance( enrollmentDate, incidenDate, entityInstanceA, programA );
+        programInstanceA = new ProgramInstance(enrollmentDate, incidenDate, entityInstanceA, programA);
         programInstanceA.setUid( "UID-PIA" );
         programInstanceService.addProgramInstance( programInstanceA );
 
-        programInstanceB = new ProgramInstance( enrollmentDate, incidenDate, entityInstanceB, programB );
-        programInstanceService.addProgramInstance( programInstanceB );
+        final ProgramInstance programInstanceB = new ProgramInstance(enrollmentDate, incidenDate, entityInstanceB, programB);
+        programInstanceService.addProgramInstance(programInstanceB);
 
         programStageInstanceA = new ProgramStageInstance( programInstanceA, stageA );
-        programStageInstanceA.setDueDate( enrollmentDate );
+        programStageInstanceA.setDueDate(enrollmentDate);
         programStageInstanceA.setUid( "UID-A" );
 
         programStageInstanceB = new ProgramStageInstance( programInstanceA, stageB );
-        programStageInstanceB.setDueDate( enrollmentDate );
+        programStageInstanceB.setDueDate(enrollmentDate);
         programStageInstanceB.setUid( "UID-B" );
 
-        programStageInstanceC = new ProgramStageInstance( programInstanceB, stageC );
-        programStageInstanceC.setDueDate( enrollmentDate );
+        final ProgramStageInstance programStageInstanceC = new ProgramStageInstance(programInstanceB, stageC);
+        programStageInstanceC.setDueDate(enrollmentDate);
         programStageInstanceC.setUid( "UID-C" );
 
-        programStageInstanceD1 = new ProgramStageInstance( programInstanceB, stageD );
-        programStageInstanceD1.setDueDate( enrollmentDate );
+        final ProgramStageInstance programStageInstanceD1 = new ProgramStageInstance(programInstanceB, stageD);
+        programStageInstanceD1.setDueDate(enrollmentDate);
         programStageInstanceD1.setUid( "UID-D1" );
 
-        programStageInstanceD2 = new ProgramStageInstance( programInstanceB, stageD );
-        programStageInstanceD2.setDueDate( enrollmentDate );
+        final ProgramStageInstance programStageInstanceD2 = new ProgramStageInstance(programInstanceB, stageD);
+        programStageInstanceD2.setDueDate(enrollmentDate);
         programStageInstanceD2.setUid( "UID-D2" );
 
         /*
@@ -319,12 +278,12 @@ public class ProgramStageInstanceServiceTest
         eventDataValueC = new EventDataValue( dataElementC.getUid(), "3", UserInfoTestHelper.testUserInfo( storedBy ) );
         eventDataValueD = new EventDataValue( dataElementD.getUid(), "4", UserInfoTestHelper.testUserInfo( storedBy ) );
 
-        dataElementMap.put( dataElementA.getUid(), dataElementA );
+        dataElementMap.put( dataElementA.getUid(), dataElementA);
         dataElementMap.put( dataElementB.getUid(), dataElementB );
         dataElementMap.put( dataElementC.getUid(), dataElementC );
-        dataElementMap.put( dataElementD.getUid(), dataElementD );
+        dataElementMap.put( dataElementD.getUid(), dataElementD);
 
-        dataElements = new ArrayList<>( dataElementMap.getAll() );
+        dataElements = new ArrayList<>( dataElementMap.values() );
     }
 
     @Test
@@ -414,7 +373,7 @@ public class ProgramStageInstanceServiceTest
 
         programStageInstanceService.completeProgramStageInstance( programStageInstanceA, true, mockFormat, null );
 
-        assertEquals( true, programStageInstanceService.getProgramStageInstance( idA ).isCompleted() );
+        assertTrue( programStageInstanceService.getProgramStageInstance( idA ).isCompleted() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/eventdatavalue/EventDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/eventdatavalue/EventDataValueService.java
@@ -27,12 +27,13 @@ package org.hisp.dhis.dxf2.events.eventdatavalue;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.program.ProgramStageInstance;
+
+import java.util.Map;
 
 
 /**
@@ -51,5 +52,5 @@ public interface EventDataValueService
      * @param dataElementsCache Cache with DataElements related to EventDataValues that are being updated
      */
     void processDataValues( ProgramStageInstance programStageInstance, Event event, boolean singleValue,
-        ImportOptions importOptions, ImportSummary importSummary, Cache<DataElement> dataElementsCache );
+        ImportOptions importOptions, ImportSummary importSummary, Map<String, DataElement> dataElementsCache  );
 }


### PR DESCRIPTION
This PR reverts a change that uses a static Map to cache DataValues when fetching events.
This change was already applied to the branch KSOIDC_2.34, but never ported to 2.34.

backport from: d5c4119d67638d07f8d801c781a3f7f0c525f369