### PR TITLE
fix: Wrong result when using V{creation_date} with analytics boundaries [DHIS2-10304]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCompletedDate.java
@@ -46,6 +46,6 @@ public class vCompletedDate extends ProgramDateVariable
 
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
                 null, "completeddate", visitor.getReportingStartDate(),
-                visitor.getReportingStartDate(), visitor.getProgramIndicator() );
+                visitor.getReportingEndDate(), visitor.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
@@ -43,6 +43,6 @@ public class vCreationDate
     {
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
             null, "created", visitor.getReportingStartDate(),
-            visitor.getReportingStartDate(), visitor.getProgramIndicator() );
+            visitor.getReportingEndDate(), visitor.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -126,7 +126,7 @@ public class ProgramIndicatorServiceVariableTest
         assertEquals("created",
             getSql("V{creation_date}" ) );
 
-        assertEquals("(select created from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and created is not null and executiondate < cast( '2020-01-02' as date ) and executiondate >= cast( '2020-01-01' as date ) order by executiondate desc limit 1 )",
+        assertEquals("(select created from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and created is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date ) order by executiondate desc limit 1 )",
             getSqlEnrollment("V{creation_date}" ) );
     }
 


### PR DESCRIPTION
PR fix this issue by providing the correct reporting end date.