### PR TITLE
chore: Change central Maven repository

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -196,8 +196,8 @@
       <artifactId>jaxb-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.ws</groupId>
-      <artifactId>jaxws-api</artifactId>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.ws</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -22,13 +22,6 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <!-- DHIS -->

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -81,19 +81,16 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.10.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>
         </exclusion>
-
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql </artifactId>
-      <version>1.10.1</version>
     </dependency>
     <dependency>
       <groupId>io.github.benas</groupId>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgisContainerProvider.java
@@ -30,10 +30,10 @@ package org.hisp.dhis.container;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgisContainerProvider;
+import org.testcontainers.utility.DockerImageName;
 
 /**
- * Custom PostgisContainerProvider to create
- * {@link DhisPostgreSQLContainer}
+ * Custom PostgisContainerProvider to create {@link DhisPostgreSQLContainer}
  *
  * @author Ameen Mohamed <ameen@dhis2.org>
  *
@@ -43,6 +43,7 @@ public class DhisPostgisContainerProvider
     extends PostgisContainerProvider
 {
     private static final String DEFAULT_TAG = "10";
+
     private static final String DEFAULT_IMAGE = "mdillon/postgis";
 
     @Override
@@ -54,7 +55,9 @@ public class DhisPostgisContainerProvider
     @Override
     public JdbcDatabaseContainer newInstance( String tag )
     {
-        return new DhisPostgreSQLContainer( DEFAULT_IMAGE + ":" + tag );
+        DockerImageName postgres = DockerImageName.parse( DEFAULT_IMAGE + ":" + tag )
+            .asCompatibleSubstituteFor( "postgres" );
+        return new DhisPostgreSQLContainer( postgres );
     }
 
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/container/DhisPostgreSQLContainer.java
@@ -1,7 +1,7 @@
 package org.hisp.dhis.container;
 
 /*
- * Copyright (c) 2004-2020, University of Oslo
+ * Copyright (c) 2004-2021, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Custom {@link PostgreSQLContainer} that provides additional fluent API to
@@ -44,7 +45,7 @@ public class DhisPostgreSQLContainer<SELF extends DhisPostgreSQLContainer<SELF>>
 {
     private Set<String> customPostgresConfigs = new HashSet<>();
 
-    public DhisPostgreSQLContainer( final String dockerImageName )
+    public DhisPostgreSQLContainer( DockerImageName dockerImageName )
     {
         super( dockerImageName );
     }
@@ -76,9 +77,8 @@ public class DhisPostgreSQLContainer<SELF extends DhisPostgreSQLContainer<SELF>>
 
     /**
      * Append custom postgres configuration to be customized when starting the
-     * container. The configAndValue should be of the form
-     * "configName=configValue". This method can be invoked multiple times to
-     * add multiple custom commands.
+     * container. The configAndValue should be of the form "configName=configValue".
+     * This method can be invoked multiple times to add multiple custom commands.
      *
      * @param configAndValue The configuration and value of the form
      *        "configName=configValue"
@@ -92,6 +92,4 @@ public class DhisPostgreSQLContainer<SELF extends DhisPostgreSQLContainer<SELF>>
         }
         return self();
     }
-
-
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -45,9 +45,20 @@
 
   <repositories>
     <repository>
-      <id>MavenCentral</id>
-      <name>Maven repository</name>
+      <id>central</id>
       <url>https://repo1.maven.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
       <snapshots>
         <enabled>false</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -70,29 +81,20 @@
       </snapshots>
     </repository>
     <repository>
-      <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>https://repo.osgeo.org/repository/release/</url>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>daily</updatePolicy>
-      </snapshots>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-    </repository>
-    <repository>
-      <id>jvnet-nexus-staging</id>
-      <url>https://maven.java.net/content/repositories/staging/</url>
-      <layout>default</layout>
-      <snapshots>
-        <updatePolicy>daily</updatePolicy>
-      </snapshots>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
 
   <issueManagement>
     <system>Launchpad</system>
@@ -1670,15 +1672,9 @@
         <version>1.3.2</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.ws</groupId>
-        <artifactId>jaxws-api</artifactId>
-        <version>2.4.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>jakarta.xml.ws</groupId>
+        <artifactId>jakarta.xml.ws-api</artifactId>
+        <version>${jakarta.xml.ws-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
@@ -2074,6 +2070,7 @@
     <hibernate-validator.version>5.0.3.Final</hibernate-validator.version>
     <jclouds.version>2.2.0</jclouds.version>
     <antlr.version>4.7.2</antlr.version>
+    <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
     <!-- Keep in sync with Hibernate -->
     <javassist.version>3.23.1-GA</javassist.version>
     <!-- unit test dependencies-->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2002,6 +2002,23 @@
         <version>0.2.5</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>postgresql </artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+
       <!-- Monitoring -->
       <dependency>
         <groupId>io.micrometer</groupId>
@@ -2078,6 +2095,7 @@
     <jackson.version>2.11.2</jackson.version>
     <log4j.version>2.13.0</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
     <geotools.version>18.0</geotools.version>
     <jasperreports.version>6.3.1</jasperreports.version>
     <jacoco.version>0.8.2</jacoco.version>


### PR DESCRIPTION
The previous default Maven repository, "maven.java.net" is no longer working because of an expired SSL certificate.

* This also includes this: chore: Upgrade TestContainers (#7271)

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>