### PR TITLE
perf: Add indexes on relationshipitem and programinstance tables [DHIS2-10479]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_29__Add_indexes_in_relationshipitem_and_programinstance_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_29__Add_indexes_in_relationshipitem_and_programinstance_tables.sql
@@ -1,4 +1,4 @@
-create index if not exists programinstance_trackedentityinstance on programinstance (trackedentityinstanceid);
-create index if not exists relationshipitem_trackedentityinstance on relationshipitem (trackedentityinstanceid);
-create index if not exists relationshipitem_programinstance on relationshipitem (programinstanceid);
-create index if not exists relationshipitem_programstageinstance on relationshipitem (programstageinstanceid);
+create index if not exists in_programinstance_trackedentityinstance on programinstance (trackedentityinstanceid);
+create index if not exists in_relationshipitem_trackedentityinstance on relationshipitem (trackedentityinstanceid);
+create index if not exists in_relationshipitem_programinstance on relationshipitem (programinstanceid);
+create index if not exists in_relationshipitem_programstageinstance on relationshipitem (programstageinstanceid);

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_29__Add_indexes_in_relationshipitem_and_programinstance_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_29__Add_indexes_in_relationshipitem_and_programinstance_tables.sql
@@ -1,4 +1,4 @@
-create index if not exists in_programinstance_trackedentityinstance on programinstance (trackedentityinstanceid);
-create index if not exists in_relationshipitem_trackedentityinstance on relationshipitem (trackedentityinstanceid);
-create index if not exists in_relationshipitem_programinstance on relationshipitem (programinstanceid);
-create index if not exists in_relationshipitem_programstageinstance on relationshipitem (programstageinstanceid);
+create index if not exists in_programinstance_trackedentityinstanceid on programinstance (trackedentityinstanceid);
+create index if not exists in_relationshipitem_trackedentityinstanceid on relationshipitem (trackedentityinstanceid);
+create index if not exists in_relationshipitem_programinstanceid on relationshipitem (programinstanceid);
+create index if not exists in_relationshipitem_programstageinstanceid on relationshipitem (programstageinstanceid);

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_29__Add_indexes_in_relationshipitem_and_programinstance_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_29__Add_indexes_in_relationshipitem_and_programinstance_tables.sql
@@ -1,0 +1,4 @@
+create index if not exists programinstance_trackedentityinstance on programinstance (trackedentityinstanceid);
+create index if not exists relationshipitem_trackedentityinstance on relationshipitem (trackedentityinstanceid);
+create index if not exists relationshipitem_programinstance on relationshipitem (programinstanceid);
+create index if not exists relationshipitem_programstageinstance on relationshipitem (programstageinstanceid);


### PR DESCRIPTION
Joining entity tables (trackedentityinstance, programinstance, programstageinstance, relationshipitem) is the most common join in our queries. Having indexes on the column used to perform the joining on these tables will improve the performance of such queries.

- trackedentityinstance table has no foreign key, so no index is needed here
- programinstance table was missing an index on trackedentityinstanceid column
- programstageinstance table already has an index on programinstanceid column
- relationshipitem table is missing indexes on all 3 foreign key columns