### PR TITLE
feat: expose app_hub_id from application manifest in apps api [DHIS2-10565]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -80,6 +80,8 @@ public class App
 
     private String description;
 
+    private String appHubId;
+
     private AppIcons icons;
 
     private AppDeveloper developer;
@@ -172,6 +174,18 @@ public class App
     public void setVersion( String version )
     {
         this.version = version;
+    }
+
+    @JsonProperty( "app_hub_id" )
+    @JacksonXmlProperty( localName = "app_hub_id", namespace = DxfNamespaces.DXF_2_0 )
+    public String getAppHubId()
+    {
+        return appHubId;
+    }
+
+    public void setAppHubId( String appHubId )
+    {
+        this.appHubId = appHubId;
     }
 
     @JsonProperty( "short_name" )


### PR DESCRIPTION
This allows an `app_hub_id` to be specified in an application's `webapp.manifest`, which will then be exposed through the `/api/apps` endpoint.  This allows us to uniquely identify apps on the App Hub to check for and apply updates when they are published

Demo here - https://d2.winged.tech/dev/api/apps