### PR TITLE
fix(docker): (2.35) add fontconfig to Tomcat Docker images

### DIFF
--- a/docker/tomcat-alpine/Dockerfile
+++ b/docker/tomcat-alpine/Dockerfile
@@ -19,7 +19,9 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
 
 RUN apk add --update --no-cache \
         bash  \
-        su-exec
+        su-exec \
+        fontconfig \
+        ttf-dejavu
 
 COPY ./shared/wait-for-it.sh /usr/local/bin/
 COPY ./tomcat-alpine/docker-entrypoint.sh /usr/local/bin/

--- a/docker/tomcat-debian/Dockerfile
+++ b/docker/tomcat-debian/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         util-linux \
         bash \
-        unzip
+        unzip \
+        fontconfig
 
 COPY ./shared/wait-for-it.sh /usr/local/bin/
 COPY ./tomcat-debian/docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
Forward-port of #7052 

Error before this fix
<img width="1552" alt="Screen Shot 2020-12-23 at 17 24 08" src="https://user-images.githubusercontent.com/947888/104008176-5c03ae00-51a9-11eb-983c-18f65b17cf1e.png">
