### PR TITLE
fix: get Program from preheat using Program from ProgramStage

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.tracker.validation.ValidationFailFastException;
 
@@ -194,5 +195,10 @@ public class ValidationErrorReporter
     public boolean isInvalid( TrackerType trackerType, String uid )
     {
         return this.invalidDTOs.getOrDefault( trackerType, new ArrayList<>() ).contains( uid );
+    }
+    
+    public TrackerPreheat getPreheat()
+    {
+        return this.getValidationContext().getBundle().getPreheat();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/service/DefaultTrackerImportAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/service/DefaultTrackerImportAccessManager.java
@@ -37,8 +37,6 @@ import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_TYPE_CANT_BE_NULL;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.USER_CANT_BE_NULL;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -54,6 +52,9 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -220,10 +221,11 @@ public class DefaultTrackerImportAccessManager
         {
             checkProgramStageWriteAccess( reporter, user, programStage );
             // at this point the link between program and program stage should be validated
-            // so it is safe to fetch the Program from the pre-heat
-            final String identifier = reporter.getValidationContext().getIdentifiers().getProgramIdScheme()
-                .getIdentifier( programStage.getProgram() );
-            final Program program = reporter.getValidationContext().getProgram( identifier );
+            // so it is safe to fetch the Program from the program stage
+            final String programUid = programStage.getProgram().getUid();
+            final Program program = reporter.getPreheat().getAll( Program.class )
+                .stream().filter( p -> p.getUid().equals( programUid ) ).findAny()
+                .orElseThrow( () -> new NullPointerException( PROGRAM_CANT_BE_NULL ) );
 
             checkProgramReadAccess( reporter, user, program );
 


### PR DESCRIPTION
Make sures that during Event write access validation, the Event's Program is correctly
extracted from the pre-heat, using the Program UID associated to the Event's declared Program Stage.
This resolves an issue with importing an Event using `programIdScheme=ATTRIBUTE`.

ref: DHIS2-9895