### PR TITLE
fix: check servletPath instead of requestURI to support custom context paths [DHIS2-10519]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -145,17 +145,17 @@ public class AppOverrideFilter
         throws IOException,
         ServletException
     {
-        String requestURI = req.getRequestURI();
+        String requestPath = req.getServletPath();
 
         Pattern p = Pattern.compile( APP_PATH_PATTERN );
-        Matcher m = p.matcher( requestURI );
+        Matcher m = p.matcher( requestPath );
 
         if ( m.find() )
         {
             String appName = m.group( 1 );
             String resourcePath = m.group( 2 );
 
-            log.debug( "AppOverrideFilter :: Matched for URI " + requestURI );
+            log.debug( "AppOverrideFilter :: Matched for path " + requestPath );
 
             App app = appManager.getApp( appName );
 


### PR DESCRIPTION
The AppOverrideFilter incorrectly tested `request.getRequestURI()` which does not exclude a custom context path, if one is specified.  This change compares `request.getServletPath()` instead to ensure that the path tested is the same as is processed by Tomcat.

We could likely strip the context path from `getRequestURI` instead, but since these are not servlets but rather served files this appears to work well.

This issue is present in 2.35.1 and so should also be back-ported in 2.35.2 (#7421).