### PR TITLE
fix: unignore test after hibernate upgrade

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -99,8 +99,6 @@ public class ShowErrorWarningImplementerTest
 
     private TrackerBundle bundle;
 
-    private TrackerPreheat preheat;
-
     private ProgramStage programStage;
 
     @Override
@@ -110,7 +108,7 @@ public class ShowErrorWarningImplementerTest
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
         programStage.setUid( PROGRAM_STAGE_ID );
 
-        preheat = new TrackerPreheat();
+        TrackerPreheat preheat = new TrackerPreheat();
         preheat.put( TrackerIdentifier.UID, programStage );
 
         bundle = new TrackerBundle();
@@ -122,7 +120,6 @@ public class ShowErrorWarningImplementerTest
 
         programStage = createProgramStage( 'A', 0 );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
-//        when( preheat.get( ProgramStage.class, PROGRAM_STAGE_ID ) ).thenReturn( programStage );
     }
 
     @Test
@@ -207,13 +204,12 @@ public class ShowErrorWarningImplementerTest
 
         assertEquals( numberOfErrors, errors.size() );
 
-        errors.entrySet().stream()
-            .forEach( e -> assertTrue( e.getValue().size() == 1 ) );
+        errors.forEach( ( key, value ) -> assertEquals( 1, value.size() ) );
 
         errors
             .values()
             .stream()
-            .flatMap( e -> e.stream() )
+            .flatMap( Collection::stream )
             .forEach( e -> assertTrue( e.contains( prefix + CONTENT + " " + EVALUATED_DATA ) ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -1,3 +1,5 @@
+package org.hisp.dhis.tracker.programrule;
+
 /*
  * Copyright (c) 2004-2020, University of Oslo
  * All rights reserved.
@@ -26,15 +28,27 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.tracker.programrule;
+import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
+import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ValidationStrategy;
-import org.hisp.dhis.rules.models.*;
+import org.hisp.dhis.rules.models.RuleAction;
+import org.hisp.dhis.rules.models.RuleActionErrorOnCompletion;
+import org.hisp.dhis.rules.models.RuleActionShowError;
+import org.hisp.dhis.rules.models.RuleActionShowWarning;
+import org.hisp.dhis.rules.models.RuleActionWarningOnCompletion;
+import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
@@ -42,21 +56,10 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
-import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
-import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
-
-@RunWith( MockitoJUnitRunner.class )
-@Ignore
 public class ShowErrorWarningImplementerTest
     extends DhisSpringTest
 {
@@ -96,7 +99,6 @@ public class ShowErrorWarningImplementerTest
 
     private TrackerBundle bundle;
 
-    @Mock
     private TrackerPreheat preheat;
 
     private ProgramStage programStage;
@@ -104,6 +106,13 @@ public class ShowErrorWarningImplementerTest
     @Override
     protected void setUpTest()
     {
+        programStage = createProgramStage( 'A', 0 );
+        programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
+        programStage.setUid( PROGRAM_STAGE_ID );
+
+        preheat = new TrackerPreheat();
+        preheat.put( TrackerIdentifier.UID, programStage );
+
         bundle = new TrackerBundle();
         bundle.setEvents( getEvents() );
         bundle.setEnrollments( getEnrollments() );
@@ -113,7 +122,7 @@ public class ShowErrorWarningImplementerTest
 
         programStage = createProgramStage( 'A', 0 );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
-        when( preheat.get( ProgramStage.class, PROGRAM_STAGE_ID ) ).thenReturn( programStage );
+//        when( preheat.get( ProgramStage.class, PROGRAM_STAGE_ID ) ).thenReturn( programStage );
     }
 
     @Test
@@ -125,6 +134,7 @@ public class ShowErrorWarningImplementerTest
     }
 
     @Test
+    @Ignore
     public void testValidateShowErrorRuleActionForEventsWithValidationStrategyOnComplete()
     {
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );


### PR DESCRIPTION
Following the Hibernate upgrade (https://github.com/dhis2/dhis2-core/commit/5e4669b4c89c809989ea600900735dd71baa86e2),
 one test was ignored.
This PR remove the `@Ignore` annotation from the test class and fixes the underlying issue.
Note that one test method is still ignored.