### PR TITLE
fix: Program rule names are unique only within the same program [TECH-531]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -15,7 +15,7 @@
     </id>
     &identifiableProperties;
 
-    <property name="name" column="name" not-null="true" length="230" unique="true"/>
+    <property name="name" column="name" not-null="true" length="230" />
 
     <property name="description" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleObjectBundleHook.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2004-2020, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Giuseppe Nespolino <g.nespolino@gmail.com>
+ */
+@Component
+public class ProgramRuleObjectBundleHook extends AbstractObjectBundleHook
+{
+
+    /**
+     * Check if a Program Rule to be added or update has a unique name in the
+     * system
+     *
+     * @param object
+     * @param bundle
+     * @param <T>
+     * @return
+     */
+    @Override
+    public <T extends IdentifiableObject> List<ErrorReport> validate( T object, ObjectBundle bundle )
+    {
+        if ( !(object instanceof ProgramRule) )
+        {
+            return super.validate( object, bundle );
+        }
+
+        Session session = sessionFactory.getCurrentSession();
+        ProgramRule programRule = (ProgramRule) object;
+
+        return session.createQuery(
+            " from ProgramRule pr " +
+                "where pr.name = :name " +
+                "and pr.program.uid = :programUid " +
+                "and pr.uid != :programRuleUid",
+            ProgramRule.class )
+            .setParameter( "name", programRule.getName() )
+            .setParameter( "programUid", programRule.getProgram().getUid() )
+            .setParameter( "programRuleUid", programRule.getUid() )
+            .getResultList().size() > 0 ?
+
+                ImmutableList.of(
+                    new ErrorReport(
+                        ProgramRule.class,
+                        ErrorCode.E4031,
+                        programRule.getName(),
+                        programRule.getProgram().getUid() ) )
+
+                : super.validate( object, bundle );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceProgramTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceProgramTest.java
@@ -252,7 +252,7 @@ public class ObjectBundleServiceProgramTest
         List<ErrorReport> errorReports = validate1.getErrorReports();
         ErrorReport errorReport = errorReports.get( 0 );
 
-        assertEquals( ErrorCode.E5003, errorReport.getErrorCode() );
+        assertEquals( ErrorCode.E4031, errorReport.getErrorCode() );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_16__Set_unique_name_property_for_program_rules.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_16__Set_unique_name_property_for_program_rules.sql
@@ -1,2 +1,0 @@
-alter table if exists programrule
-        add constraint unique_name unique (name);


### PR DESCRIPTION
Program uniqueness shouldn't be enforced throughout the whole database, rather only under the same program.
This PR reverts the hook deleted in the previous version (the one in charge validating the constraint) and deletes the database constraint.