### PR TITLE
fix: update job status consistently with enabled flag [TECH-413]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -32,11 +32,13 @@ import static org.hisp.dhis.scheduling.JobType.values;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.hisp.dhis.common.IdentifiableObjectStore;
@@ -50,6 +52,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Primitives;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Henning Håkonsen
@@ -177,6 +181,7 @@ public class DefaultJobConfigurationService
     }
 
     @Override
+    @Transactional
     public void refreshScheduling( JobConfiguration jobConfiguration )
     {
         if ( jobConfiguration.isEnabled() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -40,6 +40,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.beanutils.PropertyUtils;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -52,8 +54,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Primitives;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Henning Håkonsen

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
-import org.hisp.dhis.scheduling.JobStatus;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.descriptors.JobConfigurationSchemaDescriptor;
@@ -104,13 +103,6 @@ public class JobConfigurationController
     @Override
     protected void postPatchEntity( JobConfiguration jobConfiguration )
     {
-        if ( !jobConfiguration.isEnabled() )
-        {
-            jobConfiguration.setJobStatus( JobStatus.DISABLED );
-        }
-
-        jobConfigurationService.addJobConfiguration( jobConfiguration );
-
         jobConfigurationService.refreshScheduling( jobConfiguration );
     }
 }


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

As far as I can tell the issue was unstable update of the `jobStatus` in relation to the `enabled` property.
When testing this the outcome was unpredictable. Sometimes the updated did the expected change. Sometimes it did not.
I'd say it came done to the `refreshScheduling` method lacking the `@Transactional` annotation which made the write unreliable.

I also removed everything from `postPatchEntity` except the call to `refreshScheduling` since that method already covered the logic duplicated in `postPatchEntity`. While the removed `addJobConfiguration` call would allow this to work with so far not existing entities this should never apply to a PATCH so I deemed this unnecessary as well.

### Testing
Followed the instructions given in TECH-413

1. First create a job. POST `{"name":"Test","jobType":"DATA_INTEGRITY","cronExpression":"0 0 3 ? * MON"}` to http://localhost:8080/api/32/jobConfigurations (check job UID in response)
2. Then send a PATCH to http://localhost:8080/api/32/jobConfigurations/{jobID} with `{"enabled":false}`
3. Then http://localhost:8080/api/32/jobConfigurations/{jobID} the `jobStatus` and `enabled` should be consistent, either `enabled=false` and `jobStatus="DISABLED"` or `enabled=true` and `jobStatus="SCHEDULED"`
