### PR TITLE
fix: (2.34) NPE in metadata import [DHIS2-10200]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
@@ -33,6 +33,8 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.option.OptionSet;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Component
 public class OptionSetObjectBundleHook
     extends AbstractObjectBundleHook
@@ -66,8 +68,8 @@ public class OptionSetObjectBundleHook
             return;
         }
 
-        optionSet.getOptions().forEach( option -> {
-
+        optionSet.getOptions().stream().filter( Objects::nonNull ).forEach( option ->
+        {
             if ( option.getOptionSet() == null )
             {
                 option.setOptionSet( optionSet );


### PR DESCRIPTION
NPE is raised while importing metadata. The problem seems to be with OptionSet. Only non-null options in the OptionSet will be processed.