### PR TITLE
feat: Config property for disabling server-side program rules [DHIS2-10380]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -29,11 +29,13 @@ package org.hisp.dhis.programrule.engine;
  */
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.external.conf.ConfigurationKey.SYSTEM_PROGRAM_RULE_SERVER_EXECUTION;
 
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
@@ -75,11 +77,14 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
 
     private final ProgramRuleService programRuleService;
 
+    private final DhisConfigurationProvider config;
+
     public DefaultProgramRuleEngineService(
         @Qualifier( "serviceTrackerRuleEngine" ) ProgramRuleEngine programRuleEngineNew,
         @Qualifier( "notificationRuleEngine" ) ProgramRuleEngine programRuleEngine,
         List<RuleActionImplementer> ruleActionImplementers, ProgramInstanceService programInstanceService,
-        ProgramStageInstanceService programStageInstanceService, ProgramRuleService programRuleService, ProgramService programService )
+        ProgramStageInstanceService programStageInstanceService, ProgramRuleService programRuleService,
+        ProgramService programService, DhisConfigurationProvider config )
     {
         checkNotNull( programRuleEngine );
         checkNotNull( programRuleEngineNew );
@@ -88,6 +93,7 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
         checkNotNull( programStageInstanceService );
         checkNotNull( programRuleService );
         checkNotNull( programService );
+        checkNotNull( config );
 
         this.programRuleEngine = programRuleEngine;
         this.programRuleEngineNew = programRuleEngineNew;
@@ -96,12 +102,18 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
         this.programStageInstanceService = programStageInstanceService;
         this.programRuleService = programRuleService;
         this.programService = programService;
+        this.config = config;
     }
 
     @Override
     @Transactional
     public List<RuleEffect> evaluateEnrollmentAndRunEffects( long programInstanceId )
     {
+        if ( config.isDisabled( SYSTEM_PROGRAM_RULE_SERVER_EXECUTION ) )
+        {
+            return Lists.newArrayList();
+        }
+
         ProgramInstance programInstance = programInstanceService.getProgramInstance( programInstanceId );
 
         if ( programInstance == null )
@@ -128,6 +140,11 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
     @Transactional
     public List<RuleEffect> evaluateEventAndRunEffects( long programStageInstanceId )
     {
+        if ( config.isDisabled( SYSTEM_PROGRAM_RULE_SERVER_EXECUTION ) )
+        {
+            return Lists.newArrayList();
+        }
+
         ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( programStageInstanceId );
 
         return evaluateEventAndRunEffects( psi );
@@ -137,6 +154,11 @@ public class DefaultProgramRuleEngineService implements ProgramRuleEngineService
     @Transactional
     public List<RuleEffect> evaluateEventAndRunEffects( String event )
     {
+        if ( config.isDisabled( SYSTEM_PROGRAM_RULE_SERVER_EXECUTION ) )
+        {
+            return Lists.newArrayList();
+        }
+
         ProgramStageInstance psi = programStageInstanceService.getProgramStageInstance( event );
 
         return evaluateEventAndRunEffects( psi );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -33,11 +33,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+import static org.hisp.dhis.external.conf.ConfigurationKey.SYSTEM_PROGRAM_RULE_SERVER_EXECUTION;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.*;
 import org.hisp.dhis.programrule.ProgramRule;
@@ -91,6 +94,9 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     @Mock
     private ProgramService programService;
 
+    @Mock
+    private DhisConfigurationProvider config;
+
     @Spy
     private ArrayList<RuleActionImplementer> ruleActionImplementers;
 
@@ -123,6 +129,8 @@ public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
 
         // stub for ruleActionSendMessage
         Mockito.lenient().when( ruleActionSendMessage.accept( any() ) ).thenReturn( true );
+
+        Mockito.when( config.isDisabled( SYSTEM_PROGRAM_RULE_SERVER_EXECUTION ) ).thenReturn( false );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -43,6 +43,7 @@ public enum ConfigurationKey
     SYSTEM_MONITORING_USERNAME( "system.monitoring.username" ),
     SYSTEM_MONITORING_PASSWORD( "system.monitoring.password" ),
     SYSTEM_SQL_VIEW_TABLE_PROTECTION( "system.sql_view_table_protection", Constants.ON, false ),
+    SYSTEM_PROGRAM_RULE_SERVER_EXECUTION( "system.program_rule.server_execution", Constants.ON, false ),
     NODE_ID( "node.id", "", false ),
     ENCRYPTION_PASSWORD( "encryption.password", "", true ),
     CONNECTION_DIALECT( "connection.dialect", "", false ),


### PR DESCRIPTION
Adds a new DHIS 2 config property `system.program_rule.server_execution` = `on | off`. Default value is `on` and there is no change in current behavior.

When facing high CPU usage in production, server-side program rules are sometimes the main cause. From a sysadmin perspective it is useful to be able to quickly disable server-side program rules without doing invasive changes to the metadata.
