### PR TITLE
fix: fixes an issue where we counted the same attribute multiple times during preheat

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
@@ -72,10 +72,12 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier
         Map<TrackedEntityAttribute, List<String>> uniqueAttributes = params.getTrackedEntities()
             .stream()
             .flatMap( tei -> tei.getAttributes().stream() )
-            .filter( tea -> uniqueTrackedEntityAttributes.stream()
-                .anyMatch( uniqueAttr -> uniqueAttr.getUid().equals( tea.getAttribute() ) ) )
-            .collect( Collectors.toMap( a -> extractAttribute( a.getAttribute(), uniqueTrackedEntityAttributes ),
-                a -> extractValues( params.getTrackedEntities(), a.getAttribute() ) ) );
+            .map( Attribute::getAttribute )
+            .distinct()
+            .filter( teaUid -> uniqueTrackedEntityAttributes.stream()
+                .anyMatch( uniqueAttr -> uniqueAttr.getUid().equals( teaUid ) ) )
+            .collect( Collectors.toMap( a -> extractAttribute( a, uniqueTrackedEntityAttributes ),
+                a -> extractValues( params.getTrackedEntities(), a ) ) );
 
         return trackedEntityAttributeValueService.getUniqueAttributeByValues( uniqueAttributes )
             .stream()


### PR DESCRIPTION
While finding unique values in the preheater, we did not consider multiple tracked entities could share the same attributes, but with different values. This fix will convert the stream to using the uid of the attributes and only get the distinct values before collection.