### PR TITLE
fix: use 'bidirectional' property from RelationshipType on validation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessor.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.springframework.stereotype.Component;
@@ -48,6 +49,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor
 {
+
     /**
      * Process the bundle's relationships collection and remove relationships that
      * are duplicated.
@@ -59,7 +61,6 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor
      *
      * REL 1 --- TEI A
      *       --- TEI B
-     *       --- bi = false
      *
      * REL 2 --- TEI A
      *       --- TEI B
@@ -112,30 +113,39 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor
     {
         Predicate<Relationship> validRelationship = rel -> StringUtils.isNotEmpty( rel.getRelationship() )
             && StringUtils.isNotEmpty( rel.getRelationshipType() ) &&
-            rel.getFrom() != null && rel.getTo() != null;
+            rel.getFrom() != null && rel.getTo() != null
+            && getRelationshipType( rel.getRelationshipType(), bundle ) != null;
 
         // Create a map where both key and value must be unique
         BidiMap<String, String> map = new DualHashBidiMap<>();
 
-        // Add a pseudo hash of all relationships to the map. If the relationship is bidirectional, first
+        // Add a pseudo hash of all relationships to the map. If the relationship is
+        // bidirectional, first
         // sort the Relationship Items
         bundle.getRelationships().stream().filter( validRelationship )
-            .forEach( rel -> map.put( rel.getRelationship(), hash( rel ) ) );
+            .forEach( rel -> map.put( rel.getRelationship(), hash( rel, bundle ) ) );
 
         // Remove duplicated Relationships from the bundle, if any
         bundle.getRelationships()
             .removeIf( rel -> validRelationship.test( rel ) && !map.containsKey( rel.getRelationship() ) );
     }
 
-    private String hash( Relationship rel )
+    private String hash( Relationship rel, TrackerBundle bundle )
     {
+        RelationshipType relationshipType = getRelationshipType( rel.getRelationshipType(), bundle );
         return rel.getRelationshipType() + "-"
-            + (rel.isBidirectional() ? sortItems( rel ) : rel.getFrom() + "-" + rel.getTo()) + rel.isBidirectional();
+            + (relationshipType.isBidirectional() ? sortItems( rel ) : rel.getFrom() + "-" + rel.getTo())
+            + relationshipType.isBidirectional();
     }
 
     private String sortItems( Relationship rel )
     {
         return Stream.of( rel.getFrom().toString(), rel.getTo().toString() ).sorted()
             .collect( Collectors.joining( "-" ) );
+    }
+
+    private RelationshipType getRelationshipType( String uid, TrackerBundle bundle )
+    {
+        return bundle.getPreheat().get( RelationshipType.class, uid );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessorTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,23 +22,86 @@ public class DuplicateRelationshipsPreProcessorTest
 {
     private DuplicateRelationshipsPreProcessor preProcessor;
 
+    private TrackerPreheat preheat;
+
+    private final String REL_TYPE_BIDIRECTIONAL_UID = CodeGenerator.generateUid();
+
+    private final String REL_TYPE_NONBIDIRECTIONAL_UID = CodeGenerator.generateUid();
+
     @Before
     public void setUp()
     {
+        preheat = new TrackerPreheat();
+
+        RelationshipType relationshipTypeBidirectional = new RelationshipType();
+        relationshipTypeBidirectional.setUid( REL_TYPE_BIDIRECTIONAL_UID );
+        relationshipTypeBidirectional.setBidirectional( true );
+
+        RelationshipType relationshipTypeNonBidirectional = new RelationshipType();
+        relationshipTypeNonBidirectional.setUid( REL_TYPE_NONBIDIRECTIONAL_UID );
+
+        preheat.put( TrackerIdentifier.UID, relationshipTypeBidirectional );
+        preheat.put( TrackerIdentifier.UID, relationshipTypeNonBidirectional );
+
         this.preProcessor = new DuplicateRelationshipsPreProcessor();
     }
 
+
+    @Test
+    public void test_relationshipIsIgnored_on_null_relType()
+    {
+        String relType = CodeGenerator.generateUid();
+        String fromTeiUid = CodeGenerator.generateUid();
+        String toTeiUid = CodeGenerator.generateUid();
+
+        Relationship relationship1 = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .from( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .build();
+
+        Relationship relationship2 = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .from( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .build();
+
+        TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( this.preheat )
+            .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
+
+        preProcessor.process( bundle );
+
+        assertThat( bundle.getRelationships(), hasSize( 2 ) );
+    }
+
+    /*
+     * Verifies that:
+     * 
+     * - given 2 identical relationships
+     * 
+     * - one is removed
+     */
     @Test
     public void test_on_identical_rels_1_is_removed()
     {
-        String relType = CodeGenerator.generateUid();
+        String relType = REL_TYPE_NONBIDIRECTIONAL_UID;
         String fromTeiUid = CodeGenerator.generateUid();
         String toTeiUid = CodeGenerator.generateUid();
 
         Relationship relationship1 = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .relationshipType( relType )
-            .bidirectional( false )
             .from( RelationshipItem.builder()
                 .trackedEntity( fromTeiUid )
                 .build() )
@@ -47,7 +113,6 @@ public class DuplicateRelationshipsPreProcessorTest
         Relationship relationship2 = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .relationshipType( relType )
-            .bidirectional( false )
             .from( RelationshipItem.builder()
                 .trackedEntity( fromTeiUid )
                 .build() )
@@ -57,6 +122,7 @@ public class DuplicateRelationshipsPreProcessorTest
             .build();
 
         TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
 
         preProcessor.process( bundle );
@@ -64,57 +130,22 @@ public class DuplicateRelationshipsPreProcessorTest
         assertThat( bundle.getRelationships(), hasSize( 1 ) );
     }
 
+    /*
+     * Verifies that:
+     *
+     * - given 2 non-identical relationships
+     *
+     * - none is removed
+     */
     @Test
     public void test_on_different_rels_none_is_removed()
     {
-        String relType = CodeGenerator.generateUid();
-        String fromTeiUid = CodeGenerator.generateUid();
-        String toTeiUid = CodeGenerator.generateUid();
-
-        Relationship relationship1 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( false )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .build();
-
-        Relationship relationship2 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( false )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .enrollment( toTeiUid )
-                        .build() )
-                .build();
-
-        TrackerBundle bundle = TrackerBundle.builder()
-                .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
-
-        preProcessor.process( bundle );
-
-        assertThat( bundle.getRelationships(), hasSize( 2 ) );
-    }
-
-    @Test
-    public void test_on_identical_but_inverted_rels_none_is_removed()
-    {
-
-        String relType = CodeGenerator.generateUid();
         String fromTeiUid = CodeGenerator.generateUid();
         String toTeiUid = CodeGenerator.generateUid();
 
         Relationship relationship1 = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType )
-            .bidirectional( false )
+            .relationshipType( REL_TYPE_NONBIDIRECTIONAL_UID )
             .from( RelationshipItem.builder()
                 .trackedEntity( fromTeiUid )
                 .build() )
@@ -125,17 +156,17 @@ public class DuplicateRelationshipsPreProcessorTest
 
         Relationship relationship2 = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType )
-            .bidirectional( false )
+            .relationshipType( REL_TYPE_NONBIDIRECTIONAL_UID )
             .from( RelationshipItem.builder()
-                .trackedEntity( toTeiUid )
+                .trackedEntity( fromTeiUid )
                 .build() )
             .to( RelationshipItem.builder()
-                .trackedEntity( fromTeiUid )
+                .enrollment( toTeiUid )
                 .build() )
             .build();
 
         TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
 
         preProcessor.process( bundle );
@@ -143,120 +174,146 @@ public class DuplicateRelationshipsPreProcessorTest
         assertThat( bundle.getRelationships(), hasSize( 2 ) );
     }
 
+    /*
+     * Verifies that:
+     *
+     * - given 2 relationships having identical but "inverted" data
+     *
+     * - none is removed
+     */
     @Test
-    public void test_on_identical_rels_but_inverted_both_bi_1_is_removed()
+    public void test_on_identical_but_inverted_rels_none_is_removed()
     {
-        String relType = CodeGenerator.generateUid();
+        String relType = REL_TYPE_NONBIDIRECTIONAL_UID;
         String fromTeiUid = CodeGenerator.generateUid();
         String toTeiUid = CodeGenerator.generateUid();
 
         Relationship relationship1 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( true )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .build();
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .bidirectional( false )
+            .from( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .build();
 
         Relationship relationship2 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( true )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .build();
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .bidirectional( false )
+            .from( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .build();
 
         TrackerBundle bundle = TrackerBundle.builder()
-                .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
-
-        preProcessor.process( bundle );
-
-        assertThat( bundle.getRelationships(), hasSize( 1 ) );
-    }
-
-    @Test
-    public void test_on_identical_rels_both_bi_1_is_removed()
-    {
-        String relType = CodeGenerator.generateUid();
-        String fromTeiUid = CodeGenerator.generateUid();
-        String toTeiUid = CodeGenerator.generateUid();
-
-        Relationship relationship1 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( true )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .build();
-
-        Relationship relationship2 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( true )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .build();
-
-        TrackerBundle bundle = TrackerBundle.builder()
-                .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
-
-        preProcessor.process( bundle );
-
-        assertThat( bundle.getRelationships(), hasSize( 1 ) );
-    }
-
-    @Test
-    public void identical_rels_one_bi_other_uni_none_is_removed()
-    {
-        String relType = CodeGenerator.generateUid();
-        String fromTeiUid = CodeGenerator.generateUid();
-        String toTeiUid = CodeGenerator.generateUid();
-
-        Relationship relationship1 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( false )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .build();
-
-        Relationship relationship2 = Relationship.builder()
-                .relationship( CodeGenerator.generateUid() )
-                .relationshipType( relType )
-                .bidirectional( true )
-                .from( RelationshipItem.builder()
-                        .trackedEntity( fromTeiUid )
-                        .build() )
-                .to( RelationshipItem.builder()
-                        .trackedEntity( toTeiUid )
-                        .build() )
-                .build();
-
-        TrackerBundle bundle = TrackerBundle.builder()
-                .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
+            .preheat( this.preheat )
+            .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
 
         preProcessor.process( bundle );
 
         assertThat( bundle.getRelationships(), hasSize( 2 ) );
+    }
+
+    /*
+     * Verifies that:
+     *
+     * - given 2 identical relationships having identical but "inverted" data
+     * 
+     * - and relationship type's bidirectional property = true
+     *
+     * - none is removed
+     */
+    @Test
+    public void test_on_identical_rels_but_inverted_type_bi_1_is_removed()
+    {
+        String relType = REL_TYPE_BIDIRECTIONAL_UID;
+        String fromTeiUid = CodeGenerator.generateUid();
+        String toTeiUid = CodeGenerator.generateUid();
+
+        Relationship relationship1 = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .from( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .build();
+
+        Relationship relationship2 = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .from( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .build();
+
+        TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( this.preheat )
+            .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
+
+        preProcessor.process( bundle );
+
+        assertThat( bundle.getRelationships(), hasSize( 1 ) );
+    }
+
+    /*
+     * Verifies that:
+     *
+     * - given 2 identical relationships
+     *
+     * - and relationship type's bidirectional property = true
+     *
+     * - one is removed
+     */
+    @Test
+    public void test_on_identical_rels_relType_bi_1_is_removed()
+    {
+        String relType = REL_TYPE_BIDIRECTIONAL_UID;
+        String fromTeiUid = CodeGenerator.generateUid();
+        String toTeiUid = CodeGenerator.generateUid();
+
+        Relationship relationship1 = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .bidirectional( true )
+            .from( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .build();
+
+        Relationship relationship2 = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .relationshipType( relType )
+            .bidirectional( true )
+            .from( RelationshipItem.builder()
+                .trackedEntity( fromTeiUid )
+                .build() )
+            .to( RelationshipItem.builder()
+                .trackedEntity( toTeiUid )
+                .build() )
+            .build();
+
+        TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( this.preheat )
+            .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
+
+        preProcessor.process( bundle );
+
+        assertThat( bundle.getRelationships(), hasSize( 1 ) );
     }
 }


### PR DESCRIPTION
Fixes a bug during Tracker Import relationship "deduplication", where the wrong "bidirectional" property was checked upon validation.
The correct property to check is on the `RelationshipType` object, rather than the `Relationship` object.

ref: DHIS2-9965