### PR TITLE
fix: (2.35) Parse unregistered SMS command with simple text [DHIS2-10502]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
@@ -103,6 +103,12 @@ public class UnregisteredSMSListener
     }
 
     @Override
+    protected boolean hasCorrectFormat( IncomingSms sms, SMSCommand smsCommand )
+    {
+        return true;
+    }
+
+    @Override
     protected void postProcess( IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage )
     {
         UserGroup userGroup = smsCommand.getUserGroup();


### PR DESCRIPTION
Unregistered SMS command parser fails to parse the command. The format applied to other commands cannot be applied to Unregistered parser.