### PR TITLE
fix: prevent create/update/delete of system jobs [DHIS2-10505]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/CollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/CollectionService.java
@@ -38,10 +38,12 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageException;
  */
 public interface CollectionService
 {
-    void addCollectionItems( IdentifiableObject object, String propertyName, List<IdentifiableObject> objects )
+    void addCollectionItems( IdentifiableObject object, String propertyName,
+        List<? extends IdentifiableObject> objects )
         throws Exception;
 
-    void delCollectionItems( IdentifiableObject object, String propertyName, List<IdentifiableObject> objects )
+    void delCollectionItems( IdentifiableObject object, String propertyName,
+        List<? extends IdentifiableObject> objects )
         throws Exception;
 
     void clearCollectionItems( IdentifiableObject object, String pvProperty )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
@@ -91,7 +91,8 @@ public class DefaultCollectionService
 
     @Override
     @SuppressWarnings( "unchecked" )
-    public void addCollectionItems( IdentifiableObject object, String propertyName, List<IdentifiableObject> objects )
+    public void addCollectionItems( IdentifiableObject object, String propertyName,
+        List<? extends IdentifiableObject> objects )
         throws Exception
     {
         Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
@@ -171,7 +172,8 @@ public class DefaultCollectionService
 
     @Override
     @SuppressWarnings( "unchecked" )
-    public void delCollectionItems( IdentifiableObject object, String propertyName, List<IdentifiableObject> objects )
+    public void delCollectionItems( IdentifiableObject object, String propertyName,
+        List<? extends IdentifiableObject> objects )
         throws Exception
     {
         Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
@@ -28,11 +28,11 @@
 package org.hisp.dhis.dxf2.metadata.collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -58,17 +58,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class DefaultCollectionService
     implements CollectionService
 {
-    private IdentifiableObjectManager manager;
+    private final IdentifiableObjectManager manager;
 
-    private DbmsManager dbmsManager;
+    private final DbmsManager dbmsManager;
 
-    private HibernateCacheManager cacheManager;
+    private final HibernateCacheManager cacheManager;
 
-    private AclService aclService;
+    private final AclService aclService;
 
-    private SchemaService schemaService;
+    private final SchemaService schemaService;
 
-    private CurrentUserService currentUserService;
+    private final CurrentUserService currentUserService;
 
     public DefaultCollectionService( IdentifiableObjectManager manager, DbmsManager dbmsManager,
         HibernateCacheManager cacheManager, AclService aclService, SchemaService schemaService,
@@ -90,159 +90,99 @@ public class DefaultCollectionService
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public void addCollectionItems( IdentifiableObject object, String propertyName,
         List<? extends IdentifiableObject> objects )
         throws Exception
     {
-        Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
+        Property property = validateUpdate( object, propertyName,
+            "Only identifiable object collections can be added to." );
 
-        if ( !aclService.canUpdate( currentUserService.getCurrentUser(), object ) )
-        {
-            throw new UpdateAccessDeniedException( "You don't have the proper permissions to update this object." );
-        }
-
-        if ( !schema.haveProperty( propertyName ) )
-        {
-            throw new WebMessageException( WebMessageUtils
-                .notFound( "Property " + propertyName + " does not exist on " + object.getClass().getName() ) );
-        }
-
-        Property property = schema.getProperty( propertyName );
-
-        if ( !property.isCollection() || !property.isIdentifiableObject() )
-        {
-            throw new WebMessageException(
-                WebMessageUtils.conflict( "Only identifiable object collections can be added to." ) );
-        }
-
-        Collection<String> itemCodes = objects.stream().map( IdentifiableObject::getUid )
-            .collect( Collectors.toList() );
+        Collection<String> itemCodes = getItemCodes( objects );
 
         if ( itemCodes.isEmpty() )
         {
             return;
         }
 
-        List<? extends IdentifiableObject> items = manager
-            .get( ((Class<? extends IdentifiableObject>) property.getItemKlass()), itemCodes );
-
         manager.refresh( object );
 
         if ( property.isOwner() )
         {
-            Collection<IdentifiableObject> collection = (Collection<IdentifiableObject>) property.getGetterMethod()
-                .invoke( object );
-
-            for ( IdentifiableObject item : items )
-            {
-                if ( !collection.contains( item ) )
-                    collection.add( item );
-            }
-
-            manager.update( object );
+            addOwnedCollectionItems( object, property, itemCodes );
         }
         else
         {
-            Schema owningSchema = schemaService.getDynamicSchema( property.getItemKlass() );
-            Property owningProperty = owningSchema.propertyByRole( property.getOwningRole() );
-
-            for ( IdentifiableObject item : items )
-            {
-                try
-                {
-                    Collection<IdentifiableObject> collection = (Collection<IdentifiableObject>) owningProperty
-                        .getGetterMethod().invoke( item );
-
-                    if ( !collection.contains( object ) )
-                    {
-                        collection.add( object );
-                        manager.update( item );
-                    }
-                }
-                catch ( Exception ex )
-                {
-                }
-            }
+            addNonOwnedCollectionItems( object, property, itemCodes );
         }
 
         dbmsManager.clearSession();
         cacheManager.clearCache();
     }
 
+    private void addOwnedCollectionItems( IdentifiableObject object, Property property, Collection<String> itemCodes )
+        throws IllegalAccessException,
+        InvocationTargetException
+    {
+        Collection<IdentifiableObject> collection = getCollection( object, property );
+
+        for ( IdentifiableObject item : getItems( property, itemCodes ) )
+        {
+            if ( !collection.contains( item ) )
+                collection.add( item );
+        }
+
+        manager.update( object );
+    }
+
+    private void addNonOwnedCollectionItems( IdentifiableObject object, Property property,
+        Collection<String> itemCodes )
+    {
+        Schema owningSchema = schemaService.getDynamicSchema( property.getItemKlass() );
+        Property owningProperty = owningSchema.propertyByRole( property.getOwningRole() );
+
+        for ( IdentifiableObject item : getItems( property, itemCodes ) )
+        {
+            try
+            {
+                Collection<IdentifiableObject> collection = getCollection( item, owningProperty );
+
+                if ( !collection.contains( object ) )
+                {
+                    collection.add( object );
+                    manager.update( item );
+                }
+            }
+            catch ( Exception ex )
+            {
+                /* Ignore */
+            }
+        }
+    }
+
     @Override
-    @SuppressWarnings( "unchecked" )
     public void delCollectionItems( IdentifiableObject object, String propertyName,
         List<? extends IdentifiableObject> objects )
         throws Exception
     {
-        Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
+        Property property = validateUpdate( object, propertyName,
+            "Only identifiable object collections can be removed from." );
 
-        if ( !aclService.canUpdate( currentUserService.getCurrentUser(), object ) )
-        {
-            throw new UpdateAccessDeniedException( "You don't have the proper permissions to update this object." );
-        }
-
-        if ( !schema.haveProperty( propertyName ) )
-        {
-            throw new WebMessageException( WebMessageUtils
-                .notFound( "Property " + propertyName + " does not exist on " + object.getClass().getName() ) );
-        }
-
-        Property property = schema.getProperty( propertyName );
-
-        if ( !property.isCollection() || !property.isIdentifiableObject() )
-        {
-            throw new WebMessageException(
-                WebMessageUtils.conflict( "Only identifiable object collections can be removed from." ) );
-        }
-
-        Collection<String> itemCodes = objects.stream().map( IdentifiableObject::getUid )
-            .collect( Collectors.toList() );
+        Collection<String> itemCodes = getItemCodes( objects );
 
         if ( itemCodes.isEmpty() )
         {
             return;
         }
 
-        List<? extends IdentifiableObject> items = manager
-            .get( ((Class<? extends IdentifiableObject>) property.getItemKlass()), itemCodes );
-
         manager.refresh( object );
 
         if ( property.isOwner() )
         {
-            Collection<IdentifiableObject> collection = (Collection<IdentifiableObject>) property.getGetterMethod()
-                .invoke( object );
-
-            for ( IdentifiableObject item : items )
-            {
-                if ( collection.contains( item ) )
-                    collection.remove( item );
-            }
+            delOwnedCollectionItems( object, property, itemCodes );
         }
         else
         {
-            Schema owningSchema = schemaService.getDynamicSchema( property.getItemKlass() );
-            Property owningProperty = owningSchema.propertyByRole( property.getOwningRole() );
-
-            for ( IdentifiableObject item : items )
-            {
-                try
-                {
-                    Collection<IdentifiableObject> collection = (Collection<IdentifiableObject>) owningProperty
-                        .getGetterMethod().invoke( item );
-
-                    if ( collection.contains( object ) )
-                    {
-                        collection.remove( object );
-                        manager.update( item );
-                    }
-                }
-                catch ( Exception ex )
-                {
-                }
-            }
+            delNonOwnedCollectionItems( object, property, itemCodes );
         }
 
         manager.update( object );
@@ -251,12 +191,77 @@ public class DefaultCollectionService
         cacheManager.clearCache();
     }
 
+    private void delOwnedCollectionItems( IdentifiableObject object, Property property, Collection<String> itemCodes )
+        throws IllegalAccessException,
+        InvocationTargetException
+    {
+        Collection<IdentifiableObject> collection = getCollection( object, property );
+
+        for ( IdentifiableObject item : getItems( property, itemCodes ) )
+        {
+            collection.remove( item );
+        }
+    }
+
+    private void delNonOwnedCollectionItems( IdentifiableObject object, Property property,
+        Collection<String> itemCodes )
+    {
+        Schema owningSchema = schemaService.getDynamicSchema( property.getItemKlass() );
+        Property owningProperty = owningSchema.propertyByRole( property.getOwningRole() );
+
+        for ( IdentifiableObject item : getItems( property, itemCodes ) )
+        {
+            try
+            {
+                Collection<IdentifiableObject> collection = getCollection( item, owningProperty );
+
+                if ( collection.contains( object ) )
+                {
+                    collection.remove( object );
+                    manager.update( item );
+                }
+            }
+            catch ( Exception ex )
+            {
+                /* Ignore */
+            }
+        }
+    }
+
     @Override
-    @SuppressWarnings( "unchecked" )
     public void clearCollectionItems( IdentifiableObject object, String pvProperty )
         throws WebMessageException,
         InvocationTargetException,
         IllegalAccessException
+    {
+        Property property = validateClear( object, pvProperty );
+
+        Collection<IdentifiableObject> collection = getCollection( object, property );
+
+        manager.refresh( object );
+
+        if ( property.isOwner() )
+        {
+            collection.clear();
+            manager.update( object );
+        }
+        else
+        {
+            for ( IdentifiableObject itemObject : collection )
+            {
+                Schema itemSchema = schemaService.getDynamicSchema( property.getItemKlass() );
+                Property itemProperty = itemSchema.propertyByRole( property.getOwningRole() );
+                Collection<IdentifiableObject> itemCollection = getCollection( itemObject, itemProperty );
+                itemCollection.remove( object );
+
+                manager.update( itemObject );
+                manager.refresh( itemObject );
+            }
+        }
+    }
+
+    private Property validateClear( IdentifiableObject object, String pvProperty )
+        throws WebMessageException
     {
         Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
 
@@ -273,30 +278,50 @@ public class DefaultCollectionService
             throw new WebMessageException(
                 WebMessageUtils.conflict( "Only identifiable collections are allowed to be cleared." ) );
         }
+        return property;
+    }
 
-        Collection<IdentifiableObject> collection = (Collection<IdentifiableObject>) property.getGetterMethod()
-            .invoke( object );
+    private Property validateUpdate( IdentifiableObject object, String propertyName, String message )
+        throws WebMessageException
+    {
+        Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
 
-        manager.refresh( object );
-
-        if ( property.isOwner() )
+        if ( !aclService.canUpdate( currentUserService.getCurrentUser(), object ) )
         {
-            collection.clear();
-            manager.update( object );
+            throw new UpdateAccessDeniedException( "You don't have the proper permissions to update this object." );
         }
-        else
-        {
-            for ( IdentifiableObject itemObject : collection )
-            {
-                Schema itemSchema = schemaService.getDynamicSchema( property.getItemKlass() );
-                Property itemProperty = itemSchema.propertyByRole( property.getOwningRole() );
-                Collection<IdentifiableObject> itemCollection = (Collection<IdentifiableObject>) itemProperty
-                    .getGetterMethod().invoke( itemObject );
-                itemCollection.remove( object );
 
-                manager.update( itemObject );
-                manager.refresh( itemObject );
-            }
+        if ( !schema.haveProperty( propertyName ) )
+        {
+            throw new WebMessageException( WebMessageUtils
+                .notFound( "Property " + propertyName + " does not exist on " + object.getClass().getName() ) );
         }
+
+        Property property = schema.getProperty( propertyName );
+
+        if ( !property.isCollection() || !property.isIdentifiableObject() )
+        {
+            throw new WebMessageException( WebMessageUtils.conflict( message ) );
+        }
+        return property;
+    }
+
+    private Collection<String> getItemCodes( List<? extends IdentifiableObject> objects )
+    {
+        return objects.stream().map( IdentifiableObject::getUid ).collect( toList() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private List<? extends IdentifiableObject> getItems( Property property, Collection<String> itemCodes )
+    {
+        return manager.get( ((Class<? extends IdentifiableObject>) property.getItemKlass()), itemCodes );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private Collection<IdentifiableObject> getCollection( IdentifiableObject object, Property property )
+        throws IllegalAccessException,
+        InvocationTargetException
+    {
+        return (Collection<IdentifiableObject>) property.getGetterMethod().invoke( object );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.Collections.singletonList;
+
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -148,7 +150,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
     protected static final String DEFAULTS = "INCLUDE";
 
-    private Cache<String, Long> paginationCountCache = new Cache2kBuilder<String, Long>()
+    private final Cache<String, Long> paginationCountCache = new Cache2kBuilder<String, Long>()
     {
     }
         .expireAfterWrite( 1, TimeUnit.MINUTES )
@@ -478,23 +480,24 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new UpdateAccessDeniedException( "You don't have the proper permissions to update this object." );
         }
 
-        Patch patch = null;
-
-        if ( isJson( request ) )
-        {
-            patch = patchService.diff(
-                new PatchParams( jsonMapper.readTree( request.getInputStream() ) ) );
-        }
-        else if ( isXml( request ) )
-        {
-            patch = patchService.diff(
-                new PatchParams( xmlMapper.readTree( request.getInputStream() ) ) );
-        }
+        Patch patch = diff( request );
 
         prePatchEntity( persistedObject );
         patchService.apply( patch, persistedObject );
         manager.update( persistedObject );
         postPatchEntity( persistedObject );
+    }
+
+    private Patch diff( HttpServletRequest request )
+        throws IOException,
+        WebMessageException
+    {
+        ObjectMapper mapper = isJson( request ) ? jsonMapper : isXml( request ) ? xmlMapper : null;
+        if ( mapper == null )
+        {
+            throw new WebMessageException( WebMessageUtils.badRequest( "Unknown payload format." ) );
+        }
+        return patchService.diff( new PatchParams( mapper.readTree( request.getInputStream() ) ) );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )
@@ -540,10 +543,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new WebMessageException( WebMessageUtils.badRequest( "Unknown payload format." ) );
         }
 
+        prePatchEntity( persistedObject );
         Object value = property.getGetterMethod().invoke( object );
-
         property.getSetterMethod().invoke( persistedObject, value );
-
         manager.update( persistedObject );
         postPatchEntity( persistedObject );
     }
@@ -1034,14 +1036,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         HttpServletRequest request )
         throws Exception
     {
-        List<T> objects = getEntity( pvUid );
-        IdentifiableObjects identifiableObjects = renderService.fromJson( request.getInputStream(),
-            IdentifiableObjects.class );
-
-        collectionService.delCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getDeletions() ) );
-        collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getAdditions() ) );
+        addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+            renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
@@ -1052,14 +1048,17 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         HttpServletRequest request )
         throws Exception
     {
-        List<T> objects = getEntity( pvUid );
-        IdentifiableObjects identifiableObjects = renderService.fromXml( request.getInputStream(),
-            IdentifiableObjects.class );
+        addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+            renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
+    }
 
-        collectionService.delCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getDeletions() ) );
-        collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getAdditions() ) );
+    private void addCollectionItems( String pvProperty, T object, IdentifiableObjects items )
+        throws Exception
+    {
+        preUpdateItems( object, items );
+        collectionService.delCollectionItems( object, pvProperty, items.getDeletions() );
+        collectionService.addCollectionItems( object, pvProperty, items.getAdditions() );
+        postUpdateItems( object, items );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
@@ -1069,13 +1068,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         HttpServletRequest request )
         throws Exception
     {
-        List<T> objects = getEntity( pvUid );
-        IdentifiableObjects identifiableObjects = renderService.fromJson( request.getInputStream(),
-            IdentifiableObjects.class );
-
-        collectionService.clearCollectionItems( objects.get( 0 ), pvProperty );
-        collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
+        replaceCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+            renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE )
@@ -1085,13 +1079,17 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         HttpServletRequest request )
         throws Exception
     {
-        List<T> objects = getEntity( pvUid );
-        IdentifiableObjects identifiableObjects = renderService.fromXml( request.getInputStream(),
-            IdentifiableObjects.class );
+        replaceCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+            renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
+    }
 
-        collectionService.clearCollectionItems( objects.get( 0 ), pvProperty );
-        collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
+    private void replaceCollectionItems( String pvProperty, T object, IdentifiableObjects items )
+        throws Exception
+    {
+        preUpdateItems( object, items );
+        collectionService.clearCollectionItems( object, pvProperty );
+        collectionService.addCollectionItems( object, pvProperty, items.getAdditions() );
+        postUpdateItems( object, items );
     }
 
     @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.POST )
@@ -1104,15 +1102,18 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         throws Exception
     {
         List<T> objects = getEntity( pvUid );
-        response.setStatus( HttpServletResponse.SC_NO_CONTENT );
-
         if ( objects.isEmpty() )
         {
             throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), pvUid ) );
         }
 
-        collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
+        T object = objects.get( 0 );
+        IdentifiableObjects items = new IdentifiableObjects();
+        items.setAdditions( singletonList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
+
+        preUpdateItems( object, items );
+        collectionService.addCollectionItems( object, pvProperty, items.getIdentifiableObjects() );
+        postUpdateItems( object, items );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_JSON_VALUE )
@@ -1122,12 +1123,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         HttpServletRequest request )
         throws Exception
     {
-        List<T> objects = getEntity( pvUid );
-        IdentifiableObjects identifiableObjects = renderService.fromJson( request.getInputStream(),
-            IdentifiableObjects.class );
-
-        collectionService.delCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
+        deleteCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+            renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_XML_VALUE )
@@ -1137,12 +1134,16 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         HttpServletRequest request )
         throws Exception
     {
-        List<T> objects = getEntity( pvUid );
-        IdentifiableObjects identifiableObjects = renderService.fromXml( request.getInputStream(),
-            IdentifiableObjects.class );
+        deleteCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+            renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
+    }
 
-        collectionService.delCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
+    private void deleteCollectionItems( String pvProperty, T object, IdentifiableObjects items )
+        throws Exception
+    {
+        preUpdateItems( object, items );
+        collectionService.delCollectionItems( object, pvProperty, items.getIdentifiableObjects() );
+        postUpdateItems( object, items );
     }
 
     @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.DELETE )
@@ -1161,8 +1162,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), pvUid ) );
         }
 
-        collectionService.delCollectionItems( objects.get( 0 ), pvProperty,
-            Lists.newArrayList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
+        IdentifiableObjects items = new IdentifiableObjects();
+        items.setIdentifiableObjects( singletonList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
+        deleteCollectionItems( pvProperty, objects.get( 0 ), items );
     }
 
     @PutMapping( value = "/{uid}/sharing", consumes = "application/json" )
@@ -1235,6 +1237,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     }
 
     protected void preCreateEntity( T entity )
+        throws Exception
     {
     }
 
@@ -1243,6 +1246,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     }
 
     protected void preUpdateEntity( T entity, T newEntity )
+        throws Exception
     {
     }
 
@@ -1265,6 +1269,15 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     }
 
     protected void postPatchEntity( T entity )
+    {
+    }
+
+    protected void preUpdateItems( T entity, IdentifiableObjects items )
+        throws Exception
+    {
+    }
+
+    protected void postUpdateItems( T entity, IdentifiableObjects items )
     {
     }
 


### PR DESCRIPTION
### Summary
Prevents creation, update or deletion of system jobs by checking the `configuable` flag in the pre-action hooks.

Background: A system job is a a `JobConfiguration` where `configurable` property is `false`.

Changes to the abstract controller that could be considered fixes (and cleanup):

* Since collection item patch endpoints of abstract controller did not have pre-post hooks two new hooks were added:
 * `preUpdateItems`: invoked before any update to a collection of a resource target object
 * `postUpdateItems`: invoked after any update to a collection of a resource target object

* The `updateObjectProperty` endpoint was missing a call to `prePatchEntity` which was added.

* The `Patch` based property update return HTTP 404 in case neither JSON nor XML are send instead of failing with a NPE.

* The signature of `CollectionService` methods `addCollectionItems` and `delCollectionItems` was changed slightly to accept `List<? extends IdentifiableObject>` instead if `List<IdentifiableObject>` which required the caller to wrap arguments in another list to perform the type conversion.

Having made that small signature change in `DefaultCollectionService` sonarcloud would fail the checks because of method complexity being to high for the methods which signature were updated. So I extracted methods until sonar would be happy.

### Automatic Testing
I did not create any new tests as the type of error that could be introduced by the changes requires e2e tests.
For that reason I added the _run-api-tests_ label. Since the changes affect almost all controllers I'd think that errors should be found in existing e2e tests.

### Manual Testing
Scenarios:

* GET run a system job should fail: http://localhost:8080/api/33/jobConfigurations/sHMedQF7VYa/execute => HTTP 403
* DELETE a system job should fail: http://localhost:8080/api/33/jobConfigurations/sHMedQF7VYa/ => HTTP 422
* PATCH/PUT a system job should fail: http://localhost:8080/api/33/jobConfigurations/sHMedQF7VYa/ with `{ "enabled": false}` => HTTP 422
* PATCH/PUT a system job property directly should fail: http://localhost:8080/api/33/jobConfigurations/sHMedQF7VYa/enabled  (with any body, e.g. just `{}`) => HTTP 422
* PUT an existing system job should fail: http://localhost:8080/api/33/jobConfigurations/sHMedQF7VYa (with any body, e.g. just `{}`) => HTTP 422
* POST a new job that tries to be a system job should fail: http://localhost:8080/api/33/jobConfigurations/ with JSON body => HTTP 400
```json
{
  "name": "Illegal",
  "enabled": true,
  "leaderOnlyJob": true,
  "externalAccess": false,
  "jobType": "CREDENTIALS_EXPIRY_ALERT",
  "cronExpression": "0 0 2 * * ?",
  "schedulingType": "CRON",
  "configurable": false
}
```
**Note** that after having tested that system jobs cannot be changed any longer redo the above scenarios with a user created (non system) job UID and verify that operations can be performed as long as parameters and bodies supplied are correct.

**Note** that this PR also prevents updates to collection properties of system job should they ever get any. Currently they do not but should a relation be added it equally cannot be changed for system jobs.

