### PR TITLE
chore: make password validation deterministic [TECH-549]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/PasswordValidationError.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/PasswordValidationError.java
@@ -28,36 +28,46 @@
 package org.hisp.dhis.user;
 
 /**
- * Created by zubair on 08.03.17.
+ * Possible reasons for passwords to be invalid.
+ *
+ * @author Jan Bernitt
  */
-@FunctionalInterface
-public interface PasswordValidationRule
+public enum PasswordValidationError
 {
+    PASSWORD_IS_MANDATORY( "mandatory_parameter_missing",
+        "Username or Password is missing" ),
+    PASSWORD_TOO_LONG_TOO_SHORT( "password_length_validation",
+        "Password must have at least %d, and at most %d characters" ),
+    PASSWORD_MUST_HAVE_DIGIT( "password_digit_validation",
+        "Password must have at least one digit" ),
+    PASSWORD_MUST_HAVE_UPPER( "password_uppercase_validation",
+        "Password must have at least one upper case" ),
+    PASSWORD_MUST_HAVE_SPECIAL( "password_specialcharacter_validation",
+        "Password must have at least one special character" ),
+    PASSWORD_CONTAINS_RESERVED_WORD( "password_dictionary_validation",
+        "Password must not have any generic word" ),
+    PASSWORD_CONTAINS_NAME_OR_EMAIL( "password_username_validation",
+        "Username/Email must not be a part of password" ),
+    PASSWORD_ALREADY_USED_BEFORE( "password_history_validation",
+        "Password must not be one of the previous %d passwords" );
 
-    /**
-     * Validates user password to make sure it comply with requirements related
-     * to password strength.
-     *
-     * Not all rules are applicable all the time. If a rule does not apply it
-     * returns {@link PasswordValidationResult#VALID}.
-     *
-     * @param credentialsInfo info to check
-     * @return {@link PasswordValidationResult}
-     */
-    PasswordValidationResult validate( CredentialsInfo credentialsInfo );
+    private final String message;
 
-    /**
-     * Utility method to chain multiple {@link PasswordValidationRule}s to a
-     * complex rule with a defined sequence in which rules are checked.
-     *
-     * @param next Rule to check in case this is valid
-     * @return result of this check if invalid, otherwise result of next check
-     */
-    default PasswordValidationRule then( PasswordValidationRule next )
+    private final String i18nKey;
+
+    PasswordValidationError( String i18nKey, String message )
     {
-        return credentialsInfo -> {
-            PasswordValidationResult result = validate( credentialsInfo );
-            return !result.isValid() ? result : next.validate( credentialsInfo );
-        };
+        this.message = message;
+        this.i18nKey = i18nKey;
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+
+    public String getI18nKey()
+    {
+        return i18nKey;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/PasswordValidationResult.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/PasswordValidationResult.java
@@ -40,9 +40,17 @@ public class PasswordValidationResult
 
     public PasswordValidationResult( PasswordValidationError error, Object... args )
     {
-        this.message = error == null ? null
-            : args.length == 0 ? error.getMessage() : String.format( error.getMessage(), args );
+        this.message = getMessage( error, args );
         this.error = error;
+    }
+
+    private String getMessage( PasswordValidationError error, Object[] args )
+    {
+        if ( error == null )
+        {
+            return null;
+        }
+        return args.length == 0 ? error.getMessage() : String.format( error.getMessage(), args );
     }
 
     public String getErrorMessage()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/PasswordValidationResult.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/PasswordValidationResult.java
@@ -32,55 +32,31 @@ package org.hisp.dhis.user;
  */
 public class PasswordValidationResult
 {
-    private String errorMessage;
+    public static final PasswordValidationResult VALID = new PasswordValidationResult( null );
 
-    private String i18ErrorMessage;
+    private final String message;
 
-    private boolean valid;
+    private final PasswordValidationError error;
 
-    public PasswordValidationResult()
+    public PasswordValidationResult( PasswordValidationError error, Object... args )
     {
-    }
-
-    public PasswordValidationResult( boolean valid )
-    {
-        this.valid = valid;
-    }
-
-    public PasswordValidationResult( String errorMessage, String i18ErrorMessage, boolean valid )
-    {
-        this.errorMessage = errorMessage;
-        this.i18ErrorMessage = i18ErrorMessage;
-        this.valid = valid;
+        this.message = error == null ? null
+            : args.length == 0 ? error.getMessage() : String.format( error.getMessage(), args );
+        this.error = error;
     }
 
     public String getErrorMessage()
     {
-        return errorMessage;
-    }
-
-    public void setErrorMessage( String errorMessage )
-    {
-        this.errorMessage = errorMessage;
+        return message;
     }
 
     public boolean isValid()
     {
-        return valid;
-    }
-
-    public void setValid( boolean valid )
-    {
-        this.valid = valid;
+        return error == null;
     }
 
     public String getI18ErrorMessage()
     {
-        return i18ErrorMessage;
-    }
-
-    public void setI18ErrorMessage( String i18ErrorMessage )
-    {
-        this.i18ErrorMessage = i18ErrorMessage;
+        return error == null ? null : error.getI18nKey();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DigitPatternValidationRule.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DigitPatternValidationRule.java
@@ -27,42 +27,22 @@
  */
 package org.hisp.dhis.user;
 
-import java.util.regex.Pattern;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_DIGIT;
 
-import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Component;
+import java.util.regex.Pattern;
 
 /**
  * Created by zubair on 08.03.17.
  */
-@Component( "org.hisp.dhis.user.DigitPatternValidationRule" )
 public class DigitPatternValidationRule implements PasswordValidationRule
 {
     private static final Pattern DIGIT_PATTERN = Pattern.compile( ".*\\d.*" );
 
-    public static final String ERROR = "Password must have at least one digit";
-
-    private static final String I18_ERROR = "password_digit_validation";
-
     @Override
-    public PasswordValidationResult validate( CredentialsInfo credentialsInfo )
+    public PasswordValidationResult validate( CredentialsInfo credentials )
     {
-        if ( StringUtils.isBlank( credentialsInfo.getPassword() ) )
-        {
-            return new PasswordValidationResult( MANDATORY_PARAMETER_MISSING, I18_MANDATORY_PARAMETER_MISSING, false );
-        }
-
-        if ( !DIGIT_PATTERN.matcher( credentialsInfo.getPassword() ).matches() )
-        {
-            return new PasswordValidationResult( ERROR, I18_ERROR, false );
-        }
-
-        return new PasswordValidationResult( true );
-    }
-
-    @Override
-    public boolean isRuleApplicable( CredentialsInfo credentialsInfo )
-    {
-        return true;
+        return !DIGIT_PATTERN.matcher( credentials.getPassword() ).matches()
+            ? new PasswordValidationResult( PASSWORD_MUST_HAVE_DIGIT )
+            : PasswordValidationResult.VALID;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/PasswordDictionaryValidationRule.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/PasswordDictionaryValidationRule.java
@@ -27,48 +27,30 @@
  */
 package org.hisp.dhis.user;
 
-import java.util.Arrays;
-import java.util.List;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_CONTAINS_RESERVED_WORD;
 
-import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Component;
+import java.util.List;
 
 /**
  * Created by zubair on 16.03.17.
  */
-@Component( "org.hisp.dhis.user.PasswordDictionaryValidationRule" )
-public class PasswordDictionaryValidationRule
-    implements PasswordValidationRule
+public class PasswordDictionaryValidationRule implements PasswordValidationRule
 {
-    public static final String ERROR = "Password must not have any generic word";
-
-    public static final String I18_ERROR = "password_dictionary_validation";
-
-    private static final List<String> DICTIONARY = Arrays.asList( "user", "admin", "system", "administrator",
+    private static final List<String> DICTIONARY = asList( "user", "admin", "system", "administrator",
         "username", "password", "login", "manager" );
 
     @Override
-    public boolean isRuleApplicable( CredentialsInfo credentialsInfo )
+    public PasswordValidationResult validate( CredentialsInfo credentials )
     {
-        return true;
-    }
-
-    @Override
-    public PasswordValidationResult validate( CredentialsInfo credentialsInfo )
-    {
-        if ( StringUtils.isBlank( credentialsInfo.getPassword() ) )
-        {
-            return new PasswordValidationResult( MANDATORY_PARAMETER_MISSING, I18_MANDATORY_PARAMETER_MISSING, false );
-        }
-
         for ( String reserved : DICTIONARY )
         {
-            if ( StringUtils.containsIgnoreCase( credentialsInfo.getPassword(), reserved ) )
+            if ( containsIgnoreCase( credentials.getPassword(), reserved ) )
             {
-                return new PasswordValidationResult( ERROR, I18_ERROR, false );
+                return new PasswordValidationResult( PASSWORD_CONTAINS_RESERVED_WORD );
             }
         }
-
-        return new PasswordValidationResult( true );
+        return PasswordValidationResult.VALID;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/PasswordMandatoryValidationRule.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/PasswordMandatoryValidationRule.java
@@ -27,37 +27,22 @@
  */
 package org.hisp.dhis.user;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_IS_MANDATORY;
+
 /**
- * Created by zubair on 08.03.17.
+ * A {@link PasswordValidationRule} that makes sure the password is set. This
+ * should be the first rule in a sequence of rules.
+ *
+ * @author Jan Bernitt
  */
-@FunctionalInterface
-public interface PasswordValidationRule
+public class PasswordMandatoryValidationRule implements PasswordValidationRule
 {
-
-    /**
-     * Validates user password to make sure it comply with requirements related
-     * to password strength.
-     *
-     * Not all rules are applicable all the time. If a rule does not apply it
-     * returns {@link PasswordValidationResult#VALID}.
-     *
-     * @param credentialsInfo info to check
-     * @return {@link PasswordValidationResult}
-     */
-    PasswordValidationResult validate( CredentialsInfo credentialsInfo );
-
-    /**
-     * Utility method to chain multiple {@link PasswordValidationRule}s to a
-     * complex rule with a defined sequence in which rules are checked.
-     *
-     * @param next Rule to check in case this is valid
-     * @return result of this check if invalid, otherwise result of next check
-     */
-    default PasswordValidationRule then( PasswordValidationRule next )
+    @Override
+    public PasswordValidationResult validate( CredentialsInfo credentials )
     {
-        return credentialsInfo -> {
-            PasswordValidationResult result = validate( credentialsInfo );
-            return !result.isValid() ? result : next.validate( credentialsInfo );
-        };
+        return isBlank( credentials.getPassword() ) || !credentials.isNewUser() && isBlank( credentials.getUsername() )
+            ? new PasswordValidationResult( PASSWORD_IS_MANDATORY )
+            : PasswordValidationResult.VALID;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/SpecialCharacterValidationRule.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/SpecialCharacterValidationRule.java
@@ -27,43 +27,22 @@
  */
 package org.hisp.dhis.user;
 
-import java.util.regex.Pattern;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_SPECIAL;
 
-import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Component;
+import java.util.regex.Pattern;
 
 /**
  * Created by zubair on 16.03.17.
  */
-@Component( "org.hisp.dhis.user.SpecialCharacterValidationRule" )
-public class SpecialCharacterValidationRule
-    implements PasswordValidationRule
+public class SpecialCharacterValidationRule implements PasswordValidationRule
 {
     private static final Pattern SPECIAL_CHARACTER = Pattern.compile( ".*[^A-Za-z0-9].*" );
 
-    public static final String ERROR = "Password must have at least one special character";
-
-    public static final String I18_ERROR = "password_specialcharacter_validation";
-
     @Override
-    public PasswordValidationResult validate( CredentialsInfo credentialsInfo )
+    public PasswordValidationResult validate( CredentialsInfo credentials )
     {
-        if ( StringUtils.isBlank( credentialsInfo.getPassword() ) )
-        {
-            return new PasswordValidationResult( MANDATORY_PARAMETER_MISSING, I18_MANDATORY_PARAMETER_MISSING, false );
-        }
-
-        if ( !SPECIAL_CHARACTER.matcher( credentialsInfo.getPassword() ).matches() )
-        {
-            return new PasswordValidationResult( ERROR, I18_ERROR, false );
-        }
-
-        return new PasswordValidationResult( true );
-    }
-
-    @Override
-    public boolean isRuleApplicable( CredentialsInfo credentialsInfo )
-    {
-        return true;
+        return !SPECIAL_CHARACTER.matcher( credentials.getPassword() ).matches()
+            ? new PasswordValidationResult( PASSWORD_MUST_HAVE_SPECIAL )
+            : PasswordValidationResult.VALID;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UpperCasePatternValidationRule.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UpperCasePatternValidationRule.java
@@ -27,42 +27,22 @@
  */
 package org.hisp.dhis.user;
 
-import java.util.regex.Pattern;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_UPPER;
 
-import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Component;
+import java.util.regex.Pattern;
 
 /**
  * Created by zubair on 08.03.17.
  */
-@Component( "org.hisp.dhis.user.UpperCasePatternValidationRule" )
 public class UpperCasePatternValidationRule implements PasswordValidationRule
 {
-    public static final String ERROR = "Password must have at least one upper case";
-
-    public static final String I18_ERROR = "password_uppercase_validation";
-
     private static final Pattern UPPERCASE_PATTERN = Pattern.compile( ".*[A-Z].*" );
 
     @Override
     public PasswordValidationResult validate( CredentialsInfo credentialsInfo )
     {
-        if ( StringUtils.isBlank( credentialsInfo.getPassword() ) )
-        {
-            return new PasswordValidationResult( MANDATORY_PARAMETER_MISSING, I18_MANDATORY_PARAMETER_MISSING, false );
-        }
-
-        if ( !UPPERCASE_PATTERN.matcher( credentialsInfo.getPassword() ).matches() )
-        {
-            return new PasswordValidationResult( ERROR, I18_ERROR, false );
-        }
-
-        return new PasswordValidationResult( true );
-    }
-
-    @Override
-    public boolean isRuleApplicable( CredentialsInfo credentialsInfo )
-    {
-        return true;
+        return !UPPERCASE_PATTERN.matcher( credentialsInfo.getPassword() ).matches()
+            ? new PasswordValidationResult( PASSWORD_MUST_HAVE_UPPER )
+            : PasswordValidationResult.VALID;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserParameterValidationRule.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserParameterValidationRule.java
@@ -27,54 +27,28 @@
  */
 package org.hisp.dhis.user;
 
-import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Component;
+import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
+import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_CONTAINS_NAME_OR_EMAIL;
 
 /**
  * @author Zubair
  */
-@Component( "org.hisp.dhis.user.UserParameterValidationRule" )
-public class UserParameterValidationRule
-    implements PasswordValidationRule
+public class UserParameterValidationRule implements PasswordValidationRule
 {
-    public static final String ERROR = "Username/Email must not be a part of password";
-
-    private static final String I18_ERROR = "password_username_validation";
-
     @Override
-    public boolean isRuleApplicable( CredentialsInfo credentialsInfo )
+    public PasswordValidationResult validate( CredentialsInfo credentials )
     {
-        return true;
-    }
-
-    @Override
-    public PasswordValidationResult validate( CredentialsInfo credentialsInfo )
-    {
-        String email = credentialsInfo.getEmail();
-        String password = credentialsInfo.getPassword();
-        String username = credentialsInfo.getUsername();
-
-        // other parameters will be skipped in case of new user
-        if ( credentialsInfo.isNewUser() )
-        {
-            if ( StringUtils.isBlank( password ) )
-            {
-                return new PasswordValidationResult( MANDATORY_PARAMETER_MISSING, I18_MANDATORY_PARAMETER_MISSING,
-                    false );
-            }
-        }
-        else if ( StringUtils.isBlank( password ) || StringUtils.isBlank( username ) )
-        {
-            return new PasswordValidationResult( MANDATORY_PARAMETER_MISSING, I18_MANDATORY_PARAMETER_MISSING, false );
-        }
+        String email = credentials.getEmail();
+        String password = credentials.getPassword();
+        String username = credentials.getUsername();
 
         // Password should not contain part of either username or email
-        if ( StringUtils.containsIgnoreCase( password, StringUtils.defaultIfEmpty( username, null ) ) ||
-            StringUtils.containsIgnoreCase( password, StringUtils.defaultIfEmpty( email, null ) ) )
+        if ( containsIgnoreCase( password, defaultIfEmpty( username, null ) ) ||
+            containsIgnoreCase( password, defaultIfEmpty( email, null ) ) )
         {
-            return new PasswordValidationResult( ERROR, I18_ERROR, false );
+            return new PasswordValidationResult( PASSWORD_CONTAINS_NAME_OR_EMAIL );
         }
-
-        return new PasswordValidationResult( true );
+        return PasswordValidationResult.VALID;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationServiceTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import static java.util.Arrays.asList;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_ALREADY_USED_BEFORE;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_CONTAINS_NAME_OR_EMAIL;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_CONTAINS_RESERVED_WORD;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_IS_MANDATORY;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_DIGIT;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_SPECIAL;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_UPPER;
+import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_TOO_LONG_TOO_SHORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Tests the {@link PasswordValidationService}
+ *
+ * @author Jan Bernitt
+ */
+public class PasswordValidationServiceTest
+{
+
+    private PasswordValidationService validation;
+
+    private PasswordEncoder encoder;
+
+    @Before
+    public void setUp()
+    {
+        encoder = mock( PasswordEncoder.class );
+
+        UserService userService = mock( UserService.class );
+        UserCredentials credentials = new UserCredentials();
+        credentials.setPreviousPasswords( asList( "$kyWalker1", "$kyWalker2", "$kyWalker3" ) );
+        when( userService.getUserCredentialsByUsername( anyString() ) ).thenReturn( credentials );
+
+        CurrentUserService currentUserService = mock( CurrentUserService.class );
+        when( currentUserService.getCurrentUsername() ).thenReturn( "Luke" );
+
+        SystemSettingManager systemSettings = mock( SystemSettingManager.class );
+        when( systemSettings.getSystemSetting( SettingKey.MIN_PASSWORD_LENGTH ) ).thenReturn( 8 );
+        when( systemSettings.getSystemSetting( SettingKey.MAX_PASSWORD_LENGTH ) ).thenReturn( 16 );
+        validation = new DefaultPasswordValidationService( encoder, userService, currentUserService, systemSettings );
+    }
+
+    @Test
+    public void tooShortPasswords()
+    {
+        assertInvalid( "Luke", "Sev€n77", PASSWORD_TOO_LONG_TOO_SHORT, 8, 16 );
+        assertInvalid( "Lucky", "Sky", PASSWORD_TOO_LONG_TOO_SHORT, 8, 16 );
+    }
+
+    @Test
+    public void tooLongPasswords()
+    {
+        assertInvalid( "Luke", "17teen17teen17teen", PASSWORD_TOO_LONG_TOO_SHORT, 8, 16 );
+        assertInvalid( "Lucky", "JediKnightSkywalker", PASSWORD_TOO_LONG_TOO_SHORT, 8, 16 );
+    }
+
+    @Test
+    public void passwordIsMandatory()
+    {
+        assertInvalid( "Luke", "", PASSWORD_IS_MANDATORY );
+        assertInvalid( "Lucky", null, PASSWORD_IS_MANDATORY );
+    }
+
+    @Test
+    public void usernameIsMandatory()
+    {
+        assertInvalid( "", "$kyWalker7", PASSWORD_IS_MANDATORY );
+        assertInvalid( null, "$kyWalker7", PASSWORD_IS_MANDATORY );
+    }
+
+    @Test
+    public void passwordMustHaveDigits()
+    {
+        assertInvalid( "Luke", "$kyWalker", PASSWORD_MUST_HAVE_DIGIT );
+        assertInvalid( "Lucky", "$kyWalker", PASSWORD_MUST_HAVE_DIGIT );
+    }
+
+    @Test
+    public void passwordMustHaveUpperCaseLetters()
+    {
+        assertInvalid( "Luke", "$kywalker7", PASSWORD_MUST_HAVE_UPPER );
+        assertInvalid( "Lucky", "$kywalker7", PASSWORD_MUST_HAVE_UPPER );
+    }
+
+    @Test
+    public void passwordMustHaveSpecialCharacters()
+    {
+        assertInvalid( "Luke", "SkyWalker7", PASSWORD_MUST_HAVE_SPECIAL );
+        assertInvalid( "Lucky", "SkyWalker7", PASSWORD_MUST_HAVE_SPECIAL );
+    }
+
+    @Test
+    public void passwordMustNotContainReservedWords()
+    {
+        for ( String reserved : new String[] { "user", "admin", "system",
+            "username", "password", "login", "manager" } )
+        {
+            assertInvalid( "Luke", "$kY7" + reserved, PASSWORD_CONTAINS_RESERVED_WORD );
+            assertInvalid( "Lucky", reserved + "$kY7", PASSWORD_CONTAINS_RESERVED_WORD );
+        }
+    }
+
+    @Test
+    public void passwordMustNotContainUsername()
+    {
+        assertInvalid( "Luke", "$kyLuke7", PASSWORD_CONTAINS_NAME_OR_EMAIL );
+        assertInvalid( "Lucky", "LuckyW@lker7", PASSWORD_CONTAINS_NAME_OR_EMAIL );
+    }
+
+    @Test
+    public void passwordMustNotContainEmail()
+    {
+        assertInvalid( new CredentialsInfo( "Luke", "Sky@walker.nu7", "Sky@walker.nu", true ),
+            PASSWORD_CONTAINS_NAME_OR_EMAIL );
+        assertInvalid( new CredentialsInfo( "Luke", "Sky@walker.nu7", "Sky@walker.nu", false ),
+            PASSWORD_CONTAINS_NAME_OR_EMAIL );
+    }
+
+    @Test
+    public void passwordMustNotHaveBeenUsedBefore()
+    {
+        when( encoder.matches( any(), any() ) ).thenReturn( true );
+        assertInvalid( "Luke", "$kyWalker1", PASSWORD_ALREADY_USED_BEFORE, 24 );
+        assertInvalid( "Lucky", "$kyWalker2", PASSWORD_ALREADY_USED_BEFORE, 24 );
+    }
+
+    private void assertInvalid( String username, String password, PasswordValidationError expected, Object... args )
+    {
+        assertInvalid( username, password, username + "@force.net", expected, args );
+    }
+
+    private void assertInvalid( String username, String password, String email, PasswordValidationError expected,
+        Object... args )
+    {
+        if ( username != null && !username.isEmpty() )
+        {
+            assertInvalid( new CredentialsInfo( username, password, email, true ), expected, args );
+            assertInvalid( new CredentialsInfo( username, password, null, true ), expected, args );
+        }
+        assertInvalid( new CredentialsInfo( username, password, email, false ), expected, args );
+        assertInvalid( new CredentialsInfo( username, password, null, false ), expected, args );
+    }
+
+    private void assertInvalid( CredentialsInfo credentials, PasswordValidationError expected, Object... args )
+    {
+        PasswordValidationResult actual = validation.validate( credentials );
+        assertFalse( actual.isValid() );
+        assertEquals( actual.getErrorMessage(), expected.getI18nKey(), actual.getI18ErrorMessage() );
+        assertEquals( String.format( expected.getMessage(), args ), actual.getErrorMessage() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationServiceTest.java
@@ -38,6 +38,8 @@ import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_MUST_HAVE_UPPE
 import static org.hisp.dhis.user.PasswordValidationError.PASSWORD_TOO_LONG_TOO_SHORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -164,6 +166,13 @@ public class PasswordValidationServiceTest
         assertInvalid( "Lucky", "$kyWalker2", PASSWORD_ALREADY_USED_BEFORE, 24 );
     }
 
+    @Test
+    public void validPasswords()
+    {
+        assertValid( "Luke", "$kyWalker42" );
+        assertValid( "Lucky", "m@yThe4thBeWithU" );
+    }
+
     private void assertInvalid( String username, String password, PasswordValidationError expected, Object... args )
     {
         assertInvalid( username, password, username + "@force.net", expected, args );
@@ -187,5 +196,21 @@ public class PasswordValidationServiceTest
         assertFalse( actual.isValid() );
         assertEquals( actual.getErrorMessage(), expected.getI18nKey(), actual.getI18ErrorMessage() );
         assertEquals( String.format( expected.getMessage(), args ), actual.getErrorMessage() );
+    }
+
+    private void assertValid( String username, String password )
+    {
+        assertValid( new CredentialsInfo( username, password, username + "@force.net", true ) );
+        assertValid( new CredentialsInfo( username, password, username + "@force.net", false ) );
+        assertValid( new CredentialsInfo( username, password, null, true ) );
+        assertValid( new CredentialsInfo( username, password, null, false ) );
+    }
+
+    private void assertValid( CredentialsInfo credentials )
+    {
+        PasswordValidationResult actual = validation.validate( credentials );
+        assertTrue( actual.isValid() );
+        assertNull( actual.getErrorMessage() );
+        assertNull( actual.getI18ErrorMessage() );
     }
 }


### PR DESCRIPTION
### Summary
Testing the Web API in #7475 I got problems testing the API since the password validation was not deterministic producing different errors on different environments in case multiple violations were present.

This PR makes the password validation deterministic.
The `PasswordValidationRule` implementations are no longer spring `@Component`s. Instead they are composed explicitly to a sequence in the constructor of `DefaultPasswordValidationService`.

With the order being deterministic rules later in the sequence no longer have to check if mandatory parameters  are present. 

On top I did a bit of code style cleanup ;)

* extracted enum for the error codes and messages
* extracted new rule `PasswordMandatoryValidationRule` to explicitly handle the mandatory input value check
* used the enum in `PasswordValidationResult` which now makes sure a result is either valid without errors or has errors and is invalid
* removed setters from `PasswordValidationResult` (immutable value)
* simplified the `PasswordValidationRule` to a `@FunctionalInterface`

### Automatic Testing
I only slightly adopted the existing unit test `PasswordValidationRuleTest` so it becomes obvious to the reviewer that the behaviour is still as expected.

I added a new test for the service to make sure that the composed `PasswordValidationRule` used by the service has the expected effect.