### PR TITLE
fix: Repair broken OAuth2 authorization_code flow

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -64,6 +64,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.A
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerEndpointsConfiguration;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
 import org.springframework.security.oauth2.provider.code.JdbcAuthorizationCodeServices;
@@ -104,7 +105,7 @@ public class DhisWebApiWebSecurityConfig
      */
     @Configuration
     @Order( 1001 )
-    @Import( { AuthorizationServerEndpointsConfiguration.class, AuthorizationServerEndpointsConfiguration.class } )
+    @Import( { AuthorizationServerEndpointsConfiguration.class } )
     public class OAuth2SecurityConfig extends WebSecurityConfigurerAdapter implements AuthorizationServerConfigurer
     {
         @Autowired
@@ -123,6 +124,8 @@ public class DhisWebApiWebSecurityConfig
         @Autowired
         private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
+
+
         @Override
         protected void configure( HttpSecurity http )
             throws Exception
@@ -130,6 +133,9 @@ public class DhisWebApiWebSecurityConfig
             AuthorizationServerSecurityConfigurer configurer = new AuthorizationServerSecurityConfigurer();
             FrameworkEndpointHandlerMapping handlerMapping = endpoints.oauth2EndpointHandlerMapping();
             http.setSharedObject( FrameworkEndpointHandlerMapping.class, handlerMapping );
+
+            endpoints.authorizationEndpoint().setUserApprovalPage( "forward:/uaa/oauth/confirm_access" );
+            endpoints.authorizationEndpoint().setErrorPage( "forward:/uaa/oauth/error" );
 
             configure( configurer );
             http.apply( configurer );
@@ -199,12 +205,15 @@ public class DhisWebApiWebSecurityConfig
         {
             ProviderManager providerManager = new ProviderManager(
                 ImmutableList.of( twoFactorAuthenticationProvider, customLdapAuthenticationProvider ) );
+
             if ( authenticationEventPublisher != null )
             {
                 providerManager.setAuthenticationEventPublisher( authenticationEventPublisher );
             }
+
             endpoints
                 .prefix( "/uaa" )
+                .userApprovalHandler( new DefaultUserApprovalHandler() )
                 .authorizationCodeServices( jdbcAuthorizationCodeServices() )
                 .tokenStore( tokenStore() )
                 .authenticationManager( providerManager );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -124,8 +124,6 @@ public class DhisWebApiWebSecurityConfig
         @Autowired
         private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
-
-
         @Override
         protected void configure( HttpSecurity http )
             throws Exception

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
@@ -1,0 +1,140 @@
+package org.hisp.dhis.webapi.security.config;
+
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hisp.dhis.system.velocity.VelocityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.security.oauth2.provider.AuthorizationRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.SessionAttributes;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
+import org.springframework.web.util.HtmlUtils;
+
+@Controller
+@SessionAttributes( "authorizationRequest" )
+public class OAuth2ConfirmAccessController
+{
+    @Autowired
+    @Qualifier( "org.hisp.dhis.system.velocity.VelocityManager" )
+    VelocityManager velocityManager;
+
+    @RequestMapping( "/oauth/confirm_access" )
+    public ModelAndView getAccessConfirmationB( Map<String, Object> model, HttpServletRequest request )
+        throws Exception
+    {
+        Map<String, Object> vars = new HashMap<>();
+
+        AuthorizationRequest authorizationRequest = (AuthorizationRequest) model.get( "authorizationRequest" );
+        if ( authorizationRequest != null )
+        {
+            String clientId = authorizationRequest.getClientId();
+            vars.put( "client_id", clientId );
+        }
+
+        String approvalContent = velocityManager.render( vars, "confirm_access" );
+
+        if ( request.getAttribute( "_csrf" ) != null )
+        {
+            model.put( "_csrf", request.getAttribute( "_csrf" ) );
+        }
+
+        View approvalView = new View()
+        {
+            @Override
+            public String getContentType()
+            {
+                return "text/html";
+            }
+
+            @Override
+            public void render( Map<String, ?> model, HttpServletRequest request, HttpServletResponse response )
+                throws Exception
+            {
+                response.setContentType( getContentType() );
+                response.getWriter().append( approvalContent );
+            }
+        };
+
+        return new ModelAndView( approvalView, model );
+    }
+
+    @RequestMapping( "/oauth/error" )
+    public ModelAndView handleError( HttpServletRequest request )
+    {
+        String errorSummary;
+
+        // The error summary may contain malicious user input,
+        // it needs to be escaped to prevent XSS
+        Object error = request.getAttribute( "error" );
+        if ( error instanceof OAuth2Exception )
+        {
+            OAuth2Exception oauthError = (OAuth2Exception) error;
+            errorSummary = HtmlUtils.htmlEscape( oauthError.getSummary() );
+        }
+        else
+        {
+            errorSummary = "Unknown error";
+        }
+
+        Map<String, Object> vars = new HashMap<>();
+        vars.put( "error_summary", errorSummary );
+
+        String errorContent = velocityManager.render( vars, "error" );
+
+        View errorView = new View()
+        {
+            @Override
+            public String getContentType()
+            {
+                return "text/html";
+            }
+
+            @Override
+            public void render( Map<String, ?> model, HttpServletRequest request, HttpServletResponse response )
+                throws Exception
+            {
+                response.setContentType( getContentType() );
+                response.getWriter().append( errorContent );
+            }
+        };
+
+        return new ModelAndView( errorView, new HashMap<>() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.webapi.security.config;
-
 /*
  * Copyright (c) 2004-2021, University of Oslo
  * All rights reserved.
@@ -27,6 +25,7 @@ package org.hisp.dhis.webapi.security.config;
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.webapi.security.config;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +34,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.system.velocity.VelocityManager;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/resources/confirm_access.vm
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/resources/confirm_access.vm
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+
+<head>
+  <title>OAuth2 Confirm Access</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../../dhis-web-commons/bootstrap/css/bootstrap.min.css">
+</head>
+
+<body style="padding-top: 70px;">
+
+<nav class="navbar navbar-inverse navbar-fixed-top">
+  <div class="container-fluid">
+
+    <div class="navbar-header">
+      <a class="navbar-brand" href="#">DHIS2 OAuth2</a>
+    </div>
+
+  </div>
+</nav>
+
+<div class="container-fluid">
+  <div class="row col-lg-6 col-lg-offset-3 col-md-6 col-md-offset-3">
+    <div class="row">
+      <h4>Do you authorize '$!{object.client_id}' to access your protected resources?</h4>
+    </div>
+    <div class="row">
+      <form id="authorizeForm" action="authorize" method="POST">
+        <input name="user_oauth_approval" value="true" type="hidden"/>
+        <button type="submit" class="btn btn-primary btn-lg btn-block">Authorize</button>
+      </form>
+    </div>
+    <div class="row">
+      <form id="denyForm" action="authorize" method="POST">
+        <input name="user_oauth_approval" value="false" type="hidden"/>
+        <button type="submit" class="btn btn-default btn-lg btn-block">Deny</button>
+      </form>
+    </div>
+  </div>
+</div>
+
+</body>
+
+</html>

--- a/dhis-2/dhis-web/dhis-web-api/src/main/resources/error.vm
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/resources/error.vm
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+
+<head>
+  <title>OAuth2 Error</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../../dhis-web-commons/bootstrap/css/bootstrap.min.css">
+</head>
+
+<body style="padding-top: 70px;">
+
+<nav class="navbar navbar-inverse navbar-fixed-top">
+  <div class="container-fluid">
+
+    <div class="navbar-header">
+      <a class="navbar-brand" href="#">DHIS2 OAuth2</a>
+    </div>
+
+  </div>
+</nav>
+
+<div class="container-fluid">
+  <div class="row col-lg-6 col-lg-offset-3 col-md-6 col-md-offset-3">
+    <div class="row">
+      <h4>Error: '$!{object.error_summary}'</h4>
+    </div>
+  </div>
+</div>
+
+</body>
+
+</html>


### PR DESCRIPTION
### Summary
This fix restores the OAuth2 authorization_code flow in DHIS2 described in the issue: [https://jira.dhis2.org/browse/DHIS2-10169](https://jira.dhis2.org/browse/DHIS2-10169)
Before this fix, when doing the authorization_code flow the server would not show the approval or deny access page after successfully logging in.
We are adding back the approval & error html pages used in 2.34.
The authorization_code should now work as described in the documentation: [https://docs.dhis2.org/master/en/developer/html/webapi_authentication.html#1.2.3.4](https://docs.dhis2.org/master/en/developer/html/webapi_authentication.html#1.2.3.4)

### Automatic Testing
There exists no automatic tests for the authorization_code flow. This probably needs to be implemented as an end-to-end test due to browser based multiple page redirecting nature of the protocol.

### Manual Testing
* Add an OAuth2 client in the System Settings app.
* Go to this URL in your browser: http://localhost:8080/uaa/oauth/authorize?client_id=YOUR_CLIENT_ID_STEP1&response_type=code
* Log in
* Approve the access
* Observe that you get redirected to the redirect URL defined in step 1 and that the URL has a &code=GENERATED_AUTH_CODE
* Try to exchange the auth. code for an access/refresh token with this POST request: 
```
POST http://localhost:8080/uaa/oauth/token
Authorization: Basic YOUR_CLIENT_ID_FROM_STEP1 YOUR_CLIENT_SECRET_FROM_STEP1
Accept: application/json
Content-Type: application/x-www-form-urlencoded

grant_type=authorization_code&code=GENERATED_AUTH_CODE
```

### Issue
[https://jira.dhis2.org/browse/DHIS2-10169](https://jira.dhis2.org/browse/DHIS2-10169)