### PR TITLE
feat: Add username to /api/sharing/search results [DHIS2-7396]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -409,7 +409,7 @@ public class SharingController
             SharingUserAccess sharingUserAccess = new SharingUserAccess();
             sharingUserAccess.setId( user.getUid() );
             sharingUserAccess.setName( user.getDisplayName() );
-            sharingUserAccess.setDisplayName( user.getDisplayName() );
+            sharingUserAccess.setDisplayName( user.getDisplayName() + " (" + user.getUsername() + ")" );
 
             sharingUsers.add( sharingUserAccess );
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -409,7 +409,8 @@ public class SharingController
             SharingUserAccess sharingUserAccess = new SharingUserAccess();
             sharingUserAccess.setId( user.getUid() );
             sharingUserAccess.setName( user.getDisplayName() );
-            sharingUserAccess.setDisplayName( user.getDisplayName() + " (" + user.getUsername() + ")" );
+            sharingUserAccess.setDisplayName( user.getDisplayName() );
+            sharingUserAccess.setUsername( user.getUsername() );
 
             sharingUsers.add( sharingUserAccess );
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/sharing/SharingUserAccess.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/sharing/SharingUserAccess.java
@@ -41,6 +41,8 @@ public class SharingUserAccess
 
     private String displayName;
 
+    private String username;
+
     private String access;
 
     public SharingUserAccess()
@@ -78,6 +80,17 @@ public class SharingUserAccess
     public void setDisplayName( String displayName )
     {
         this.displayName = displayName;
+    }
+
+    @JsonProperty
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public void setUsername( String username )
+    {
+        this.username = username;
     }
 
     @JsonProperty


### PR DESCRIPTION
See [DHIS2-7396](https://jira.dhis2.org/browse/DHIS2-7396).

It was decided that the best way to implement this is to have the backend return a new field username in response to /api/sharing/search. The frontend can then display the username as it wants.