### PR TITLE
fix: ANTLR 'Expresion is empty' DHIS2-10227

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -220,7 +220,7 @@
     <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.6</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.12</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.13</dhis-antlr-expression-parser.version>
     <ow2.asm.version>9.0</ow2.asm.version>
   </properties>
 


### PR DESCRIPTION
The fix is in dhis2-antlr-expression-parser at https://github.com/dhis2/dhis2-antlr-expression-parser/commit/0559a04ade0568c4304b9dc47e5e1fadd5a08915. This PR merely references the new version. It fixes all the test cases referenced in https://jira.dhis2.org/browse/DHIS2-10227. (See the comment there.)