### PR TITLE
fix: ignored entries are also returned in global stats [DHIS2-10390]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/TrackerApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/TrackerApiResponse.java
@@ -70,10 +70,15 @@ public class TrackerApiResponse
 
     public TrackerApiResponse validateSuccessfulImport()
     {
+        return validateSuccessfulImportWithIgnored( 0 );
+    }
+
+    public TrackerApiResponse validateSuccessfulImportWithIgnored(int ignoredCount)
+    {
         validate()
             .statusCode( 200 )
             .body( "status", equalTo( "OK" ) )
-            .body( "stats.ignored", equalTo( 0 ) )
+            .body( "stats.ignored", equalTo( ignoredCount ) )
             .body( "stats.total", greaterThanOrEqualTo( 1 ) )
             .body( "bundleReport.typeReportMap", notNullValue() );
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/relationships/RelationshipsTests.java
@@ -190,7 +190,7 @@ public class RelationshipsTests
         // when posting the same payload, then relationship is ignored when in
         // the same way
         trackerActions.postAndGetJobReport( jsonObject )
-            .validateSuccessfulImport()
+            .validateSuccessfulImportWithIgnored( 1 )
             .validateRelationships()
             .body( "stats.ignored", equalTo( 1 ) );
 
@@ -237,7 +237,7 @@ public class RelationshipsTests
         // when posting the same payload, then relationship is ignored both ways
         Stream.of( jsonObject, trackerActions.invertRelationship( jsonObject ) )
             .map( trackerActions::postAndGetJobReport )
-            .map( TrackerApiResponse::validateSuccessfulImport )
+            .map( tar -> tar.validateSuccessfulImportWithIgnored( 1 ) )
             .map( TrackerApiResponse::validateRelationships )
             .forEach( validatableResponse -> validatableResponse.body( "stats.ignored", equalTo( 1 ) ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -112,7 +112,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
             final T trackerDto = dtos.get( idx );
 
             TrackerObjectReport objectReport = new TrackerObjectReport( getType(), trackerDto.getUid(), idx );
-            typeReport.addObjectReport( objectReport );
 
             try
             {
@@ -135,6 +134,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
                 {
                     session.persist( convertedDto );
                     typeReport.getStats().incCreated();
+                    typeReport.addObjectReport( objectReport );
                 }
                 else
                 {
@@ -142,6 +142,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
                     {
                         session.merge( convertedDto );
                         typeReport.getStats().incUpdated();
+                        typeReport.addObjectReport( objectReport );
                     }
                     else
                     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -143,6 +143,10 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
                         session.merge( convertedDto );
                         typeReport.getStats().incUpdated();
                     }
+                    else
+                    {
+                        typeReport.getStats().incIgnored();
+                    }
                 }
 
                 updateAttributes( session, bundle.getPreheat(), trackerDto, convertedDto );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReportFinalizer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReportFinalizer.java
@@ -108,8 +108,10 @@ public class TrackerImportReportFinalizer
         TrackerTimingsStats timingsStats, Map<TrackerType, Integer> bundleSize )
     {
         TrackerStats stats = TrackerStats.builder().build();
-        stats.merge( bundleReport.getStats() );
-        stats.setIgnored( Math.toIntExact( validationReport.size() ) );
+        TrackerStats brs = bundleReport.getStats();
+        stats.merge( brs );
+
+        stats.setIgnored( brs.getTotal() - brs.getUpdated() - brs.getCreated() - brs.getDeleted() );
 
         return TrackerImportReport.builder()
             .status( status )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReportFinalizer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerImportReportFinalizer.java
@@ -110,9 +110,7 @@ public class TrackerImportReportFinalizer
         TrackerStats stats = TrackerStats.builder().build();
         TrackerStats brs = bundleReport.getStats();
         stats.merge( brs );
-
-        stats.setIgnored( brs.getTotal() - brs.getUpdated() - brs.getCreated() - brs.getDeleted() );
-
+        stats.setIgnored( Math.toIntExact( validationReport.size() ) + brs.getIgnored() );
         return TrackerImportReport.builder()
             .status( status )
             .validationReport( validationReport )


### PR DESCRIPTION
1. global (root) import stats were not correct when ignoring relationships.
2. ignored relationships were added to objectReport which was wrong.

This PR fixes these 2 issues