### PR TITLE
fix: [DHIS2-10459] Fix reference structure in Preheat used in the validation stage

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
@@ -107,6 +107,8 @@ public class DefaultTrackerPreheatService implements TrackerPreheatService, Appl
             }
         }
 
+        preheat.createReferenceTree();
+
         log.info( "(" + preheat.getUsername() + ") Import:TrackerPreheat took " + timer.toString() );
 
         return preheat;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/ReferenceTrackerEntity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/ReferenceTrackerEntity.java
@@ -45,4 +45,9 @@ public class ReferenceTrackerEntity
      * populated if uid references a ProgramStage or a Program Stage Instance
      */
     private final String parentUid;
+
+    public boolean isRoot()
+    {
+        return this.parentUid.equals( "ROOT" );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -27,14 +27,7 @@
  */
 package org.hisp.dhis.tracker.preheat;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -64,6 +57,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 
 import com.google.api.client.util.Lists;
+import com.google.common.collect.ArrayListMultimap;
 import com.scalified.tree.TreeNode;
 import com.scalified.tree.multinode.ArrayMultiTreeNode;
 
@@ -86,6 +80,14 @@ public class TrackerPreheat
      */
     @Getter
     private Map<Class<? extends IdentifiableObject>, Map<String, IdentifiableObject>> map = new HashMap<>();
+
+    /**
+     * List of all payload references by tracker type which are not present in
+     * thedatabase. This will be used to create the reference tree that
+     * represents the hierarchical structure of the references.
+     */
+    private ArrayListMultimap<TrackerType, ReferenceTrackerEntity> referenceTrackerEntities = ArrayListMultimap
+        .create();
 
     /**
      * Internal tree of all payload references which are not present in the
@@ -263,7 +265,6 @@ public class TrackerPreheat
      * Fetch all the metadata objects from the pre-heat, by object type
      *
      * @param klass The metadata class to fetch
-     *
      * @return a List of pre-heated object or empty list
      */
     @SuppressWarnings( "unchecked" )
@@ -494,26 +495,35 @@ public class TrackerPreheat
         this.programInstancesWithoutRegistration.put( programUid, programInstance );
     }
 
+    public void createReferenceTree()
+    {
+        referenceTrackerEntities.get( TrackerType.TRACKED_ENTITY )
+            .forEach( r -> referenceTree.add( new ArrayMultiTreeNode<>( r.getUid() ) ) );
+
+        referenceTrackerEntities.get( TrackerType.ENROLLMENT )
+            .forEach( this::addElementInReferenceTree );
+
+        referenceTrackerEntities.get( TrackerType.EVENT )
+            .forEach( this::addElementInReferenceTree );
+    }
+
     private void addReference( TrackerType trackerType, ReferenceTrackerEntity referenceTrackerEntity )
     {
-        if ( trackerType.equals( TrackerType.TRACKED_ENTITY ) )
+        referenceTrackerEntities.put( trackerType, referenceTrackerEntity );
+    }
+
+    private void addElementInReferenceTree( ReferenceTrackerEntity referenceTrackerEntity )
+    {
+        final TreeNode<String> node = referenceTree.find( referenceTrackerEntity.getParentUid() );
+
+        if ( node != null )
+        {
+            node.add( new ArrayMultiTreeNode<>( referenceTrackerEntity.getUid() ) );
+        }
+        else
         {
             referenceTree.add( new ArrayMultiTreeNode<>( referenceTrackerEntity.getUid() ) );
-
         }
-        else if ( trackerType.equals( TrackerType.ENROLLMENT ) || trackerType.equals( TrackerType.EVENT ) )
-        {
-            final TreeNode<String> node = referenceTree.find( referenceTrackerEntity.getParentUid() );
-
-            if ( node != null )
-            {
-                node.add( new ArrayMultiTreeNode<>( referenceTrackerEntity.getUid() ) );
-            }
-            else
-            {
-                referenceTree.add( new ArrayMultiTreeNode<>( referenceTrackerEntity.getUid() ) );
-            }
-        } // TODO luciano what about relationship?
     }
 
     public Optional<ReferenceTrackerEntity> getReference( String uid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
@@ -38,7 +38,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper( uses = { DebugMapper.class, OrganisationUnitMapper.class, UserGroupAccessMapper.class,
-    UserAccessMapper.class } )
+    UserAccessMapper.class, TrackedEntityTypeMapper.class } )
 public interface ProgramMapper extends PreheatMapper<Program>
 {
     ProgramMapper INSTANCE = Mappers.getMapper( ProgramMapper.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
@@ -221,6 +221,7 @@ public class PreCheckOwnershipValidationHook
             {
                 if ( !reference.get().isRoot() )
                 {
+                    teiUid = reference.get().getParentUid();
                 }
                 else
                 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
@@ -221,7 +221,6 @@ public class PreCheckOwnershipValidationHook
             {
                 if ( !reference.get().isRoot() )
                 {
-                    teiUid = reference.get().getParentUid();
                 }
                 else
                 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -308,6 +308,7 @@ public class TrackerPreheatTest
         } );
 
         preheat.putEvents( TrackerIdScheme.UID, psiList, allEvents );
+        preheat.createReferenceTree();
 
         Optional<ReferenceTrackerEntity> reference = preheat.getReference( allEvents.get( 0 ).getUid() );
         assertThat( reference.get().getUid(), is( allEvents.get( 0 ).getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/TrackerEntityInstanceStrategyTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/TrackerEntityInstanceStrategyTest.java
@@ -87,6 +87,7 @@ public class TrackerEntityInstanceStrategyTest
 
         // when
         strategy.add( params, uids, preheat );
+        preheat.createReferenceTree();
 
         assertTrue( preheat.getReference( trackedEntities.get( 0 ).getTrackedEntity() ).isPresent() );
         assertTrue( preheat.getReference( trackedEntities.get( 1 ).getTrackedEntity() ).isPresent() );
@@ -123,6 +124,7 @@ public class TrackerEntityInstanceStrategyTest
 
         // when
         strategy.add( params, uids, preheat );
+        preheat.createReferenceTree();
 
         assertFalse( preheat.getReference( trackedEntities.get( 0 ).getTrackedEntity() ).isPresent() );
         assertTrue( preheat.getReference( trackedEntities.get( 1 ).getTrackedEntity() ).isPresent() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventDefaultEnrollmentPreProcessorTest.java
@@ -136,6 +136,7 @@ public class EventDefaultEnrollmentPreProcessorTest
         TrackerPreheat preheat = new TrackerPreheat();
         preheat.putEnrollments( TrackerIdScheme.UID, new ArrayList<>(), Collections.singletonList( enrollment ) );
         preheat.putEvents( TrackerIdScheme.UID, new ArrayList<>(), Collections.singletonList( event ) );
+        preheat.createReferenceTree();
 
         TrackerBundle bundle = TrackerBundle.builder()
             .preheat( preheat )


### PR DESCRIPTION
In the Preheat we are loading from the DB all the metadata and data linked to the payload.
In the Preheat we also need to know if an entity is linked to another entity in the payload, this information is used to perform some validations.
We were creating a `referenceTree`, with the structure of entities that are presents in the payload but not in the DB, while populating the Preheat, but this wasn't always correct depending on the order of the loading.

The solution was to create a flat reference map and at the end of the loading mount the correct structure 
TEI -> Enrollment -> Event

DHIS2-10459