### PR TITLE
fix: (2.34) acl service performance with userGroup.members()

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupInfoService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupInfoService.java
@@ -1,0 +1,36 @@
+package org.hisp.dhis.user;
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public interface UserGroupInfoService
+{
+    /**
+     * Check if given user is member of given UserGroup
+     */
+    boolean isMember( UserGroup userGroup, String userUid );
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupInfoStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupInfoStore.java
@@ -1,0 +1,39 @@
+package org.hisp.dhis.user;
+
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public interface UserGroupInfoStore
+{
+    String ID = UserGroupInfoStore.class.getName();
+
+    /**
+     * Check if given user is member of given UserGroup
+     */
+    boolean isMember( UserGroup userGroup, String userUid );
+}

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.security.acl.AccessStringHelper.Permission;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAccess;
 import org.hisp.dhis.user.UserGroupAccess;
+import org.hisp.dhis.user.UserGroupInfoService;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -60,11 +61,15 @@ public class DefaultAclService implements AclService
 {
     private final SchemaService schemaService;
 
-    public DefaultAclService( SchemaService schemaService )
+    private final UserGroupInfoService userGroupInfoService;
+
+    public DefaultAclService( SchemaService schemaService, UserGroupInfoService userGroupInfoService )
     {
         checkNotNull( schemaService );
+        checkNotNull( userGroupInfoService );
 
         this.schemaService = schemaService;
+        this.userGroupInfoService = userGroupInfoService;
     }
 
     @Override
@@ -654,7 +659,7 @@ public class DefaultAclService implements AclService
             // Check if user is allowed to read this object through group access
 
             if ( AccessStringHelper.isEnabled( userGroupAccess.getAccess(), permission )
-                    && userGroupAccess.getUserGroup().getMembers().contains( user ) )
+                && userGroupInfoService.isMember( userGroupAccess.getUserGroup(), user.getUid() ) )
             {
                 return true;
             }
@@ -665,7 +670,7 @@ public class DefaultAclService implements AclService
             // Check if user is allowed to read to this object through user access
 
             if ( AccessStringHelper.isEnabled( userAccess.getAccess(), permission )
-                    && user.equals( userAccess.getUser() ) )
+                && user.equals( userAccess.getUser() ) )
             {
                 return true;
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupInfoService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupInfoService.java
@@ -1,0 +1,86 @@
+package org.hisp.dhis.user;
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.commons.util.SystemUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Service
+public class DefaultUserGroupInfoService implements UserGroupInfoService
+{
+    private final Environment env;
+
+    private final CacheProvider cacheProvider;
+
+    private final UserGroupInfoStore userGroupInfoStore;
+
+    /**
+     * Cache for checking if user is member of a UserGroup
+     * Cache key userGroupUid-userUid
+     */
+    private Cache<Boolean> IS_USER_GROUP_MEMBER;
+
+    @PostConstruct
+    public void init()
+    {
+        IS_USER_GROUP_MEMBER = cacheProvider.newCacheBuilder( Boolean.class )
+            .forRegion( "isUserGroupMember" )
+            .expireAfterWrite( 3, TimeUnit.HOURS )
+            .withInitialCapacity( 1000 )
+            .forceInMemory()
+            .withMaximumSize( SystemUtils.isTestRun( env.getActiveProfiles() ) ? 0 : 1000000 ).build();
+    }
+
+    public DefaultUserGroupInfoService( Environment env, CacheProvider cacheProvider,
+        UserGroupInfoStore userGroupInfoStore )
+    {
+        checkNotNull( env );
+        checkNotNull( cacheProvider );
+        checkNotNull( userGroupInfoStore );
+
+        this.env = env;
+        this.cacheProvider = cacheProvider;
+        this.userGroupInfoStore = userGroupInfoStore;
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public boolean isMember( UserGroup userGroup, String userUid )
+    {
+        return IS_USER_GROUP_MEMBER.get( userGroup.getUid() + "-" + userUid, bol -> userGroupInfoStore.isMember( userGroup, userUid ) ).get();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupInfoInfoStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupInfoInfoStore.java
@@ -1,0 +1,65 @@
+package org.hisp.dhis.user.hibernate;
+
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hibernate.SessionFactory;
+import org.hibernate.jpa.QueryHints;
+import org.hibernate.query.Query;
+import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.user.UserGroupInfoStore;
+import org.springframework.stereotype.Repository;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Viet Nguyen
+ */
+@Repository
+public class HibernateUserGroupInfoInfoStore
+    implements UserGroupInfoStore
+{
+    private final SessionFactory sessionFactory;
+
+    public HibernateUserGroupInfoInfoStore( SessionFactory sessionFactory )
+    {
+        checkNotNull( sessionFactory );
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    public boolean isMember( UserGroup userGroup, String userUid )
+    {
+        String sql = "select 1 from UserGroup ug inner join ug.members u where ug.uid = :userGroupUid and u.uid = :userUid";
+        Query query = sessionFactory.getCurrentSession().createQuery( sql );
+        query.setParameter( "userGroupUid", userGroup.getUid() );
+        query.setParameter( "userUid", userUid );
+        query.setHint( QueryHints.HINT_CACHEABLE, true );
+        return query.getResultList().size() == 1 ? true : false;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserGroupInfoStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserGroupInfoStoreTest.java
@@ -1,0 +1,66 @@
+package org.hisp.dhis.user;
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hisp.dhis.DhisSpringTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.testcontainers.shaded.com.google.common.collect.Sets;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UserGroupInfoStoreTest extends DhisSpringTest
+{
+    @Autowired
+    private UserGroupInfoStore userGroupInfoStore;
+
+    @Autowired
+    private UserGroupService userGroupService;
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    public void testIsUserGroupMember()
+    {
+        User userA = createUser( 'A' );
+        userService.addUser( userA );
+
+        UserGroup userGroupA = createUserGroup( 'A', Sets.newHashSet( userA ) );
+        UserGroup userGroupB = createUserGroup( 'B', new HashSet<>() );
+
+        userGroupService.addUserGroup( userGroupA );
+        userGroupService.addUserGroup( userGroupB );
+
+        assertTrue( userGroupInfoStore.isMember( userGroupA, userA.getUid() ) );
+        assertFalse( userGroupInfoStore.isMember( userGroupB, userA.getUid() ) );
+    }
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10342
Issue: 
- in a database with userGroups have 200k members, the aclService.checkSharingPermission() is very slow.
The reason is  that we used hibernate lazy to load all userGroup.members and check if given user is in that list. 
This causes n+1 issue and also load the whole user table to memory many times. 

Fix: 
- This PR add a new class `UserGroupInfoStore` to do the userGroup is member check in database. 
We can't use `UserGroupStore` for this because it has dependency on `AclService` which in result will introduce circular dependency issue.
- A cache is also used to store the result of the check above for each combination userGroup-user

This fix need to be forward port to 2.35

a POST request to api/trackedEntityInstance take 33 seconds  to complete and reduced to 100ms after the fix

Before 
<img width="1384" alt="Screen Shot 2021-02-18 at 2 45 08 PM" src="https://user-images.githubusercontent.com/766102/108322472-139fcd00-71f8-11eb-9b08-323f9332f340.png">

After
<img width="1435" alt="Screen Shot 2021-02-18 at 2 31 40 PM" src="https://user-images.githubusercontent.com/766102/108322533-26b29d00-71f8-11eb-83a1-973a52593197.png">
