### PR TITLE
fix: DHIS2-10646: Backport fix for known NPE

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -194,13 +194,16 @@ public abstract class AbstractAnalyticsService
             metadataItemMap.put( value.getUid(), new MetadataItem( value.getDisplayProperty( params.getDisplayProperty() ), includeDetails ? value.getUid() : null, value.getCode() ) );
         }
 
-        params.getItemLegends().forEach( legend -> metadataItemMap.put( legend.getUid(),
-                new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null, legend.getCode() ) ) );
+        params.getItemLegends().stream().filter( legend -> legend != null ).forEach( legend -> metadataItemMap.put(
+            legend.getUid(),
+            new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null, legend.getCode() ) ) );
 
-        params.getItemOptions().forEach( option -> metadataItemMap.put( option.getUid(),
-                new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null, option.getCode() ) ) );
+        params.getItemOptions().stream().filter( option -> option != null ).forEach( option -> metadataItemMap.put(
+            option.getUid(),
+            new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null, option.getCode() ) ) );
 
-        params.getItemsAndItemFilters().forEach( item -> metadataItemMap.put( item.getItemId(),
+        params.getItemsAndItemFilters().stream().filter( item -> item != null )
+            .forEach( item -> metadataItemMap.put( item.getItemId(),
                 new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
 
         return metadataItemMap;


### PR DESCRIPTION
This issue is related to List gaps containig null elements. This was already fixed upstream. I'm bringing the same fix to 2.33