### PR TITLE
fix: translation is not saved in first time

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -373,7 +373,7 @@ public class BaseIdentifiableObject
     @JacksonXmlProperty( localName = "translation", namespace = DxfNamespaces.DXF_2_0 )
     public Set<Translation> getTranslations()
     {
-        return translations != null ? translations : new HashSet<>();
+        return translations;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -203,17 +204,14 @@ public class DefaultIdentifiableObjectManager
     public void updateTranslations( IdentifiableObject persistedObject, Set<Translation> translations )
     {
         Session session = sessionFactory.getCurrentSession();
-        persistedObject.getTranslations().clear();
-        session.flush();
-
-        translations.forEach( translation -> {
-            if ( StringUtils.isNotEmpty( translation.getValue() ) )
-            {
-                persistedObject.getTranslations().add( translation );
-            }
-        } );
 
         BaseIdentifiableObject translatedObject = (BaseIdentifiableObject) persistedObject;
+
+        translatedObject.setTranslations(
+            translations.stream()
+                .filter( t -> !StringUtils.isEmpty( t.getValue() ) )
+                .collect( Collectors.toSet() ) );
+
         translatedObject.setLastUpdated( new Date() );
         translatedObject.setLastUpdatedBy( currentUserService.getCurrentUser() );
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-8262

Issue: translation is not saved in first POST request
Fix: 
- Remove the code for creating new HashSet in BaseIdentifiableObject.getTranslations()
- Set the whole input set of translations into the object instead of calling .add() method.

