### PR TITLE
fix: translatable=true  even if object doesn't have translations column

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/BaseIdentifiableObject_.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/BaseIdentifiableObject_.java
@@ -37,4 +37,6 @@ public class BaseIdentifiableObject_
 {
     public static final String CREATED_BY = "createdBy";
 
+    public static final String TRANSLATIONS = "translations";
+
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translatable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translatable.java
@@ -55,5 +55,5 @@ public @interface Translatable
      * Translation key for storing translation in json format. If not defined
      * then property name is used as the key.
      */
-    String key();
+    String key() default "";
 }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.schema.introspection;
 
 import java.util.Map;
 
+import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.system.util.AnnotationUtils;
 
@@ -44,6 +45,13 @@ public class TranslatablePropertyIntrospector implements PropertyIntrospector
     @Override
     public void introspect( Class<?> klass, Map<String, Property> properties )
     {
+        Property translationsProperty = properties.get( BaseIdentifiableObject_.TRANSLATIONS );
+
+        if ( translationsProperty == null || !translationsProperty.isPersisted() )
+        {
+            return;
+        }
+
         Map<String, String> translatableFields = AnnotationUtils.getTranslatableAnnotatedFields( klass );
 
         for ( Property property : properties.values() )

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
@@ -30,26 +30,76 @@ package org.hisp.dhis.schema;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.schema.introspection.TranslatablePropertyIntrospector;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class TranslatablePropertyIntrospectorTest extends DhisSpringTest
 {
-    @Autowired
-    private SchemaService schemaService;
-
     @Test
     public void testGetTranslatableProperties()
     {
-        Schema deSchema = schemaService.getSchema( DataElement.class );
-        Map<String, Property> propertyMap = deSchema.getPropertyMap();
-        assertTrue( propertyMap.containsKey( "name" ) );
-        assertTrue( propertyMap.containsKey( "code" ) );
+        TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
+
+        Property propTranslation = new Property( DataElement.class );
+        propTranslation.setName( "translations" );
+        propTranslation.setFieldName( "translations" );
+        propTranslation.setPersisted( true );
+
+        Property propName = new Property( DataElement.class );
+        propName.setName( "name" );
+        propName.setFieldName( "name" );
+        propName.setPersisted( true );
+
+        Property propCode = new Property( DataElement.class );
+        propCode.setName( "code" );
+        propCode.setFieldName( "code" );
+        propCode.setPersisted( true );
+
+        Map<String, Property> propertyMap = new HashMap<>();
+        propertyMap.put( "name", propName );
+        propertyMap.put( "code", propCode );
+        propertyMap.put( "translations", propTranslation );
+
+        assertFalse( propertyMap.get( "name" ).isTranslatable() );
+
+        introspector.introspect( DataElement.class, propertyMap );
+
         assertTrue( propertyMap.get( "name" ).isTranslatable() );
+        assertFalse( propertyMap.get( "code" ).isTranslatable() );
+    }
+
+    /**
+     * If an object doesn't have column translations in database, then none of
+     * properties will have translations = true even if it is marked with
+     * annotation Translatable
+     */
+    @Test
+    public void testNonTranslatableObject()
+    {
+        TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
+
+        Property propName = new Property( DataElement.class );
+        propName.setName( "name" );
+        propName.setPersisted( true );
+
+        Property propCode = new Property( DataElement.class );
+        propCode.setName( "code" );
+        propCode.setPersisted( true );
+
+        Map<String, Property> propertyMap = new HashMap<>();
+        propertyMap.put( "name", propName );
+        propertyMap.put( "code", propCode );
+
+        assertFalse( propertyMap.get( "name" ).isTranslatable() );
+
+        introspector.introspect( DataElement.class, propertyMap );
+
+        assertFalse( propertyMap.get( "name" ).isTranslatable() );
         assertFalse( propertyMap.get( "code" ).isTranslatable() );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/AnnotationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/AnnotationUtils.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.hisp.dhis.translation.Translatable;
@@ -135,7 +136,7 @@ public class AnnotationUtils
             if ( translatableAnnotation != null )
             {
                 mapFields.put( translatableAnnotation.propertyName(),
-                    translatableAnnotation.key() != null ? translatableAnnotation.key()
+                    !StringUtils.isEmpty( translatableAnnotation.key() ) ? translatableAnnotation.key()
                         : translatableAnnotation.propertyName() );
             }
         } );


### PR DESCRIPTION
Issue: If an object doesn't have `translations` jsonb column in database,  properties marked with `@Translatable` have translatable = true
Fix: Add a check to make sure object doesn't mapped with `translations` column in DB won't have any properties with `translatable=true`