### PR TITLE
fix: check bundled instead of isBundled when validating query [DHIS2-10497]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -230,7 +230,7 @@ public class DefaultAppManager
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );
             }
 
-            if ( "isBundled".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
+            if ( "bundled".equalsIgnoreCase( split[0] ) && !"true".equalsIgnoreCase( split[2] )
                 && !"false".equalsIgnoreCase( split[2] ) )
             {
                 throw new QueryParserException( INVALID_FILTER_MSG + filter );


### PR DESCRIPTION
There was a minor bug in the implementation of DHIS2-9555 which prevented the server from checking the value of the bundled parameter against the only valid values true and false.

This has been solved in 2.36 in #7352 but needs to be backported to 2.35 and tested on 2.36