### PR TITLE
chore: Change central Maven repository

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -196,8 +196,8 @@
       <artifactId>jaxb-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.ws</groupId>
-      <artifactId>jaxws-api</artifactId>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.ws</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -22,13 +22,6 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <!-- DHIS -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -246,19 +246,6 @@
       </snapshots>
     </repository>
     <repository>
-      <id>ossrh</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-      </snapshots>
-    </repository>
-    <repository>
       <id>osgeo</id>
       <name>Open Source Geospatial Foundation Repository</name>
       <url>https://repo.osgeo.org/repository/release/</url>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -258,6 +258,19 @@
       </releases>
     </repository>
     <repository>
+      <id>ossrh</id>
+      <name>Sonatype OSS</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -234,7 +234,6 @@
   </distributionManagement>
 
   <repositories>
-
     <repository>
       <id>central</id>
       <url>https://repo1.maven.org/maven2</url>
@@ -270,6 +269,10 @@
       <releases>
         <updatePolicy>never</updatePolicy>
       </releases>
+    </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
     </repository>
   </repositories>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -242,7 +242,7 @@
         <enabled>true</enabled>
       </releases>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <updatePolicy>daily</updatePolicy>
       </snapshots>
     </repository>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -111,7 +111,7 @@
     <jaxb-impl.version>2.4.0-b180830.0438</jaxb-impl.version>
     <jaxb-osgi.version>2.4.0-b180830.0438</jaxb-osgi.version>
     <jaxws-ri.version>2.3.2</jaxws-ri.version>
-    <jaxws-api.version>2.4.0</jaxws-api.version>
+    <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <xercesImpl.version>2.12.0</xercesImpl.version>
 
@@ -234,17 +234,17 @@
   </distributionManagement>
 
   <repositories>
+
     <repository>
-      <id>MavenCentral</id>
-      <name>Maven repository</name>
+      <id>central</id>
       <url>https://repo1.maven.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
       </snapshots>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
     </repository>
     <repository>
       <id>ossrh</id>
@@ -271,18 +271,17 @@
         <updatePolicy>never</updatePolicy>
       </releases>
     </repository>
-    <repository>
-      <id>jvnet-nexus-staging</id>
-      <url>https://maven.java.net/content/repositories/staging/</url>
-      <layout>default</layout>
-      <snapshots>
-        <updatePolicy>daily</updatePolicy>
-      </snapshots>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-    </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
 
   <issueManagement>
     <system>Launchpad</system>
@@ -1869,15 +1868,9 @@
         <version>${javax.annotation-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.ws</groupId>
-        <artifactId>jaxws-api</artifactId>
-        <version>${jaxws-api.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>jakarta.xml.ws</groupId>
+        <artifactId>jakarta.xml.ws-api</artifactId>
+        <version>${jakarta.xml.ws-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
The previous default Maven repository, "maven.java.net" is no longer working because of an expired SSL certificate.

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>