### PR TITLE
fix: keep translations during PUT json object when 'skipTranslation=true' is set [DHIS2-10660]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -315,8 +315,10 @@ public class DefaultObjectBundleService implements ObjectBundleService
 
             if ( bundle.getMergeMode() != MergeMode.NONE )
             {
-                mergeService.merge( new MergeParams<>( object, persistedObject ).setMergeMode( bundle.getMergeMode() )
-                    .setSkipSharing( bundle.isSkipSharing() ) );
+                mergeService.merge( new MergeParams<>( object, persistedObject )
+                    .setMergeMode( bundle.getMergeMode() )
+                    .setSkipSharing( bundle.isSkipSharing() )
+                    .setSkipTranslation( bundle.isSkipTranslation() ) );
             }
 
             if ( bundle.getOverrideUser() != null )

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonError.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonError.java
@@ -85,7 +85,8 @@ public interface JsonError extends JsonObject
                 }
             }
         };
-        str.append( getMessage() );
+        String message = getMessage();
+        str.append( message != null ? message : "(no error message in response)" );
         if ( getTypeReport().exists() )
         {
             printer.accept( getTypeReport().getErrorReports() );

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponse.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponse.java
@@ -118,13 +118,23 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
         }
         catch ( PathNotFoundException ex )
         {
-            Object res = orElse.apply( ex );
-            if ( res instanceof RuntimeException )
-            {
-                throw (RuntimeException) res;
-            }
-            return res;
+            return transformException( ex, orElse );
         }
+        catch ( IllegalArgumentException ex )
+        {
+            // is thrown for empty content
+            return transformException( new PathNotFoundException( ex.getMessage() ), orElse );
+        }
+    }
+
+    private Object transformException( PathNotFoundException ex, Function<JsonPathException, Object> orElse )
+    {
+        Object res = orElse.apply( ex );
+        if ( res instanceof RuntimeException )
+        {
+            throw (RuntimeException) res;
+        }
+        return res;
     }
 
     @Override

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -35,6 +35,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -784,6 +785,14 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             .setUser( user )
             .setImportStrategy( ImportStrategy.UPDATE )
             .addObject( parsed );
+
+        if ( params.isSkipTranslation() )
+        {
+            // TODO this is a workaround to keep translations, preheat needs fix
+            params.setSkipTranslation( false );
+            T entity = manager.get( getEntityClass(), pvUid );
+            ((BaseIdentifiableObject) parsed).setTranslations( new HashSet<>( entity.getTranslations() ) );
+        }
 
         ImportReport importReport = importService.importMetadata( params );
         WebMessage webMessage = WebMessageUtils.objectReport( importReport );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -138,7 +138,10 @@ public class MapController
         Map newMap = deserializeJsonEntity( request, response );
         newMap.setUid( uid );
 
-        mergeService.merge( new MergeParams<>( newMap, map ).setMergeMode( params.getMergeMode() ) );
+        mergeService.merge( new MergeParams<>( newMap, map )
+            .setMergeMode( params.getMergeMode() )
+            .setSkipSharing( params.isSkipSharing() )
+            .setSkipTranslation( params.isSkipTranslation() ) );
         mappingService.updateMap( map );
     }
 


### PR DESCRIPTION
### Problem
The `PUT` JSON object operation in generic CRUD controller does replace (clear) the translations even when using the `skipTranslation=true` parameter.

### Findings
The `skipTranslation` flag was not forwarded to `MergeParams` performing the merge between existing and update object.

This did however not fix the issue because somewhere during or because of the preheat the translations get lost for the persisted object so that at the point of the merge both the updating and the persisted object do not have translations.
I investigated but this feels like a bigger issue in the preheat, a box I did not want to open but that should be opened in a dedicated ticket.

Instead I used a workaround in the controller for the `PUT` operation. 
When translations should be skipped the persisted object is loaded and the translations copied over to the parsed object so that they appear as part of the source. With this the merge obviously now should not skip translations so the flag is flipped.

### Automatic testing 
A new test was added to the `AbstractCrudControllerTest` with the following scenario:
1. create a new object
2. add translations to it
3. check the translations are present
4. update the object (without translations in the payload but with `skipTranslation=true`)
5. check again that translations are still present
