### PR TITLE
fix: invoke default methods for proxy via method handles in java 8 [TECH-549]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponse.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponse.java
@@ -29,7 +29,9 @@ package org.hisp.dhis.webapi.json;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
@@ -329,10 +331,14 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
                                 declaringClass )
                             .bindTo( proxy ).invokeWithArguments();
                     }
-                    return MethodHandles.lookup()
+                    Constructor<Lookup> constructor = Lookup.class
+                        .getDeclaredConstructor( Class.class );
+                    constructor.setAccessible( true );
+                    return constructor.newInstance( declaringClass )
                         .in( declaringClass )
                         .unreflectSpecial( method, declaringClass )
-                        .bindTo( proxy ).invokeWithArguments( args );
+                        .bindTo( proxy )
+                        .invokeWithArguments();
                 }
                 // call the same method on the wrapped object (assuming it has
                 // it)


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

I skipped over https://dzone.com/articles/correct-reflective-access-to-interface-default-methods too fast and missed that the approach shown first wasn't working in some cases. This PR now uses the approach that is the working one for java 8. 

Tested locally with java 8 that the tests previously failing now pass. As the PR builder does not use java 8 it should be no surprise that it passes.