### PR TITLE
fix: Rename normalized outlier enum constant

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/NormalizedOutlierMethod.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/NormalizedOutlierMethod.java
@@ -32,5 +32,5 @@ package org.hisp.dhis.visualization;
  */
 public enum NormalizedOutlierMethod
 {
-    XY_RATIO
+    Y_RESIDUALS_LINEAR
 }


### PR DESCRIPTION
The existing constant name needs to be replaced by the new name.