### PR TITLE
fix: consistent use of @Transactional [TECH-546]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueAuditStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueAuditStore.java
@@ -44,6 +44,15 @@ public interface DataValueAuditStore
     String ID = DataValueAuditStore.class.getName();
 
     /**
+     * Updates the given audit.
+     *
+     * OBS! This is for use in tests only!
+     *
+     * @param dataValueAudit entry to update
+     */
+    void updateDataValueAudit( DataValueAudit dataValueAudit );
+
+    /**
      * Adds a DataValueAudit.
      *
      * @param dataValueAudit the DataValueAudit to add.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
@@ -105,6 +105,7 @@ public class DefaultAttributeService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Attribute getAttribute( String uid )
     {
         Optional<Attribute> attribute = attributeCache.get( uid, attr -> attributeStore.getByUid( uid ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.hibernate.SessionFactory;
 import org.hisp.dhis.attribute.exception.NonUniqueAttributeValueException;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -62,17 +61,14 @@ public class DefaultAttributeService
 
     private final IdentifiableObjectManager manager;
 
-    private final SessionFactory sessionFactory;
-
     public DefaultAttributeService( AttributeStore attributeStore, IdentifiableObjectManager manager,
-        SessionFactory sessionFactory, CacheProvider cacheProvider )
+        CacheProvider cacheProvider )
     {
         checkNotNull( attributeStore );
         checkNotNull( manager );
 
         this.attributeStore = attributeStore;
         this.manager = manager;
-        this.sessionFactory = sessionFactory;
         this.attributeCache = cacheProvider.createMetadataAttributesCache();
     }
 
@@ -187,7 +183,7 @@ public class DefaultAttributeService
         }
 
         object.getAttributeValues().add( attributeValue );
-        sessionFactory.getCurrentSession().save( object );
+        manager.update( object );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -106,6 +107,7 @@ public class DefaultCalendarService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Calendar getSystemCalendar()
     {
         String calendarKey = (String) settingManager.getSystemSetting( SettingKey.CALENDAR );
@@ -128,6 +130,7 @@ public class DefaultCalendarService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DateFormat getSystemDateFormat()
     {
         String dateFormatKey = (String) settingManager.getSystemSetting( SettingKey.DATE_FORMAT );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -1138,6 +1138,7 @@ public class DefaultIdentifiableObjectManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<Class<? extends IdentifiableObject>, IdentifiableObject> getDefaults()
     {
         Optional<IdentifiableObject> categoryObjects = defaultObjectCache.get( Category.class.getName(),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementService.java
@@ -100,7 +100,7 @@ public class DefaultDataElementService
     }
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public DataElement getDataElement( long id )
     {
         return dataElementStore.get( id );
@@ -220,7 +220,7 @@ public class DefaultDataElementService
     }
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public DataElementGroup getDataElementGroup( long id )
     {
         return dataElementGroupStore.get( id );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueAuditStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueAuditStore.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.period.PeriodStore;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Lists;
 
@@ -82,6 +83,13 @@ public class HibernateDataValueAuditStore extends HibernateGenericStore<DataValu
     // -------------------------------------------------------------------------
     // DataValueAuditStore implementation
     // -------------------------------------------------------------------------
+
+    @Override
+    @Transactional
+    public void updateDataValueAudit( DataValueAudit dataValueAudit )
+    {
+        getSession().update( dataValueAudit );
+    }
 
     @Override
     public void addDataValueAudit( DataValueAudit dataValueAudit )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -92,7 +92,6 @@ import com.google.common.collect.Lists;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Slf4j
-@Transactional // TODO check if this class can be readOnly
 @Service( "org.hisp.dhis.preheat.PreheatService" )
 @Scope( value = "prototype", proxyMode = ScopedProxyMode.INTERFACES )
 public class DefaultPreheatService implements PreheatService
@@ -141,6 +140,7 @@ public class DefaultPreheatService implements PreheatService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Preheat preheat( PreheatParams params )
     {
         Timer timer = new SystemTimer().start();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -914,6 +914,7 @@ public class DefaultPreheatService implements PreheatService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void refresh( IdentifiableObject object )
     {
         PreheatParams preheatParams = new PreheatParams();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageSectionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageSectionService.java
@@ -57,6 +57,7 @@ public class DefaultProgramStageSectionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional
     public long saveProgramStageSection( ProgramStageSection programStageSection )
     {
         programStageSectionStore.save( programStageSection );
@@ -64,12 +65,14 @@ public class DefaultProgramStageSectionService
     }
 
     @Override
+    @Transactional
     public void deleteProgramStageSection( ProgramStageSection programStageSection )
     {
         programStageSectionStore.delete( programStageSection );
     }
 
     @Override
+    @Transactional
     public void updateProgramStageSection( ProgramStageSection programStageSection )
     {
         programStageSectionStore.update( programStageSection );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultCurrentUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultCurrentUserService.java
@@ -87,6 +87,7 @@ public class DefaultCurrentUserService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public User getCurrentUser()
     {
         String username = getCurrentUsername();
@@ -232,12 +233,14 @@ public class DefaultCurrentUserService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public UserCredentials getCurrentUserCredentials()
     {
         return userStore.getUserCredentialsByUsername( getCurrentUsername() );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public CurrentUserGroupInfo getCurrentUserGroupsInfo()
     {
         UserInfo currentUserInfo = getCurrentUserInfo();
@@ -252,6 +255,7 @@ public class DefaultCurrentUserService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public CurrentUserGroupInfo getCurrentUserGroupsInfo( UserInfo userInfo )
     {
         if ( userInfo == null )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserSettingService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserSettingService.java
@@ -212,7 +212,7 @@ public class DefaultUserSettingService
     }
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public List<UserSetting> getAllUserSettings()
     {
         User currentUser = currentUserService.getCurrentUser();
@@ -221,6 +221,7 @@ public class DefaultUserSettingService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Serializable> getUserSettingsWithFallbackByUserAsMap( User user,
         Set<UserSettingKey> userSettingKeys,
         boolean useFallback )
@@ -251,7 +252,7 @@ public class DefaultUserSettingService
     }
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public List<UserSetting> getUserSettings( User user )
     {
         if ( user == null )
@@ -275,6 +276,7 @@ public class DefaultUserSettingService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Serializable> getUserSettingsAsMap()
     {
         Set<UserSettingKey> userSettingKeys = Stream.of( UserSettingKey.values() ).collect( Collectors.toSet() );
@@ -305,18 +307,12 @@ public class DefaultUserSettingService
 
         String cacheKey = getCacheKey( key.getName(), username );
 
-        SerializableOptional result = userSettingCache
-            .get( cacheKey, c -> getUserSettingOptional( key, username ) ).get();
-
-        if ( !result.isPresent() && NAME_SETTING_KEY_MAP.containsKey( key.getName() ) )
-        {
-            return SerializableOptional.of(
-                systemSettingManager.getSystemSetting( NAME_SETTING_KEY_MAP.get( key.getName() ) ) );
-        }
-        else
-        {
-            return result;
-        }
+        return userSettingCache
+            .get( cacheKey, c -> getUserSettingOptional( key, username ) )
+            .orElseGet( () -> NAME_SETTING_KEY_MAP.containsKey( key.getName() )
+                ? SerializableOptional
+                    .of( systemSettingManager.getSystemSetting( NAME_SETTING_KEY_MAP.get( key.getName() ) ) )
+                : SerializableOptional.empty() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -40,7 +40,9 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueAudit;
 import org.hisp.dhis.datavalue.DataValueAuditService;
+import org.hisp.dhis.datavalue.DataValueAuditStore;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -73,6 +75,13 @@ public class FileResourceCleanUpJobTest
 
     @Autowired
     private DataValueAuditService dataValueAuditService;
+
+    /**
+     * We use the store directly to backdate audit entries what is usually not
+     * possible
+     */
+    @Autowired
+    private DataValueAuditStore dataValueAuditStore;
 
     @Autowired
     private DataValueService dataValueService;
@@ -141,8 +150,9 @@ public class FileResourceCleanUpJobTest
         dataValueService.updateDataValue( dataValueB );
         fileResource.setAssigned( true );
 
-        dataValueAuditService.getDataValueAudits( dataValueB ).get( 0 )
-            .setCreated( getDate( 2000, 1, 1 ) );
+        DataValueAudit audit = dataValueAuditService.getDataValueAudits( dataValueB ).get( 0 );
+        audit.setCreated( getDate( 2000, 1, 1 ) );
+        dataValueAuditStore.updateDataValueAudit( audit );
 
         cleanUpJob.execute( null );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserSettingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserSettingServiceTest.java
@@ -132,12 +132,12 @@ public class UserSettingServiceTest
 
         assertEquals( UserSettingKey.MESSAGE_EMAIL_NOTIFICATION.getDefaultValue(), emailNotification );
 
-        userSettingService.saveUserSetting( UserSettingKey.MESSAGE_EMAIL_NOTIFICATION, new Boolean( false ), userA );
+        userSettingService.saveUserSetting( UserSettingKey.MESSAGE_EMAIL_NOTIFICATION, Boolean.FALSE, userA );
 
         emailNotification = (Boolean) userSettingService.getUserSetting( UserSettingKey.MESSAGE_EMAIL_NOTIFICATION,
             userA );
 
-        assertEquals( new Boolean( false ), emailNotification );
+        assertEquals( Boolean.FALSE, emailNotification );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -30,7 +30,9 @@ package org.hisp.dhis.dxf2.datavalueset;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_AGGREGATE;
-import static org.hisp.dhis.system.notification.NotificationLevel.*;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
+import static org.hisp.dhis.system.notification.NotificationLevel.WARN;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 
 import java.io.InputStream;
@@ -727,6 +729,7 @@ public class DefaultDataValueSetService
     }
 
     @Override
+    @Transactional
     public ImportSummary saveDataValueSetPdf( InputStream in, ImportOptions importOptions )
     {
         return saveDataValueSetPdf( in, importOptions, null );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -118,6 +119,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ObjectBundle create( ObjectBundleParams params )
     {
         PreheatParams preheatParams = params.getPreheatParams();
@@ -140,6 +142,7 @@ public class DefaultObjectBundleService implements ObjectBundleService
     }
 
     @Override
+    @Transactional
     public ObjectBundleCommitReport commit( ObjectBundle bundle )
     {
         Map<Class<?>, TypeReport> typeReports = new HashMap<>();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -49,7 +49,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Slf4j
 @Service( "org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService" )
-@Transactional
 public class DefaultObjectBundleValidationService
     implements
     ObjectBundleValidationService
@@ -65,6 +64,7 @@ public class DefaultObjectBundleValidationService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ObjectBundleValidationReport validate( ObjectBundle bundle )
     {
         Timer timer = new SystemTimer().start();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceExportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceExportTest.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.datavalue.DataExportParams;
@@ -60,6 +61,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.user.CurrentUserService;
@@ -90,6 +92,9 @@ public class DataValueSetServiceExportTest
     private OrganisationUnitService organisationUnitService;
 
     @Autowired
+    private DataElementService dataElementService;
+
+    @Autowired
     private DataValueSetService dataValueSetService;
 
     @Autowired
@@ -97,6 +102,9 @@ public class DataValueSetServiceExportTest
 
     @Autowired
     private AttributeService attributeService;
+
+    @Autowired
+    private PeriodService periodService;
 
     @Autowired
     private UserService _userService;
@@ -144,17 +152,29 @@ public class DataValueSetServiceExportTest
 
     private User user;
 
+    private String peAUid;
+
     @Override
     public void setUpTest()
     {
         userService = _userService;
+
+        peA = createPeriod( PeriodType.getByNameIgnoreCase( MonthlyPeriodType.NAME ), getDate( 2016, 3, 1 ),
+            getDate( 2016, 3, 31 ) );
+        peB = createPeriod( PeriodType.getByNameIgnoreCase( MonthlyPeriodType.NAME ), getDate( 2016, 4, 1 ),
+            getDate( 2016, 4, 30 ) );
+        periodService.addPeriod( peA );
+        periodService.addPeriod( peB );
+
+        peAUid = peA.getUid();
+
         deA = createDataElement( 'A' );
         deB = createDataElement( 'B' );
         deC = createDataElement( 'C' );
 
-        idObjectManager.save( deA );
-        idObjectManager.save( deB );
-        idObjectManager.save( deC );
+        dataElementService.addDataElement( deA );
+        dataElementService.addDataElement( deB );
+        dataElementService.addDataElement( deC );
 
         ccA = createCategoryCombo( 'A' );
 
@@ -186,17 +206,13 @@ public class DataValueSetServiceExportTest
         dataSetService.addDataSet( dsA );
         dataSetService.addDataSet( dsB );
 
-        peA = createPeriod( PeriodType.getByNameIgnoreCase( MonthlyPeriodType.NAME ), getDate( 2016, 3, 1 ),
-            getDate( 2016, 3, 31 ) );
-        peB = createPeriod( PeriodType.getByNameIgnoreCase( MonthlyPeriodType.NAME ), getDate( 2016, 4, 1 ),
-            getDate( 2016, 4, 30 ) );
-
         ouA = createOrganisationUnit( 'A' );
         ouB = createOrganisationUnit( 'B', ouA );
         ouC = createOrganisationUnit( 'C' ); // Not in hierarchy of A
 
         organisationUnitService.addOrganisationUnit( ouA );
         organisationUnitService.addOrganisationUnit( ouB );
+        organisationUnitService.addOrganisationUnit( ouC );
 
         ogA = createOrganisationUnitGroup( 'A' );
 
@@ -274,7 +290,7 @@ public class DataValueSetServiceExportTest
         {
             assertNotNull( dv );
             assertEquals( ouA.getUid(), dv.getOrgUnit() );
-            assertEquals( peA.getUid(), dv.getPeriod() );
+            assertEquals( peAUid, dv.getPeriod() );
         }
     }
 
@@ -302,7 +318,7 @@ public class DataValueSetServiceExportTest
         {
             assertNotNull( dv );
             assertEquals( ouB.getUid(), dv.getOrgUnit() );
-            assertEquals( peA.getUid(), dv.getPeriod() );
+            assertEquals( peAUid, dv.getPeriod() );
         }
     }
 
@@ -330,7 +346,7 @@ public class DataValueSetServiceExportTest
         for ( org.hisp.dhis.dxf2.datavalue.DataValue dv : dvs.getDataValues() )
         {
             assertNotNull( dv );
-            assertEquals( peA.getUid(), dv.getPeriod() );
+            assertEquals( peAUid, dv.getPeriod() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
@@ -292,17 +292,17 @@ public class DataValueSetServiceTest extends TransactionalIntegrationTest
 
         AttributeValue av1 = createAttributeValue( attribute, "DE1" );
 
-        attributeService.addAttributeValue( deA, av1 );
-
         dataElementService.addDataElement( deA );
-        attributeService.addAttributeValue( deB, createAttributeValue( attribute, "DE2" ) );
         dataElementService.addDataElement( deB );
-        attributeService.addAttributeValue( deC, createAttributeValue( attribute, "DE3" ) );
         dataElementService.addDataElement( deC );
-        attributeService.addAttributeValue( deD, createAttributeValue( attribute, "DE4" ) );
         dataElementService.addDataElement( deD );
         dataElementService.addDataElement( deF );
         dataElementService.addDataElement( deG );
+
+        attributeService.addAttributeValue( deA, av1 );
+        attributeService.addAttributeValue( deB, createAttributeValue( attribute, "DE2" ) );
+        attributeService.addAttributeValue( deC, createAttributeValue( attribute, "DE3" ) );
+        attributeService.addAttributeValue( deD, createAttributeValue( attribute, "DE4" ) );
 
         idObjectManager.save( osA );
 
@@ -311,12 +311,13 @@ public class DataValueSetServiceTest extends TransactionalIntegrationTest
         dsA.addDataSetElement( deC );
         dsA.addDataSetElement( deD );
 
-        attributeService.addAttributeValue( ouA, createAttributeValue( attribute, "OU1" ) );
         organisationUnitService.addOrganisationUnit( ouA );
-        attributeService.addAttributeValue( ouB, createAttributeValue( attribute, "OU2" ) );
         organisationUnitService.addOrganisationUnit( ouB );
-        attributeService.addAttributeValue( ouC, createAttributeValue( attribute, "OU3" ) );
         organisationUnitService.addOrganisationUnit( ouC );
+
+        attributeService.addAttributeValue( ouA, createAttributeValue( attribute, "OU1" ) );
+        attributeService.addAttributeValue( ouB, createAttributeValue( attribute, "OU2" ) );
+        attributeService.addAttributeValue( ouC, createAttributeValue( attribute, "OU3" ) );
 
         dsA.addOrganisationUnit( ouA );
         dsA.addOrganisationUnit( ouC );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -86,6 +87,9 @@ public class ObjectBundleServiceAttributesTest
 
     @Autowired
     private AttributeService attributeService;
+
+    @Autowired
+    private DataElementService dataElementService;
 
     @Override
     public void setUpTest()
@@ -270,7 +274,7 @@ public class ObjectBundleServiceAttributesTest
         attribute.setMandatory( true );
         attribute.setDataElementAttribute( true );
 
-        manager.save( attribute );
+        attributeService.addAttribute( attribute );
 
         AttributeValue attributeValue1 = new AttributeValue( "Value1", attribute );
         AttributeValue attributeValue2 = new AttributeValue( "Value2", attribute );
@@ -280,13 +284,13 @@ public class ObjectBundleServiceAttributesTest
         DataElement de2 = createDataElement( 'B' );
         DataElement de3 = createDataElement( 'C' );
 
+        dataElementService.addDataElement( de1 );
+        dataElementService.addDataElement( de2 );
+        dataElementService.addDataElement( de3 );
+
         attributeService.addAttributeValue( de1, attributeValue1 );
         attributeService.addAttributeValue( de2, attributeValue2 );
         attributeService.addAttributeValue( de3, attributeValue3 );
-
-        manager.save( de1 );
-        manager.save( de2 );
-        manager.save( de3 );
 
         User user = createUser( 'A' );
         manager.save( user );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
@@ -238,7 +238,8 @@ public class ObjectBundleServiceAttributesTest
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
         List<ObjectReport> objectReports = validationReport.getObjectReports( DataElement.class );
 
-        assertEquals( 0, validationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E4009 ).size() );
+        assertFalse( objectReports.isEmpty() );
+        assertEquals( 2, validationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E4009 ).size() );
     }
 
     @Test
@@ -286,6 +287,7 @@ public class ObjectBundleServiceAttributesTest
             attributeService.addAttributeValue( de1, attributeValue1 );
             attributeService.addAttributeValue( de2, attributeValue2 );
             attributeService.addAttributeValue( de3, attributeValue3 );
+            manager.clear();
             return null;
         } );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
-import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -60,6 +59,7 @@ import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAuthorityGroup;
 import org.hisp.dhis.user.UserService;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -182,6 +182,7 @@ public class ObjectBundleServiceAttributesTest
     }
 
     @Test
+    @Ignore // temporary to see what other tests fail
     public void testValidateMetadataAttributeValuesMandatory()
         throws IOException
     {
@@ -226,6 +227,7 @@ public class ObjectBundleServiceAttributesTest
     }
 
     @Test
+    @Ignore // temporary to see what other tests fail
     public void testValidateMetadataAttributeValuesUnique()
         throws IOException
     {
@@ -268,17 +270,7 @@ public class ObjectBundleServiceAttributesTest
 
     private void defaultSetupWithAttributes()
     {
-        Attribute attribute = new Attribute( "AttributeA", ValueType.TEXT );
-        attribute.setUid( "d9vw7V9Mw8W" );
-        attribute.setUnique( true );
-        attribute.setMandatory( true );
-        attribute.setDataElementAttribute( true );
-
-        attributeService.addAttribute( attribute );
-
-        AttributeValue attributeValue1 = new AttributeValue( "Value1", attribute );
-        AttributeValue attributeValue2 = new AttributeValue( "Value2", attribute );
-        AttributeValue attributeValue3 = new AttributeValue( "Value3", attribute );
+        userService.addUser( createUser( 'A' ) );
 
         DataElement de1 = createDataElement( 'A' );
         DataElement de2 = createDataElement( 'B' );
@@ -288,11 +280,17 @@ public class ObjectBundleServiceAttributesTest
         dataElementService.addDataElement( de2 );
         dataElementService.addDataElement( de3 );
 
-        attributeService.addAttributeValue( de1, attributeValue1 );
-        attributeService.addAttributeValue( de2, attributeValue2 );
-        attributeService.addAttributeValue( de3, attributeValue3 );
+        Attribute attribute = new Attribute( "AttributeA", ValueType.TEXT );
+        attribute.setUid( "d9vw7V9Mw8W" );
+        attribute.setUnique( true );
+        attribute.setMandatory( true );
+        attribute.setDataElementAttribute( true );
 
-        User user = createUser( 'A' );
-        manager.save( user );
+        attributeService.addAttribute( attribute );
+
+        attributeService.addAttributeValue( de1, createAttributeValue( attribute, "Value1" ) );
+        attributeService.addAttributeValue( de2, createAttributeValue( attribute, "Value2" ) );
+        attributeService.addAttributeValue( de3, createAttributeValue( attribute, "Value3" ) );
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAuthorityGroup;
 import org.hisp.dhis.user.UserService;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -182,7 +181,6 @@ public class ObjectBundleServiceAttributesTest
     }
 
     @Test
-    @Ignore // temporary to see what other tests fail
     public void testValidateMetadataAttributeValuesMandatory()
         throws IOException
     {
@@ -227,7 +225,6 @@ public class ObjectBundleServiceAttributesTest
     }
 
     @Test
-    @Ignore // temporary to see what other tests fail
     public void testValidateMetadataAttributeValuesUnique()
         throws IOException
     {
@@ -270,7 +267,9 @@ public class ObjectBundleServiceAttributesTest
 
     private void defaultSetupWithAttributes()
     {
-        userService.addUser( createUser( 'A' ) );
+        User user = createUser( 'A' );
+        userService.addUser( user );
+        injectSecurityContext( user );
 
         DataElement de1 = createDataElement( 'A' );
         DataElement de2 = createDataElement( 'B' );
@@ -291,6 +290,10 @@ public class ObjectBundleServiceAttributesTest
         attributeService.addAttributeValue( de1, createAttributeValue( attribute, "Value1" ) );
         attributeService.addAttributeValue( de2, createAttributeValue( attribute, "Value2" ) );
         attributeService.addAttributeValue( de3, createAttributeValue( attribute, "Value3" ) );
+
+        dataElementService.updateDataElement( de1 );
+        dataElementService.updateDataElement( de2 );
+        dataElementService.updateDataElement( de3 );
 
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -197,18 +197,21 @@ public class DefaultDashboardService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DashboardSearchResult search( String query, Set<DashboardItemType> maxTypes )
     {
-        return this.search( query, maxTypes, null, null );
+        return search( query, maxTypes, null, null );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DashboardSearchResult search( Set<DashboardItemType> maxTypes )
     {
-        return this.search( maxTypes, null, null );
+        return search( maxTypes, null, null );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DashboardItem addItemContent( String dashboardUid, DashboardItemType type, String contentUid )
     {
         Dashboard dashboard = getDashboard( dashboardUid );
@@ -457,7 +460,7 @@ public class DefaultDashboardService
     public List<DashboardItem> getEventChartDashboardItems( EventChart eventChart )
     {
         return dashboardItemStore.getEventChartDashboardItems( eventChart );
-    };
+    }
 
     @Override
     @Transactional( readOnly = true )

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -37,13 +37,11 @@ import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.system.util.ReflectionUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Service( "org.hisp.dhis.schema.MergeService" )
-@Transactional
 @Slf4j
 public class DefaultMergeService implements MergeService
 {

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -196,10 +196,9 @@ public class DefaultSystemSettingManager
     public Serializable getSystemSetting( SettingKey key, Serializable defaultValue )
     {
         SerializableOptional value = settingCache.get( key.getName(),
-            k -> getSystemSettingOptional( k, defaultValue ) )
-            .orElse( SerializableOptional.of( defaultValue ) );
+            k -> getSystemSettingOptional( k, defaultValue ) ).get();
 
-        return !value.isPresent() ? defaultValue : value.get();
+        return value.get();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -212,7 +212,7 @@ public class DefaultSystemSettingManager
      */
     private SerializableOptional getSystemSettingOptional( String name, Serializable defaultValue )
     {
-        SystemSetting setting = systemSettingStore.getByNameTx( name );
+        SystemSetting setting = systemSettingStore.getByName( name );
 
         if ( setting != null && setting.hasValue() )
         {

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -180,12 +180,10 @@ public class DefaultSystemSettingManager
      * cache hits.
      */
     @Override
+    @Transactional( readOnly = true )
     public Serializable getSystemSetting( SettingKey key )
     {
-        SerializableOptional value = settingCache.get( key.getName(),
-            k -> getSystemSettingOptional( k, key.getDefaultValue() ) ).get();
-
-        return value.get();
+        return getSystemSetting( key, key.getDefaultValue() );
     }
 
     /**
@@ -194,12 +192,14 @@ public class DefaultSystemSettingManager
      * cache hits.
      */
     @Override
+    @Transactional( readOnly = true )
     public Serializable getSystemSetting( SettingKey key, Serializable defaultValue )
     {
         SerializableOptional value = settingCache.get( key.getName(),
-            k -> getSystemSettingOptional( k, defaultValue ) ).get();
+            k -> getSystemSettingOptional( k, defaultValue ) )
+            .orElse( SerializableOptional.of( defaultValue ) );
 
-        return value.get();
+        return !value.isPresent() ? defaultValue : value.get();
     }
 
     /**
@@ -263,6 +263,7 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Serializable> getSystemSettingsAsMap()
     {
         final Map<String, Serializable> settingsMap = new HashMap<>();
@@ -298,6 +299,7 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Serializable> getSystemSettings( Collection<SettingKey> keys )
     {
         Map<String, Serializable> map = new HashMap<>();
@@ -333,6 +335,7 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public String getFlagImage()
     {
         String flag = (String) getSystemSetting( SettingKey.FLAG );
@@ -341,48 +344,56 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public String getEmailHostName()
     {
         return StringUtils.trimToNull( (String) getSystemSetting( SettingKey.EMAIL_HOST_NAME ) );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public int getEmailPort()
     {
         return (Integer) getSystemSetting( SettingKey.EMAIL_PORT );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public String getEmailUsername()
     {
         return StringUtils.trimToNull( (String) getSystemSetting( SettingKey.EMAIL_USERNAME ) );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean getEmailTls()
     {
         return (Boolean) getSystemSetting( SettingKey.EMAIL_TLS );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public String getEmailSender()
     {
         return StringUtils.trimToNull( (String) getSystemSetting( SettingKey.EMAIL_SENDER ) );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean accountRecoveryEnabled()
     {
         return (Boolean) getSystemSetting( SettingKey.ACCOUNT_RECOVERY );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean selfRegistrationNoRecaptcha()
     {
         return (Boolean) getSystemSetting( SettingKey.SELF_REGISTRATION_NO_RECAPTCHA );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean emailConfigured()
     {
         return StringUtils.isNotBlank( getEmailHostName() )
@@ -390,6 +401,7 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean systemNotificationEmailValid()
     {
         String address = (String) getSystemSetting( SettingKey.SYSTEM_NOTIFICATIONS_EMAIL );
@@ -398,6 +410,7 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public boolean hideUnapprovedDataInAnalytics()
     {
         // -1 means approval is disabled
@@ -405,12 +418,14 @@ public class DefaultSystemSettingManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public String googleAnalyticsUA()
     {
         return StringUtils.trimToNull( (String) getSystemSetting( SettingKey.GOOGLE_ANALYTICS_UA ) );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Integer credentialsExpires()
     {
         return (Integer) getSystemSetting( SettingKey.CREDENTIALS_EXPIRES );

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSettingStore.java
@@ -37,16 +37,6 @@ public interface SystemSettingStore
 {
     /**
      * Returns the {@link SystemSetting} with the given name.
-     * <p>
-     * Note: This method invocation will occur within a transaction.
-     *
-     * @param name the system setting name.
-     * @return a system setting.
-     */
-    SystemSetting getByNameTx( String name );
-
-    /**
-     * Returns the {@link SystemSetting} with the given name.
      *
      * @param name the system setting name.
      * @return a system setting.

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/hibernate/HibernateSystemSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/hibernate/HibernateSystemSettingStore.java
@@ -52,7 +52,7 @@ public class HibernateSystemSettingStore
     }
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public SystemSetting getByNameTx( String name )
     {
         return getByName( name );

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/hibernate/HibernateSystemSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/hibernate/HibernateSystemSettingStore.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.setting.SystemSettingStore;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -49,13 +48,6 @@ public class HibernateSystemSettingStore
         ApplicationEventPublisher publisher )
     {
         super( sessionFactory, jdbcTemplate, publisher, SystemSetting.class, true );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public SystemSetting getByNameTx( String name )
-    {
-        return getByName( name );
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

PR addresses sonar warnings about the consistent use of `@Transactional`.

There was an issue with one of the tests because it would load and manipulate an audit entry which hibernate lazily would update (I guess this is another thing we should look into) and this lazy update would become part of the read-only transaction started to read the system setting which would then fail to perform the update. Solution is to explicitly update the audit entry. I decided to do this via store directly so that the service layer at least would not allow to update audit entries.