### PR TITLE
feat: [TECH-519] add a configuration for enabling repair before flyway migration (master)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/DhisFlyway.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/DhisFlyway.java
@@ -1,0 +1,30 @@
+package org.hisp.dhis.db.migration.config;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.output.MigrateResult;
+
+public class DhisFlyway
+    extends
+    Flyway
+{
+    private boolean repairBeforeMigrate = false;
+
+    public DhisFlyway( Configuration configuration, boolean repairBeforeMigrate )
+    {
+        super( configuration );
+        this.repairBeforeMigrate = repairBeforeMigrate;
+    }
+
+    @Override
+    public MigrateResult migrate()
+        throws FlywayException
+    {
+        if ( repairBeforeMigrate )
+        {
+            super.repair();
+        }
+        return super.migrate();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/DhisFlyway.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/DhisFlyway.java
@@ -1,10 +1,44 @@
 package org.hisp.dhis.db.migration.config;
 
+/*
+ * Copyright (c) 2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.output.MigrateResult;
 
+/**
+ * Customised Flyway to optionally run repair before migrate based on a flag.
+ * 
+ * @author Ameen Mohamed
+ *
+ */
 public class DhisFlyway
     extends
     Flyway

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.Profile;
 import javax.sql.DataSource;
 
 import static org.hisp.dhis.external.conf.ConfigurationKey.FLYWAY_OUT_OF_ORDER_MIGRATION;
+import static org.hisp.dhis.external.conf.ConfigurationKey.FLYWAY_REPAIR_BEFORE_MIGRATION;
 
 /**
  * @author Luciano Fiandesio
@@ -69,7 +70,7 @@ public class FlywayConfig
         classicConfiguration.setMixed( true );
 
         return new DhisFlyway( classicConfiguration,
-            Boolean.parseBoolean( configurationProvider.getProperty( FLYWAY_OUT_OF_ORDER_MIGRATION ) ) );
+            Boolean.parseBoolean( configurationProvider.getProperty( FLYWAY_REPAIR_BEFORE_MIGRATION ) ) );
 
     }
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
@@ -68,7 +68,8 @@ public class FlywayConfig
         classicConfiguration.setLocations( new Location( FLYWAY_MIGRATION_FOLDER ) );
         classicConfiguration.setMixed( true );
 
-        return new Flyway( classicConfiguration );
+        return new DhisFlyway( classicConfiguration,
+            Boolean.parseBoolean( configurationProvider.getProperty( FLYWAY_OUT_OF_ORDER_MIGRATION ) ) );
 
     }
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -87,6 +87,7 @@ public enum ConfigurationKey
     REDIS_ENABLED( "redis.enabled", Constants.FALSE, false ),
     REDIS_USE_SSL( "redis.use.ssl", Constants.FALSE, false ),
     FLYWAY_OUT_OF_ORDER_MIGRATION( "flyway.migrate_out_of_order", Constants.FALSE, false ),
+    FLYWAY_REPAIR_BEFORE_MIGRATION( "flyway.repair_before_migration", Constants.FALSE, false ),
     PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT( "tracker.temporary.ownership.timeout", "3", false ),
     LEADER_TIME_TO_LIVE( "leader.time.to.live.minutes", "2", false ),
     ANALYTICS_CACHE_EXPIRATION( "analytics.cache.expiration", "0" ),


### PR DESCRIPTION
Externalized config to optionally be able to run flyway repair before the migration. This is useful when you have manually fixed the db/script inconsistencies and want flyway to update the flyway_schema_history to realign the checksums. Instead of manually updating the flyway_schema_history ourselves (which is risky), simply enabling "flyway.repair_before_migration=true" in dhis.conf will initiate a flyway repair before the actual migration. [Flyway Repair](https://flywaydb.org/documentation/command/repair)