### PR TITLE
feat: (2.35) expose app_hub_id from application manifest in apps api [DHIS2-10565]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -81,6 +81,8 @@ public class App
 
     private String description;
 
+    private String appHubId;
+
     private AppIcons icons;
 
     private AppDeveloper developer;
@@ -171,6 +173,18 @@ public class App
     public void setVersion( String version )
     {
         this.version = version;
+    }
+
+    @JsonProperty( "app_hub_id" )
+    @JacksonXmlProperty( localName = "app_hub_id", namespace = DxfNamespaces.DXF_2_0 )
+    public String getAppHubId()
+    {
+        return appHubId;
+    }
+
+    public void setAppHubId( String appHubId )
+    {
+        this.appHubId = appHubId;
     }
 
     @JsonProperty( "short_name" )


### PR DESCRIPTION
Backport of #7434 - this is technically a very small non-breaking feature, but it's important to support continuous delivery of applications to 2.35 servers