### PR TITLE
fix: ConcurrentModificationException during tracker import

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
@@ -75,7 +75,7 @@ public class NotificationMap
 
     public LinkedList<Notification> getNotificationsByJobId( JobType jobType, String jobId )
     {
-        return Optional.ofNullable( notificationsWithType.get( jobType ) ).map( n -> n.get( jobId ) )
+        return Optional.ofNullable( notificationsWithType.get( jobType ) ).map( n -> new LinkedList<>( n.get( jobId ) ) )
             .orElse( new LinkedList<>() );
     }
 


### PR DESCRIPTION
The initial issue reported was a ConcurrentModificationException, which happened during a tracker import job. We encountered the error sporadically, and have no way of reproduce it 100%.

After looking through the code, it appears there is most likely one place where this happens. The case is that when we start an async tracker import, we generate a Notifier, which will keep track of the process of the job. We return a reference to this notifier in the original request-response. In theory, a client should be able to look up this notifier, to follow the progress of the job. The suspicion around this exception, is that if a client requests the notifier for the job, at the same time as a new update is added to the notifier, we end up with a ConcurrentModificationException.

Since we have no control over the iterating over the list, I decided to return the list as a new list, so the list we send to the client is not the same as the one being modified.

The idea itself was tested separately and works (Have a list, and modify it while iterating). I also tested that the notifier works as expected after my fix.


Hopefully, this solves the issue of the ConcurrentModificationException.