### PR TITLE
feat: require bundled app overrides to be configured with the coreApp flag in the manifest (DHIS2-9555)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -94,6 +94,8 @@ public class App
 
     private Set<String> authorities = new HashSet<>();
 
+    private AppSettings settings;
+    
     private boolean coreApp = false;
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -95,7 +95,7 @@ public class App
     private Set<String> authorities = new HashSet<>();
 
     private AppSettings settings;
-    
+
     private boolean coreApp = false;
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -94,14 +94,12 @@ public class App
 
     private Set<String> authorities = new HashSet<>();
 
-    private AppSettings settings;
+    private boolean coreApp = false;
 
     /**
      * Generated.
      */
     private AppStatus appState = AppStatus.OK;
-
-    private boolean isBundledApp = false;
 
     // -------------------------------------------------------------------------
     // Logic
@@ -114,9 +112,7 @@ public class App
      */
     public void init( String contextPath )
     {
-        isBundledApp = AppManager.BUNDLED_APPS.contains( getShortName() );
-
-        String appPathPrefix = isBundledApp ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
+        String appPathPrefix = isBundled() ? AppManager.BUNDLED_APP_PREFIX : INSTALLED_APP_PATH;
 
         this.baseUrl = String.join( "/", contextPath, appPathPrefix ) + getUrlFriendlyName();
 
@@ -135,10 +131,29 @@ public class App
         return getUrlFriendlyName();
     }
 
+    /**
+     * Determine if this app will overload a bundled app
+     */
     @JsonProperty
-    public boolean getIsBundledApp()
+    public boolean isBundled()
     {
-        return isBundledApp;
+        return AppManager.BUNDLED_APPS.contains( getShortName() );
+    }
+
+    /**
+     * Determine if the app is configured as a coreApp (to be served at the root
+     * namespace)
+     */
+    @JsonProperty( "core_app" )
+    @JacksonXmlProperty( localName = "core_app", namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isCoreApp()
+    {
+        return coreApp;
+    }
+
+    public void setCoreApp( boolean coreApp )
+    {
+        this.coreApp = coreApp;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -201,7 +201,7 @@ public class DefaultAppManager
         {
             apps.retainAll( getAppsByShortName( value, apps, operator ) );
         }
-        else if ( "isBundled".equalsIgnoreCase( key ) )
+        else if ( "bundled".equalsIgnoreCase( key ) )
         {
             boolean isBundled = "true".equalsIgnoreCase( value );
             apps.retainAll( getAppsByIsBundled( isBundled, apps ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -182,7 +182,7 @@ public class DefaultAppManager
     {
         return apps
             .stream()
-            .filter( app -> app.getIsBundledApp() == isBundled )
+            .filter( app -> app.isBundled() == isBundled )
             .collect( Collectors.toList() );
     }
 
@@ -201,7 +201,7 @@ public class DefaultAppManager
         {
             apps.retainAll( getAppsByShortName( value, apps, operator ) );
         }
-        else if ( "isBundledApp".equalsIgnoreCase( key ) )
+        else if ( "isBundled".equalsIgnoreCase( key ) )
         {
             boolean isBundled = "true".equalsIgnoreCase( value );
             apps.retainAll( getAppsByIsBundled( isBundled, apps ) );
@@ -229,7 +229,7 @@ public class DefaultAppManager
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );
             }
 
-            if ( "isBundledApp".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
+            if ( "isBundled".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
                 && !"false".equalsIgnoreCase( split[2] ) )
             {
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -229,7 +229,7 @@ public class DefaultAppManager
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );
             }
 
-            if ( "isBundled".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
+            if ( "bundled".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
                 && !"false".equalsIgnoreCase( split[2] ) )
             {
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
@@ -274,7 +274,8 @@ public class JCloudsAppStorageService
     private boolean validateApp( App app, Cache<App> appCache )
     {
         // -----------------------------------------------------------------
-        // Check if app with same key is currently being deleted (deletion_in_progress)
+        // Check if app with same key is currently being deleted
+        // (deletion_in_progress)
         // -----------------------------------------------------------------
         Optional<App> existingApp = appCache.getIfPresent( app.getKey() );
         if ( existingApp.isPresent() && existingApp.get().getAppState() == AppStatus.DELETION_IN_PROGRESS )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/JCloudsAppStorageService.java
@@ -271,6 +271,63 @@ public class JCloudsAppStorageService
         return reservedNamespaces;
     }
 
+    private boolean validateApp( App app, Cache<App> appCache )
+    {
+        // -----------------------------------------------------------------
+        // Check if app with same key is currently being deleted (deletion_in_progress)
+        // -----------------------------------------------------------------
+        Optional<App> existingApp = appCache.getIfPresent( app.getKey() );
+        if ( existingApp.isPresent() && existingApp.get().getAppState() == AppStatus.DELETION_IN_PROGRESS )
+        {
+            log.error( "Failed to install app: App with same name is currently being deleted" );
+
+            app.setAppState( AppStatus.DELETION_IN_PROGRESS );
+            return false;
+        }
+
+        // -----------------------------------------------------------------
+        // Check for namespace and if it's already taken by another app
+        // -----------------------------------------------------------------
+
+        String namespace = app.getActivities().getDhis().getNamespace();
+
+        if ( namespace != null && !namespace.isEmpty() && app.equals( reservedNamespaces.get( namespace ) ) )
+        {
+            log.error( String.format( "Failed to install app '%s': Namespace '%s' already taken.",
+                app.getName(), namespace ) );
+
+            app.setAppState( AppStatus.NAMESPACE_TAKEN );
+            return false;
+        }
+
+        // -----------------------------------------------------------------
+        // Check that, iff this is a bundled app, it is configured as a core app
+        // -----------------------------------------------------------------
+
+        if ( app.isBundled() != app.isCoreApp() )
+        {
+            if ( app.isBundled() )
+            {
+                log.error(
+                    String.format(
+                        "Failed to install app '%s': bundled app overrides muse be declared with core_app=true",
+                        app.getShortName() ) );
+                app.setAppState( AppStatus.INVALID_BUNDLED_APP_OVERRIDE );
+            }
+            else
+            {
+                log.error(
+                    String.format(
+                        "Failed to install app '%s': apps declared with core_app=true must override a bundled app",
+                        app.getShortName() ) );
+                app.setAppState( AppStatus.INVALID_CORE_APP );
+            }
+
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public App installApp( File file, String filename, Cache<App> appCache )
     {
@@ -301,35 +358,13 @@ public class JCloudsAppStorageService
             app.setFolderName( APPS_DIR + File.separator + filename.substring( 0, filename.lastIndexOf( '.' ) ) );
             app.setAppStorageSource( AppStorageSource.JCLOUDS );
 
-            // -----------------------------------------------------------------
-            // Check if app with same key is currently being deleted
-            // (deletion_in_progress)
-            // -----------------------------------------------------------------
-            Optional<App> existingApp = appCache.getIfPresent( app.getKey() );
-            if ( existingApp.isPresent() && existingApp.get().getAppState() == AppStatus.DELETION_IN_PROGRESS )
+            if ( !this.validateApp( app, appCache ) )
             {
-                log.error( "Failed to install app: App with same name is currently being deleted" );
-
                 zip.close();
-                app.setAppState( AppStatus.DELETION_IN_PROGRESS );
                 return app;
             }
-
-            // -----------------------------------------------------------------
-            // Check for namespace and if it's already taken by another app
-            // -----------------------------------------------------------------
 
             String namespace = app.getActivities().getDhis().getNamespace();
-
-            if ( namespace != null && !namespace.isEmpty() && app.equals( reservedNamespaces.get( namespace ) ) )
-            {
-                log.error( String.format( "Failed to install app '%s': Namespace '%s' already taken.",
-                    app.getName(), namespace ) );
-
-                zip.close();
-                app.setAppState( AppStatus.NAMESPACE_TAKEN );
-                return app;
-            }
 
             // -----------------------------------------------------------------
             // Unzip the app

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -182,7 +182,7 @@ public class AppController
             throw new WebMessageException( WebMessageUtils.notFound( "App '" + app + "' not found." ) );
         }
 
-        if ( application.getIsBundledApp() )
+        if ( application.isBundled() )
         {
             String redirectPath = application.getBaseUrl() + "/" + pageName;
 

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
@@ -52,7 +52,7 @@ public class AppsSystemAuthoritiesProvider implements SystemAuthoritiesProvider
         Set<String> authorities = new HashSet<>();
 
         appManager.getApps( null ).stream()
-            .filter( app -> !StringUtils.isEmpty( app.getShortName() ) && !app.getIsBundledApp() )
+            .filter( app -> !StringUtils.isEmpty( app.getShortName() ) && !app.isBundled() )
             .forEach( app -> {
                 authorities.add( app.getSeeAppAuthority() );
                 authorities.addAll( app.getAuthorities() );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/DefaultModuleManager.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/module/DefaultModuleManager.java
@@ -157,7 +157,7 @@ public class DefaultModuleManager
         List<App> apps = appManager
             .getAccessibleApps( contextPath )
             .stream()
-            .filter( app -> app.getAppType() == AppType.APP && !app.getIsBundledApp() )
+            .filter( app -> app.getAppType() == AppType.APP && !app.isBundled() )
             .collect( Collectors.toList() );
 
         modules.addAll( apps.stream().map( Module::getModule ).collect( Collectors.toList() ) );


### PR DESCRIPTION
Missed this during the 2.35 release push, forward-port of #6111 and #6175