### PR TITLE
fix: fixed several minor issues with preheating enrollments for events with missing reference

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
@@ -123,7 +123,7 @@ public class ProgramInstanceByTeiSupplier extends AbstractPreheatSupplier
         for ( ProgramInstance pi : resultList )
         {
             final List<Event> eventList = idToEventMap.get( makeKey( pi ) );
-            if ( !eventList.isEmpty() )
+            if ( eventList != null && !eventList.isEmpty() )
             {
                 for ( Event event : eventList )
                 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
@@ -104,10 +104,13 @@ public class ProgramInstanceByTeiSupplier extends AbstractPreheatSupplier
         Map<String, List<ProgramInstance>> result = new HashMap<>();
 
         // Build a look-up map
-        final Map<String, Event> idToEventMap = events.stream()
+        final Map<String, List<Event>> idToEventMap = events.stream()
             // filter out events without program or tei
             .filter( e -> StringUtils.isNotEmpty( e.getProgram() ) && StringUtils.isNotEmpty( e.getTrackedEntity() ) )
-            .collect( Collectors.toMap( e -> e.getProgram() + KEY_SEPARATOR + e.getTrackedEntity(), e -> e ) );
+            .map( e -> Pair.of( e.getProgram(), e.getTrackedEntity() ) )
+            .distinct()
+            .collect( Collectors.toMap( e -> e.getLeft() + KEY_SEPARATOR + e.getRight(),
+                e -> filterEventByTeiAndProgram( events, e.getRight(), e.getLeft() ) ) );
 
         // @formatter:off
         final List<ProgramInstance> resultList = programInstanceStore.getByProgramAndTrackedEntityInstance(
@@ -119,16 +122,28 @@ public class ProgramInstanceByTeiSupplier extends AbstractPreheatSupplier
 
         for ( ProgramInstance pi : resultList )
         {
-            final Event event = idToEventMap.get( makeKey( pi ) );
-            if ( event != null )
+            final List<Event> eventList = idToEventMap.get( makeKey( pi ) );
+            if ( !eventList.isEmpty() )
             {
-                final List<ProgramInstance> programInstances = result.getOrDefault( event.getUid(), new ArrayList<>() );
-                programInstances.add( pi );
-                result.put( event.getEvent(), DetachUtils.detach( ProgramInstanceMapper.INSTANCE, programInstances ) );
+                for ( Event event : eventList )
+                {
+                    final List<ProgramInstance> programInstances = result.getOrDefault( event.getEvent(),
+                        new ArrayList<>() );
+                    programInstances.add( pi );
+                    result.put( event.getEvent(),
+                        DetachUtils.detach( ProgramInstanceMapper.INSTANCE, programInstances ) );
+                }
             }
         }
 
         return result;
+    }
+
+    private List<Event> filterEventByTeiAndProgram( List<Event> events, String tei, String program )
+    {
+        return events.stream()
+            .filter( e -> e.getTrackedEntity().equals( tei ) && e.getProgram().equals( program ) )
+            .collect( Collectors.toList() );
     }
 
     private Program getProgram( TrackerPreheat preheat, String uid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceByTeiSupplier.java
@@ -123,7 +123,7 @@ public class ProgramInstanceByTeiSupplier extends AbstractPreheatSupplier
         for ( ProgramInstance pi : resultList )
         {
             final List<Event> eventList = idToEventMap.get( makeKey( pi ) );
-            if ( eventList != null && !eventList.isEmpty() )
+            if ( eventList != null )
             {
                 for ( Event event : eventList )
                 {


### PR DESCRIPTION
idToEventMap was mapping 1-1 between tei-program and event, but in reality you can have multiple events for the same tei and program. The mapping is now between the key, tei-program and a list of events that match the combination.

Instead of mapping the result for 1 event, all events that match the key will now map to the PI.

Updated a wrong .getUid with .getEvent. At this point, .getUid will always return null, while getEvent will always return a uid.