### PR TITLE
fix: Fix clear cache chore to clear all caches created in CacheProvider

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsService.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 
 /**
@@ -172,11 +171,4 @@ public interface AnalyticsService
      * @return a mapping of dimensional items and aggregated data values.
      */
     Map<String, Object> getAggregatedDataValueMapping( AnalyticalObject object );
-
-    /**
-     * Event handler for {@link ApplicationCacheClearedEvent}.
-     *
-     * @param event the {@link ApplicationCacheClearedEvent}.
-     */
-    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -52,12 +52,10 @@ import org.hisp.dhis.common.CombinationGenerator;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.visualization.Visualization;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 /**
@@ -171,13 +169,6 @@ public class DefaultAnalyticsService
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );
 
         return getAggregatedDataValueMapping( params );
-    }
-
-    @Override
-    @EventListener
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
-        analyticsCache.invalidateAll();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
@@ -33,7 +33,6 @@ import org.hisp.dhis.analytics.AnalyticsMetaDataKey;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 
 /**
  * This interface is responsible for retrieving aggregated event data. Data will
@@ -132,11 +131,4 @@ public interface EventAnalyticsService
      * @return event clusters as a Grid object.
      */
     Rectangle getRectangle( EventQueryParams params );
-
-    /**
-     * Event handler for {@link ApplicationCacheClearedEvent}.
-     *
-     * @param event the {@link ApplicationCacheClearedEvent}.
-     */
-    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -30,35 +30,14 @@ package org.hisp.dhis.analytics.event.data;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
-import static org.hisp.dhis.analytics.DataQueryParams.DENOMINATOR_HEADER_NAME;
-import static org.hisp.dhis.analytics.DataQueryParams.DENOMINATOR_ID;
-import static org.hisp.dhis.analytics.DataQueryParams.DIVISOR_HEADER_NAME;
-import static org.hisp.dhis.analytics.DataQueryParams.DIVISOR_ID;
-import static org.hisp.dhis.analytics.DataQueryParams.FACTOR_HEADER_NAME;
-import static org.hisp.dhis.analytics.DataQueryParams.FACTOR_ID;
-import static org.hisp.dhis.analytics.DataQueryParams.MULTIPLIER_HEADER_NAME;
-import static org.hisp.dhis.analytics.DataQueryParams.MULTIPLIER_ID;
-import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_HEADER_NAME;
-import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_ID;
-import static org.hisp.dhis.analytics.DataQueryParams.VALUE_HEADER_NAME;
-import static org.hisp.dhis.analytics.DataQueryParams.VALUE_ID;
+import static org.hisp.dhis.analytics.DataQueryParams.*;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
-import static org.hisp.dhis.common.ValueType.BOOLEAN;
-import static org.hisp.dhis.common.ValueType.DATE;
-import static org.hisp.dhis.common.ValueType.NUMBER;
-import static org.hisp.dhis.common.ValueType.TEXT;
-import static org.hisp.dhis.reporttable.ReportTable.COLUMN_NAMES;
-import static org.hisp.dhis.reporttable.ReportTable.DASH_PRETTY_SEPARATOR;
-import static org.hisp.dhis.reporttable.ReportTable.SPACE;
-import static org.hisp.dhis.reporttable.ReportTable.TOTAL_COLUMN_PRETTY_NAME;
+import static org.hisp.dhis.common.ValueType.*;
+import static org.hisp.dhis.reporttable.ReportTable.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -68,26 +47,9 @@ import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.EventAnalyticsDimensionalItem;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.analytics.cache.AnalyticsCache;
-import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
-import org.hisp.dhis.analytics.event.EventAnalyticsManager;
-import org.hisp.dhis.analytics.event.EventAnalyticsService;
-import org.hisp.dhis.analytics.event.EventAnalyticsUtils;
-import org.hisp.dhis.analytics.event.EventDataQueryService;
-import org.hisp.dhis.analytics.event.EventQueryParams;
-import org.hisp.dhis.analytics.event.EventQueryPlanner;
-import org.hisp.dhis.analytics.event.EventQueryValidator;
+import org.hisp.dhis.analytics.event.*;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
-import org.hisp.dhis.common.AnalyticalObject;
-import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.EventAnalyticalObject;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
-import org.hisp.dhis.common.MetadataItem;
-import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -97,7 +59,6 @@ import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.util.Timer;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Preconditions;
@@ -651,15 +612,6 @@ public class DefaultEventAnalyticsService
         params = queryPlanner.planEventQuery( params );
 
         return eventAnalyticsManager.getRectangle( params );
-    }
-
-    @Override
-    @EventListener
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
-        analyticsCache.invalidateAll();
-
-        log.info( "Event analytics cache cleared" );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ImplementableRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ImplementableRuleService.java
@@ -33,12 +33,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleService;
-import org.springframework.context.event.EventListener;
 
 abstract class ImplementableRuleService
 {
@@ -79,12 +77,6 @@ abstract class ImplementableRuleService
 
         getProgramRulesCache().put( program.getUid(), !programRulesByActionTypes.isEmpty() );
         return programRulesByActionTypes;
-    }
-
-    @EventListener
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
-        getProgramRulesCache().invalidateAll();
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mock/MockAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mock/MockAnalyticsService.java
@@ -34,12 +34,7 @@ import java.util.Map;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.common.AnalyticalObject;
-import org.hisp.dhis.common.DimensionType;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.period.Period;
 
@@ -123,11 +118,6 @@ public class MockAnalyticsService
     public Map<String, Object> getAggregatedDataValueMapping( AnalyticalObject object )
     {
         throw new NotImplementedException( "" );
-    }
-
-    @Override
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -115,26 +115,28 @@ public class DefaultCacheProvider implements CacheProvider
         return cacheBuilderProvider.newCacheBuilder();
     }
 
-    @Override
-    public <V> Cache<V> createAnalyticsResponseCache( Duration initialExpirationTime )
+    private <V> Cache<V> registerCache( Cache<V> cache )
     {
-        Cache<V> cache = this.<V> newBuilder()
-            .forRegion( Region.analyticsResponse.name() )
-            .expireAfterWrite( initialExpirationTime.toMillis(), MILLISECONDS )
-            .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
-            .build();
         allCaches.add( cache );
         return cache;
     }
 
     @Override
+    public <V> Cache<V> createAnalyticsResponseCache( Duration initialExpirationTime )
+    {
+        return registerCache( this.<V> newBuilder()
+            .forRegion( Region.analyticsResponse.name() )
+            .expireAfterWrite( initialExpirationTime.toMillis(), MILLISECONDS )
+            .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
+            .build() );
+    }
+
+    @Override
     public <V> Cache<V> createAppCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.appCache.name() )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     /**
@@ -145,210 +147,178 @@ public class DefaultCacheProvider implements CacheProvider
     @Override
     public <V> Cache<V> createDefaultObjectCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.defaultObjectCache.name() )
             .expireAfterAccess( 12, TimeUnit.HOURS )
             .withInitialCapacity( 4 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_100 ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createIsDataApprovedCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.isDataApproved.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createAllConstantsCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.allConstantsCache.name() )
             .expireAfterWrite( 2, TimeUnit.MINUTES )
             .withInitialCapacity( 1 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_1 ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createInUserOrgUnitHierarchyCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.inUserOuHierarchy.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createInUserSearchOrgUnitHierarchyCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.inUserSearchOuHierarchy.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createUserCaptureOrgUnitThresholdCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.userCaptureOuCountThreshold.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createPeriodIdCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.periodIdCache.name() )
             .expireAfterWrite( 24, TimeUnit.HOURS )
             .withInitialCapacity( 200 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createUserAccountRecoverAttemptCache( V defaultValue )
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.userAccountRecoverAttempt.name() )
             .expireAfterWrite( 15, MINUTES )
             .withDefaultValue( defaultValue )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createUserFailedLoginAttemptCache( V defaultValue )
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.userFailedLoginAttempt.name() )
             .expireAfterWrite( 15, MINUTES )
             .withDefaultValue( defaultValue )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createProgramOwnerCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.programOwner.name() )
             .expireAfterWrite( 5, TimeUnit.MINUTES )
             .withMaximumSize( orZeroInTestRun( SIZE_1K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createProgramTempOwnerCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.programTempOwner.name() )
             .expireAfterWrite( 30, TimeUnit.MINUTES )
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createUserIdCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.userIdCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .withInitialCapacity( 200 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createCurrentUserGroupInfoCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.currentUserGroupInfoCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createUserSettingCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.userSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createAttrOptionComboIdCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.attrOptionComboIdCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createSystemSettingCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.systemSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withMaximumSize( orZeroInTestRun( SIZE_1K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     /**
@@ -358,110 +328,94 @@ public class DefaultCacheProvider implements CacheProvider
     @Override
     public <V> Cache<V> createGoogleAccessTokenCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.googleAccessToken.name() )
             .expireAfterAccess( 10, MINUTES )
             .withMaximumSize( orZeroInTestRun( 1 ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createDataItemsPaginationCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.dataItemsPagination.name() )
             .expireAfterWrite( 5, MINUTES )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createMetadataAttributesCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.metadataAttributes.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_1K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createCanDataWriteCocCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.canDataWriteCocCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createAnalyticsSqlCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.analyticsSql.name() )
             .expireAfterWrite( 10, TimeUnit.HOURS )
             .withInitialCapacity( 10000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createDataElementCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.dataElementCache.name() )
             .expireAfterWrite( 60, TimeUnit.MINUTES )
             .withInitialCapacity( 1000 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createPropertyTransformerCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.propertyTransformerCache.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withInitialCapacity( 20 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_20K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @Override
     public <V> Cache<V> createProgramRulesCache()
     {
-        Cache<V> cache = this.<V> newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.programRulesCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 20 )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( SIZE_1K ) )
-            .build();
-        allCaches.add( cache );
-        return cache;
+            .build() );
     }
 
     @EventListener


### PR DESCRIPTION
Clear application cache command in the Data Administration app was clearing just a very small subset of the caches that we have in the system.
Now that we have all the caches in the CacheProvider it is easy to centralise that command and clear all the caches.