### PR TITLE
ci: disable cleanup on ci

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -4,4 +4,4 @@ services:
   e2e-test:
     stdin_open: true
     image: "${IMAGE_NAME}"
-    command: ./wait-for-it.sh web:8080 -t 0 -- mvn test -Dinstance.url=http://web:8080/api -Duser.default.username=admin -Duser.default.password=district
+    command: ./wait-for-it.sh web:8080 -t 0 -- mvn test -Dinstance.url=http://web:8080/api -Dtest.cleanup=false -Duser.default.username=admin -Duser.default.password=district

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/helpers/config/Config.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/helpers/config/Config.java
@@ -56,4 +56,7 @@ public interface Config
 
     @Key( "user.admin.password" )
     String adminUserPassword();
+
+    @Key( "test.cleanup" )
+    Boolean shouldCleanUp();
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/MetadataSetupExtension.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/MetadataSetupExtension.java
@@ -137,13 +137,14 @@ public class MetadataSetupExtension
 
     @Override
     public void close()
-        throws Throwable
     {
-        TestCleanUp testCleanUp = new TestCleanUp();
+        if ( TestConfiguration.get().shouldCleanUp() ) {
+            TestCleanUp testCleanUp = new TestCleanUp();
 
-        iterateCreatedData( id -> {
-            testCleanUp.deleteEntity( createdData.get( id ), id );
-        } );
+            iterateCreatedData( id -> {
+                testCleanUp.deleteEntity( createdData.get( id ), id );
+            } );
+        }
 
     }
 }


### PR DESCRIPTION
In order to save time, I disabled the cleanup on CI. We don't catch errors that happen during the deletion of created entities and there's no harm in leaving the test database since we dispose of the docker container. 