### PR TITLE
feat: Combined datavalue/file endpoint DHIS2-7757

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -173,7 +173,8 @@ public class DataValueController
         @RequestParam( required = false ) Boolean followUp,
         @RequestParam( required = false ) boolean force,
         @RequestParam MultipartFile file )
-        throws WebMessageException, IOException
+        throws WebMessageException,
+        IOException
     {
         FileResource fileResource = fileResourceUtils.saveFileResource( file, FileResourceDomain.DATA_VALUE );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang3.StringUtils;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -31,10 +31,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.util.Date;
 
 import javax.servlet.http.HttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang3.StringUtils;
@@ -59,6 +59,7 @@ import com.google.common.io.ByteSource;
  * @author Lars Helge Overland
  */
 @Component
+@Slf4j
 public class FileResourceUtils
 {
     @Autowired
@@ -155,7 +156,7 @@ public class FileResourceUtils
         }
     }
 
-    public FileResource saveFile( MultipartFile file, FileResourceDomain domain )
+    public FileResource saveFileResource( MultipartFile file, FileResourceDomain domain )
         throws WebMessageException,
         IOException
     {
@@ -168,6 +169,9 @@ public class FileResourceUtils
 
         long contentLength = file.getSize();
 
+        log.info( "File uploaded with filename: '{}', original filename: '{}', content type: '{}', content length: {}",
+            filename, file.getOriginalFilename(), file.getContentType(), contentLength );
+
         if ( contentLength <= 0 )
         {
             throw new WebMessageException( WebMessageUtils.conflict( "Could not read file or file is empty." ) );
@@ -177,12 +181,7 @@ public class FileResourceUtils
 
         String contentMd5 = bytes.hash( Hashing.md5() ).toString();
 
-        FileResource fileResource = new FileResource( filename, contentType, contentLength, contentMd5,
-            FileResourceDomain.DATA_VALUE );
-        fileResource.setAssigned( false );
-        fileResource.setCreated( new Date() );
-        fileResource.setCreatedBy( currentUserService.getCurrentUser() );
-        fileResource.setDomain( domain );
+        FileResource fileResource = new FileResource( filename, contentType, contentLength, contentMd5, domain );
 
         File tmpFile = toTempFile( file );
 

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.fileresource.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.fileresource.js
@@ -209,11 +209,12 @@
         setButtonBlocked();
 
         $fileInput.fileupload( {
-            url: '../api/fileResources',
+            url: '../api/dataValues/file',
             paramName: 'file',
             multipart: true,
             replaceFileInput: false,
             progressInterval: 250, /* ms */
+            formData: formData,
             start: function( e ) {
                 $button.button( 'disable' );
                 $progressBar.toggleClass( 'upload-progress-bar-complete', false );
@@ -231,11 +232,7 @@
             },
             done: function( e, data ) {
                 var fileResource = data.result.response.fileResource;
-                $input.val( fileResource.id );
-
-                saveFileResource( dataElementId, optionComboId, $input.attr( 'id' ), fileResource, function() {
-                    onFileDataValueSavedSuccess( fileResource );
-                } );
+                onFileDataValueSavedSuccess( fileResource );
             }
         } );
 

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.js
@@ -337,18 +337,6 @@ function saveTrueOnly( dataElementId, optionComboId, fieldId )
     valueSaver.save();
 }
 
-function saveFileResource( dataElementId, optionComboId, fieldId, fileResource, onSuccessCallback )
-{
-    fieldId = '#' + fieldId;
-
-    var periodId = $( '#selectedPeriodId' ).val();
-
-    var dataSetId = $( '#selectedDataSetId' ).val();
-
-    var valueSaver = new FileResourceValueSaver( dataElementId, periodId, optionComboId, dataSetId, fileResource, fieldId, dhis2.de.cst.colorGreen, onSuccessCallback );
-    valueSaver.save();
-}
-
 /**
  * Supportive method.
  */
@@ -459,13 +447,4 @@ function ValueSaver( de, pe, co, ds, value, fieldId, resultColor )
     {
         $( fieldId ).css( 'background-color', color );
     }
-}
-
-function FileResourceValueSaver( de, pe, co, ds, fileResource, fieldId, resultColor, onSuccessCallback )
-{
-    var valueSaver = new ValueSaver( de, pe, co, ds, fileResource.id, fieldId, resultColor );
-
-    valueSaver.setAfterHandleSuccess( onSuccessCallback );
-
-    return valueSaver;
 }


### PR DESCRIPTION
See [DHIS2-7757](https://jira.dhis2.org/browse/DHIS2-7757). This PR adds the endpoint POST `/dataValues/file` to allow the frontend to post a file data value along with its file contents in a single request. It also changes the data entry app to use this new endpoint.

This avoids the problem of a file being uploaded without the _dataValue_ if the network connection fails between the two requests. It will also allow checking in the future of file size and type if they are restricted by the data element, to avoid storing a file with disallowed properties.

### Backend changes

The logic to save files in _FileResourceController_ was moved to _FileResourceUtils_, where it can be called from both the _FileResourceController_ and the _DataValueController_. Actually, a near-identical copy of this logic already existed in _FileResourceUtils_, but was unused. This logic was tweaked slightly to match exactly the logic that was in _FileResourceController_.

A new POST endpoint `dataValues/file` was added to _DataValueController_. The _dataValue_-saving logic was moved from the POST `/dataValues` endpoint `saveDataValue` to the private method `saveDataValueInternal`, so it could be called from both the existing `/dataValues` endpoint and the new `/dataValues/file` endpoint. The new endpoint method, `saveFileDataValue`, calls _FileResourceUtils.saveFileResource_ to save the file, and then `saveDataValueInternal` to save the associated data value.

The existing frontend code was tested against the new backend code, to be sure that the `/fileResources` endpoint continues to work as it did before.

### Frontend changes

In `entry.fileresource.js` the fileUpload code was changed to make a single POST to the new `/dataValues/file` endpoint instead of the two POSTs to `/fileResources` and then `/dataValues`.

The `entry.js` functions `saveFileResource` and `FileResourceValueSaver` were removed, since they are no longer needed.