### PR TITLE
fix: add fontconfig to Tomcat Docker images [2.34]

### DIFF
--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+echo ""
+echo "Run:"
+echo "> sdk use java 8.0.265-open"
+echo ""
+
+#
+## bash environment
+#
+
+if test "$BASH" = "" || "$BASH" -uc "a=();true \"\${a[@]}\"" 2>/dev/null; then
+    # Bash 4.4, Zsh
+    set -euo pipefail
+else
+    # Bash 4.3 and older chokes on empty arrays with set -u.
+    set -eo pipefail
+fi
+shopt -s nullglob globstar
+
+#
+## script environment
+#
+
+D2CLUSTER="${1:-}"
+IMAGE=dhis2/core
+TAG=local
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT="$DIR/.."
+ARTIFACTS="$ROOT/docker/artifacts"
+
+print() {
+    echo -e "\033[1m$1\033[0m" 1>&2
+}
+
+#
+## The Business
+#
+
+# Requires maven to be on the classpath
+# Skips clean and test phases
+
+print "Building dhis2-core..."
+
+mvn clean install -T1C -Pdev -Pjdk11 -f $DIR/pom.xml
+mvn clean install -T1C -Pdev -Pjdk11 -f $DIR/dhis-web/pom.xml
+
+rm -rf "$ARTIFACTS/*"
+mkdir -p "$ARTIFACTS"
+cp -f "$DIR/dhis-web/dhis-web-portal/target/dhis.war" "$ARTIFACTS/dhis.war"
+
+print "Build succeeded, creating Docker image $IMAGE:$TAG..."
+
+cd $ARTIFACTS
+sha256sum ./dhis.war > ./sha256sum.txt
+md5sum ./dhis.war > ./md5sum.txt
+
+ONLY_DEFAULT=1 $ROOT/docker/build-containers.sh $IMAGE:$TAG $TAG
+
+print "Successfully created Docker image $IMAGE:$TAG"
+
+if test -z $D2CLUSTER; then
+    print "No cluster name specified, skipping deploy"
+else
+    print "Deploying to d2 cluster $D2CLUSTER..."
+
+    d2 cluster up $D2CLUSTER --image $IMAGE:$TAG
+    d2 cluster logs $D2CLUSTER
+fi

--- a/docker/tomcat-alpine/Dockerfile
+++ b/docker/tomcat-alpine/Dockerfile
@@ -19,7 +19,9 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
 
 RUN apk add --update --no-cache \
         bash  \
-        su-exec
+        su-exec \
+        fontconfig \
+        ttf-dejavu
 
 COPY ./shared/wait-for-it.sh /usr/local/bin/
 COPY ./tomcat-alpine/docker-entrypoint.sh /usr/local/bin/

--- a/docker/tomcat-debian/Dockerfile
+++ b/docker/tomcat-debian/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         util-linux \
         bash \
-        unzip
+        unzip \
+        fontconfig
 
 COPY ./shared/wait-for-it.sh /usr/local/bin/
 COPY ./tomcat-debian/docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
This PR adds `fontconfig` to both `debian` and `alpine` Tomcat images, and also `ttf-dejavu` to `alpine`.  These packages are required for the Push Analysis feature to work.

**NB** - the `8.0-jre8-slim` image appears to be broken, we should probably remove it (in a separate PR)