### PR TITLE
fix: [DHIS2-10522] Fix the mapping for program stage and program

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapper.java
@@ -39,7 +39,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, UserGroupAccessMapper.class, UserGroupAccessMapper.class } )
+@Mapper( uses = { DebugMapper.class, UserGroupAccessMapper.class, UserGroupAccessMapper.class,
+    TrackedEntityTypeMapper.class } )
 public interface ProgramStageMapper extends PreheatMapper<ProgramStage>
 {
     ProgramStageMapper INSTANCE = Mappers.getMapper( ProgramStageMapper.class );


### PR DESCRIPTION
Incorrect mapping of Sharing object in Program linked to a Program Stage was throwing a LazyInitializationException when validating Ownership