### PR TITLE
fix: ANTLR 'Expression is empty' DHIS2-10227

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -524,7 +524,7 @@
       <dependency>
         <groupId>org.hisp.dhis.parser</groupId>
         <artifactId>dhis-antlr-expression-parser</artifactId>
-        <version>1.0.12</version>
+        <version>1.0.13</version>
       </dependency>
       <dependency>
         <groupId>org.hisp.dhis</groupId>


### PR DESCRIPTION
Backporting JIRA #DHIS2-10227 to 2.34