### PR TITLE
fix: Fix lazy exception for default category combo

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -91,9 +91,8 @@ public class TrackerIdentifierCollector
         TrackerIdentifierParams params,
         Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults )
     {
-        defaults.forEach( ( defaultClass, defaultMetadata ) -> {
-            addIdentifier( map, defaultClass, params.getIdScheme().getIdScheme(), defaultMetadata.getUid() );
-        } );
+        defaults.forEach( ( defaultClass, defaultMetadata ) ->
+            addIdentifier( map, defaultClass, params.getIdScheme().getIdScheme(), defaultMetadata.getUid() ) );
     }
 
     private static void collectTrackedEntities(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -69,7 +70,8 @@ public class TrackerIdentifierCollector
 {
     public final static String ID_WILDCARD = "*";
 
-    public static Map<Class<?>, Set<String>> collect( TrackerImportParams params )
+    public static Map<Class<?>, Set<String>> collect( TrackerImportParams params,
+        Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults )
     {
         Map<Class<?>, Set<String>> map = new HashMap<>();
 
@@ -80,8 +82,18 @@ public class TrackerIdentifierCollector
         // Using "*" signals that all the entities of the given type have to be preloaded in the Preheat
         map.put( TrackedEntityType.class, ImmutableSet.of( ID_WILDCARD ) );
         map.put( RelationshipType.class, ImmutableSet.of( ID_WILDCARD ) );
+        collectDefaults( map, params.getIdentifiers(), defaults );
 
         return map;
+    }
+
+    private static void collectDefaults( Map<Class<?>, Set<String>> map,
+        TrackerIdentifierParams params,
+        Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults )
+    {
+        defaults.forEach( ( defaultClass, defaultMetadata ) -> {
+            addIdentifier( map, defaultClass, params.getIdScheme().getIdScheme(), defaultMetadata.getUid() );
+        } );
     }
 
     private static void collectTrackedEntities(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -224,11 +224,23 @@ public class TrackerPreheat
     }
 
     /**
+     * Get a default value from the Preheat
+     *
+     * @param defaultClass The type of object to retrieve
+     * @return The default object of the class provided
+     */
+    public <T extends IdentifiableObject> T getDefault( Class<T> defaultClass )
+    {
+        String uid = this.defaults.get( defaultClass ).getUid();
+        return this.get( defaultClass, uid );
+    }
+
+    /**
      * Fetch a metadata object from the pre-heat, based on the type of the object
      * and the cached identifier.
      *
      * @param klass The metadata class to fetch
-     * @param key The key used during the pre-heat creation
+     * @param key   The key used during the pre-heat creation
      * @return A metadata object or null
      */
     @SuppressWarnings( "unchecked" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryComboMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryComboMapper.java
@@ -29,15 +29,10 @@ package org.hisp.dhis.tracker.preheat.mappers;
  */
 
 import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.category.CategoryOption;
-import org.hisp.dhis.category.CategoryOptionCombo;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
-
-import java.util.Set;
 
 @Mapper( uses = DebugMapper.class )
 public interface CategoryComboMapper

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryComboMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryComboMapper.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.tracker.preheat.mappers;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.mapstruct.BeanMapping;
@@ -38,21 +39,16 @@ import org.mapstruct.factory.Mappers;
 
 import java.util.Set;
 
-@Mapper( uses = { DebugMapper.class, CategoryOptionMapper.class, CategoryComboMapper.class } )
-public interface CategoryOptionComboMapper
-    extends PreheatMapper<CategoryOptionCombo>
+@Mapper( uses = DebugMapper.class )
+public interface CategoryComboMapper
+    extends PreheatMapper<CategoryCombo>
 {
-    CategoryOptionComboMapper INSTANCE = Mappers.getMapper( CategoryOptionComboMapper.class );
+    CategoryComboMapper INSTANCE = Mappers.getMapper( CategoryComboMapper.class );
 
     @BeanMapping( ignoreByDefault = true )
     @Mapping( target = "id" )
     @Mapping( target = "uid" )
     @Mapping( target = "name" )
     @Mapping( target = "code" )
-    @Mapping( target = "categoryOptions", qualifiedByName = "categoryOptions" )
-    @Mapping( target = "categoryCombo" )
-    CategoryOptionCombo map( CategoryOptionCombo categoryOptionCombo );
-
-    @Named( "categoryOptions" )
-    Set<CategoryOption> mapCategoryOptions( Set<CategoryOption> categoryOptionSet );
+    CategoryCombo map( CategoryCombo categoryCombo );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
@@ -85,7 +85,7 @@ public class ClassBasedSupplier extends AbstractPreheatSupplier implements Appli
          * reference type (e.g. Enrollment) and the value is a Set of identifiers (e.g.
          * a list of all Enrollment UIDs found in the payload)
          */
-        Map<Class<?>, Set<String>> identifierMap = TrackerIdentifierCollector.collect( params );
+        Map<Class<?>, Set<String>> identifierMap = TrackerIdentifierCollector.collect( params, preheat.getDefaults() );
 
         for ( Class<?> klass : identifierMap.keySet() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -316,8 +316,8 @@ public class PreCheckDataRelationsValidationHook
     {
         if ( categoryOptionCombo == null )
         {
-            CategoryOptionCombo defaultCategoryCombo = (CategoryOptionCombo) preheat.getDefaults()
-                .get( CategoryOptionCombo.class );
+            CategoryOptionCombo defaultCategoryCombo = preheat
+                .getDefault( CategoryOptionCombo.class );
 
             if ( defaultCategoryCombo != null && !aocIsEmpty )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -250,8 +250,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
             return;
         }
 
-        FileResource fileResource = reporter.getValidationContext().getBundle().getPreheat()
-            .get( FileResource.class, attr.getValue() );
+        FileResource fileResource = reporter.getValidationContext().getFileResource( attr.getValue() );
         
         addErrorIfNull( fileResource, reporter, E1084, attr.getValue() );
         addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, E1009, attr.getValue() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.api.client.util.Maps;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
@@ -74,7 +75,7 @@ public class TrackerPreheatServiceTest extends TrackerTest
     public void testCollectIdentifiersSimple()
     {
         TrackerImportParams params = new TrackerImportParams();
-        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params );
+        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params, Maps.newHashMap() );
         assertEquals( collectedMap.keySet().size(), 2 );
         assertTrue( collectedMap.containsKey( TrackedEntityType.class ) );
         assertTrue( collectedMap.containsKey( RelationshipType.class ) );
@@ -90,7 +91,7 @@ public class TrackerPreheatServiceTest extends TrackerTest
         assertTrue( params.getEnrollments().isEmpty() );
         assertFalse( params.getEvents().isEmpty() );
 
-        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params );
+        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params, Maps.newHashMap() );
 
         assertTrue( collectedMap.containsKey( DataElement.class ) );
         assertTrue( collectedMap.containsKey( Program.class ) );
@@ -147,7 +148,7 @@ public class TrackerPreheatServiceTest extends TrackerTest
         assertTrue( params.getEnrollments().isEmpty() );
         assertTrue( params.getEvents().isEmpty() );
 
-        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params );
+        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params, Maps.newHashMap() );
 
         assertTrue( collectedMap.containsKey( TrackedEntity.class ) );
         Set<String> trackedEntities = collectedMap.get( TrackedEntity.class );


### PR DESCRIPTION
Preheat defaults were retrieved from the DB and they didn't pass through the process of mapping present in the preheat.
I added the default to the TrackerIdentifierCollector, so they can go through the same process as all the other metadata and have all the needed fields correctly initialised