### PR TITLE
feat: Optionally report passive dashboard views

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/AggregatedStatistics.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/AggregatedStatistics.java
@@ -57,6 +57,8 @@ public class AggregatedStatistics
 
     private Integer dashboardViews;
 
+    private Integer passiveDashboardViews;
+
     private Integer dataSetReportViews;
 
     private Integer totalViews;
@@ -74,6 +76,8 @@ public class AggregatedStatistics
     private Integer averageEventChartViews;
 
     private Integer averageDashboardViews;
+
+    private Integer averagePassiveDashboardViews;
 
     private Integer savedMaps;
 
@@ -221,6 +225,17 @@ public class AggregatedStatistics
     }
 
     @JsonProperty
+    public Integer getPassiveDashboardViews()
+    {
+        return passiveDashboardViews;
+    }
+
+    public void setPassiveDashboardViews( Integer passiveDashboardViews )
+    {
+        this.passiveDashboardViews = passiveDashboardViews;
+    }
+
+    @JsonProperty
     public Integer getDataSetReportViews()
     {
         return dataSetReportViews;
@@ -262,6 +277,17 @@ public class AggregatedStatistics
     public void setAverageDashboardViews( Integer averageDashboardViews )
     {
         this.averageDashboardViews = averageDashboardViews;
+    }
+
+    @JsonProperty
+    public Integer getAveragePassiveDashboardViews()
+    {
+        return averagePassiveDashboardViews;
+    }
+
+    public void setAveragePassiveDashboardViews( Integer averagePassiveDashboardViews )
+    {
+        this.averagePassiveDashboardViews = averagePassiveDashboardViews;
     }
 
     @JsonProperty
@@ -432,6 +458,7 @@ public class AggregatedStatistics
             ", eventReportViews=" + eventReportViews +
             ", eventChartViews=" + eventChartViews +
             ", dashboardViews=" + dashboardViews +
+            ", passiveDashboardViews=" + passiveDashboardViews +
             ", dataSetReportViews=" + dataSetReportViews +
             ", totalViews=" + totalViews +
             ", averageViews=" + averageViews +
@@ -441,6 +468,7 @@ public class AggregatedStatistics
             ", averageEventReportViews=" + averageEventReportViews +
             ", averageEventChartViews=" + averageEventChartViews +
             ", averageDashboardViews=" + averageDashboardViews +
+            ", averagePassiveDashboardViews=" + averagePassiveDashboardViews +
             ", savedMaps=" + savedMaps +
             ", savedCharts=" + savedCharts +
             ", savedPivotTables=" + savedPivotTables +

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatistics.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatistics.java
@@ -54,6 +54,8 @@ public class DataStatistics
 
     private Double dashboardViews;
 
+    private Double passiveDashboardViews;
+
     private Double dataSetReportViews;
 
     private Double totalViews;
@@ -85,10 +87,10 @@ public class DataStatistics
     }
 
     public DataStatistics( Double mapViews, Double chartViews, Double reportTableViews, Double visualizationViews,
-        Double eventReportViews, Double eventChartViews, Double dashboardViews, Double dataSetReportViews,
-        Double totalViews, Double savedMaps, Double savedCharts, Double savedReportTables, Double savedVisualizations,
-        Double savedEventReports, Double savedEventCharts, Double savedDashboards, Double savedIndicators,
-        Double savedDataValues, Integer activeUsers, Integer users )
+        Double eventReportViews, Double eventChartViews, Double dashboardViews, Double passiveDashboardViews,
+        Double dataSetReportViews, Double totalViews, Double savedMaps, Double savedCharts, Double savedReportTables,
+        Double savedVisualizations, Double savedEventReports, Double savedEventCharts, Double savedDashboards,
+        Double savedIndicators, Double savedDataValues, Integer activeUsers, Integer users )
     {
         this.mapViews = mapViews;
         this.chartViews = chartViews;
@@ -97,6 +99,7 @@ public class DataStatistics
         this.eventReportViews = eventReportViews;
         this.eventChartViews = eventChartViews;
         this.dashboardViews = dashboardViews;
+        this.passiveDashboardViews = passiveDashboardViews;
         this.dataSetReportViews = dataSetReportViews;
         this.totalViews = totalViews;
         this.savedMaps = savedMaps;
@@ -198,6 +201,17 @@ public class DataStatistics
     public void setDashboardViews( Double dashboardViews )
     {
         this.dashboardViews = dashboardViews;
+    }
+
+    @JsonProperty
+    public Double getPassiveDashboardViews()
+    {
+        return passiveDashboardViews;
+    }
+
+    public void setPassiveDashboardViews( Double passiveDashboardViews )
+    {
+        this.passiveDashboardViews = passiveDashboardViews;
     }
 
     @JsonProperty
@@ -344,6 +358,7 @@ public class DataStatistics
             ", eventReportViews=" + eventReportViews +
             ", eventChartViews=" + eventChartViews +
             ", dashboardViews=" + dashboardViews +
+            ", passiveDashboardViews=" + passiveDashboardViews +
             ", totalViews=" + totalViews +
             ", savedMaps=" + savedMaps +
             ", savedCharts=" + savedCharts +

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsEventType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsEventType.java
@@ -42,6 +42,7 @@ public enum DataStatisticsEventType
     EVENT_REPORT_VIEW( "eventreport" ),
     EVENT_CHART_VIEW( "eventchart" ),
     DASHBOARD_VIEW( "dashboard" ),
+    PASSIVE_DASHBOARD_VIEW( "dashboard" ),
     DATA_SET_REPORT_VIEW( "dataset" ),
     TOTAL_VIEW( null );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/datastatistics/hibernate/DataStatistics.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/datastatistics/hibernate/DataStatistics.hbm.xml
@@ -20,6 +20,7 @@
     <property name="eventReportViews" column="eventreportviews" type="double"/>
     <property name="eventChartViews" column="eventchartviews" type="double"/>
     <property name="dashboardViews" column="dashboardviews" type="double"/>
+    <property name="passiveDashboardViews" column="passivedashboardviews" type="double"/>
     <property name="dataSetReportViews" column="datasetreportviews" type="double" />
     <property name="activeUsers" column="active_users" type="int"/>
     <property name="totalViews" column="totalviews" type="double"/>

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -136,6 +136,7 @@ public class DefaultDataStatisticsService
             eventCountMap.get( DataStatisticsEventType.EVENT_REPORT_VIEW ),
             eventCountMap.get( DataStatisticsEventType.EVENT_CHART_VIEW ),
             eventCountMap.get( DataStatisticsEventType.DASHBOARD_VIEW ),
+            eventCountMap.get( DataStatisticsEventType.PASSIVE_DASHBOARD_VIEW ),
             eventCountMap.get( DataStatisticsEventType.DATA_SET_REPORT_VIEW ),
             eventCountMap.get( DataStatisticsEventType.TOTAL_VIEW ),
             savedMaps, savedCharts, savedReportTables, savedVisualizations, savedEventReports,

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsStore.java
@@ -99,6 +99,7 @@ public class HibernateDataStatisticsStore
             ads.setEventReportViews( resultSet.getInt( "eventReportViews" ) );
             ads.setEventChartViews( resultSet.getInt( "eventChartViews" ) );
             ads.setDashboardViews( resultSet.getInt( "dashboardViews" ) );
+            ads.setPassiveDashboardViews( resultSet.getInt( "passiveDashboardViews" ) );
             ads.setDataSetReportViews( resultSet.getInt( "dataSetReportViews" ) );
             ads.setTotalViews( resultSet.getInt( "totalViews" ) );
             ads.setAverageViews( resultSet.getInt( "averageViews" ) );
@@ -108,6 +109,7 @@ public class HibernateDataStatisticsStore
             ads.setAverageEventReportViews( resultSet.getInt( "averageEventReportViews" ) );
             ads.setAverageEventChartViews( resultSet.getInt( "averageEventChartViews" ) );
             ads.setAverageDashboardViews( resultSet.getInt( "averageDashboardViews" ) );
+            ads.setAveragePassiveDashboardViews( resultSet.getInt( "averagePassiveDashboardViews" ) );
             ads.setSavedMaps( resultSet.getInt( "savedMaps" ) );
             ads.setSavedCharts( resultSet.getInt( "savedCharts" ) );
             ads.setSavedPivotTables( resultSet.getInt( "savedReportTables" ) );
@@ -229,6 +231,7 @@ public class HibernateDataStatisticsStore
             "cast(round(cast(sum(eventreportviews) as numeric),0) as int) as eventReportViews, " +
             "cast(round(cast(sum(eventchartviews) as numeric),0) as int) as eventChartViews," +
             "cast(round(cast(sum(dashboardviews) as numeric),0) as int) as dashboardViews, " +
+            "cast(round(cast(sum(passivedashboardviews) as numeric),0) as int) as passiveDashboardViews, " +
             "cast(round(cast(sum(datasetreportviews) as numeric),0) as int) as dataSetReportViews, " +
             "max(active_users) as activeUsers," +
             "coalesce(sum(totalviews)/nullif(max(active_users), 0), 0) as averageViews," +
@@ -238,6 +241,7 @@ public class HibernateDataStatisticsStore
             "coalesce(sum(eventreportviews)/nullif(max(active_users), 0), 0) as averageEventReportViews, " +
             "coalesce(sum(eventchartviews)/nullif(max(active_users), 0), 0) as averageEventChartViews, " +
             "coalesce(sum(dashboardviews)/nullif(max(active_users), 0), 0) as averageDashboardViews, " +
+            "coalesce(sum(passivedashboardviews)/nullif(max(active_users), 0), 0) as averagePassiveDashboardViews, " +
             "cast(round(cast(sum(totalviews) as numeric),0) as int) as totalViews," +
             "cast(round(cast(sum(maps) as numeric),0) as int) as savedMaps," +
             "cast(round(cast(sum(charts) as numeric),0) as int) as savedCharts," +

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -71,8 +71,8 @@ public class DataStatisticsServiceTest
 
         dse1 = new DataStatisticsEvent();
         dse2 = new DataStatisticsEvent( DataStatisticsEventType.EVENT_CHART_VIEW, now, "TestUser" );
-        DataStatistics ds = new DataStatistics( 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 11.0, 10.0, 12.0, 11.0, 13.0,
-            14.0, 15.0, 16.0, 17.0, 11.0, 10, 18 );
+        DataStatistics ds = new DataStatistics( 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 11.0, 10.0, 12.0, 11.0,
+            13.0, 14.0, 15.0, 16.0, 17.0, 11.0, 10, 18 );
 
         hibernateDataStatisticsStore.save( ds );
         snapId1 = ds.getId();

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsStoreTest.java
@@ -68,14 +68,14 @@ public class DataStatisticsStoreTest
         throws Exception
     {
         ds1 = new DataStatistics();
-        ds2 = new DataStatistics( 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 8.0, 11.0, 12.0, 13.0, 14.0, 11.0, 15.0,
-            16.0, 17.0, 11.0, 10, 18 );
-        ds3 = new DataStatistics( 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 11.0, 12.0, 13.0, 14.0, 15.0, 12.0, 16.0,
-            17.0, 18.0, 11.0, 10, 19 );
-        ds4 = new DataStatistics( 1.0, 1.5, 2.0, 1.0, 6.0, 5.0, 4.0, 8.0, 10.0, 4.0, 4.0, 5.0, 9.0, 7.0, 14.0, 6.0, 4.0,
-            11.9, 3, 2 );
-        ds5 = new DataStatistics( 3.0, 3.5, 6.0, 4.0, 3.0, 5.0, 7.0, 8.0, 10.0, 1.6, 5.5, 6.4, 8.3, 8.2, 16.0, 9.4, 9.6,
-            11.0, 5, 9 );
+        ds2 = new DataStatistics( 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 17.0, 10.0, 8.0, 11.0, 12.0, 13.0, 14.0, 11.0,
+            15.0, 16.0, 17.0, 11.0, 1, 18 );
+        ds3 = new DataStatistics( 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 17.0, 8.0, 11.0, 12.0, 13.0, 14.0, 15.0, 12.0,
+            16.0, 17.0, 18.0, 11.0, 2, 19 );
+        ds4 = new DataStatistics( 1.0, 1.5, 2.0, 1.0, 6.0, 5.0, 4.0, 16.0, 8.0, 10.0, 4.0, 4.0, 5.0, 9.0, 7.0, 14.0,
+            6.0, 4.0, 11.9, 3, 2 );
+        ds5 = new DataStatistics( 3.0, 3.5, 6.0, 4.0, 3.0, 5.0, 7.0, 16.0, 8.0, 10.0, 1.6, 5.5, 6.4, 8.3, 8.2, 16.0,
+            9.4, 9.6, 11.0, 2, 9 );
 
         ds1Id = 0;
         ds2Id = 0;
@@ -182,5 +182,44 @@ public class DataStatisticsStoreTest
         List<AggregatedStatistics> asList = dataStatisticsStore.getSnapshotsInInterval( EventInterval.YEAR,
             getDate( 2015, 3, 21 ), getDate( 2016, 3, 21 ) );
         assertEquals( 1, asList.size() );
+
+        AggregatedStatistics as = asList.get( 0 );
+
+        assertEqualsInt( 6, as.getMapViews() );
+        assertEqualsInt( 9, as.getChartViews() );
+        assertEqualsInt( 13, as.getPivotTableViews() );
+        assertEqualsInt( 18, as.getEventReportViews() );
+        assertEqualsInt( 21, as.getEventChartViews() );
+        assertEqualsInt( 24, as.getDashboardViews() );
+        assertEqualsInt( 66, as.getPassiveDashboardViews() );
+        assertEqualsInt( 34, as.getDataSetReportViews() );
+        assertEqualsInt( 39, as.getTotalViews() );
+        assertEqualsInt( 13, as.getAverageViews() );
+        assertEqualsInt( 2, as.getAverageMapViews() );
+        assertEqualsInt( 3, as.getAverageChartViews() );
+        assertEqualsInt( 4, as.getAveragePivotTableViews() );
+        assertEqualsInt( 6, as.getAverageEventReportViews() );
+        assertEqualsInt( 7, as.getAverageEventChartViews() );
+        assertEqualsInt( 8, as.getAverageDashboardViews() );
+        assertEqualsInt( 22, as.getAveragePassiveDashboardViews() );
+        assertEqualsInt( 29, as.getSavedMaps() );
+        assertEqualsInt( 35, as.getSavedCharts() );
+        assertEqualsInt( 38, as.getSavedPivotTables() );
+        assertEqualsInt( 38, as.getSavedEventReports() );
+        assertEqualsInt( 61, as.getSavedEventCharts() );
+        assertEqualsInt( 48, as.getSavedDashboards() );
+        assertEqualsInt( 49, as.getSavedIndicators() );
+        assertEqualsInt( 45, as.getSavedDataValues() );
+        assertEqualsInt( 3, as.getActiveUsers() );
+        assertEqualsInt( 19, as.getUsers() );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    private void assertEqualsInt( int expected, int actual )
+    {
+        assertEquals( (long) expected, (long) actual );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -182,6 +182,8 @@ public enum SettingKey
     ANALYTICS_HIDE_BIMONTHLY_PERIODS( "keyHideBiMonthlyPeriods", Boolean.FALSE, Boolean.class ),
     GATHER_ANALYTICAL_OBJECT_STATISTICS_IN_DASHBOARD_VIEWS( "keyGatherAnalyticalObjectStatisticsInDashboardViews",
         Boolean.FALSE, Boolean.class ),
+    COUNT_PASSIVE_DASHBOARD_VIEWS_IN_USAGE_ANALYTICS( "keyCountPassiveDashboardViewsInUsageAnalytics",
+        Boolean.FALSE, Boolean.class ),
     DASHBOARD_CONTEXT_MENU_ITEM_SWITCH_VIEW_TYPE( "keyDashboardContextMenuItemSwitchViewType", Boolean.TRUE,
         Boolean.class ),
     DASHBOARD_CONTEXT_MENU_ITEM_OPEN_IN_RELEVANT_APP( "keyDashboardContextMenuItemOpenInRelevantApp", Boolean.TRUE,

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_30__Add_passivedashboardviews_column_to_datastatistics_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_30__Add_passivedashboardviews_column_to_datastatistics_table.sql
@@ -1,0 +1,2 @@
+alter table datastatistics
+    add column if not exists passivedashboardviews double precision;


### PR DESCRIPTION
[DHIS2-10447](https://jira.dhis2.org/browse/DHIS2-10447) is the backend work for [DHIS2-7016](https://jira.dhis2.org/browse/DHIS2-7016)

This is to support a new data statistics event type PASSIVE_DASHBOARD_VIEW, that is recorded from the front end when a dashboard is shown by default (because is the user's landing page). This is persisted as a separate usage statistics count in the database, and is returned to the frontend as part of the AggregatedStatistics object.

A new system setting key keyCountPassiveDashboardViewsInUsageAnalytics can tell the Usage Analytics app whether to include the passive dashboard views together with the regular dashboard views, when presenting them to the user.

So the backend work is to:

- Add a new Data Statistics Event Type called PASSIVE_DASHBOARD_VIEW
- Add a new DataStatistics field passiveDashboardViews (object, hibernate mapping, and Flyway patch)
- Add new AggregatedStatistics fields passiveDashboardViews and averagePassiveDashboardViews
- Add a new system setting keyCountPassiveDashboardViewsInUsageAnalytics