### PR TITLE
fix: [DHIS2-10257] add new authority F_VIEW_SERVER_INFO for cluster leader api

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/DefaultAdminUserPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/DefaultAdminUserPopulator.java
@@ -80,7 +80,8 @@ public class DefaultAdminUserPopulator
         "F_UNCOMPLETE_EVENT",
         "F_EDIT_EXPIRED",
         "F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION",
-        "F_TRACKER_IMPORTER_EXPERIMENTAL" );
+        "F_TRACKER_IMPORTER_EXPERIMENTAL",
+        "F_VIEW_SERVER_INFO" );
 
     private final UserService userService;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -427,6 +427,7 @@ F_REPORT_EXTERNAL=Report External Access
 F_UNCOMPLETE_EVENT=Uncomplete events
 F_SKIP_DATA_IMPORT_AUDIT=Skip data import audit
 F_TRACKER_IMPORTER_EXPERIMENTAL=Tracker importer experimental
+F_VIEW_SERVER_INFO=View server information
 
 #-- Common ---------------------------------------------------------------------#
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_uk.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_uk.properties
@@ -427,6 +427,7 @@ F_REPORT_EXTERNAL=Report External Access
 F_UNCOMPLETE_EVENT=Uncomplete events
 F_SKIP_DATA_IMPORT_AUDIT=Skip data import audit
 F_TRACKER_IMPORTER_EXPERIMENTAL=Tracker importer experimental
+F_VIEW_SERVER_INFO=View server information
 
 #-- Common ---------------------------------------------------------------------#
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/cluster/ClusterController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/cluster/ClusterController.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.leader.election.LeaderNodeInfo;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -60,6 +61,7 @@ public class ClusterController
     // -------------------------------------------------------------------------
 
     @GetMapping( value = "/leader" )
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_VIEW_SERVER_INFO')" )
     public @ResponseBody LeaderNodeInfo getLeaderInfo()
         throws WebMessageException
     {


### PR DESCRIPTION
Add new authority "F_VIEW_SERVER_INFO" . At the moment only used for `/api/cluster/leader`  but can be used for all server/infra related APIs in the future.