### PR TITLE
fix: [DHIS2-10398] program filter restrictToCapture scope

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -74,7 +74,7 @@ public class ProgramController
 
         List<Program> entityList;
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ),
-            options.getRootJunction() );
+            options.getRootJunction(), options.isTrue( "restrictToCaptureScope" ) );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 


### PR DESCRIPTION
Programs endpoint was not using the restrictToCaptureScope for the db level filtering. 