### PR TITLE
fix: fix program rule assign value implementer [DHIS2-10098]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleService.java
@@ -94,6 +94,8 @@ public interface ProgramRuleService
      */
     List<ProgramRule> getAllProgramRule();
 
+    List<ProgramRule> getProgramRuleByProgram( Set<String> programs );
+
     List<ProgramRule> getImplementableProgramRules( Program program, Set<ProgramRuleActionType> types );
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleStore.java
@@ -47,21 +47,29 @@ public interface ProgramRuleStore
      * @return ProgramRuleVariable list
      */
     List<ProgramRule> get( Program program );
-    
+
     /**
      * Returns a {@link ProgramRule}.
      *
-     * @param name the name of the ProgramRule to return.
+     * @param name    the name of the ProgramRule to return.
      * @param program {@link Program}.
      * @return the ProgramRule with the given name
      */
     ProgramRule getByName( String name, Program program );
 
     /**
+     * Returns all {@link ProgramRule} by program.
+     *
+     * @param programIds
+     * @return ProgramRule list
+     */
+    List<ProgramRule> getByProgram( Set<String> programIds );
+
+    /**
      * Get validation by {@link Program}
      *
      * @param program Program
-     * @param key Search Program Rule by key
+     * @param key     Search Program Rule by key
      * @return ProgramRule list
      */
     List<ProgramRule> get( Program program, String key );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
@@ -106,6 +106,13 @@ public class DefaultProgramRuleService
 
     @Override
     @Transactional( readOnly = true )
+    public List<ProgramRule> getProgramRuleByProgram( Set<String> programs )
+    {
+        return programRuleStore.getByProgram( programs );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
     public List<ProgramRule> getAllProgramRule()
     {
         return programRuleStore.getAll();

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
@@ -85,9 +85,21 @@ public class HibernateProgramRuleStore
     }
 
     @Override
+    public List<ProgramRule> getByProgram( Set<String> programIds )
+    {
+        Session session = getSession();
+        return session.createQuery(
+            "SELECT distinct pr FROM ProgramRule pr JOIN FETCH pr.programRuleActions pra WHERE pr.program.uid in (:ids)",
+            ProgramRule.class )
+            .setParameterList( "ids", programIds )
+            .getResultList();
+    }
+
+    @Override
     public List<ProgramRule> getImplementableProgramRules( Program program, Set<ProgramRuleActionType> types )
     {
-        return getQuery( "FROM ProgramRule pr JOIN FETCH pr.programRuleActions pra WHERE pr.program = :programId AND pra.programRuleActionType IN ( :implementableTypes )" )
+        return getQuery(
+            "FROM ProgramRule pr JOIN FETCH pr.programRuleActions pra WHERE pr.program = :programId AND pra.programRuleActionType IN ( :implementableTypes )" )
             .setParameter( "programId", program )
             .setParameter( "implementableTypes", types )
             .getResultList();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.tracker.TrackerIdentifierCollector;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -52,15 +53,20 @@ import com.google.common.collect.Lists;
  * This supplier collects all the references from the Tracker Import payload and
  * executes class-based strategies, based on the type of the object in the
  * payload.
- * 
+ *
  * @author Luciano Fiandesio
  */
 @Component
-public class ClassBasedSupplier extends AbstractPreheatSupplier implements ApplicationContextAware
+@RequiredArgsConstructor
+public class ClassBasedSupplier
+    extends AbstractPreheatSupplier
+    implements ApplicationContextAware
 {
     public static final int SPLIT_LIST_PARTITION_SIZE = 20_000;
 
     private ApplicationContext context;
+
+    private final TrackerIdentifierCollector identifierCollector;
 
     /**
      * A Map correlating a Tracker class name to the Preheat strategy class name to
@@ -85,7 +91,7 @@ public class ClassBasedSupplier extends AbstractPreheatSupplier implements Appli
          * reference type (e.g. Enrollment) and the value is a Set of identifiers (e.g.
          * a list of all Enrollment UIDs found in the payload)
          */
-        Map<Class<?>, Set<String>> identifierMap = TrackerIdentifierCollector.collect( params, preheat.getDefaults() );
+        Map<Class<?>, Set<String>> identifierMap = identifierCollector.collect( params, preheat.getDefaults() );
 
         for ( Class<?> klass : identifierMap.keySet() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategy.java
@@ -234,7 +234,7 @@ public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrate
     private List<IdentifiableObject> cacheAndReturnLookupData( Schema schema )
     {
         List<IdentifiableObject> objects;
-        if ( cache.hasKey( buildCacheKey( schema ) ) )
+        if ( cache.hasKey( buildCacheKey( schema ) ) && !cache.getAll( buildCacheKey( schema ) ).isEmpty() )
         {
             objects = new ArrayList<>( cache.getAll( buildCacheKey( schema ) ) );
 
@@ -244,7 +244,7 @@ public abstract class AbstractSchemaStrategy implements ClassBasedSupplierStrate
             objects = manager.getAll( (Class<IdentifiableObject>) schema.getKlass() );
 
             objects.forEach( rt -> cache.put( HibernateProxyUtils.getRealClass( rt ).getSimpleName(),
-                    rt.getUid(), rt, getCacheTTL(), getCapacity() ) );
+                rt.getUid(), rt, getCacheTTL(), getCapacity() ) );
         }
 
         return objects;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.tracker.programrule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.DataValue;
@@ -53,6 +54,24 @@ public class EnrollmentActionRule
     private final AttributeType attributeType;
 
     private String content;
+
+    public String getValue()
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        if ( !StringUtils.isEmpty( content ) )
+        {
+            stringBuilder.append( data );
+        }
+        if ( !StringUtils.isEmpty( stringBuilder.toString() ) )
+        {
+            stringBuilder.append( " " );
+        }
+        if ( !StringUtils.isEmpty( data ) )
+        {
+            stringBuilder.append( data );
+        }
+        return stringBuilder.toString();
+    }
 
     public Optional<Attribute> getAttribute()
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EventActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EventActionRule.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.tracker.programrule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
@@ -52,6 +53,24 @@ public class EventActionRule
     private final AttributeType attributeType;
 
     private String content;
+
+    public String getValue()
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        if ( !StringUtils.isEmpty( content ) )
+        {
+            stringBuilder.append( data );
+        }
+        if ( !StringUtils.isEmpty( stringBuilder.toString() ) )
+        {
+            stringBuilder.append( " " );
+        }
+        if ( !StringUtils.isEmpty( data ) )
+        {
+            stringBuilder.append( data );
+        }
+        return stringBuilder.toString();
+    }
 
     public Optional<DataValue> getDataValue()
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
+import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
 import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.needsToValidateDataValues;
 
 abstract public class AbstractRuleActionImplementer<T extends RuleAction>
@@ -142,10 +144,10 @@ abstract public class AbstractRuleActionImplementer<T extends RuleAction>
                         .map( effect -> new EventActionRule( event, effect.data(),
                             getField( (T) effect.ruleAction() ), getAttributeType( effect.ruleAction() ),
                             getContent( (T) effect.ruleAction() ) ) )
-                        .filter( effect -> effect.getAttributeType() != AttributeType.DATA_ELEMENT ||
+                        .filter( effect -> effect.getAttributeType() == UNKNOWN ||
                             isDataElementPartOfProgramStage( effect.getField(), programStage ) )
                         .filter(
-                            effect -> effect.getAttributeType() != AttributeType.DATA_ELEMENT ||
+                            effect -> effect.getAttributeType() == UNKNOWN ||
                                 needsToValidateDataValues( event, programStage ) )
                         .collect( Collectors.toList() );
                     return eventActionRules;
@@ -173,7 +175,9 @@ abstract public class AbstractRuleActionImplementer<T extends RuleAction>
                     .map( effect -> new EnrollmentActionRule(
                         getEnrollment( bundle, e.getKey() ).get(), effect.data(),
                         getField( (T) effect.ruleAction() ), getAttributeType( effect.ruleAction() ),
-                        getContent( (T) effect.ruleAction() )) )
+                        getContent( (T) effect.ruleAction() ) ) )
+                    .filter( actionRule -> actionRule.getAttributeType() == UNKNOWN ||
+                        actionRule.getAttributeType() == TRACKED_ENTITY_ATTRIBUTE )
                     .collect( Collectors.toList() ) ) );
     }
 
@@ -202,7 +206,7 @@ abstract public class AbstractRuleActionImplementer<T extends RuleAction>
             return ((RuleActionAttribute) ruleAction).attributeType();
         }
 
-        return AttributeType.UNKNOWN;
+        return UNKNOWN;
     }
 
     protected Optional<Event> getEvent( TrackerBundle bundle, String eventUid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -30,12 +30,16 @@ package org.hisp.dhis.tracker.programrule.implementers;
 
 import com.google.common.collect.Lists;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.rules.models.RuleActionAssign;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.DataValue;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.*;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerReportUtils;
@@ -81,7 +85,9 @@ public class AssignValueImplementer
 
         for ( EventActionRule actionRule : eventClasses.getValue() )
         {
-            if ( !actionRule.getDataValue().isPresent() || Boolean.TRUE.equals( canOverwrite ) )
+            if ( !actionRule.getDataValue().isPresent() ||
+                Boolean.TRUE.equals( canOverwrite ) ||
+                isTheSameValue( actionRule, bundle.getPreheat() ) )
             {
                 addOrOverwriteDataValue( actionRule );
                 issues.add( new ProgramRuleIssue( TrackerReportUtils
@@ -128,6 +134,34 @@ public class AssignValueImplementer
         return issues;
     }
 
+    private boolean isTheSameValue( EventActionRule actionRule, TrackerPreheat preheat )
+    {
+        DataElement dataElement = preheat.get( DataElement.class, actionRule.getField() );
+        String dataValue = actionRule.getValue();
+        Optional<DataValue> optionalDataValue = actionRule.getEvent().getDataValues().stream()
+            .filter( dv -> dv.getDataElement().equals( actionRule.getField() ) )
+            .findAny();
+        if ( optionalDataValue.isPresent() )
+        {
+            return areEquals( dataValue, optionalDataValue.get().getValue(), dataElement.getValueType() );
+        }
+
+        return false;
+    }
+
+    private boolean areEquals( String dataValue, String value, ValueType valueType )
+    {
+        if ( valueType.isNumeric() )
+        {
+            return NumberUtils.isParsable( dataValue ) &&
+                Double.parseDouble( value ) == Double.parseDouble( dataValue );
+        }
+        else
+        {
+            return value.equals( dataValue );
+        }
+    }
+
     private void addOrOverwriteDataValue( EventActionRule actionRule )
     {
         Set<DataValue> dataValues = actionRule.getEvent().getDataValues();
@@ -136,11 +170,11 @@ public class AssignValueImplementer
             .findAny();
         if ( optionalDataValue.isPresent() )
         {
-            optionalDataValue.get().setValue( actionRule.getData() );
+            optionalDataValue.get().setValue( actionRule.getValue() );
         }
         else
         {
-            dataValues.add( createDataValue( actionRule.getField(), actionRule.getData() ) );
+            dataValues.add( createDataValue( actionRule.getField(), actionRule.getValue() ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationConfig.java
@@ -58,7 +58,10 @@ public class TrackerImportValidationConfig
     protected static final List<Class<? extends TrackerValidationHook>> RULE_ENGINE_VALIDATION_HOOKS = ImmutableList.of(
 
         EnrollmentRuleValidationHook.class,
-        EventRuleValidationHook.class
+        EventRuleValidationHook.class,
+        TrackedEntityAttributeValidationHook.class,
+        EnrollmentAttributeValidationHook.class,
+        EventDataValuesValidationHook.class
     );
 
     protected static final List<Class<? extends TrackerValidationHook>> VALIDATION_ORDER = ImmutableList.of(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -61,10 +61,14 @@ import com.google.common.collect.Lists;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class TrackerPreheatServiceTest extends TrackerTest
+public class TrackerPreheatServiceTest
+    extends TrackerTest
 {
     @Autowired
     private TrackerPreheatService trackerPreheatService;
+
+    @Autowired
+    private TrackerIdentifierCollector identifierCollector;
 
     @Override
     protected void initTest()
@@ -75,7 +79,7 @@ public class TrackerPreheatServiceTest extends TrackerTest
     public void testCollectIdentifiersSimple()
     {
         TrackerImportParams params = new TrackerImportParams();
-        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params, Maps.newHashMap() );
+        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
         assertEquals( collectedMap.keySet().size(), 2 );
         assertTrue( collectedMap.containsKey( TrackedEntityType.class ) );
         assertTrue( collectedMap.containsKey( RelationshipType.class ) );
@@ -91,7 +95,7 @@ public class TrackerPreheatServiceTest extends TrackerTest
         assertTrue( params.getEnrollments().isEmpty() );
         assertFalse( params.getEvents().isEmpty() );
 
-        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params, Maps.newHashMap() );
+        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
 
         assertTrue( collectedMap.containsKey( DataElement.class ) );
         assertTrue( collectedMap.containsKey( Program.class ) );
@@ -148,7 +152,7 @@ public class TrackerPreheatServiceTest extends TrackerTest
         assertTrue( params.getEnrollments().isEmpty() );
         assertTrue( params.getEvents().isEmpty() );
 
-        Map<Class<?>, Set<String>> collectedMap = TrackerIdentifierCollector.collect( params, Maps.newHashMap() );
+        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
 
         assertTrue( collectedMap.containsKey( TrackedEntity.class ) );
         Set<String> trackedEntities = collectedMap.get( TrackedEntity.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
+import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
 import static org.hisp.dhis.tracker.programrule.IssueType.ERROR;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -67,12 +68,6 @@ import static org.mockito.Mockito.when;
 public class SetMandatoryFieldValidatorTest
     extends DhisConvenienceTest
 {
-
-    private final static String CONTENT = "SHOW ERROR DATA";
-
-    private final static String DATA = "2 + 2";
-
-    private final static String EVALUATED_DATA = "4.0";
 
     private final static String ACTIVE_ENROLLMENT_ID = "ActiveEnrollmentUid";
 
@@ -114,6 +109,7 @@ public class SetMandatoryFieldValidatorTest
         firstProgramStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
 
         dataElementA = createDataElement( 'A' );
+        dataElementA.setUid( DATA_ELEMENT_ID );
         ProgramStageDataElement programStageDataElementA = createProgramStageDataElement( firstProgramStage,
             dataElementA, 0 );
         firstProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementA ) );
@@ -189,7 +185,6 @@ public class SetMandatoryFieldValidatorTest
     }
 
     @Test
-    @Ignore // TODO: fix the logic in the implementer
     public void testValidateWithErrorMandatoryFieldsForEnrollments()
     {
         bundle.setEnrollments(
@@ -254,7 +249,7 @@ public class SetMandatoryFieldValidatorTest
     {
         DataValue dataValue = new DataValue();
         dataValue.setValue( DATA_ELEMENT_VALUE );
-        dataValue.setDataElement( dataElementA.getUid() );
+        dataValue.setDataElement( DATA_ELEMENT_ID );
         return Sets.newHashSet( dataValue );
     }
 
@@ -289,14 +284,6 @@ public class SetMandatoryFieldValidatorTest
         return Lists.newArrayList( attribute );
     }
 
-    private Map<String, List<RuleEffect>> getRuleEventEffectsLinkedToDataElement()
-    {
-        Map<String, List<RuleEffect>> ruleEffectsByEvent = Maps.newHashMap();
-        ruleEffectsByEvent.put( FIRST_EVENT_ID, getRuleEffectsLinkedToDataElement() );
-        ruleEffectsByEvent.put( SECOND_EVENT_ID, getRuleEffectsLinkedToDataElement() );
-        return ruleEffectsByEvent;
-    }
-
     private Map<String, List<RuleEffect>> getRuleEventEffects()
     {
         Map<String, List<RuleEffect>> ruleEffectsByEvent = Maps.newHashMap();
@@ -315,25 +302,12 @@ public class SetMandatoryFieldValidatorTest
 
     private List<RuleEffect> getRuleEffects()
     {
-        RuleAction actionAssign = RuleActionSetMandatoryField.create( dataElementA.getUid(), DATA_ELEMENT );
+        RuleAction ruleActionSetMandatoryDataValue = RuleActionSetMandatoryField
+            .create( DATA_ELEMENT_ID, DATA_ELEMENT );
+        RuleAction ruleActionSetMandatoryAttribute = RuleActionSetMandatoryField
+            .create( ATTRIBUTE_ID, TRACKED_ENTITY_ATTRIBUTE );
 
-        return Lists.newArrayList( RuleEffect.create( actionAssign ) );
-    }
-
-    private List<RuleEffect> getRuleEffectsLinkedToDataElement()
-    {
-        RuleAction actionShowWarning = RuleActionShowWarning
-            .create( IssueType.WARNING.name() + CONTENT, DATA, DATA_ELEMENT_ID, DATA_ELEMENT );
-        RuleAction actionShowWarningOnComplete = RuleActionWarningOnCompletion
-            .create( IssueType.WARNING.name() + CONTENT, DATA, DATA_ELEMENT_ID, DATA_ELEMENT );
-        RuleAction actionShowError = RuleActionShowError
-            .create( ERROR.name() + CONTENT, DATA, DATA_ELEMENT_ID, DATA_ELEMENT );
-        RuleAction actionShowErrorOnCompletion = RuleActionErrorOnCompletion
-            .create( ERROR.name() + CONTENT, DATA, DATA_ELEMENT_ID, DATA_ELEMENT );
-
-        return Lists.newArrayList( RuleEffect.create( actionShowWarning, EVALUATED_DATA ),
-            RuleEffect.create( actionShowWarningOnComplete, EVALUATED_DATA ),
-            RuleEffect.create( actionShowError, EVALUATED_DATA ),
-            RuleEffect.create( actionShowErrorOnCompletion, EVALUATED_DATA ) );
+        return Lists.newArrayList( RuleEffect.create( ruleActionSetMandatoryAttribute ),
+            RuleEffect.create( ruleActionSetMandatoryDataValue ) );
     }
 }


### PR DESCRIPTION
- If the assigned value is the same as the value in the payload, not error is returned
- Put in the IdentifierCollector also the uids of data elements and attributes linked to program rules
- Fix preheat cache for wildcard entities. It was always empty after the TTL
- Run data values and attribute validators after rule engine has run