### PR TITLE
fix: Filtering issue for ReportTable and Chart

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
+import static org.hisp.dhis.webapi.utils.PaginationUtils.getPaginationData;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.io.IOException;
@@ -36,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -43,6 +46,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.chart.Chart;
@@ -53,7 +58,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.common.SubscribableObject;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
@@ -115,7 +119,6 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.LinkService;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -154,6 +157,12 @@ public abstract class ChartFacadeController
     // --------------------------------------------------------------------------
     // Dependencies
     // --------------------------------------------------------------------------
+
+    private Cache<String, Long> paginationCountCache = new Cache2kBuilder<String, Long>()
+    {
+    }
+        .expireAfterWrite( 1, TimeUnit.MINUTES )
+        .build();
 
     @Autowired
     protected IdentifiableObjectManager manager;
@@ -244,6 +253,12 @@ public abstract class ChartFacadeController
                 "You don't have the proper permissions to read objects of this type." );
         }
 
+        // Force the load of Visualizations of Chart types only.
+        // The only non-chart type, currently, is PIVOT_TABLE. So we only
+        // exclude this
+        // type.
+        filters.add( "type:!eq:" + PIVOT_TABLE );
+
         List<Visualization> entities = getEntityList( metadata, options, filters, orders );
 
         // Conversion point
@@ -253,8 +268,10 @@ public abstract class ChartFacadeController
 
         if ( options.hasPaging() && pager == null )
         {
-            pager = new Pager( options.getPage(), charts.size(), options.getPageSize() );
-            charts = PagerUtils.pageCollection( charts, pager );
+            long count = paginationCountCache.computeIfAbsent(
+                composePaginationCountKey( currentUser, filters, options ),
+                () -> countTotal( options, filters, orders ) );
+            pager = new Pager( options.getPage(), count, options.getPageSize() );
         }
 
         handleLinksAndAccess( charts, fields, false, currentUser );
@@ -534,7 +551,7 @@ public abstract class ChartFacadeController
         }
 
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
-            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
+            getPaginationData( options ), options.getRootJunction() );
         query.setUser( user );
         query.setObjects( entities );
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
@@ -1164,8 +1181,8 @@ public abstract class ChartFacadeController
         throws QueryParserException
     {
         List<Visualization> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders,
-            new Pagination(), options.getRootJunction() );
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ),
+            options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
 
@@ -1179,6 +1196,20 @@ public abstract class ChartFacadeController
         }
 
         return entityList;
+    }
+
+    private long countTotal( WebOptions options, List<String> filters, List<Order> orders )
+    {
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
+            options.getRootJunction() );
+
+        return queryService.count( query );
+    }
+
+    private String composePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
+    {
+        return currentUser.getUsername() + "." + getEntityName() + "." + String.join( "|", filters ) + "."
+            + options.getRootJunction().name();
     }
 
     private List<?> getEntity( String uid )
@@ -1275,8 +1306,7 @@ public abstract class ChartFacadeController
                 copyProperties( visualization, chart, "type" );
 
                 // Consider only Visualization type that is a Chart
-                if ( visualization.getType() != null
-                    && !"PIVOT_TABLE".equalsIgnoreCase( visualization.getType().name() ) )
+                if ( visualization.getType() != null )
                 {
                     // Set the correct type
                     chart.setType( ChartType.valueOf( visualization.getType().name() ) );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
+import static org.hisp.dhis.webapi.utils.PaginationUtils.getPaginationData;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -43,6 +45,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -50,7 +54,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.common.SubscribableObject;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
@@ -113,7 +116,6 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.service.LinkService;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.BeanUtils;
@@ -154,6 +156,12 @@ public abstract class ReportTableFacadeController
     // --------------------------------------------------------------------------
     // Dependencies
     // --------------------------------------------------------------------------
+
+    private Cache<String, Long> paginationCountCache = new Cache2kBuilder<String, Long>()
+    {
+    }
+        .expireAfterWrite( 1, TimeUnit.MINUTES )
+        .build();
 
     @Autowired
     protected IdentifiableObjectManager manager;
@@ -244,6 +252,12 @@ public abstract class ReportTableFacadeController
                 "You don't have the proper permissions to read objects of this type." );
         }
 
+        // Force the load of Visualizations of Chart types only.
+        // The only non-chart type, currently, is PIVOT_TABLE. So we only
+        // exclude this
+        // type.
+        filters.add( "type:eq:" + PIVOT_TABLE );
+
         List<Visualization> entities = getEntityList( metadata, options, filters, orders );
 
         // Conversion point
@@ -253,8 +267,10 @@ public abstract class ReportTableFacadeController
 
         if ( options.hasPaging() && pager == null )
         {
-            pager = new Pager( options.getPage(), reportTables.size(), options.getPageSize() );
-            reportTables = PagerUtils.pageCollection( reportTables, pager );
+            long count = paginationCountCache.computeIfAbsent(
+                composePaginationCountKey( currentUser, filters, options ),
+                () -> countTotal( options, filters, orders ) );
+            pager = new Pager( options.getPage(), count, options.getPageSize() );
         }
 
         handleLinksAndAccess( reportTables, fields, false, currentUser );
@@ -534,7 +550,7 @@ public abstract class ReportTableFacadeController
         }
 
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
-            PaginationUtils.getPaginationData( options ), options.getRootJunction() );
+            getPaginationData( options ), options.getRootJunction() );
         query.setUser( user );
         query.setObjects( entities );
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
@@ -1165,7 +1181,7 @@ public abstract class ReportTableFacadeController
         throws QueryParserException
     {
         List<Visualization> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ),
             options.getRootJunction() );
         query.setDefaultOrder();
         query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
@@ -1180,6 +1196,20 @@ public abstract class ReportTableFacadeController
         }
 
         return entityList;
+    }
+
+    private long countTotal( WebOptions options, List<String> filters, List<Order> orders )
+    {
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
+            options.getRootJunction() );
+
+        return queryService.count( query );
+    }
+
+    private String composePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
+    {
+        return currentUser.getUsername() + "." + getEntityName() + "." + String.join( "|", filters ) + "."
+            + options.getRootJunction().name();
     }
 
     private List<?> getEntity( String uid )
@@ -1236,9 +1266,7 @@ public abstract class ReportTableFacadeController
         {
             for ( final Visualization visualization : entities )
             {
-                // Consider only Visualization types of Pivot Table
-                if ( visualization.getType() != null
-                    && "PIVOT_TABLE".equalsIgnoreCase( visualization.getType().name() ) )
+                if ( visualization.getType() != null )
                 {
                     final ReportTable reportTable = new ReportTable();
                     BeanUtils.copyProperties( visualization, reportTable );


### PR DESCRIPTION
This will bring back the performance and filtering to the same level as other endpoints.
This was already merged in 2.34 and 2.35. It's being "forward ported" to master.

