### PR TITLE
chore: remove unused parameters from cache API [TECH-532]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheBuilder.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheBuilder.java
@@ -48,7 +48,7 @@ public interface CacheBuilder<V>
      * @throws IllegalArgumentException if specified maximumSize is a negative
      *         value.
      */
-    public CacheBuilder<V> withMaximumSize( long maximumSize );
+    CacheBuilder<V> withMaximumSize( long maximumSize );
 
     /**
      * Sets the minimum total size for the internal data structures.
@@ -58,7 +58,7 @@ public interface CacheBuilder<V>
      * @return this {@code CacheBuilder} instance (for chaining)
      * @throws IllegalArgumentException if {@code initialCapacity} is negative
      */
-    public CacheBuilder<V> withInitialCapacity( int initialCapacity );
+    CacheBuilder<V> withInitialCapacity( int initialCapacity );
 
     /**
      * Set the cacheRegion for the cache instance to be built. If not specified
@@ -68,7 +68,7 @@ public interface CacheBuilder<V>
      * @return The builder instance.
      * @throws IllegalArgumentException if specified region is null.
      */
-    public CacheBuilder<V> forRegion( String region );
+    CacheBuilder<V> forRegion( String region );
 
     /**
      * Configure the cache instance to expire the keys, if the expiry duration
@@ -79,7 +79,7 @@ public interface CacheBuilder<V>
      * @return The builder instance.
      * @throws IllegalArgumentException if specified timeUnit is null.
      */
-    public CacheBuilder<V> expireAfterAccess( long duration, TimeUnit timeUnit );
+    CacheBuilder<V> expireAfterAccess( long duration, TimeUnit timeUnit );
 
     /**
      * Configure the cache instance to expire the keys, if the expiry duration
@@ -90,7 +90,7 @@ public interface CacheBuilder<V>
      * @return The builder instance.
      * @throws IllegalArgumentException if specified timeUnit is null.
      */
-    public CacheBuilder<V> expireAfterWrite( long duration, TimeUnit timeUnit );
+    CacheBuilder<V> expireAfterWrite( long duration, TimeUnit timeUnit );
 
     /**
      * Configure the cache instance to have a default value if the key does not
@@ -100,7 +100,7 @@ public interface CacheBuilder<V>
      * @param defaultValue The default value
      * @return The builder instance.
      */
-    public CacheBuilder<V> withDefaultValue( V defaultValue );
+    CacheBuilder<V> withDefaultValue( V defaultValue );
 
     /**
      * Configure the cache instance to use local inmemory storage even in
@@ -109,68 +109,68 @@ public interface CacheBuilder<V>
      *
      * @return The builder instance.
      */
-    public CacheBuilder<V> forceInMemory();
+    CacheBuilder<V> forceInMemory();
 
     /**
      * Configure the cache instance to disable caching.
      *
      * @return The builder instance.
      */
-    public CacheBuilder<V> disabled();
+    CacheBuilder<V> disabled();
 
     /**
      * Construct the cache instance based on the input parameters and return it.
      *
      * @return The cache instance created.
      */
-    public Cache<V> build();
+    Cache<V> build();
 
     /**
      * Getter for maximumSize
      *
      * @return the maximumSize value set in the builder
      */
-    public long getMaximumSize();
+    long getMaximumSize();
 
     /**
      * Getter for initialCapacity
      *
      * @return the initialCapacity value set in the builder
      */
-    public int getInitialCapacity();
+    int getInitialCapacity();
 
     /**
      * Getter for region
      *
      * @return the region set in the builder
      */
-    public String getRegion();
+    String getRegion();
 
     /**
      * Getter for refreshExpiryOnAccess
      *
      * @return the refreshExpiryOnAccess flag set in the builder
      */
-    public boolean isRefreshExpiryOnAccess();
+    boolean isRefreshExpiryOnAccess();
 
     /**
      * Getter for expiryEnabled
      *
      * @return the expiryEnabled flag set in the builder
      */
-    public boolean isExpiryEnabled();
+    boolean isExpiryEnabled();
 
     /**
      * Getter for expiryInSeconds
      *
      * @return the expiryInSeconds value set in the builder
      */
-    public long getExpiryInSeconds();
+    long getExpiryInSeconds();
 
     /**
      * Getter for defaultvalue
      *
      * @return the defaultvalue value set in the builder
      */
-    public V getDefaultValue();
+    V getDefaultValue();
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/AnalyticsCache.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/AnalyticsCache.java
@@ -65,7 +65,7 @@ public class AnalyticsCache
         // Set a default expiration time to always expire, as the TTL will be
         // always overwritten during "put" operations.
         long initialExpirationTime = analyticsCacheSettings.fixedExpirationTimeOrDefault();
-        this.queryCache = cacheProvider.createAnalyticsResponseCache( Grid.class,
+        this.queryCache = cacheProvider.createAnalyticsResponseCache(
             Duration.ofSeconds( initialExpirationTime ) );
         log.info( String.format( "Analytics server-side cache is enabled with expiration time (in seconds): %d",
             initialExpirationTime ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -97,7 +97,7 @@ public class DefaultAppManager
         this.localAppStorageService = localAppStorageService;
         this.jCloudsAppStorageService = jCloudsAppStorageService;
         this.keyJsonValueService = keyJsonValueService;
-        this.appCache = cacheProvider.createAppCache( App.class );
+        this.appCache = cacheProvider.createAppCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
@@ -73,7 +73,7 @@ public class DefaultAttributeService
         this.attributeStore = attributeStore;
         this.manager = manager;
         this.sessionFactory = sessionFactory;
-        this.attributeCache = cacheProvider.createMetadataAttributesCache( Attribute.class );
+        this.attributeCache = cacheProvider.createMetadataAttributesCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -120,7 +120,7 @@ public class DefaultIdentifiableObjectManager
         this.sessionFactory = sessionFactory;
         this.currentUserService = currentUserService;
         this.schemaService = schemaService;
-        this.defaultObjectCache = cacheProvider.createDefaultObjectCache( IdentifiableObject.class );
+        this.defaultObjectCache = cacheProvider.createDefaultObjectCache();
     }
 
     // --------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -130,7 +130,7 @@ public class HibernateDataApprovalStore
         this.categoryService = categoryService;
         this.systemSettingManager = systemSettingManager;
         this.statementBuilder = statementBuilder;
-        this.isApprovedCache = cacheProvider.createIsDataApprovedCache( Boolean.class );
+        this.isApprovedCache = cacheProvider.createIsDataApprovedCache();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultAggregateAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultAggregateAccessManager.java
@@ -55,14 +55,13 @@ public class DefaultAggregateAccessManager
 
     private final AclService aclService;
 
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
     public DefaultAggregateAccessManager( AclService aclService, CacheProvider cacheProvider )
     {
         checkNotNull( aclService );
         checkNotNull( cacheProvider );
 
         this.aclService = aclService;
-        this.canDataWriteCocCache = (Cache) cacheProvider.createCanDataWriteCocCache( List.class );
+        this.canDataWriteCocCache = cacheProvider.createCanDataWriteCocCache();
     }
 
     // ---------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -242,7 +242,6 @@ public class DefaultExpressionService
     // Constructor
     // -------------------------------------------------------------------------
 
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
     public DefaultExpressionService(
         @Qualifier( "org.hisp.dhis.expression.ExpressionStore" ) HibernateGenericStore<Expression> expressionStore,
         DataElementService dataElementService, ConstantService constantService, CategoryService categoryService,
@@ -264,7 +263,7 @@ public class DefaultExpressionService
         this.organisationUnitGroupService = organisationUnitGroupService;
         this.dimensionService = dimensionService;
         this.idObjectManager = idObjectManager;
-        this.constantMapCache = (Cache) cacheProvider.createAllConstantsCache( Map.class );
+        this.constantMapCache = cacheProvider.createAllConstantsCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -117,9 +117,9 @@ public class DefaultOrganisationUnitService
         this.currentUserService = currentUserService;
         this.configurationService = configurationService;
         this.userSettingService = userSettingService;
-        this.inUserOrgUnitHierarchyCache = cacheProvider.createInUserOrgUnitHierarchyCache( Boolean.class );
-        this.inUserOrgUnitSearchHierarchyCache = cacheProvider.createInUserSearchOrgUnitHierarchyCache( Boolean.class );
-        this.userCaptureOrgCountThresholdCache = cacheProvider.createUserCaptureOrgUnitThresholdCache( Boolean.class );
+        this.inUserOrgUnitHierarchyCache = cacheProvider.createInUserOrgUnitHierarchyCache();
+        this.inUserOrgUnitSearchHierarchyCache = cacheProvider.createInUserSearchOrgUnitHierarchyCache();
+        this.userCaptureOrgCountThresholdCache = cacheProvider.createUserCaptureOrgUnitThresholdCache();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -78,7 +78,7 @@ public class HibernatePeriodStore
         super( sessionFactory, jdbcTemplate, publisher, Period.class, currentUserService, aclService, true );
 
         transientIdentifiableProperties = true;
-        this.periodIdCache = cacheProvider.createPeriodIdCache( Long.class );
+        this.periodIdCache = cacheProvider.createPeriodIdCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -177,7 +177,7 @@ public class DefaultProgramIndicatorService
         this.programIndicatorGroupStore = programIndicatorGroupStore;
         this.i18nManager = i18nManager;
         this.relationshipTypeService = relationshipTypeService;
-        this.analyticsSqlCache = cacheProvider.createAnalyticsSqlCache( String.class );
+        this.analyticsSqlCache = cacheProvider.createAnalyticsSqlCache();
     }
 
     public static final ImmutableMap<Integer, ExpressionItem> PROGRAM_INDICATOR_ITEMS = ImmutableMap

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultSecurityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultSecurityService.java
@@ -163,8 +163,8 @@ public class DefaultSecurityService
         this.systemSettingManager = systemSettingManager;
         this.i18nManager = i18nManager;
         this.jsonMapper = jsonMapper;
-        this.userFailedLoginAttemptCache = cacheProvider.createUserFailedLoginAttemptCache( Integer.class, 0 );
-        this.userAccountRecoverAttemptCache = cacheProvider.createUserAccountRecoverAttemptCache( Integer.class, 0 );
+        this.userFailedLoginAttemptCache = cacheProvider.createUserFailedLoginAttemptCache( 0 );
+        this.userAccountRecoverAttemptCache = cacheProvider.createUserAccountRecoverAttemptCache( 0 );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -106,8 +106,8 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
         this.organisationUnitService = organisationUnitService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
         this.config = config;
-        this.ownerCache = cacheProvider.createProgramOwnerCache( OrganisationUnit.class );
-        this.tempOwnerCache = cacheProvider.createProgramTempOwnerCache( Boolean.class );
+        this.ownerCache = cacheProvider.createProgramOwnerCache();
+        this.tempOwnerCache = cacheProvider.createProgramTempOwnerCache();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultCurrentUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultCurrentUserService.java
@@ -78,9 +78,8 @@ public class DefaultCurrentUserService
         checkNotNull( userStore );
 
         this.userStore = userStore;
-        this.usernameIdCache = cacheProvider.createUserIdCacheCache( Long.class );
-        this.currentUserGroupInfoCache = cacheProvider
-            .createCurrentUserGroupInfoCache( CurrentUserGroupInfo.class );
+        this.usernameIdCache = cacheProvider.createUserIdCacheCache();
+        this.currentUserGroupInfoCache = cacheProvider.createCurrentUserGroupInfoCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserSettingService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserSettingService.java
@@ -96,7 +96,7 @@ public class DefaultUserSettingService
         this.userSettingStore = userSettingStore;
         this.userService = userService;
         this.systemSettingManager = systemSettingManager;
-        this.userSettingCache = cacheProvider.createUserSettingCache( SerializableOptional.class );
+        this.userSettingCache = cacheProvider.createUserSettingCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
@@ -38,7 +38,6 @@ import java.util.List;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.importer.EventImporter;
@@ -157,7 +156,7 @@ public class JacksonEventService extends AbstractEventService
         this.eventSyncService = eventSyncService;
         this.jsonMapper = jsonMapper;
         this.xmlMapper = xmlMapper;
-        this.dataElementCache = cacheProvider.createDataElementCache( DataElement.class );
+        this.dataElementCache = cacheProvider.createDataElementCache();
     }
 
     @SuppressWarnings( "unchecked" )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/util/InputUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/util/InputUtils.java
@@ -60,7 +60,7 @@ public class InputUtils
     {
         this.categoryService = categoryService;
         this.idObjectManager = idObjectManager;
-        this.attrOptionComboIdCache = cacheProvider.createAttrOptionComboIdCache( Long.class );
+        this.attrOptionComboIdCache = cacheProvider.createAttrOptionComboIdCache();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.fieldfilter;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +89,7 @@ public class DefaultFieldFilterServiceTest
         throws Exception
     {
         CacheProvider cacheProvider = mock( CacheProvider.class );
-        when( cacheProvider.createPropertyTransformerCache( any() ) ).thenReturn( new NoOpCache<>() );
+        when( cacheProvider.createPropertyTransformerCache() ).thenReturn( new NoOpCache<>() );
         service = new DefaultFieldFilterService( fieldParser, schemaService, aclService, currentUserService,
             attributeService, cacheProvider, new HashSet<>() );
     }

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -130,7 +130,7 @@ public class DefaultFieldFilterService implements FieldFilterService
         this.currentUserService = currentUserService;
         this.attributeService = attributeService;
         this.nodeTransformers = nodeTransformers == null ? new HashSet<>() : nodeTransformers;
-        this.transformerCache = cacheProvider.createPropertyTransformerCache( PropertyTransformer.class );
+        this.transformerCache = cacheProvider.createPropertyTransformerCache();
     }
 
     @PostConstruct

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.fieldfilter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -111,7 +110,7 @@ public class DefaultFieldFilterServiceTest
         }, sessionFactory );
 
         CacheProvider cacheProvider = mock( CacheProvider.class );
-        when( cacheProvider.createPropertyTransformerCache( any() ) ).thenReturn( new NoOpCache<>() );
+        when( cacheProvider.createPropertyTransformerCache() ).thenReturn( new NoOpCache<>() );
         service = new DefaultFieldFilterService( new DefaultFieldParser(), schemaService, aclService,
             currentUserService, attributeService, cacheProvider, nodeTransformers );
         service.init();

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -97,7 +97,7 @@ public class DefaultSystemSettingManager
         this.systemSettingStore = systemSettingStore;
         this.pbeStringEncryptor = pbeStringEncryptor;
         this.flags = flags;
-        this.settingCache = cacheProvider.createSystemSettingCache( SerializableOptional.class );
+        this.settingCache = cacheProvider.createSystemSettingCache();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheBuilderProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheBuilderProvider.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.cache;
 
-import java.util.Map;
-
 /**
  * Provides cache builder to build instances.
  *
@@ -44,15 +42,6 @@ public interface CacheBuilderProvider
      * @return A cache builder instance for the specified value type. Returns a
      *         {@link ExtendedCacheBuilder}.
      */
-    <V> CacheBuilder<V> newCacheBuilder( Class<V> valueType );
+    <V> CacheBuilder<V> newCacheBuilder();
 
-    /**
-     * Creates a new {@link ExtendedCacheBuilder} that can be used to build a
-     * cache that stores the Map of keyType and valueType specified.
-     *
-     * @param valueType The class type of values to be stored in cache.
-     * @return A cache builder instance for the specified value type. Returns a
-     *         {@link ExtendedCacheBuilder}.
-     */
-    <K, V> ExtendedCacheBuilder<Map<K, V>> newCacheBuilder( Class<K> keyType, Class<V> valueType );
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheBuilderProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheBuilderProvider.java
@@ -38,7 +38,6 @@ public interface CacheBuilderProvider
      * Creates a new {@link ExtendedCacheBuilder} that can be used to build a
      * cache that stores the valueType specified.
      *
-     * @param valueType The class type of values to be stored in cache.
      * @return A cache builder instance for the specified value type. Returns a
      *         {@link ExtendedCacheBuilder}.
      */

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -43,54 +43,54 @@ import java.time.Duration;
 public interface CacheProvider
 {
 
-    <V> Cache<V> createAnalyticsResponseCache( Class<V> valueType, Duration initialExpirationTime );
+    <V> Cache<V> createAnalyticsResponseCache( Duration initialExpirationTime );
 
-    <V> Cache<V> createAppCache( Class<V> valueType );
+    <V> Cache<V> createAppCache();
 
-    <V> Cache<V> createDefaultObjectCache( Class<V> valueType );
+    <V> Cache<V> createDefaultObjectCache();
 
-    <V> Cache<V> createIsDataApprovedCache( Class<V> valueType );
+    <V> Cache<V> createIsDataApprovedCache();
 
-    <V> Cache<V> createAllConstantsCache( Class<V> valueType );
+    <V> Cache<V> createAllConstantsCache();
 
-    <V> Cache<V> createInUserOrgUnitHierarchyCache( Class<V> valueType );
+    <V> Cache<V> createInUserOrgUnitHierarchyCache();
 
-    <V> Cache<V> createInUserSearchOrgUnitHierarchyCache( Class<V> valueType );
+    <V> Cache<V> createInUserSearchOrgUnitHierarchyCache();
 
-    <V> Cache<V> createUserCaptureOrgUnitThresholdCache( Class<V> valueType );
+    <V> Cache<V> createUserCaptureOrgUnitThresholdCache();
 
-    <V> Cache<V> createPeriodIdCache( Class<V> valueType );
+    <V> Cache<V> createPeriodIdCache();
 
-    <V> Cache<V> createUserFailedLoginAttemptCache( Class<V> valueType, V defaultValue );
+    <V> Cache<V> createUserFailedLoginAttemptCache( V defaultValue );
 
-    <V> Cache<V> createUserAccountRecoverAttemptCache( Class<V> valueType, V defaultValue );
+    <V> Cache<V> createUserAccountRecoverAttemptCache( V defaultValue );
 
-    <V> Cache<V> createProgramOwnerCache( Class<V> valueType );
+    <V> Cache<V> createProgramOwnerCache();
 
-    <V> Cache<V> createProgramTempOwnerCache( Class<V> valueType );
+    <V> Cache<V> createProgramTempOwnerCache();
 
-    <V> Cache<V> createUserIdCacheCache( Class<V> valueType );
+    <V> Cache<V> createUserIdCacheCache();
 
-    <V> Cache<V> createCurrentUserGroupInfoCache( Class<V> valueType );
+    <V> Cache<V> createCurrentUserGroupInfoCache();
 
-    <V> Cache<V> createUserSettingCache( Class<V> valueType );
+    <V> Cache<V> createUserSettingCache();
 
-    <V> Cache<V> createAttrOptionComboIdCache( Class<V> valueType );
+    <V> Cache<V> createAttrOptionComboIdCache();
 
-    <V> Cache<V> createSystemSettingCache( Class<V> valueType );
+    <V> Cache<V> createSystemSettingCache();
 
-    <V> Cache<V> createGoogleAccessTokenCache( Class<V> valueType );
+    <V> Cache<V> createGoogleAccessTokenCache();
 
-    <V> Cache<V> createDataItemsPaginationCache( Class<V> valueType );
+    <V> Cache<V> createDataItemsPaginationCache();
 
-    <V> Cache<V> createMetadataAttributesCache( Class<V> valueType );
+    <V> Cache<V> createMetadataAttributesCache();
 
-    <V> Cache<V> createCanDataWriteCocCache( Class<V> valueType );
+    <V> Cache<V> createCanDataWriteCocCache();
 
-    <V> Cache<V> createAnalyticsSqlCache( Class<V> valueType );
+    <V> Cache<V> createAnalyticsSqlCache();
 
-    <V> Cache<V> createDataElementCache( Class<V> valueType );
+    <V> Cache<V> createDataElementCache();
 
-    <V> Cache<V> createPropertyTransformerCache( Class<V> valueType );
+    <V> Cache<V> createPropertyTransformerCache();
 
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheBuilderProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheBuilderProvider.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.cache;
 
-import java.util.Map;
-
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -49,15 +47,9 @@ public class DefaultCacheBuilderProvider implements CacheBuilderProvider
     private RedisTemplate<String, ?> redisTemplate;
 
     @Override
-    public <V> ExtendedCacheBuilder<V> newCacheBuilder( Class<V> valueType )
+    public <V> ExtendedCacheBuilder<V> newCacheBuilder()
     {
         return new ExtendedCacheBuilder<V>( redisTemplate, configurationProvider );
-    }
-
-    @Override
-    public <K, V> ExtendedCacheBuilder<Map<K, V>> newCacheBuilder( Class<K> keyType, Class<V> valueType )
-    {
-        return new ExtendedCacheBuilder<Map<K, V>>( redisTemplate, configurationProvider );
     }
 
     @Autowired

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheBuilderProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheBuilderProvider.java
@@ -47,9 +47,9 @@ public class DefaultCacheBuilderProvider implements CacheBuilderProvider
     private RedisTemplate<String, ?> redisTemplate;
 
     @Override
-    public <V> ExtendedCacheBuilder<V> newCacheBuilder()
+    public <V> CacheBuilder<V> newCacheBuilder()
     {
-        return new ExtendedCacheBuilder<V>( redisTemplate, configurationProvider );
+        return new ExtendedCacheBuilder<>( redisTemplate, configurationProvider );
     }
 
     @Autowired

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -54,6 +54,7 @@ public class DefaultCacheProvider implements CacheProvider
      * Enum is used to make sure we do not use same region twice. Each method
      * should have its own constant.
      */
+    @SuppressWarnings( "squid:S115" ) // allow non enum-ish names
     private enum Region
     {
         analyticsResponse,

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -50,6 +50,39 @@ import org.springframework.stereotype.Component;
 public class DefaultCacheProvider implements CacheProvider
 {
 
+    /**
+     * Enum is used to make sure we do not use same region twice. Each method
+     * should have its own constant.
+     */
+    private enum Region
+    {
+        analyticsResponse,
+        appCache,
+        defaultObjectCache,
+        isDataApproved,
+        allConstantsCache,
+        inUserOuHierarchy,
+        inUserSearchOuHierarchy,
+        userCaptureOuCountThreshold,
+        periodIdCache,
+        userAccountRecoverAttempt,
+        userFailedLoginAttempt,
+        programOwner,
+        programTempOwner,
+        userIdCache,
+        currentUserGroupInfoCache,
+        userSetting,
+        attrOptionComboIdCache,
+        systemSetting,
+        googleAccessToken,
+        dataItemsPagination,
+        metadataAttributes,
+        canDataWriteCocCache,
+        analyticsSql,
+        dataElementCache,
+        propertyTransformerCache
+    }
+
     private final CacheBuilderProvider cacheBuilderProvider;
 
     private final Environment environment;
@@ -59,34 +92,34 @@ public class DefaultCacheProvider implements CacheProvider
         return isTestRun( environment.getActiveProfiles() ) ? 0 : value;
     }
 
-    private <V> CacheBuilder<V> newBuilder( Class<V> valueType )
+    private <V> CacheBuilder<V> newBuilder()
     {
-        return cacheBuilderProvider.newCacheBuilder( valueType );
+        return cacheBuilderProvider.newCacheBuilder();
     }
 
     @Override
-    public <V> Cache<V> createAnalyticsResponseCache( Class<V> valueType, Duration initialExpirationTime )
+    public <V> Cache<V> createAnalyticsResponseCache( Duration initialExpirationTime )
     {
-        return newBuilder( valueType )
-            .forRegion( "analyticsResponse" )
+        return this.<V> newBuilder()
+            .forRegion( Region.analyticsResponse.name() )
             .expireAfterWrite( initialExpirationTime.toMillis(), MILLISECONDS )
             .withMaximumSize( orZeroInTestRun( 20000 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createAppCache( Class<V> valueType )
+    public <V> Cache<V> createAppCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "appCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.appCache.name() )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createDefaultObjectCache( Class<V> valueType )
+    public <V> Cache<V> createDefaultObjectCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "defaultObjectCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.defaultObjectCache.name() )
             .expireAfterAccess( 2, TimeUnit.HOURS )
             .withInitialCapacity( 4 )
             .forceInMemory()
@@ -95,20 +128,20 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createIsDataApprovedCache( Class<V> valueType )
+    public <V> Cache<V> createIsDataApprovedCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "isDataApproved" )
+        return this.<V> newBuilder()
+            .forRegion( Region.isDataApproved.name() )
             .expireAfterAccess( 12, TimeUnit.HOURS )
             .withMaximumSize( orZeroInTestRun( 20000 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createAllConstantsCache( Class<V> valueType )
+    public <V> Cache<V> createAllConstantsCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "allConstantsCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.allConstantsCache.name() )
             .expireAfterAccess( 2, TimeUnit.MINUTES )
             .withInitialCapacity( 1 )
             .forceInMemory()
@@ -117,10 +150,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createInUserOrgUnitHierarchyCache( Class<V> valueType )
+    public <V> Cache<V> createInUserOrgUnitHierarchyCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "inUserOuHierarchy" )
+        return this.<V> newBuilder()
+            .forRegion( Region.inUserOuHierarchy.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -129,10 +162,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createInUserSearchOrgUnitHierarchyCache( Class<V> valueType )
+    public <V> Cache<V> createInUserSearchOrgUnitHierarchyCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "inUserSearchOuHierarchy" )
+        return this.<V> newBuilder()
+            .forRegion( Region.inUserSearchOuHierarchy.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -141,10 +174,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createUserCaptureOrgUnitThresholdCache( Class<V> valueType )
+    public <V> Cache<V> createUserCaptureOrgUnitThresholdCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "userCaptureOuCountThreshold" )
+        return this.<V> newBuilder()
+            .forRegion( Region.userCaptureOuCountThreshold.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -153,10 +186,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createPeriodIdCache( Class<V> valueType )
+    public <V> Cache<V> createPeriodIdCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "periodIdCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.periodIdCache.name() )
             .expireAfterWrite( 24, TimeUnit.HOURS )
             .withInitialCapacity( 200 )
             .forceInMemory()
@@ -165,50 +198,50 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createUserAccountRecoverAttemptCache( Class<V> valueType, V defaultValue )
+    public <V> Cache<V> createUserAccountRecoverAttemptCache( V defaultValue )
     {
-        return newBuilder( valueType )
-            .forRegion( "userAccountRecoverAttempt" )
+        return this.<V> newBuilder()
+            .forRegion( Region.userAccountRecoverAttempt.name() )
             .expireAfterWrite( 15, TimeUnit.MINUTES )
             .withDefaultValue( defaultValue )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createUserFailedLoginAttemptCache( Class<V> valueType, V defaultValue )
+    public <V> Cache<V> createUserFailedLoginAttemptCache( V defaultValue )
     {
-        return newBuilder( valueType )
-            .forRegion( "userFailedLoginAttempt" )
+        return this.<V> newBuilder()
+            .forRegion( Region.userFailedLoginAttempt.name() )
             .expireAfterWrite( 15, TimeUnit.MINUTES )
             .withDefaultValue( defaultValue )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createProgramOwnerCache( Class<V> valueType )
+    public <V> Cache<V> createProgramOwnerCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "programOwner" )
+        return this.<V> newBuilder()
+            .forRegion( Region.programOwner.name() )
             .expireAfterWrite( 5, TimeUnit.MINUTES )
             .withMaximumSize( orZeroInTestRun( 1000 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createProgramTempOwnerCache( Class<V> valueType )
+    public <V> Cache<V> createProgramTempOwnerCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "programTempOwner" )
+        return this.<V> newBuilder()
+            .forRegion( Region.programTempOwner.name() )
             .expireAfterWrite( 30, TimeUnit.MINUTES )
             .withMaximumSize( orZeroInTestRun( 4000 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createUserIdCacheCache( Class<V> valueType )
+    public <V> Cache<V> createUserIdCacheCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "userIdCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.userIdCache.name() )
             .expireAfterAccess( 1, TimeUnit.HOURS )
             .withInitialCapacity( 200 )
             .forceInMemory()
@@ -217,30 +250,30 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createCurrentUserGroupInfoCache( Class<V> valueType )
+    public <V> Cache<V> createCurrentUserGroupInfoCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "currentUserGroupInfoCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.currentUserGroupInfoCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .forceInMemory()
             .build();
     }
 
     @Override
-    public <V> Cache<V> createUserSettingCache( Class<V> valueType )
+    public <V> Cache<V> createUserSettingCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "userSetting" )
+        return this.<V> newBuilder()
+            .forRegion( Region.userSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withMaximumSize( orZeroInTestRun( 10000 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createAttrOptionComboIdCache( Class<V> valueType )
+    public <V> Cache<V> createAttrOptionComboIdCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "attrOptionComboIdCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.attrOptionComboIdCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -249,30 +282,30 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createSystemSettingCache( Class<V> valueType )
+    public <V> Cache<V> createSystemSettingCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "systemSetting" )
+        return this.<V> newBuilder()
+            .forRegion( Region.systemSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withMaximumSize( orZeroInTestRun( 400 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createGoogleAccessTokenCache( Class<V> valueType )
+    public <V> Cache<V> createGoogleAccessTokenCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "googleAccessToken" )
+        return this.<V> newBuilder()
+            .forRegion( Region.googleAccessToken.name() )
             .expireAfterAccess( 10, TimeUnit.MINUTES )
             .withMaximumSize( orZeroInTestRun( 1 ) )
             .build();
     }
 
     @Override
-    public <V> Cache<V> createDataItemsPaginationCache( Class<V> valueType )
+    public <V> Cache<V> createDataItemsPaginationCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "dataItemsPagination" )
+        return this.<V> newBuilder()
+            .forRegion( Region.dataItemsPagination.name() )
             .expireAfterWrite( 5, MINUTES )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -281,10 +314,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createMetadataAttributesCache( Class<V> valueType )
+    public <V> Cache<V> createMetadataAttributesCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "metadataAttributes" )
+        return this.<V> newBuilder()
+            .forRegion( Region.metadataAttributes.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( 10000 ) )
@@ -292,10 +325,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createCanDataWriteCocCache( Class<V> valueType )
+    public <V> Cache<V> createCanDataWriteCocCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "canDataWriteCocCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.canDataWriteCocCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -304,10 +337,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createAnalyticsSqlCache( Class<V> valueType )
+    public <V> Cache<V> createAnalyticsSqlCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "analyticsSql" )
+        return this.<V> newBuilder()
+            .forRegion( Region.analyticsSql.name() )
             .expireAfterAccess( 10, TimeUnit.HOURS )
             .withInitialCapacity( 10000 )
             .forceInMemory()
@@ -316,10 +349,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createDataElementCache( Class<V> valueType )
+    public <V> Cache<V> createDataElementCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "dataElementCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.dataElementCache.name() )
             .expireAfterAccess( 60, TimeUnit.MINUTES )
             .withInitialCapacity( 1000 )
             .forceInMemory()
@@ -328,10 +361,10 @@ public class DefaultCacheProvider implements CacheProvider
     }
 
     @Override
-    public <V> Cache<V> createPropertyTransformerCache( Class<V> valueType )
+    public <V> Cache<V> createPropertyTransformerCache()
     {
-        return newBuilder( valueType )
-            .forRegion( "propertyTransformerCache" )
+        return this.<V> newBuilder()
+            .forRegion( Region.propertyTransformerCache.name() )
             .expireAfterAccess( 12, TimeUnit.HOURS )
             .withInitialCapacity( 20 )
             .forceInMemory()

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/ExtendedCacheBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/ExtendedCacheBuilder.java
@@ -44,9 +44,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 @Slf4j
 public class ExtendedCacheBuilder<V> extends SimpleCacheBuilder<V>
 {
-    private DhisConfigurationProvider configurationProvider;
+    private final DhisConfigurationProvider configurationProvider;
 
-    private RedisTemplate<String, ?> redisTemplate;
+    private final RedisTemplate<String, ?> redisTemplate;
 
     private boolean forceInMemory;
 
@@ -96,22 +96,22 @@ public class ExtendedCacheBuilder<V> extends SimpleCacheBuilder<V>
         if ( getMaximumSize() == 0 || isDisabled() )
         {
             log.info( String.format( "NoOp Cache instance created for region:'%s'", getRegion() ) );
-            return new NoOpCache<V>( this );
+            return new NoOpCache<>( this );
         }
         else if ( forceInMemory )
         {
             log.info( String.format( "Local Cache (forced) instance created for region:'%s'", getRegion() ) );
-            return new LocalCache<V>( this );
+            return new LocalCache<>( this );
         }
         else if ( configurationProvider.getProperty( ConfigurationKey.REDIS_ENABLED ).equalsIgnoreCase( "true" ) )
         {
             log.info( String.format( "Redis Cache instance created for region:'%s'", getRegion() ) );
-            return new RedisCache<V>( this );
+            return new RedisCache<>( this );
         }
         else
         {
             log.info( String.format( "Local Cache instance created for region:'%s'", getRegion() ) );
-            return new LocalCache<V>( this );
+            return new LocalCache<>( this );
         }
     }
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
@@ -68,7 +68,7 @@ public class TokenController
     public TokenController( DhisConfigurationProvider config, CacheProvider cacheProvider )
     {
         this.config = config;
-        this.tokenCache = cacheProvider.createGoogleAccessTokenCache( GoogleAccessToken.class );
+        this.tokenCache = cacheProvider.createGoogleAccessTokenCache();
     }
 
     @RequestMapping( value = "/google", method = RequestMethod.GET, produces = "application/json" )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandler.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandler.java
@@ -85,7 +85,7 @@ class ResponseHandler
         this.queryService = queryService;
         this.linkService = linkService;
         this.fieldFilterService = fieldFilterService;
-        this.pageCountingCache = cacheProvider.createDataItemsPaginationCache( Long.class );
+        this.pageCountingCache = cacheProvider.createDataItemsPaginationCache();
     }
 
     /**

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
@@ -100,7 +100,7 @@ public class ResponseHandlerTest
     {
         String[] testEnvironmentVars = { "test" };
         when( environment.getActiveProfiles() ).thenReturn( testEnvironmentVars );
-        when( cacheProvider.createDataItemsPaginationCache( Long.class ) ).thenReturn( new NoOpCache<>() );
+        when( cacheProvider.createDataItemsPaginationCache() ).thenReturn( new NoOpCache<>() );
         responseHandler = new ResponseHandler( queryService, linkService, fieldFilterService, cacheProvider );
     }
 


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

Based on a discussion with @larshelge this PR removes the unused value type parameter in the cache API.

As the `CacheBuilderProvider#newCacheBuilder` with two types was unused and since the type arguments got removed `CacheBuilderProvider` now only has a single method.

To lower the risk of regions being accidentally reused a `Region` enum was added.

