### PR TITLE
fix(push-analysis): [2.34] correct conditional when checking visualization type (DHIS2-10166)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/resources/push-analysis-main-html.vm
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/resources/push-analysis-main-html.vm
@@ -51,7 +51,7 @@
                                                 #link ( $itemLink.get( $dashboardItem.getUid() ), "View in Pivot Table app" )
                                             </div>
                                         #else
-                                            #if( $dashboardItem.getType() == "PIVOT_TABLE" )
+                                            #if( $dashboardItem.getType() == "VISUALIZATION" && $dashboardItem.getVisualization().getType() == "PIVOT_TABLE" )
                                                 $itemHtml.get( $dashboardItem.getUid() )
                                             #else
                                                 #img( $itemHtml.get( $dashboardItem.getUid() ) )


### PR DESCRIPTION
Corrected fix for #6972, the visualization type is not the same as the dashboard item type (we should definitely simplify this distinction)

After this change:

<img width="634" alt="Screen Shot 2020-12-23 at 17 47 18" src="https://user-images.githubusercontent.com/947888/103019376-ff688800-4546-11eb-9125-efb55e6ccffd.png">
