### PR TITLE
fix: DHIS2-9839: Data elements sorting in event report.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -30,9 +30,13 @@ package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
-import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_NAME_COL_SUFFIX;
 import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_GEOMETRY_COL_SUFFIX;
-import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.*;
+import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_NAME_COL_SUFFIX;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ORG_UNIT_STRUCT_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
 import static org.hisp.dhis.system.util.MathUtils.getRounded;
 
@@ -152,13 +156,14 @@ public abstract class AbstractJdbcEventAnalyticsManager
         return sql;
     }
 
-    private String getSortColumns(EventQueryParams params , SortOrder order) {
-
+    private String getSortColumns( EventQueryParams params, SortOrder order )
+    {
         String sql = "";
 
         for ( DimensionalItemObject item : order.equals( SortOrder.ASC ) ? params.getAsc() : params.getDesc() )
         {
-            if ( DimensionItemType.PROGRAM_INDICATOR.equals( item.getDimensionItemType() ) )
+            if ( DimensionItemType.PROGRAM_INDICATOR.equals( item.getDimensionItemType() )
+                || DimensionItemType.DATA_ELEMENT.equals( item.getDimensionItemType() ) )
             {
                 sql += quote( item.getUid() );
             }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -346,7 +346,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         final String sql = subject.getEventsOrEnrollmentsSql( eventQueryParamsBuilder.build(), 100 );
 
         assertThat( sql, containsString(
-            "order by \"" + piA.getUid() + "\" asc,ax.\"" + deA.getUid() + "\" asc,\"" + piB.getUid() + "\"" ) );
+            "order by \"" + piA.getUid() + "\" asc,\"" + deA.getUid() + "\" asc,\"" + piB.getUid() + "\"" ) );
     }
 
     private void verifyFirstOrLastAggregationTypeSubquery( AnalyticsAggregationType analyticsAggregationType )


### PR DESCRIPTION
This change will allow data elements to be sorted as expected. The query below illustrates how it works.

`/api/29/analytics/enrollments/query/IpHINAT79UW.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&dimension=ZzYYXq4fJie.sj3j9Hwc7so&dimension=ZzYYXq4fJie.lNNb3truQoi&stage=ZzYYXq4fJie&displayProperty=NAME&outputType=ENROLLMENT&desc=ZzYYXq4fJie.sj3j9Hwc7so&pageSize=100&page=1`