### PR TITLE
fix: (2.35) send message rule action when stage is part of registration

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/DataValueUpdatedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/DataValueUpdatedEvent.java
@@ -35,16 +35,16 @@ import org.springframework.context.ApplicationEvent;
  */
 public class DataValueUpdatedEvent extends ApplicationEvent
 {
-    private long programStageInstance;
+    private String programStageInstanceUid;
 
-    public DataValueUpdatedEvent( Object source, long programStageInstance )
+    public DataValueUpdatedEvent( Object source, String programStageInstanceUid )
     {
         super( source );
-        this.programStageInstance = programStageInstance;
+        this.programStageInstanceUid = programStageInstanceUid;
     }
 
-    public long getProgramStageInstance()
+    public String getProgramStageInstanceUid()
     {
-        return programStageInstance;
+        return programStageInstanceUid;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineService.java
@@ -56,5 +56,7 @@ public interface ProgramRuleEngineService
      */
     List<RuleEffect> evaluateEventAndRunEffects( long event );
 
+    List<RuleEffect> evaluateEventAndRunEffects( String event );
+
     RuleValidationResult getDescription( String condition, String programId );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationListener.java
@@ -28,58 +28,53 @@ package org.hisp.dhis.program.notification;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.program.notification.event.ProgramEnrollmentCompletionNotificationEvent;
 import org.hisp.dhis.program.notification.event.ProgramRuleEnrollmentEvent;
 import org.hisp.dhis.program.notification.event.ProgramRuleStageEvent;
 import org.hisp.dhis.program.notification.event.ProgramStageCompletionNotificationEvent;
 import org.hisp.dhis.program.notification.event.ProgramEnrollmentNotificationEvent;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Created by zubair@dhis2.org on 18.01.18.
  */
 @Async
+@RequiredArgsConstructor
 @Component( "org.hisp.dhis.program.notification.ProgramNotificationListener" )
 public class ProgramNotificationListener
 {
     private final ProgramNotificationService programNotificationService;
 
-    public ProgramNotificationListener( ProgramNotificationService programNotificationService )
-    {
-        checkNotNull( programNotificationService );
-        this.programNotificationService = programNotificationService;
-    }
-
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onEnrollment( ProgramEnrollmentNotificationEvent event )
     {
         programNotificationService.sendEnrollmentNotifications( event.getProgramInstance() );
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onCompletion( ProgramEnrollmentCompletionNotificationEvent event )
     {
         programNotificationService.sendEnrollmentCompletionNotifications( event.getProgramInstance() );
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onEvent( ProgramStageCompletionNotificationEvent event )
     {
         programNotificationService.sendEventCompletionNotifications( event.getProgramStageInstance() );
     }
 
     // Published by rule engine
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onProgramRuleEnrollment( ProgramRuleEnrollmentEvent event )
     {
         programNotificationService.sendProgramRuleTriggeredNotifications( event.getTemplate(), event.getProgramInstance() );
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onProgramRuleEvent( ProgramRuleStageEvent event )
     {
         programNotificationService.sendProgramRuleTriggeredEventNotifications( event.getTemplate(), event.getProgramStageInstance() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -258,6 +258,7 @@ public class ServiceConfig
     public Map<ImportStrategy, List<Class<? extends Processor>>> eventInsertPostProcessorMap()
     {
         return ImmutableMap.of( CREATE, newArrayList(
+            PublishEventPostProcessor.class,
             ProgramNotificationPostProcessor.class,
             EventInsertAuditPostProcessor.class ) );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -59,6 +59,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -151,8 +152,9 @@ public class EventManager
 
             // Post processing only the events that passed validation and were persisted
             // correctly.
-            processingManager.getPostInsertProcessorFactory().process( workContext, events.stream()
-                .filter( e -> !eventPersistenceFailedUids.contains( e.getEvent() ) ).collect( toList() ) );
+            List<Event> savedEvents = events.stream().filter( e -> !eventPersistenceFailedUids.contains( e.getEvent() ) ).collect( toList() );
+
+            processingManager.getPostInsertProcessorFactory().process( workContext, savedEvents );
 
             incrementSummaryTotals( events, importSummaries, CREATE );
 
@@ -216,8 +218,10 @@ public class EventManager
 
             // Post processing only the events that passed validation and were persisted
             // correctly.
-            processingManager.getPostUpdateProcessorFactory().process( workContext, events.stream()
-                .filter( e -> !eventPersistenceFailedUids.contains( e.getEvent() ) ).collect( toList() ) );
+
+            List<Event> savedEvents = events.stream().filter( e -> !eventPersistenceFailedUids.contains( e.getEvent() ) ).collect( toList() );
+
+            processingManager.getPostUpdateProcessorFactory().process( workContext, savedEvents );
 
             incrementSummaryTotals( events, importSummaries, UPDATE );
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -130,6 +130,28 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
     {
         ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( programStageInstanceId );
 
+        return evaluateEventAndRunEffects( psi );
+    }
+
+    @Override
+    @Transactional
+    public List<RuleEffect> evaluateEventAndRunEffects( String event )
+    {
+        ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( event );
+
+        return evaluateEventAndRunEffects( psi );
+    }
+
+    @Override
+    public RuleValidationResult getDescription( String condition, String programId )
+    {
+        Program program = programService.getProgram( programId );
+
+        return programRuleEngineNew.getDescription( condition, program );
+    }
+
+    private List<RuleEffect> evaluateEventAndRunEffects( ProgramStageInstance psi )
+    {
         if ( psi == null )
         {
             return Lists.newArrayList();
@@ -137,8 +159,8 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
 
         ProgramInstance programInstance = programInstanceService.getProgramInstance( psi.getProgramInstance().getId() );
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( psi.getProgramInstance(), psi,
-            programInstance.getProgramStageInstances() );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, psi,
+                programInstance.getProgramStageInstances() );
 
         for ( RuleEffect effect : ruleEffects )
         {
@@ -150,13 +172,5 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
         }
 
         return ruleEffects;
-    }
-
-    @Override
-    public RuleValidationResult getDescription( String condition, String programId )
-    {
-        Program program = programService.getProgram( programId );
-
-        return programRuleEngineNew.getDescription( condition, program );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineListener.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineListener.java
@@ -28,47 +28,41 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
  * @author Zubair Asghar.
  */
 
 @Async
+@RequiredArgsConstructor
 @Component( "org.hisp.dhis.programrule.engine.ProgramRuleEngineListener" )
 public class ProgramRuleEngineListener
 {
     private final ProgramRuleEngineService programRuleEngineService;
 
-    public ProgramRuleEngineListener( ProgramRuleEngineService programRuleEngineService )
-    {
-        checkNotNull( programRuleEngineService );
-        this.programRuleEngineService = programRuleEngineService;
-    }
-
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onEnrollment( EnrollmentEvaluationEvent event )
     {
         programRuleEngineService.evaluateEnrollmentAndRunEffects( event.getProgramInstance() );
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onDataValueChange( DataValueUpdatedEvent event )
     {
-        programRuleEngineService.evaluateEventAndRunEffects( event.getProgramStageInstance() );
+        programRuleEngineService.evaluateEventAndRunEffects( event.getProgramStageInstanceUid() );
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onEventCompletion( StageCompletionEvaluationEvent event )
     {
         programRuleEngineService.evaluateEventAndRunEffects( event.getProgramStageInstance() );
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener( fallbackExecution = true )
     public void onScheduledEvent( StageScheduledEvaluationEvent event )
     {
         programRuleEngineService.evaluateEventAndRunEffects( event.getProgramStageInstance() );


### PR DESCRIPTION
Backport JIRA #DHIS2-9935 to 2.35
PR fixes the problem with notification events. The event will be invoked in case of insert/update, previously it was only being done for updates.
The change includes the addition of fallbackExecution = true flag in @TransactionalEventListener annotation to make sure the event is invoked even if there is no transaction running.