### PR TITLE
chore: Change central Maven repository

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -187,8 +187,8 @@
       <artifactId>jaxb-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.ws</groupId>
-      <artifactId>jaxws-api</artifactId>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.ws</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -22,13 +22,6 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <!-- DHIS -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -49,22 +49,14 @@
 
   <repositories>
     <repository>
-      <id>MavenCentral</id>
-      <name>Maven repository</name>
+      <id>central</id>
       <url>https://repo1.maven.org/maven2</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>ossrh</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
       </snapshots>
     </repository>
     <repository>
@@ -73,9 +65,40 @@
       <url>https://repo.osgeo.org/repository/release/</url>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+    </repository>
+    <repository>
+      <id>ossrh</id>
+      <name>Sonatype OSS</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
       </snapshots>
     </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
 
   <issueManagement>
     <system>Launchpad</system>
@@ -1576,11 +1599,7 @@
         <artifactId>jaxb-core</artifactId>
         <version>2.3.0</version>
       </dependency>
-<!--      <dependency>-->
-<!--        <groupId>com.sun.xml.bind</groupId>-->
-<!--        <artifactId>jaxb-impl</artifactId>-->
-<!--        <version>2.3.0</version>-->
-<!--      </dependency>-->
+
       <dependency>
         <groupId>javax.xml.ws</groupId>
         <artifactId>jaxws-api</artifactId>
@@ -1592,17 +1611,16 @@
           </exclusion>
         </exclusions>
       </dependency>
-<!--      <dependency>-->
-<!--        <groupId>com.sun.xml.bind</groupId>-->
-<!--        <artifactId>jaxb-impl</artifactId>-->
-<!--        <version>2.3.0</version>-->
-<!--      </dependency>-->
       <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
       </dependency>
-
+    <dependency>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
+      <version>${jakarta.xml.ws-api.version}</version>
+    </dependency>
 
       <dependency>
         <groupId>com.sun.xml.ws</groupId>
@@ -1662,6 +1680,7 @@
     <hibernate-validator.version>5.0.3.Final</hibernate-validator.version>
     <jclouds.version>2.0.3</jclouds.version>
     <antlr.version>4.7.2</antlr.version>
+    <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
     <!-- Keep in sync with Hibernate -->
     <javassist.version>3.20.0-GA</javassist.version>
     <!-- unit test dependencies-->


### PR DESCRIPTION
The previous default Maven repository, "maven.java.net" is no longer working because of an expired SSL certificate.

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>