### PR TITLE
fix: remove column from dhis2_base_schema

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/base/dhis2_base_schema.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/base/dhis2_base_schema.sql
@@ -1513,7 +1513,6 @@ CREATE TABLE dataset (
     notifycompletinguser boolean,
     workflowid integer,
     openfutureperiods integer,
-    openperiodsaftercoenddate integer,
     fieldcombinationrequired boolean,
     validcompleteonly boolean,
     novaluerequirescomment boolean,


### PR DESCRIPTION
Commit https://github.com/dhis2/dhis2-core/commit/cfdc0aaad13324e40e609c8f76a8e6f4b2838669 for DHIS2-9081 mistakenly added to dhis2_base_schema.sql the new column dataset.openperiodsaftercoenddate. That should not have been done because dhis2_base_schema.sql should be frozen at the 2.30 db schema. This PR is to undo the mistake.