### PR TITLE
fix: content-aware jsonb equals() implementation [DHIS2-10622]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryType.java
@@ -108,7 +108,6 @@ public class JsonBinaryType implements UserType, ParameterizedType
 
     @Override
     public boolean equals( Object x, Object y )
-            throws HibernateException
     {
         return x == y || (x != null && y != null && (x.equals( y ) || safeContentBasedEquals( x, y )));
     }
@@ -130,7 +129,7 @@ public class JsonBinaryType implements UserType, ParameterizedType
     {
         try
         {
-            return Optional.ofNullable( resultingMapper.readValue( resultingMapper.writeValueAsString( o ),
+            return Optional.of( resultingMapper.readValue( resultingMapper.writeValueAsString( o ),
                     MAP_STRING_OBJECT_TYPE_REFERENCE ) );
         }
         catch ( Exception e )

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
@@ -1,5 +1,3 @@
-package org.hisp.dhis.hibernate.jsonb.type;
-
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
@@ -27,7 +25,18 @@ package org.hisp.dhis.hibernate.jsonb.type;
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.hibernate.jsonb.type;
 
+import static org.hisp.dhis.render.type.ValueTypeRenderingType.BAR_CODE;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.hisp.dhis.render.DeviceRenderTypeMap;
+import org.hisp.dhis.render.RenderDevice;
+import org.hisp.dhis.render.type.ValueTypeRenderingObject;
 import org.hisp.dhis.translation.Translation;
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,5 +76,36 @@ public class JsonBinaryTypeTest
     public void deepCopyNull()
     {
         Assert.assertNull( jsonBinaryType.deepCopy( null ) );
+    }
+
+    @Test
+    public void testEquals()
+    {
+        DeviceRenderTypeMap<ValueTypeRenderingObject> objOne = getDeviceRenderTypeAs(
+                this::getValueTypeRenderingObject );
+        DeviceRenderTypeMap<Map<String, Object>> objTwo = getDeviceRenderTypeAs( this::getMap );
+
+        assertTrue( jsonBinaryType.equals( objOne, objTwo ) );
+    }
+
+    private <T> DeviceRenderTypeMap<T> getDeviceRenderTypeAs( Supplier<T> genericInstanceSupplier )
+    {
+        DeviceRenderTypeMap<T> objectDeviceRenderTypeMap = new DeviceRenderTypeMap<>();
+        objectDeviceRenderTypeMap.put( RenderDevice.MOBILE, genericInstanceSupplier.get() );
+        return objectDeviceRenderTypeMap;
+    }
+
+    private ValueTypeRenderingObject getValueTypeRenderingObject()
+    {
+        ValueTypeRenderingObject valueTypeRenderingObject = new ValueTypeRenderingObject();
+        valueTypeRenderingObject.setType( BAR_CODE );
+        return valueTypeRenderingObject;
+    }
+
+    private Map<String, Object> getMap()
+    {
+        Map<String, Object> map = new HashMap<>();
+        map.put( "type", BAR_CODE.name() );
+        return map;
     }
 }


### PR DESCRIPTION
Jsonb columns using generics (like `DeviceTypeRenderMap`) failed to return equals=true even when untouched, and though were marked as dirty by Hibernate even immediately after `save()`.
This caused some unwanted and unnecessary updates for each explicit or implicit `flush()`, which in some cases led to unexpected behaviors/bugs.
This patch still relies at first on `equals()`, and only as a last chance to compare the serialized json version of objects to ensure they are unchanged.

Most likely this bug also affects newer versions, so if this patch is accepted I'll port it to 2.34/2.35/2.36/dev