### PR TITLE
fix: resolve conflict w/PR 7453 DHIS2-9317

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -426,14 +426,11 @@ public class PredictionAnalyticsDataFetcherTest
     {
         Grid grid = new ListGrid();
 
-        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader(
-            new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader(
-            new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader(
-            new GridHeader( ATTRIBUTEOPTIONCOMBO_DIM_ID, "AOC", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, "java.lang.Double", false, true ) );
+        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( ATTRIBUTEOPTIONCOMBO_DIM_ID, "AOC", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, false, true ) );
 
         return grid;
     }
@@ -442,12 +439,10 @@ public class PredictionAnalyticsDataFetcherTest
     {
         Grid grid = new ListGrid();
 
-        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader(
-            new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader(
-            new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, "java.lang.String", false, true ) );
-        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, "java.lang.Double", false, true ) );
+        grid.addHeader( new GridHeader( PERIOD_DIM_ID, "Period", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( DATA_X_DIM_ID, "DimensionItem", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( ORGUNIT_DIM_ID, "OrganisationUnit", ValueType.TEXT, false, true ) );
+        grid.addHeader( new GridHeader( "value", "Value", ValueType.NUMBER, false, true ) );
 
         return grid;
     }


### PR DESCRIPTION
This is an additional commit from [DHIS2-9317](https://jira.dhis2.org/browse/DHIS2-9317).

The checks were run on [pull/7214](https://github.com/dhis2/dhis2-core/pull/7214) from [DHIS2-9317](https://jira.dhis2.org/browse/DHIS2-9317) (feat: Speed predictor datavalue fetching) 2 days before it was merged into trunk. During that time, commit [07369c2](https://github.com/dhis2/dhis2-core/commit/03c1ed23e1ba4ab2eb79afa4e8ce8f3d3d3d326f) changed a constructor for GridHeader to infer valueType rather than requiring it in the constructor. The DHIS2-9317 code had the obsolete GridHeader argument. This PR fixes that. (The changes weren't in the same classes, so git didn't have any conflict.)