### PR TITLE
fix: [DHIS2-10293] Fix program rules linked to tracked entity attributes

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperService.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.rules.DataItem;
 import org.hisp.dhis.rules.models.*;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 
 /**
  * RuleEngine has its own domain model. This service is responsible for
@@ -87,7 +88,8 @@ public interface ProgramRuleEntityMapperService
     /**
      * @return A mapped RuleEnrollment for DHIS enrollment i.e ProgramInstance.
      */
-    RuleEnrollment toMappedRuleEnrollment( ProgramInstance programInstance );
+    RuleEnrollment toMappedRuleEnrollment( ProgramInstance programInstance,
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues );
 
     /**
      * Fetch display name for {@link ProgramRuleVariable}, {@link org.hisp.dhis.constant.Constant}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -527,13 +527,17 @@ public abstract class AbstractEventService implements EventService
         event.setProgram( program.getUid() );
         event.setEnrollment( programStageInstance.getProgramInstance().getUid() );
         event.setProgramStage( programStageInstance.getProgramStage().getUid() );
-        event.setAttributeOptionCombo( programStageInstance.getAttributeOptionCombo().getUid() );
-        event.setAttributeCategoryOptions( String.join( ";", programStageInstance.getAttributeOptionCombo()
+        CategoryOptionCombo attributeOptionCombo = programStageInstance.getAttributeOptionCombo();
+        if ( attributeOptionCombo != null )
+        {
+            event.setAttributeOptionCombo( attributeOptionCombo.getUid() );
+            event.setAttributeCategoryOptions( String.join( ";", attributeOptionCombo
                 .getCategoryOptions().stream().map( CategoryOption::getUid ).collect( Collectors.toList() ) ) );
-
+        }
         if ( programStageInstance.getProgramInstance().getEntityInstance() != null )
         {
-            event.setTrackedEntityInstance( programStageInstance.getProgramInstance().getEntityInstance().getUid() );
+            event
+                .setTrackedEntityInstance( programStageInstance.getProgramInstance().getEntityInstance().getUid() );
         }
 
         Collection<EventDataValue> dataValues;
@@ -544,11 +548,11 @@ public abstract class AbstractEventService implements EventService
         else
         {
             Set<String> dataElementsToSync = programStageInstance.getProgramStage().getProgramStageDataElements()
-                    .stream().filter( psde -> !psde.getSkipSynchronization() ).map( psde -> psde.getDataElement().getUid() )
-                    .collect( Collectors.toSet() );
+                .stream().filter( psde -> !psde.getSkipSynchronization() ).map( psde -> psde.getDataElement().getUid() )
+                .collect( Collectors.toSet() );
 
             dataValues = programStageInstance.getEventDataValues().stream()
-                    .filter( dv -> dataElementsToSync.contains( dv.getDataElement() ) ).collect( Collectors.toSet() );
+                .filter( dv -> dataElementsToSync.contains( dv.getDataElement() ) ).collect( Collectors.toSet() );
         }
 
         for ( EventDataValue dataValue : dataValues )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -28,17 +28,9 @@ package org.hisp.dhis.programrule.engine;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
-import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.ValueType;
@@ -50,13 +42,7 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.programrule.ProgramRule;
-import org.hisp.dhis.programrule.ProgramRuleAction;
-import org.hisp.dhis.programrule.ProgramRuleActionType;
-import org.hisp.dhis.programrule.ProgramRuleService;
-import org.hisp.dhis.programrule.ProgramRuleVariable;
-import org.hisp.dhis.programrule.ProgramRuleVariableService;
-import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
+import org.hisp.dhis.programrule.*;
 import org.hisp.dhis.rules.DataItem;
 import org.hisp.dhis.rules.ItemValueType;
 import org.hisp.dhis.rules.models.*;
@@ -66,11 +52,12 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import lombok.extern.slf4j.Slf4j;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
+import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
 
 /**
  * Created by zubair@dhis2.org on 19.10.17.

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -263,7 +263,8 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     }
 
     @Override
-    public RuleEnrollment toMappedRuleEnrollment( ProgramInstance enrollment )
+    public RuleEnrollment toMappedRuleEnrollment( ProgramInstance enrollment,
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues )
     {
         if ( enrollment == null )
         {
@@ -279,10 +280,20 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
             orgUnitCode = enrollment.getOrganisationUnit().getCode();
         }
 
-        List<RuleAttributeValue> ruleAttributeValues = Lists.newArrayList();
+        List<RuleAttributeValue> ruleAttributeValues;
+
         if ( enrollment.getEntityInstance() != null )
         {
             ruleAttributeValues = enrollment.getEntityInstance().getTrackedEntityAttributeValues()
+                .stream()
+                .filter( Objects::nonNull )
+                .map( attr -> RuleAttributeValue.create( attr.getAttribute().getUid(),
+                    getTrackedEntityAttributeValue( attr ) ) )
+                .collect( Collectors.toList() );
+        }
+        else
+        {
+            ruleAttributeValues = trackedEntityAttributeValues
                 .stream()
                 .filter( Objects::nonNull )
                 .map( attr -> RuleAttributeValue.create( attr.getAttribute().getUid(),

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.rules.RuleEngine;
 import org.hisp.dhis.rules.RuleEngineContext;
 import org.hisp.dhis.rules.RuleEngineIntent;
 import org.hisp.dhis.rules.models.*;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.UserAuthorityGroup;
 
@@ -100,12 +101,18 @@ public class ProgramRuleEngine
 
     public List<RuleEffect> evaluate( ProgramInstance enrollment, Set<ProgramStageInstance> events )
     {
-        return evaluateProgramRules( enrollment, null, events, enrollment.getProgram() );
+        return evaluate( enrollment, events, Lists.newArrayList() );
+    }
+
+    public List<RuleEffect> evaluate( ProgramInstance enrollment, Set<ProgramStageInstance> events,
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues )
+    {
+        return evaluateProgramRules( enrollment, null, events, enrollment.getProgram(), trackedEntityAttributeValues );
     }
 
     public List<RuleEffect> evaluateProgramEvent( ProgramStageInstance event, Program program )
     {
-        return evaluateProgramRules( null, event, Sets.newHashSet(), program );
+        return evaluateProgramRules( null, event, Sets.newHashSet(), program, Lists.newArrayList() );
     }
 
     public List<RuleEffect> evaluate( ProgramInstance enrollment, ProgramStageInstance programStageInstance,
@@ -115,17 +122,19 @@ public class ProgramRuleEngine
         {
             return Lists.newArrayList();
         }
-        return evaluateProgramRules( enrollment, programStageInstance, events, enrollment.getProgram() );
+        return evaluateProgramRules( enrollment, programStageInstance, events, enrollment.getProgram(),
+            Lists.newArrayList() );
     }
 
     private List<RuleEffect> evaluateProgramRules( ProgramInstance enrollment,
-        ProgramStageInstance programStageInstance, Set<ProgramStageInstance> events, Program program )
+        ProgramStageInstance programStageInstance, Set<ProgramStageInstance> events, Program program,
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues )
     {
         List<RuleEffect> ruleEffects = new ArrayList<>();
 
         List<RuleEvent> ruleEvents = getRuleEvents( events, programStageInstance );
 
-        RuleEnrollment ruleEnrollment = getRuleEnrollment( enrollment );
+        RuleEnrollment ruleEnrollment = getRuleEnrollment( enrollment, trackedEntityAttributeValues );
 
         try
         {
@@ -271,9 +280,10 @@ public class ProgramRuleEngine
         return programRuleEntityMapperService.toMappedRuleEvents( events, programStageInstance );
     }
 
-    private RuleEnrollment getRuleEnrollment( ProgramInstance enrollment )
+    private RuleEnrollment getRuleEnrollment( ProgramInstance enrollment,
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues )
     {
-        return programRuleEntityMapperService.toMappedRuleEnrollment( enrollment );
+        return programRuleEntityMapperService.toMappedRuleEnrollment( enrollment, trackedEntityAttributeValues );
     }
 
     private List<RuleEffect> getRuleEngineEvaluation( RuleEngine ruleEngine, RuleEnrollment enrollment,

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -188,7 +188,7 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         when( programStageInstanceService.getProgramStageInstance( anyLong() ) ).thenReturn( programStageInstance );
         when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( programInstance );
 
-        when( programRuleEngine.evaluate( any(), any(), any() ) ).thenReturn( effects );
+        when( programRuleEngine.evaluate( any(), any(), anySet() ) ).thenReturn( effects );
 
         setProgramRuleActionType_SendMessage();
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -324,8 +324,9 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     public void testExceptionWhenMandatoryValueMissingMappedEnrollment()
     {
-        assertThrows( IllegalStateException.class, () -> subject.toMappedRuleEnrollment( programInstanceB,
-            Lists.newArrayList() ) );
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues = Lists.newArrayList();
+        assertThrows( IllegalStateException.class,
+            () -> subject.toMappedRuleEnrollment( programInstanceB, trackedEntityAttributeValues ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.api.client.util.Lists;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -323,13 +324,14 @@ public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     public void testExceptionWhenMandatoryValueMissingMappedEnrollment()
     {
-        assertThrows( IllegalStateException.class, () -> subject.toMappedRuleEnrollment( programInstanceB ) );
+        assertThrows( IllegalStateException.class, () -> subject.toMappedRuleEnrollment( programInstanceB,
+            Lists.newArrayList() ) );
     }
 
     @Test
     public void testMappedEnrollment()
     {
-        RuleEnrollment ruleEnrollment = subject.toMappedRuleEnrollment( programInstance );
+        RuleEnrollment ruleEnrollment = subject.toMappedRuleEnrollment( programInstance, Lists.newArrayList() );
 
         assertEquals( ruleEnrollment.enrollment(), programInstance.getUid() );
         assertEquals( ruleEnrollment.organisationUnit(), programInstance.getOrganisationUnit().getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/AttributeValueConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/AttributeValueConverterService.java
@@ -30,13 +30,11 @@ package org.hisp.dhis.tracker.converter;
 
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
 
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/AttributeValueConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/AttributeValueConverterService.java
@@ -1,0 +1,100 @@
+package org.hisp.dhis.tracker.converter;
+
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.tracker.domain.Attribute;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.util.DateUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Service
+public class AttributeValueConverterService
+    implements TrackerConverterService<Attribute, TrackedEntityAttributeValue>
+{
+    @Override
+    public Attribute to( TrackedEntityAttributeValue teav )
+    {
+        Attribute attribute = new Attribute();
+
+        attribute.setAttribute( teav.getAttribute().getUid() );
+        attribute.setCode( teav.getAttribute().getCode() );
+        attribute.setDisplayName( teav.getAttribute().getDisplayName() );
+        attribute.setCreatedAt( teav.getCreated().toString() );
+        attribute.setUpdatedAt( teav.getLastUpdated().toString() );
+        attribute.setStoredBy( teav.getStoredBy() );
+        attribute.setValueType( teav.getAttribute().getValueType() );
+        attribute.setValue( teav.getValue() );
+
+        return attribute;
+    }
+
+    @Override
+    public List<Attribute> to( List<TrackedEntityAttributeValue> attributeValues )
+    {
+        return attributeValues.stream().map( this::to ).collect( Collectors.toList() );
+    }
+
+    @Override
+    public TrackedEntityAttributeValue from( TrackerPreheat preheat, Attribute at )
+    {
+        TrackedEntityAttribute attribute = preheat.get( TrackedEntityAttribute.class, at.getAttribute() );
+
+        TrackedEntityAttributeValue teav = new TrackedEntityAttributeValue();
+
+        teav.setCreated( DateUtils.parseDate( at.getCreatedAt() ) );
+        teav.setLastUpdated( DateUtils.parseDate( at.getUpdatedAt()) );
+        teav.setStoredBy( at.getStoredBy() );
+        teav.setValue( at.getValue() );
+        teav.setAttribute( attribute );
+
+        return teav;
+    }
+
+    @Override
+    public List<TrackedEntityAttributeValue> from( TrackerPreheat preheat, List<Attribute> attributes )
+    {
+        return attributes.stream().map( n -> from( preheat, n ) ).collect( Collectors.toList() );
+    }
+
+    @Override
+    public TrackedEntityAttributeValue fromForRuleEngine( TrackerPreheat preheat, Attribute object )
+    {
+        return null;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -28,7 +28,6 @@ package org.hisp.dhis.tracker.programrule;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.api.client.util.Lists;
 import com.google.api.client.util.Sets;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -28,16 +28,22 @@ package org.hisp.dhis.tracker.programrule;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.api.client.util.Lists;
 import com.google.api.client.util.Sets;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerProgramRuleService;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
+import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -55,24 +61,22 @@ import java.util.stream.Stream;
  * @author Enrico Colasante
  */
 @Service
+@RequiredArgsConstructor
 public class DefaultTrackerProgramRuleService
     implements TrackerProgramRuleService
 {
+    @NonNull
+    @Qualifier( "serviceTrackerRuleEngine" )
     private final ProgramRuleEngine programRuleEngine;
 
+    @NonNull
     private final TrackerConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService;
 
+    @NonNull
     private final TrackerConverterService<Event, ProgramStageInstance> eventTrackerConverterService;
 
-    public DefaultTrackerProgramRuleService(
-        @Qualifier( "serviceTrackerRuleEngine" ) ProgramRuleEngine programRuleEngine,
-        TrackerConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService,
-        TrackerConverterService<Event, ProgramStageInstance> eventTrackerConverterService )
-    {
-        this.programRuleEngine = programRuleEngine;
-        this.enrollmentTrackerConverterService = enrollmentTrackerConverterService;
-        this.eventTrackerConverterService = eventTrackerConverterService;
-    }
+    @NonNull
+    private final TrackerConverterService<Attribute, TrackedEntityAttributeValue> attributeValueTrackerConverterService;
 
     @Override
     @Transactional( readOnly = true )
@@ -84,8 +88,35 @@ public class DefaultTrackerProgramRuleService
             .collect( Collectors.toMap( Enrollment::getEnrollment, e -> {
                 ProgramInstance enrollment = enrollmentTrackerConverterService.fromForRuleEngine( bundle.getPreheat(),
                     e );
-                return programRuleEngine.evaluate( enrollment, Sets.newHashSet() );
+
+                return programRuleEngine.evaluate( enrollment, Sets.newHashSet(),
+                    getAttributes( e, bundle ) );
             } ) );
+    }
+
+    private List<TrackedEntityAttributeValue> getAttributes( Enrollment enrollment, TrackerBundle bundle )
+    {
+        List<TrackedEntityAttributeValue> attributeValues = attributeValueTrackerConverterService
+            .from( bundle.getPreheat(), enrollment.getAttributes() );
+
+        TrackedEntityInstance trackedEntity = bundle.getPreheat()
+            .getTrackedEntity( bundle.getIdentifier(), enrollment.getTrackedEntity() );
+
+        if ( trackedEntity != null )
+        {
+            attributeValues.addAll( trackedEntity.getTrackedEntityAttributeValues() );
+        }
+        else
+        {
+            bundle.getTrackedEntity( enrollment.getTrackedEntity() )
+                .ifPresent( tei -> {
+                    List<TrackedEntityAttributeValue> teiAttributes = attributeValueTrackerConverterService
+                        .from( bundle.getPreheat(), tei.getAttributes() );
+                    attributeValues.addAll( teiAttributes );
+                } );
+        }
+
+        return attributeValues;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -47,8 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
-import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
+import static org.hisp.dhis.rules.models.AttributeType.*;
 import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.needsToValidateDataValues;
 
 abstract public class AbstractRuleActionImplementer<T extends RuleAction>
@@ -144,10 +143,10 @@ abstract public class AbstractRuleActionImplementer<T extends RuleAction>
                         .map( effect -> new EventActionRule( event, effect.data(),
                             getField( (T) effect.ruleAction() ), getAttributeType( effect.ruleAction() ),
                             getContent( (T) effect.ruleAction() ) ) )
-                        .filter( effect -> effect.getAttributeType() == UNKNOWN ||
+                        .filter( effect -> effect.getAttributeType() != DATA_ELEMENT ||
                             isDataElementPartOfProgramStage( effect.getField(), programStage ) )
                         .filter(
-                            effect -> effect.getAttributeType() == UNKNOWN ||
+                            effect -> effect.getAttributeType() != DATA_ELEMENT ||
                                 needsToValidateDataValues( event, programStage ) )
                         .collect( Collectors.toList() );
                     return eventActionRules;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -142,6 +142,7 @@ public enum TrackerErrorCode
     E1047( "Event: `{0}`, date belongs to an expired period. It is not possible to create such event." ),
 
     E1200( "Rule engine error: `{0}`" ),
+    E1201( "Rule engine warning: `{0}`" ),
 
     E1302( "DataElement `{0}` is not valid: `{1}`" ),
     E1303( "Mandatory DataElement `{0}` is not present" ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -145,6 +145,6 @@ public class ValidationUtils
         programRuleIssues
             .stream()
             .filter( issue -> issue.getIssueType().equals( WARNING ) )
-            .forEach( e -> reporter.addWarning( newWarningReport( TrackerErrorCode.E1200 ).addArg( e.getMessage() ) ) );
+            .forEach( e -> reporter.addWarning( newWarningReport( TrackerErrorCode.E1201 ).addArg( e.getMessage() ) ) );
     }
 }


### PR DESCRIPTION
- Passing the TEAs to the context to be built and sent to rule engine
- Fixing rule engine warning message
- Creating the attribute converter service