### PR TITLE
fix: performance improvent for users api when filtering with userCredentials.username (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -172,8 +172,16 @@ public class HibernateUserStore
             hql += " ";
         }
 
-        hql += "from User u " +
-            "inner join u.userCredentials uc ";
+        hql += "from User u ";
+
+        if ( count )
+        {
+            hql += "inner join u.userCredentials uc ";
+        }
+        else
+        {
+            hql += "inner join fetch u.userCredentials uc ";
+        }
 
         if ( params.isPrefetchUserGroups() && !count )
         {


### PR DESCRIPTION
use fetch for usercredentials. one to one relation with users. so in listing its more often beneficial to prefetch them to avoid the n+1 problem. 