### PR TITLE
feat: add parse Date from pattern yyyyMMdd

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -92,6 +92,7 @@ public class DateUtils
         DateTimeFormat.forPattern( "yyyy-MM-dd HH:mm:ssZ" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM" ).getParser(),
+        DateTimeFormat.forPattern( "yyyyMMdd" ).getParser(),
         DateTimeFormat.forPattern( "yyyy" ).getParser()
     };
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
@@ -36,19 +36,21 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hisp.dhis.util.DateUtils.dateIsValid;
 import static org.hisp.dhis.util.DateUtils.dateTimeIsValid;
-import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.util.DateUtils.getMediumDate;
+import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Date;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.TimeZone;
 
 import org.hisp.dhis.calendar.impl.NepaliCalendar;
@@ -337,6 +339,25 @@ public class DateUtilsTest
         assertEquals( month, cal.get( Calendar.MONTH ) + 1 );
         assertEquals( day, cal.get( Calendar.DAY_OF_MONTH ) );
         assertEquals( 0, cal.get( Calendar.HOUR_OF_DAY ) );
+    }
+
+    @Test
+    public void testParseDate()
+    {
+        assertIsParseTo( 2020, 4, 22, "2020-04-22" );
+        assertIsParseTo( 2020, 4, 22, "20200422" );
+        assertIsParseTo( 2019, 4, 1, "2019-04" );
+        assertIsParseTo( 2021, 1, 1, "2021" );
+    }
+
+    private void assertIsParseTo( int year, int month, int day, String actual )
+    {
+        LocalDate date = Instant.ofEpochMilli( parseDate( actual ).getTime() )
+            .atZone( ZoneOffset.systemDefault() )
+            .toLocalDate();
+        assertEquals( year, date.getYear() );
+        assertEquals( month, date.getMonthValue() );
+        assertEquals( day, date.getDayOfMonth() );
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

This is a suggestion to extend the allowed pattern since otherwise a value of `20200101` is misunderstood as the year `20200101`.
Most code will not cause errors but simply perform its `Date` based operation with a most likely unexpected value as users will assume that if a value of `20200101` is not rejected it is a valid way to provide the 1st of January 2020. 

This is conceptually a breaking change but since it first breaks in the year 10000 I think we are good ;)