### PR TITLE
fix: [DHIS2-10375] I/O error when large number of tei is fetched from get teis APis

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -266,6 +266,12 @@ public class TrackedEntityInstanceQueryParams
     private boolean synchronizationQuery;
 
     /**
+     * Indicates to use legacy fetching mechanism in case the tei result count
+     * is high
+     */
+    private boolean useLegacy;
+
+    /**
      * Indicates a point in the time used to decide the data that should not be
      * synchronized
      */
@@ -1174,6 +1180,17 @@ public class TrackedEntityInstanceQueryParams
     public TrackedEntityInstanceQueryParams setInternalSearch( boolean internalSearch )
     {
         this.internalSearch = internalSearch;
+        return this;
+    }
+
+    public boolean isUseLegacy()
+    {
+        return useLegacy;
+    }
+
+    public TrackedEntityInstanceQueryParams setUseLegacy( boolean useLegacy )
+    {
+        this.useLegacy = useLegacy;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -275,9 +275,9 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
             trackedEntityInstances = this.trackedEntityInstanceAggregate.find( ids, params,
                 queryParams );
-        }
 
-        addSearchAudit( trackedEntityInstances, queryParams.getUser() );
+            addSearchAudit( trackedEntityInstances, queryParams.getUser() );
+        }
 
         return trackedEntityInstances;
     }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.controller.exception.OperationNotAllowedException;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.security.access.AccessDeniedException;
@@ -86,7 +87,7 @@ public class CrudControllerAdvice
 {
     // Add sensitive exceptions into this array
     private static final Class<?>[] SENSITIVE_EXCEPTIONS = { BadSqlGrammarException.class,
-        org.hibernate.QueryException.class };
+        org.hibernate.QueryException.class, DataAccessResourceFailureException.class };
 
     private static final String GENERIC_ERROR_MESSAGE = "An unexpected error has occured. Please contact your system administrator";
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -119,7 +119,7 @@ import com.google.common.collect.Lists;
 @RequiredArgsConstructor
 public class TrackedEntityInstanceController
 {
-    private static final int TEI_COUNT_THRESHOLD_FOR_USE_LEGACY = 100;
+    public static final int TEI_COUNT_THRESHOLD_FOR_USE_LEGACY = 500;
 
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
@@ -158,7 +158,7 @@ public class TrackedEntityInstanceController
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
         
-        int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, false );
+        int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
         
         if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
         {
@@ -167,7 +167,7 @@ public class TrackedEntityInstanceController
 
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances(
             queryParams,
-            getTrackedEntityInstanceParams( fields ), false );
+            getTrackedEntityInstanceParams( fields ), true );
 
         RootNode rootNode = NodeUtils.createMetadata();
        

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -119,6 +119,8 @@ import com.google.common.collect.Lists;
 @RequiredArgsConstructor
 public class TrackedEntityInstanceController
 {
+    private static final int TEI_COUNT_THRESHOLD_FOR_USE_LEGACY = 100;
+
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     private final org.hisp.dhis.trackedentity.TrackedEntityInstanceService instanceService;
@@ -155,15 +157,20 @@ public class TrackedEntityInstanceController
         List<String> fields = contextService.getFieldsFromRequestOrAll();
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
+        
+        int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, false );
+        
+        if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
+        {
+            queryParams.setUseLegacy( true );
+        }
 
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances(
             queryParams,
             getTrackedEntityInstanceParams( fields ), false );
 
         RootNode rootNode = NodeUtils.createMetadata();
-
-        int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, false );
-
+       
         if ( queryParams.isPaging() && queryParams.isTotalPages() )
         {
             Pager pager = new Pager( queryParams.getPageWithDefault(), count, queryParams.getPageSizeWithDefault() );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -157,9 +157,9 @@ public class TrackedEntityInstanceController
         List<String> fields = contextService.getFieldsFromRequestOrAll();
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
-        
+
         int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
-        
+
         if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
         {
             queryParams.setUseLegacy( true );
@@ -170,7 +170,7 @@ public class TrackedEntityInstanceController
             getTrackedEntityInstanceParams( fields ), true );
 
         RootNode rootNode = NodeUtils.createMetadata();
-       
+
         if ( queryParams.isPaging() && queryParams.isTotalPages() )
         {
             Pager pager = new Pager( queryParams.getPageWithDefault(), count, queryParams.getPageSizeWithDefault() );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -75,10 +75,11 @@ public class TrackerTrackedEntitiesExportController
         List<String> fields = contextService.getFieldsFromRequestOrAll();
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
-        
+
         int teiCount = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
-       
-        if ( teiCount > TrackedEntityInstanceController.TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
+
+        if ( teiCount > TrackedEntityInstanceController.TEI_COUNT_THRESHOLD_FOR_USE_LEGACY
+            && queryParams.isSkipPaging() )
         {
             queryParams.setUseLegacy( true );
         }


### PR DESCRIPTION
For both the get teis api
`api/trackedEntityInstances`
`api/tracker/trackedEntities` 

when large number of teis is returned in the response then the api crashes. This happens when "skipPaging=true" in the request AND the scope is very high that it returns a high number (say in the order of 10,000s). This is because of a refactoring done to improve performance. In the refactored mechanism, we first fetch the ids first and then the actual entities using those ids. If skipPaging is not forced, then default paging is used and the number of results is always small.
The refactoring means that these 10,000 ids are first fetched and then a humongous hql query is constructed by concatenating a clause like "where id in [comma separated string of the 10000 ids] and then a further concatenation to make sure the initial order is preserved. This creates an hql thats of insane string length which creates a `DataAccessResourceFailureException` 

**The fix**
We want to maintain the improved/refactored performance for most cases, however in the rare scenario that the huge bulk of teis is requested, we check the count and the skipPaging parameter and use a **useLegacy** in the TrackedEntityInstanceQueryParam to switch to the legacy version of getting teis. At the moment the threshold is set to 500. Meaning if paging is explicitly skipped using `skipPaging=true` and the tei count is above 500, then the legacy (before refactoring) mechanism is used. 
