### PR TITLE
fix: [DHIS2-10351] incorrect result pageSize in case of multiple enrollment/event match criteria (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueAuditService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
@@ -215,6 +216,8 @@ public class DefaultTrackedEntityInstanceService
             params.addFiltersIfNotExist( QueryItem.getQueryItems( attributes ) );
         }
 
+        handleSortAttributes( params );
+
         decideAccess( params );
 
         // AccessValidation should be skipped only and only if it is internal
@@ -236,6 +239,34 @@ public class DefaultTrackedEntityInstanceService
         params.handleCurrentUserSelectionMode();
 
         return trackedEntityInstanceStore.getTrackedEntityInstanceIds( params );
+    }
+
+    /**
+     * This method handles any dynamic sort order columns in the params. These
+     * has to be added to attribute list if there it is neither present in
+     * attribute list nor filter list.
+     *
+     * For example, if attributes or filters doesnt have a specific
+     * trackedentityattribute uid, but sorting has been requested for that tea
+     * uid, then we need to add them to the attribute list.
+     *
+     * @param params The TEIQueryParams object
+     */
+    private void handleSortAttributes( TrackedEntityInstanceQueryParams params )
+    {
+        if ( params.hasAttributeAsOrder() )
+        {
+            // Collecting TEAs for all non static sort order columns.
+            List<TrackedEntityAttribute> sortAttributes = params.getOrders().stream()
+                .filter( orderParam -> !OrderColumn.isStaticColumn( orderParam.getField() ) ).map( orderParam -> {
+                    return attributeService.getTrackedEntityAttribute( orderParam.getField() );
+                } ).collect( Collectors.toList() );
+
+            // adding to attributes conditionally if they are also not present
+            // in filters.
+            params.addAttributesIfNotExist( QueryItem.getQueryItems( sortAttributes ).stream()
+                .filter( sAtt -> !params.getFilters().contains( sAtt ) ).collect( Collectors.toList() ) );
+        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -760,6 +760,7 @@ public class HibernateTrackedEntityInstanceStore
     {
         if ( params.hasOrders() )
         {
+            String attributeOrderSuffix = gridQuery ? " " : ".value ";
             ArrayList<String> orderFields = new ArrayList<>();
 
             for ( OrderParam order : params.getOrders() )
@@ -769,23 +770,12 @@ public class HibernateTrackedEntityInstanceStore
                     String columnName = TrackedEntityInstanceQueryParams.OrderColumn.getColumn( order.getField() );
                     orderFields.add( columnName + " " + order.getDirection() );
                 }
-                else if ( isAttributeOrder( params, order.getField() ) )
-                {
-                    if ( gridQuery )
-                    {
-                        orderFields
-                            .add( statementBuilder.columnQuote( order.getField() ) + " " + order.getDirection() );
-                    }
-                    else
-                    {
-                        orderFields
-                            .add( statementBuilder.columnQuote( order.getField() ) + ".value " + order.getDirection() );
-                    }
-                }
-                else if ( isFilterOrder( params, order.getField() ) && !gridQuery )
+                else if ( isAttributeOrder( params, order.getField() )
+                    || isAttributeFilterOrder( params, order.getField() ) )
                 {
                     orderFields
-                        .add( statementBuilder.columnQuote( order.getField() ) + ".value " + order.getDirection() );
+                        .add( statementBuilder.columnQuote( order.getField() ) + attributeOrderSuffix
+                            + order.getDirection() );
                 }
             }
 
@@ -819,7 +809,7 @@ public class HibernateTrackedEntityInstanceStore
         return false;
     }
 
-    private boolean isFilterOrder( TrackedEntityInstanceQueryParams params, String attributeId )
+    private boolean isAttributeFilterOrder( TrackedEntityInstanceQueryParams params, String attributeId )
     {
         if ( params.hasFilters() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -172,28 +172,48 @@ public class HibernateTrackedEntityInstanceStore
     @SuppressWarnings( "unchecked" )
     public List<Long> getTrackedEntityInstanceIds( TrackedEntityInstanceQueryParams params )
     {
-        String hql = buildTrackedEntityInstanceHql( params, true )
-            .replaceFirst( "inner join fetch tei.programInstances", "inner join tei.programInstances" )
-            .replaceFirst( "inner join fetch pi.programStageInstances", "inner join pi.programStageInstances" )
-            .replaceFirst( "inner join fetch psi.assignedUser", "inner join psi.assignedUser" )
-            .replaceFirst( "inner join fetch tei.programOwners", "inner join tei.programOwners" );
+        SqlHelper hlp = new SqlHelper();
 
-        // If it is a sync job running a query, I need to adjust an HQL a bit,
-        // because I am adding 2 joins and don't want duplicates in results
-        if ( params.isSynchronizationQuery() )
+        // Select clause
+        String sql = "select tei.trackedentityinstanceid as teiid,row_number() over (";
+
+        String orderByClause = getOrderClauseSql( params, false );
+        sql += orderByClause + ") as rn ";
+
+        // From and where clause
+        sql += getFromWhereClauseSql( params, hlp );
+
+        // Order clause
+        sql += orderByClause;
+
+        // Subquery to group by and eliminate duplicate teis and preserve order
+        sql = wrapSqlToPreserveOrderAfterGroupBy( sql );
+
+        // Paging clause
+        sql += addConditionally( params.isPaging(),
+            () -> " limit " + params.getPageSizeWithDefault() + " offset " + params.getOffset() );
+
+        log.debug( "Tracked entity instance query SQL: " + sql );
+
+        SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
+
+        List<Long> ids = new ArrayList<>();
+
+        while ( rowSet.next() )
         {
-            hql = hql.replaceFirst( SELECT_TEI, "select distinct tei from" );
+            ids.add( rowSet.getLong( "teiid" ) );
         }
 
-        Query query = getSession().createQuery( hql );
+        return ids;
+    }
 
-        if ( params.isPaging() )
-        {
-            query.setFirstResult( params.getOffset() );
-            query.setMaxResults( params.getPageSizeWithDefault() );
-        }
-
-        return query.list();
+    private String wrapSqlToPreserveOrderAfterGroupBy( String sql )
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "select teiid, min(rn) as mrn from (" );
+        sb.append( sql );
+        sb.append( ") as tei_joined_numbered group by teiid order by mrn " );
+        return sb.toString();
     }
 
     private String buildTrackedEntityInstanceCountHql( TrackedEntityInstanceQueryParams params )
@@ -204,7 +224,7 @@ public class HibernateTrackedEntityInstanceStore
             .replaceFirst( "inner join fetch pi.programStageInstances", "inner join pi.programStageInstances" )
             .replaceFirst( "inner join fetch psi.assignedUser", "inner join psi.assignedUser" )
             .replaceFirst( "inner join fetch tei.programOwners", "inner join tei.programOwners" )
-            .replaceFirst( Pattern.quote( getOrderClause( params ) ), " " );
+            .replaceFirst( Pattern.quote( getOrderClauseHql( params ) ), " " );
     }
 
     private String withProgram( TrackedEntityInstanceQueryParams params, SqlHelper hlp )
@@ -249,7 +269,7 @@ public class HibernateTrackedEntityInstanceStore
             hql += addWhereConditionally( hlp, params.hasProgramIncidentEndDate(),
                 () -> "pi.incidentDate < '" + getMediumDateString( params.getProgramIncidentEndDate() ) + "'" );
 
-            hql += addWhereConditionally( hlp, params.isIncludeDeleted(),
+            hql += addWhereConditionally( hlp, !params.isIncludeDeleted(),
                 () -> "pi.deleted is false " );
 
         }
@@ -391,7 +411,7 @@ public class HibernateTrackedEntityInstanceStore
 
         hql += addWhereConditionally( hlp, !params.isIncludeDeleted(), () -> " tei.deleted is false " );
 
-        hql += getOrderClause( params );
+        hql += getOrderClauseHql( params );
 
         return hql;
     }
@@ -430,13 +450,13 @@ public class HibernateTrackedEntityInstanceStore
         // From and where clause
         // ---------------------------------------------------------------------
 
-        sql += getFromWhereClause( params, hlp );
+        sql += getFromWhereClauseSql( params, hlp );
 
         // ---------------------------------------------------------------------
         // Order clause
         // ---------------------------------------------------------------------
 
-        sql += getGridOrderClause( params );
+        sql += getOrderClauseSql( params, true );
 
         // ---------------------------------------------------------------------
         // Paging clause
@@ -500,7 +520,7 @@ public class HibernateTrackedEntityInstanceStore
         // From and where clause
         // ---------------------------------------------------------------------
 
-        sql += getFromWhereClause( params, hlp );
+        sql += getFromWhereClauseSql( params, hlp );
 
         // ---------------------------------------------------------------------
         // Query
@@ -517,7 +537,7 @@ public class HibernateTrackedEntityInstanceStore
      * From, join and where clause. For attribute params, restriction is set in
      * inner join. For query params, restriction is set in where clause.
      */
-    private String getFromWhereClause( TrackedEntityInstanceQueryParams params, SqlHelper hlp )
+    private String getFromWhereClauseSql( TrackedEntityInstanceQueryParams params, SqlHelper hlp )
     {
         final String regexp = statementBuilder.getRegexpMatch();
         final String wordStart = statementBuilder.getRegexpWordStart();
@@ -532,77 +552,13 @@ public class HibernateTrackedEntityInstanceStore
         if ( params.hasProgram() )
         {
             // Using program owner OU instead of registration OU.
-            sql += "inner join (select trackedentityinstanceid, organisationunitid from trackedentityprogramowner where programid = ";
-            sql += params.getProgram().getId()
-                + ") as tepo ON tei.trackedentityinstanceid = tepo.trackedentityinstanceid ";
             teiOuSource = "tepo.organisationunitid";
-
-            sql += "inner join ("
-                + "select trackedentityinstanceid, min(case when status='ACTIVE' then 0 when status='COMPLETED' then 1 else 2 end) as status "
-                + "from programinstance pi ";
-
-            if ( params.hasFilterForEvents() )
-            {
-                sql += " inner join (select programinstanceid from programstageinstance psi ";
-
-                sql += addConditionally( params.hasAssignedUsers(),
-                    () -> "left join userinfo au on (psi.assigneduserid=au.userinfoid)" );
-
-                sql += getEventWhereClause( params );
-
-                sql += ") as psi on pi.programinstanceid = psi.programinstanceid ";
-            }
-
-            sql += " where pi.programid= " + params.getProgram().getId() + " ";
-
-            sql += addConditionally( params.hasProgramStatus(),
-                () -> "and status = '" + params.getProgramStatus() + "' " );
-
-            sql += addConditionally( params.hasFollowUp(), () -> "and pi.followup = " + params.getFollowUp() );
-
-            sql += addConditionally( params.hasProgramEnrollmentStartDate(), () -> "and pi.enrollmentdate >= '"
-                + getMediumDateString( params.getProgramEnrollmentStartDate() ) + "' " );
-
-            sql += addConditionally( params.hasProgramEnrollmentEndDate(), () -> "and pi.enrollmentdate <= '"
-                + getMediumDateString( params.getProgramEnrollmentEndDate() ) + "' " );
-
-            sql += addConditionally( params.hasProgramIncidentStartDate(),
-                () -> "and pi.incidentdate >= '" + getMediumDateString( params.getProgramIncidentStartDate() ) + "' " );
-
-            sql += addConditionally( params.hasProgramIncidentEndDate(),
-                () -> "and pi.incidentdate <= '" + getMediumDateString( params.getProgramIncidentEndDate() ) + "' " );
-
-            sql += addConditionally( params.isIncludeDeleted(),
-                () -> "and pi.deleted is false" );
-
-            sql += " group by trackedentityinstanceid ) as en on tei.trackedentityinstanceid = en.trackedentityinstanceid ";
+            sql += withProgramSql( params, hlp );
         }
 
         sql += "inner join organisationunit ou on " + teiOuSource + " = ou.organisationunitid ";
 
-        for ( QueryItem item : params.getAttributesAndFilters() )
-        {
-            final String col = statementBuilder.columnQuote( item.getItemId() );
-
-            final String joinClause = item.hasFilter() ? "inner join" : "left join";
-
-            sql += joinClause + " " + "trackedentityattributevalue as " + col + " " + "on " + col
-                + ".trackedentityinstanceid = tei.trackedentityinstanceid " + "and " + col
-                + ".trackedentityattributeid = " + item.getItem().getId() + " ";
-
-            if ( !params.isOrQuery() && item.hasFilter() )
-            {
-                for ( QueryFilter filter : item.getFilters() )
-                {
-                    final String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
-
-                    final String queryCol = item.isNumeric() ? (col + ".value") : "lower(" + col + ".value)";
-
-                    sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
-                        + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
-                }
-            }
-        }
+        sql += addAttributesAndFiltersClauseSql( params );
 
         sql += addWhereConditionally( hlp, params.hasTrackedEntityInstances(),
             () -> " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" );
@@ -647,6 +603,18 @@ public class HibernateTrackedEntityInstanceStore
                 + getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) ) + ") ";
         }
 
+        sql += addAttributeOrFiltersSql( params, hlp, regexp, wordStart, wordEnd, anyChar );
+
+        sql += addWhereConditionally( hlp, !params.isIncludeDeleted(), () -> " tei.deleted is false " );
+
+        return sql;
+    }
+
+    private String addAttributeOrFiltersSql( TrackedEntityInstanceQueryParams params, SqlHelper hlp,
+        final String regexp, final String wordStart, final String wordEnd, final String anyChar )
+    {
+        String sql = "";
+
         if ( params.isOrQuery() && params.hasAttributesOrFilters() )
         {
             final String start = params.getQuery().isOperator( QueryOperator.LIKE ) ? anyChar : wordStart;
@@ -674,13 +642,89 @@ public class HibernateTrackedEntityInstanceStore
 
             sql = removeLastAnd( sql ) + ") ";
         }
+        return sql;
+    }
 
-        sql += addWhereConditionally( hlp, !params.isIncludeDeleted(), () -> " tei.deleted is false " );
+    private String addAttributesAndFiltersClauseSql( TrackedEntityInstanceQueryParams params )
+    {
+        String sql = "";
+        for ( QueryItem item : params.getAttributesAndFilters() )
+        {
+            final String col = statementBuilder.columnQuote( item.getItemId() );
+
+            final String joinClause = item.hasFilter() ? "inner join" : "left join";
+
+            sql += joinClause + " " + "trackedentityattributevalue as " + col + " " + "on " + col
+                + ".trackedentityinstanceid = tei.trackedentityinstanceid " + "and " + col
+                + ".trackedentityattributeid = " + item.getItem().getId() + " ";
+
+            if ( !params.isOrQuery() && item.hasFilter() )
+            {
+                for ( QueryFilter filter : item.getFilters() )
+                {
+                    final String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
+
+                    final String queryCol = item.isNumeric() ? (col + ".value") : "lower(" + col + ".value)";
+
+                    sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
+                        + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
+                }
+            }
+        }
+        return sql;
+    }
+
+    private String withProgramSql( TrackedEntityInstanceQueryParams params, SqlHelper hlp )
+    {
+        String sql = "";
+
+        sql += "inner join (select trackedentityinstanceid, organisationunitid from trackedentityprogramowner where programid = ";
+        sql += params.getProgram().getId()
+            + ") as tepo ON tei.trackedentityinstanceid = tepo.trackedentityinstanceid ";
+        sql += "inner join ("
+            + "select trackedentityinstanceid, min(case when status='ACTIVE' then 0 when status='COMPLETED' then 1 else 2 end) as status "
+            + "from programinstance pi ";
+
+        if ( params.hasFilterForEvents() )
+        {
+            sql += " inner join (select programinstanceid from programstageinstance psi ";
+
+            sql += addConditionally( params.hasAssignedUsers(),
+                () -> "left join userinfo au on (psi.assigneduserid=au.userinfoid)" );
+
+            sql += getEventWhereClause( params );
+
+            sql += ") as psi on pi.programinstanceid = psi.programinstanceid ";
+        }
+
+        sql += " where pi.programid= " + params.getProgram().getId() + " ";
+
+        sql += addConditionally( params.hasProgramStatus(),
+            () -> "and status = '" + params.getProgramStatus() + "' " );
+
+        sql += addConditionally( params.hasFollowUp(), () -> "and pi.followup = " + params.getFollowUp() );
+
+        sql += addConditionally( params.hasProgramEnrollmentStartDate(), () -> "and pi.enrollmentdate >= '"
+            + getMediumDateString( params.getProgramEnrollmentStartDate() ) + "' " );
+
+        sql += addConditionally( params.hasProgramEnrollmentEndDate(), () -> "and pi.enrollmentdate <= '"
+            + getMediumDateString( params.getProgramEnrollmentEndDate() ) + "' " );
+
+        sql += addConditionally( params.hasProgramIncidentStartDate(),
+            () -> "and pi.incidentdate >= '" + getMediumDateString( params.getProgramIncidentStartDate() ) + "' " );
+
+        sql += addConditionally( params.hasProgramIncidentEndDate(),
+            () -> "and pi.incidentdate <= '" + getMediumDateString( params.getProgramIncidentEndDate() ) + "' " );
+
+        sql += addConditionally( !params.isIncludeDeleted(),
+            () -> "and pi.deleted is false" );
+
+        sql += " group by trackedentityinstanceid ) as en on tei.trackedentityinstanceid = en.trackedentityinstanceid ";
 
         return sql;
     }
 
-    private String getOrderClause( TrackedEntityInstanceQueryParams params )
+    private String getOrderClauseHql( TrackedEntityInstanceQueryParams params )
     {
         String orderQuery = "order by tei.lastUpdated desc ";
 
@@ -712,7 +756,7 @@ public class HibernateTrackedEntityInstanceStore
         return orderQuery;
     }
 
-    private String getGridOrderClause( TrackedEntityInstanceQueryParams params )
+    private String getOrderClauseSql( TrackedEntityInstanceQueryParams params, boolean gridQuery )
     {
         if ( params.hasOrders() )
         {
@@ -727,7 +771,21 @@ public class HibernateTrackedEntityInstanceStore
                 }
                 else if ( isAttributeOrder( params, order.getField() ) )
                 {
-                    orderFields.add( statementBuilder.columnQuote( order.getField() ) + " " + order.getDirection() );
+                    if ( gridQuery )
+                    {
+                        orderFields
+                            .add( statementBuilder.columnQuote( order.getField() ) + " " + order.getDirection() );
+                    }
+                    else
+                    {
+                        orderFields
+                            .add( statementBuilder.columnQuote( order.getField() ) + ".value " + order.getDirection() );
+                    }
+                }
+                else if ( isFilterOrder( params, order.getField() ) && !gridQuery )
+                {
+                    orderFields
+                        .add( statementBuilder.columnQuote( order.getField() ) + ".value " + order.getDirection() );
                 }
             }
 
@@ -739,10 +797,10 @@ public class HibernateTrackedEntityInstanceStore
 
         if ( params.hasProgram() )
         {
-            return "order by en.status asc, lastUpdated desc ";
+            return "order by en.status asc, tei.lastupdated desc ";
         }
 
-        return "order by lastUpdated desc ";
+        return "order by tei.lastupdated desc ";
     }
 
     private boolean isAttributeOrder( TrackedEntityInstanceQueryParams params, String attributeId )
@@ -750,6 +808,22 @@ public class HibernateTrackedEntityInstanceStore
         if ( params.hasAttributes() )
         {
             for ( QueryItem item : params.getAttributes() )
+            {
+                if ( attributeId.equals( item.getItemId() ) )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isFilterOrder( TrackedEntityInstanceQueryParams params, String attributeId )
+    {
+        if ( params.hasFilters() )
+        {
+            for ( QueryItem item : params.getFilters() )
             {
                 if ( attributeId.equals( item.getItemId() ) )
                 {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -426,14 +426,14 @@ public class PredictionAnalyticsDataFetcherTest
     {
         Grid grid = new ListGrid();
 
-        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, "java.lang.String", false, true ) );
+        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, false, true ) );
         grid.addHeader(
-            new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, "java.lang.String", false, true ) );
+            new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, false, true ) );
         grid.addHeader(
-            new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, "java.lang.String", false, true ) );
+            new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, false, true ) );
         grid.addHeader(
-            new GridHeader( ATTRIBUTEOPTIONCOMBO_DIM_ID, "AOC", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, "java.lang.Double", false, true ) );
+            new GridHeader( ATTRIBUTEOPTIONCOMBO_DIM_ID, "AOC", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, false, true ) );
 
         return grid;
     }
@@ -442,12 +442,12 @@ public class PredictionAnalyticsDataFetcherTest
     {
         Grid grid = new ListGrid();
 
-        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, "java.lang.String", false, true ) );
+        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, false, true ) );
         grid.addHeader(
-            new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, "java.lang.String", false, true ) );
+            new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, false, true ) );
         grid.addHeader(
-            new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, "java.lang.Double", false, true ) );
+            new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, false, true ) );
 
         return grid;
     }


### PR DESCRIPTION
**Issue**
When using api/trackedEntityInstances. there are scenarios where the server returned less than the pageSize number of records even though totalcount was above the pageSize. The reason was when the tei has multiple enrollments or events that match the criteria/filter provided in the params, the left join results in duplicate rows for tei and these duplicates results in returning lesser actual tei objects than the pageSize.

**Fix**
Switched from using hql to sql, and used row_number() function with groupby to eliminate any duplicate teiIds along with using order by to maintain the original ordering as per the query params.