### PR TITLE
test: Search users across first + last names

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -206,6 +206,62 @@ public class UserServiceTest
     }
 
     @Test
+    public void testUserByQuery()
+    {
+        systemSettingManager.saveSystemSetting( CAN_GRANT_OWN_USER_AUTHORITY_GROUPS, true );
+
+        User userA = createUser( 'A' );
+        User userB = createUser( 'B' );
+
+        userA.setFirstName( "Chris" );
+        userB.setFirstName( "Chris" );
+
+        userService.addUser( userA );
+        userService.addUser( userB );
+
+        userService.addUserCredentials( userA.getUserCredentials() );
+        userService.addUserCredentials( userB.getUserCredentials() );
+
+        List<User> users = userService.getUsers( new UserQueryParams().setQuery( "Chris" ) );
+
+        assertEquals( 2, users.size() );
+        assertTrue( users.contains( userA ) );
+        assertTrue( users.contains( userB ) );
+
+        users = userService.getUsers( new UserQueryParams().setQuery( "hris SURNAM" ) );
+
+        assertEquals( 2, users.size() );
+        assertTrue( users.contains( userA ) );
+        assertTrue( users.contains( userB ) );
+
+        users = userService.getUsers( new UserQueryParams().setQuery( "hris SurnameA" ) );
+
+        assertEquals( 1, users.size() );
+        assertTrue( users.contains( userA ) );
+
+        users = userService.getUsers( new UserQueryParams().setQuery( "urnameB" ) );
+
+        assertEquals( 1, users.size() );
+        assertTrue( users.contains( userB ) );
+
+        users = userService.getUsers( new UserQueryParams().setQuery( "MAilA" ) );
+
+        assertEquals( 1, users.size() );
+        assertTrue( users.contains( userA ) );
+
+        users = userService.getUsers( new UserQueryParams().setQuery( "userNAME" ) );
+
+        assertEquals( 2, users.size() );
+        assertTrue( users.contains( userA ) );
+        assertTrue( users.contains( userB ) );
+
+        users = userService.getUsers( new UserQueryParams().setQuery( "ernameA" ) );
+
+        assertEquals( 1, users.size() );
+        assertTrue( users.contains( userA ) );
+    }
+
+    @Test
     public void testUserByOrgUnits()
     {
         // Set to avoid the "disjoint" user role constraint internally


### PR DESCRIPTION
Write a unit test for the firstname-surname/email/username query, including substring matching on firstname,space,lastname as requested by @larshelge