### PR TITLE
fix: Translations app crashed if translations isn't included in response

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -373,6 +373,11 @@ public class BaseIdentifiableObject
     @JacksonXmlProperty( localName = "translation", namespace = DxfNamespaces.DXF_2_0 )
     public Set<Translation> getTranslations()
     {
+        if ( translations == null )
+        {
+            translations = new HashSet<>();
+        }
+
         return translations;
     }
 


### PR DESCRIPTION
Quick fix for Translations app crashed if the property `translations` isn't returned in the response. 

- We already defined empty set for this `protected Set<Translation> translations = new HashSet<>();`
- I guess because this is a jsonb column, if the its null in database then jackson will ignore it while deserializes the jsonb object.