### PR TITLE
fix: set HTTP response code for POST methods not returning anything [DHIS2-10010]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -1033,6 +1033,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1050,6 +1051,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1099,6 +1101,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     }
 
     @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.POST )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -972,6 +972,7 @@ public abstract class ChartFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -989,6 +990,7 @@ public abstract class ChartFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1038,6 +1040,7 @@ public abstract class ChartFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.POST )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -77,6 +77,7 @@ import org.hisp.dhis.webapi.webdomain.MessageConversation;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -87,6 +88,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -406,8 +408,9 @@ public class MessageConversationController
     }
 
     @RequestMapping( value = "/{uid}/recipients", method = RequestMethod.POST )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addRecipientsToMessageConversation( @PathVariable( "uid" ) String uid,
-        @RequestBody MessageConversation messageConversation, HttpServletRequest request, HttpServletResponse response )
+        @RequestBody MessageConversation messageConversation )
         throws Exception
     {
         org.hisp.dhis.message.MessageConversation conversation = messageService.getMessageConversation( uid );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -972,6 +972,7 @@ public abstract class ReportTableFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -989,6 +990,7 @@ public abstract class ReportTableFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1006,6 +1008,7 @@ public abstract class ReportTableFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1038,15 +1041,14 @@ public abstract class ReportTableFacadeController
     }
 
     @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.POST )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
-        @PathVariable( "itemId" ) String pvItemId,
-        HttpServletRequest request, HttpServletResponse response )
+        @PathVariable( "itemId" ) String pvItemId )
         throws Exception
     {
         List<Visualization> objects = (List<Visualization>) getEntity( pvUid );
-        response.setStatus( HttpServletResponse.SC_NO_CONTENT );
 
         if ( objects.isEmpty() )
         {


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

### Summary

We strongly believe that a recent spring update led to more strict requirements when it comes to RESTful APIs.
As a consequence methods of type POST which do not return any value and neither set a HTTP response code where no longer completing but instead cause a redirect which usually then failed returning a 404. 

This PR fixes this situation by explicitly setting the `NO_CONTENT` HTTP status code for methods returning `void` which were not setting the code in an apparent way.

I checked all methods matching the structural pattern (which are about 150):
```
@org.springframework.web.bind.annotation.RequestMapping (method = org.springframework.web.bind.annotation.RequestMethod.POST)
		void 
```

### Testing
I explicitly tested the endpoint that was reported broken in DHIS2-10010 and that setting the response code fixed it.

```
POST http://localhost:8080/api/dataElementGroups/oDkJh5Ddh7d/dataElements
{ deletions : [{"id":"RUv0hqER0zV"}] }
```

I also checked with the debugger that the redirecting no longer occurs.
