### PR TITLE
fix: [DHIS2-10208] enrollment not updated due to validation (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -118,7 +118,8 @@ public class EnrollmentInExistingValidationHook
         // TODO: Create a dedicated sql query....?
         Set<Enrollment> activeAndCompleted = getAllEnrollments( reporter, program, tei.getUid() )
             .stream()
-            .filter( e -> EnrollmentStatus.ACTIVE == e.getStatus() || EnrollmentStatus.COMPLETED == e.getStatus() )
+            .filter( e -> !e.getEnrollment().equals( enrollment.getEnrollment() )
+                && (EnrollmentStatus.ACTIVE == e.getStatus() || EnrollmentStatus.COMPLETED == e.getStatus()) )
             .collect( Collectors.toSet() );
 
         if ( EnrollmentStatus.ACTIVE == enrollment.getStatus() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -119,7 +119,7 @@ public class EnrollmentInExistingValidationHook
         Set<Enrollment> activeAndCompleted = getAllEnrollments( reporter, program, tei.getUid() )
             .stream()
             .filter( e -> !e.getEnrollment().equals( enrollment.getEnrollment() )
-                && ( EnrollmentStatus.ACTIVE == e.getStatus() || EnrollmentStatus.COMPLETED == e.getStatus() ) )
+                && (EnrollmentStatus.ACTIVE == e.getStatus() || EnrollmentStatus.COMPLETED == e.getStatus()) )
             .collect( Collectors.toSet() );
 
         if ( EnrollmentStatus.ACTIVE == enrollment.getStatus() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -119,7 +119,7 @@ public class EnrollmentInExistingValidationHook
         Set<Enrollment> activeAndCompleted = getAllEnrollments( reporter, program, tei.getUid() )
             .stream()
             .filter( e -> !e.getEnrollment().equals( enrollment.getEnrollment() )
-                && (EnrollmentStatus.ACTIVE == e.getStatus() || EnrollmentStatus.COMPLETED == e.getStatus()) )
+                && ( EnrollmentStatus.ACTIVE == e.getStatus() || EnrollmentStatus.COMPLETED == e.getStatus() ) )
             .collect( Collectors.toSet() );
 
         if ( EnrollmentStatus.ACTIVE == enrollment.getStatus() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -224,7 +224,7 @@ public class ReportSummaryIntegrationTest
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getDeleted() );
-        
+
         inputStream = new ClassPathResource( "tracker/single_enrollment.json" ).getInputStream();
         params = renderService.fromJson( inputStream, TrackerImportParams.class );
         params.setUserId( userA.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -200,6 +200,45 @@ public class ReportSummaryIntegrationTest
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getDeleted() );
     }
+    
+    @Test
+    public void testStatsCountForOneCreatedEnrollmentAndUpdateSameEnrollment()
+        throws IOException
+    {
+        InputStream inputStream = new ClassPathResource( "tracker/single_tei.json" ).getInputStream();
+
+        TrackerImportParams params = renderService.fromJson( inputStream, TrackerImportParams.class );
+        params.setUserId( userA.getUid() );
+        trackerImportService.importTracker( params );
+
+        inputStream = new ClassPathResource( "tracker/single_enrollment.json" ).getInputStream();
+        params = renderService.fromJson( inputStream, TrackerImportParams.class );
+        params.setUserId( userA.getUid() );
+        params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
+        TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
+
+        assertNotNull( trackerImportEnrollmentReport );
+        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
+        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrorReports().isEmpty() );
+        assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
+        assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
+        assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
+        assertEquals( 0, trackerImportEnrollmentReport.getStats().getDeleted() );
+        
+        inputStream = new ClassPathResource( "tracker/single_enrollment.json" ).getInputStream();
+        params = renderService.fromJson( inputStream, TrackerImportParams.class );
+        params.setUserId( userA.getUid() );
+        params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
+        trackerImportEnrollmentReport = trackerImportService.importTracker( params );
+
+        assertNotNull( trackerImportEnrollmentReport );
+        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
+        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrorReports().isEmpty() );
+        assertEquals( 0, trackerImportEnrollmentReport.getStats().getCreated() );
+        assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
+        assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
+        assertEquals( 0, trackerImportEnrollmentReport.getStats().getDeleted() );
+    }
 
     @Test
     public void testStatsCountForOneUpdateEnrollmentAndOneCreatedEnrollment()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -200,7 +200,7 @@ public class ReportSummaryIntegrationTest
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getDeleted() );
     }
-    
+
     @Test
     public void testStatsCountForOneCreatedEnrollmentAndUpdateSameEnrollment()
         throws IOException


### PR DESCRIPTION
The validation of "enrollment already exist" check ignores if the same enrollment is being updated. This makes it impossible to update an enrollment where only one active enrollment is allowed. 