### PR TITLE
fix: (2.35) check servletPath instead of requestURI to support custom context paths [DHIS2-10519]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -146,10 +146,10 @@ public class AppOverrideFilter
     protected void doFilterInternal( HttpServletRequest req, HttpServletResponse res, FilterChain chain )
         throws IOException, ServletException
     {
-        String requestURI = req.getRequestURI();
+        String requestPath = req.getServletPath();
 
         Pattern p = Pattern.compile( APP_PATH_PATTERN );
-        Matcher m = p.matcher( requestURI );
+        Matcher m = p.matcher( requestPath );
 
         if ( m.find() )
         {
@@ -157,7 +157,7 @@ public class AppOverrideFilter
             String appName = m.group( 1 );
             String resourcePath = m.group( 2 );
 
-            log.debug( "AppOverrideFilter :: Matched for URI " + requestURI );
+            log.debug( "AppOverrideFilter :: Matched for path " + requestPath );
 
             App app = appManager.getApp( appName );
 


### PR DESCRIPTION
Backport of #7420 (important for 2.35.2)