### PR TITLE
fix: Use correct column name for enrollment_status [DHIS2-10346]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program.variable;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.program.AnalyticsType;
 
 /**
  * Program indicator variable: enrollment status
@@ -46,6 +47,11 @@ public class vEnrollmentStatus
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
+        if ( AnalyticsType.EVENT == visitor.getProgramIndicator().getAnalyticsType() )
+        {
+            return "pistatus";
+        }
+
         return "enrollmentstatus";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -175,7 +175,7 @@ public class ProgramIndicatorServiceVariableTest
     @Test
     public void testEnrollmentStatus()
     {
-        assertEquals( "enrollmentstatus",
+        assertEquals( "pistatus",
             getSql( "V{enrollment_status}" ) );
 
         assertEquals( "enrollmentstatus",

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -199,7 +199,7 @@ public class ProgramSqlGeneratorVariablesTest
     public void testEnrollmentStatus()
     {
         String sql = castString( test( "V{enrollment_status}", new DefaultLiteral(), eventIndicator ) );
-        assertThat( sql, is( "enrollmentstatus" ) );
+        assertThat( sql, is( "pistatus" ) );
     }
 
     @Test


### PR DESCRIPTION
The enrollment status column name is different in enrollment and event analytics tables. This needs to be aligned when using event analytics.