### PR TITLE
fix: DHIS2-9934: Adding correct support for shortName and displayShortName

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataitem/DataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataitem/DataItem.java
@@ -66,7 +66,15 @@ public class DataItem implements Serializable
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
+    private String shortName;
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
     private String displayName;
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
+    private String displayShortName;
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataElementQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataElementQuery.java
@@ -37,21 +37,24 @@ import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.ValueType.fromString;
 import static org.hisp.dhis.dataitem.DataItem.builder;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
-import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiableTokenFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.valueTypeFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.PROGRAM_ID;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
-import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_UNION;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
@@ -83,14 +86,14 @@ import org.springframework.stereotype.Component;
 public class DataElementQuery implements DataItemQuery
 {
     private static final String COMMON_COLUMNS = "dataelement.uid, dataelement.name, dataelement.valuetype,"
-        + " dataelement.code, dataelement.sharing as dataelement_sharing";
+        + " dataelement.code, dataelement.sharing as dataelement_sharing, dataelement.shortname";
 
     private static final String ITEM_UID = "dataelement.uid";
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public DataElementQuery( @Qualifier( "readOnlyJdbcTemplate" )
-    final JdbcTemplate jdbcTemplate )
+                             final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -120,9 +123,14 @@ public class DataElementQuery implements DataItemQuery
             final ValueType valueType = fromString( rowSet.getString( "valuetype" ) );
             final String name = trimToNull( rowSet.getString( "name" ) );
             final String displayName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_name" ) ), name );
+            final String shortName = trimToNull( rowSet.getString( "shortname" ) );
+            final String displayShortName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_shortname" ) ),
+                shortName );
 
-            dataItems.add( builder().name( name ).displayName( displayName ).id( rowSet.getString( "uid" ) )
-                .code( rowSet.getString( "code" ) ).dimensionItemType( DATA_ELEMENT ).valueType( valueType ).build() );
+            dataItems.add( builder().name( name ).shortName( shortName ).displayName( displayName )
+                .displayShortName( displayShortName ).id( rowSet.getString( "uid" ) )
+                .code( rowSet.getString( "code" ) ).dimensionItemType( DATA_ELEMENT ).valueType( valueType )
+                .build() );
         }
 
         return dataItems;
@@ -166,23 +174,8 @@ public class DataElementQuery implements DataItemQuery
 
         if ( hasStringNonBlankPresence( paramsMap, LOCALE ) )
         {
-            // Selecting only rows that contains translated names.
-            sql.append( selectRowsContainingTranslatedName( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting ALL rows, not taking into consideration
-                // translations.
-                .append( selectAllRowsIgnoringAnyTranslation() )
-
-                /// AND excluding ALL translated rows previously selected
-                /// (translated data elements).
-                .append( SPACED_WHERE + "(" + ITEM_UID + ") not in (" )
-
-                .append( selectRowsContainingTranslatedName( true ) )
-
-                // Closing NOT IN exclusions
-                .append( ")" );
+            // Selecting translated names.
+            sql.append( selectRowsContainingTranslatedName() );
         }
         else
         {
@@ -192,7 +185,7 @@ public class DataElementQuery implements DataItemQuery
 
         sql.append(
             " group by dataelement.name, " + ITEM_UID + ", dataelement.valuetype, dataelement.code, i18n_name,"
-                + " dataelement_sharing" );
+                + " dataelement_sharing, dataelement.shortname, i18n_shortname" );
 
         // Closing the temp table.
         sql.append( " ) t" );
@@ -208,8 +201,10 @@ public class DataElementQuery implements DataItemQuery
 
         // Optional filters, based on the current root junction.
         final OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );
-        optionalFilters.append( ifSet( displayFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayNameFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayShortNameFiltering( "t.i18n_shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( nameFiltering( "t.name", paramsMap ) ) );
+        optionalFilters.append( ifSet( shortNameFiltering( "t.shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( uidFiltering( "t.uid", paramsMap ) ) );
         sql.append( ifAny( optionalFilters.toString() ) );
 
@@ -222,7 +217,8 @@ public class DataElementQuery implements DataItemQuery
             sql.append( identifiableStatement );
         }
 
-        sql.append( ifSet( ordering( "t.i18n_name, t.uid", "t.name, t.uid", paramsMap ) ) );
+        sql.append( ifSet( ordering( "t.i18n_name, t.uid", "t.name, t.uid",
+            "t.i18n_shortname, t.uid", "t.shortname, t.uid", paramsMap ) ) );
         sql.append( ifSet( maxLimit( paramsMap ) ) );
 
         final String fullStatement = sql.toString();
@@ -242,24 +238,15 @@ public class DataElementQuery implements DataItemQuery
         return EMPTY;
     }
 
-    private String selectRowsContainingTranslatedName( final boolean onlyUidColumn )
+    private String selectRowsContainingTranslatedName()
     {
         final StringBuilder sql = new StringBuilder();
 
-        if ( onlyUidColumn )
-        {
-            sql.append( SPACED_SELECT + ITEM_UID );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", de_displayname.value as i18n_name" );
-        }
+        sql.append( SPACED_SELECT + COMMON_COLUMNS )
+            .append( translationNamesColumnsFor( "dataelement" ) );
 
         sql.append( " from dataelement " )
-            .append(
-                " join jsonb_to_recordset(dataelement.translations) as de_displayname(value TEXT, locale TEXT, property TEXT) on de_displayname.locale = :"
-                    + LOCALE + " and de_displayname.property = 'NAME'" );
+            .append( translationNamesJoinsOn( "dataelement" ) );
 
         return sql.toString();
     }
@@ -268,7 +255,7 @@ public class DataElementQuery implements DataItemQuery
     {
         return new StringBuilder()
             .append( SPACED_SELECT + COMMON_COLUMNS )
-            .append( ", dataelement.name as i18n_name" )
+            .append( ", dataelement.name as i18n_name, dataelement.shortname as i18n_shortname" )
             .append( " from dataelement " ).toString();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataElementQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataElementQuery.java
@@ -93,7 +93,7 @@ public class DataElementQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public DataElementQuery( @Qualifier( "readOnlyJdbcTemplate" )
-                             final JdbcTemplate jdbcTemplate )
+    final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataSetQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataSetQuery.java
@@ -89,7 +89,7 @@ public class DataSetQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public DataSetQuery( @Qualifier( "readOnlyJdbcTemplate" )
-                         final JdbcTemplate jdbcTemplate )
+    final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataSetQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataSetQuery.java
@@ -35,20 +35,23 @@ import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.hisp.dhis.common.DimensionItemType.REPORTING_RATE;
 import static org.hisp.dhis.dataitem.DataItem.builder;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
-import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiableTokenFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.PROGRAM_ID;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
-import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_UNION;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
@@ -79,14 +82,14 @@ import org.springframework.stereotype.Component;
 public class DataSetQuery implements DataItemQuery
 {
     private static final String COMMON_COLUMNS = "dataset.uid, dataset.name,"
-        + " dataset.code, dataset.sharing as dataset_sharing";
+        + " dataset.code, dataset.sharing as dataset_sharing, dataset.shortname";
 
     private static final String ITEM_UID = "dataset.uid";
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public DataSetQuery( @Qualifier( "readOnlyJdbcTemplate" )
-    final JdbcTemplate jdbcTemplate )
+                         final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -115,9 +118,14 @@ public class DataSetQuery implements DataItemQuery
         {
             final String name = trimToNull( rowSet.getString( "name" ) );
             final String displayName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_name" ) ), name );
+            final String shortName = trimToNull( rowSet.getString( "shortname" ) );
+            final String displayShortName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_shortname" ) ),
+                shortName );
 
-            dataItems.add( builder().name( name ).displayName( displayName ).id( rowSet.getString( "uid" ) )
-                .code( rowSet.getString( "code" ) ).dimensionItemType( REPORTING_RATE ).build() );
+            dataItems.add( builder().name( name ).shortName( shortName ).displayName( displayName )
+                .displayShortName( displayShortName ).id( rowSet.getString( "uid" ) )
+                .code( rowSet.getString( "code" ) ).dimensionItemType( REPORTING_RATE )
+                .build() );
         }
 
         return dataItems;
@@ -160,23 +168,8 @@ public class DataSetQuery implements DataItemQuery
 
         if ( hasStringNonBlankPresence( paramsMap, LOCALE ) )
         {
-            // Selecting only rows that contains translated names.
-            sql.append( selectRowsContainingTranslatedName( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting ALL rows, not taking into consideration
-                // translations.
-                .append( selectAllRowsIgnoringAnyTranslation() )
-
-                /// AND excluding ALL translated rows previously selected
-                /// (translated data sets).
-                .append( SPACED_WHERE + "(" + ITEM_UID + ") not in (" )
-
-                .append( selectRowsContainingTranslatedName( true ) )
-
-                // Closing NOT IN exclusions.
-                .append( ")" );
+            // Selecting translated names.
+            sql.append( selectRowsContainingTranslatedName() );
         }
         else
         {
@@ -186,7 +179,7 @@ public class DataSetQuery implements DataItemQuery
 
         sql.append(
             " group by dataset.name, " + ITEM_UID + ", dataset.code, i18n_name,"
-                + " dataset_sharing" );
+                + " dataset_sharing, dataset.shortname, i18n_shortname" );
 
         // Closing the temp table.
         sql.append( " ) t" );
@@ -200,8 +193,10 @@ public class DataSetQuery implements DataItemQuery
 
         // Optional filters, based on the current root junction.
         final OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );
-        optionalFilters.append( ifSet( displayFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayNameFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayShortNameFiltering( "t.i18n_shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( nameFiltering( "t.name", paramsMap ) ) );
+        optionalFilters.append( ifSet( shortNameFiltering( "t.shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( uidFiltering( "t.uid", paramsMap ) ) );
         sql.append( ifAny( optionalFilters.toString() ) );
 
@@ -214,7 +209,8 @@ public class DataSetQuery implements DataItemQuery
             sql.append( identifiableStatement );
         }
 
-        sql.append( ifSet( ordering( "t.i18n_name, t.uid", "t.name, t.uid", paramsMap ) ) );
+        sql.append( ifSet( ordering( "t.i18n_name, t.uid", "t.name, t.uid",
+            "t.i18n_shortname, t.uid", "t.shortname, t.uid", paramsMap ) ) );
         sql.append( ifSet( maxLimit( paramsMap ) ) );
 
         final String fullStatement = sql.toString();
@@ -224,24 +220,15 @@ public class DataSetQuery implements DataItemQuery
         return fullStatement;
     }
 
-    private String selectRowsContainingTranslatedName( final boolean onlyUidColumn )
+    private String selectRowsContainingTranslatedName()
     {
         final StringBuilder sql = new StringBuilder();
 
-        if ( onlyUidColumn )
-        {
-            sql.append( SPACED_SELECT + ITEM_UID );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", ds_displayname.value as i18n_name" );
-        }
+        sql.append( SPACED_SELECT + COMMON_COLUMNS )
+            .append( translationNamesColumnsFor( "dataset" ) );
 
         sql.append( " from dataset " )
-            .append(
-                " join jsonb_to_recordset(dataset.translations) as ds_displayname(value TEXT, locale TEXT, property TEXT) on ds_displayname.locale = :"
-                    + LOCALE + " and ds_displayname.property = 'NAME'" );
+            .append( translationNamesJoinsOn( "dataset" ) );
 
         return sql.toString();
     }
@@ -250,7 +237,7 @@ public class DataSetQuery implements DataItemQuery
     {
         return new StringBuilder()
             .append( SPACED_SELECT + COMMON_COLUMNS )
-            .append( ", dataset.name as i18n_name" )
+            .append( ", dataset.name as i18n_name, dataset.shortname as i18n_shortname" )
             .append( " from dataset " ).toString();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/IndicatorQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/IndicatorQuery.java
@@ -91,7 +91,7 @@ public class IndicatorQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public IndicatorQuery( @Qualifier( "readOnlyJdbcTemplate" )
-                           final JdbcTemplate jdbcTemplate )
+    final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/IndicatorQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/IndicatorQuery.java
@@ -36,21 +36,24 @@ import static org.hisp.dhis.common.DimensionItemType.INDICATOR;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.dataitem.DataItem.builder;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
-import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiableTokenFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.skipValueType;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.PROGRAM_ID;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
-import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_UNION;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
@@ -81,14 +84,14 @@ import org.springframework.stereotype.Component;
 public class IndicatorQuery implements DataItemQuery
 {
     private static final String COMMON_COLUMNS = "indicator.uid, indicator.name,"
-        + " indicator.code, indicator.sharing as indicator_sharing";
+        + " indicator.code, indicator.sharing as indicator_sharing, indicator.shortname";
 
     private static final String ITEM_UID = "indicator.uid";
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public IndicatorQuery( @Qualifier( "readOnlyJdbcTemplate" )
-    final JdbcTemplate jdbcTemplate )
+                           final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -120,10 +123,14 @@ public class IndicatorQuery implements DataItemQuery
         {
             final String name = trimToNull( rowSet.getString( "name" ) );
             final String displayName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_name" ) ), name );
+            final String shortName = trimToNull( rowSet.getString( "shortname" ) );
+            final String displayShortName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_shortname" ) ),
+                shortName );
 
             // Specific case where we have to force a vale type. Indicators
             // don't have a value type but they always evaluate to numbers.
-            dataItems.add( builder().name( name ).displayName( displayName ).id( rowSet.getString( "uid" ) )
+            dataItems.add( builder().name( name ).shortName( shortName ).displayName( displayName )
+                .displayShortName( displayShortName ).id( rowSet.getString( "uid" ) )
                 .code( rowSet.getString( "code" ) ).dimensionItemType( INDICATOR ).valueType( NUMBER ).build() );
         }
 
@@ -171,23 +178,8 @@ public class IndicatorQuery implements DataItemQuery
 
         if ( hasStringNonBlankPresence( paramsMap, LOCALE ) )
         {
-            // Selecting only rows that contains translated names.
-            sql.append( selectRowsContainingTranslatedName( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting ALL rows, not taking into consideration
-                // translations.
-                .append( selectAllRowsIgnoringAnyTranslation() )
-
-                /// AND excluding ALL translated rows previously selected
-                /// (translated names).
-                .append( SPACED_WHERE + "(" + ITEM_UID + ") not in (" )
-
-                .append( selectRowsContainingTranslatedName( true ) )
-
-                // Closing NOT IN exclusions.
-                .append( ")" );
+            // Selecting translated names.
+            sql.append( selectRowsContainingTranslatedName() );
         }
         else
         {
@@ -197,7 +189,7 @@ public class IndicatorQuery implements DataItemQuery
 
         sql.append(
             " group by indicator.name, " + ITEM_UID + ", indicator.code, i18n_name,"
-                + " indicator_sharing" );
+                + " indicator_sharing, indicator.shortname, i18n_shortname" );
 
         // Closing the temp table.
         sql.append( " ) t" );
@@ -211,8 +203,10 @@ public class IndicatorQuery implements DataItemQuery
 
         // Optional filters, based on the current root junction.
         final OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );
-        optionalFilters.append( ifSet( displayFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayNameFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayShortNameFiltering( "t.i18n_shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( nameFiltering( "t.name", paramsMap ) ) );
+        optionalFilters.append( ifSet( shortNameFiltering( "t.shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( uidFiltering( "t.uid", paramsMap ) ) );
         sql.append( ifAny( optionalFilters.toString() ) );
 
@@ -225,7 +219,8 @@ public class IndicatorQuery implements DataItemQuery
             sql.append( identifiableStatement );
         }
 
-        sql.append( ifSet( ordering( "t.i18n_name, t.uid", "t.name, t.uid", paramsMap ) ) );
+        sql.append( ifSet( ordering( "t.i18n_name, t.uid", "t.name, t.uid",
+            "t.i18n_shortname, t.uid", "t.shortname, t.uid", paramsMap ) ) );
         sql.append( ifSet( maxLimit( paramsMap ) ) );
 
         final String fullStatement = sql.toString();
@@ -235,24 +230,15 @@ public class IndicatorQuery implements DataItemQuery
         return fullStatement;
     }
 
-    private String selectRowsContainingTranslatedName( final boolean onlyUidColumn )
+    private String selectRowsContainingTranslatedName()
     {
         final StringBuilder sql = new StringBuilder();
 
-        if ( onlyUidColumn )
-        {
-            sql.append( SPACED_SELECT + ITEM_UID );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", i_displayname.value as i18n_name" );
-        }
+        sql.append( SPACED_SELECT + COMMON_COLUMNS )
+            .append( translationNamesColumnsFor( "indicator" ) );
 
         sql.append( " from indicator " )
-            .append(
-                " join jsonb_to_recordset(indicator.translations) as i_displayname(value TEXT, locale TEXT, property TEXT) on i_displayname.locale = :"
-                    + LOCALE + " and i_displayname.property = 'NAME'" );
+            .append( translationNamesJoinsOn( "indicator" ) );
 
         return sql.toString();
     }
@@ -261,7 +247,7 @@ public class IndicatorQuery implements DataItemQuery
     {
         return new StringBuilder()
             .append( SPACED_SELECT + COMMON_COLUMNS )
-            .append( ", indicator.name as i18n_name" )
+            .append( ", indicator.name as i18n_name, indicator.shortname as i18n_shortname" )
             .append( " from indicator " ).toString();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeQuery.java
@@ -100,7 +100,7 @@ public class ProgramAttributeQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public ProgramAttributeQuery( @Qualifier( "readOnlyJdbcTemplate" )
-                                  final JdbcTemplate jdbcTemplate )
+    final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -123,14 +123,14 @@ public class ProgramAttributeQuery implements DataItemQuery
             final String displayName = defaultIfBlank( trimToEmpty( rowSet.getString( "p_i18n_name" ) ),
                 rowSet.getString( "program_name" ) ) + SPACE
                 + defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_name" ) ),
-                trimToEmpty( rowSet.getString( "name" ) ) );
+                    trimToEmpty( rowSet.getString( "name" ) ) );
 
             final String shortName = trimToEmpty(
                 rowSet.getString( "program_shortname" ) ) + SPACE + trimToEmpty( rowSet.getString( "shortname" ) );
             final String displayShortName = defaultIfBlank( trimToEmpty( rowSet.getString( "p_i18n_shortname" ) ),
                 rowSet.getString( "program_shortname" ) ) + SPACE
                 + defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_shortname" ) ),
-                trimToEmpty( rowSet.getString( "shortname" ) ) );
+                    trimToEmpty( rowSet.getString( "shortname" ) ) );
 
             final String uid = rowSet.getString( "program_uid" ) + "." + rowSet.getString( "uid" );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramIndicatorQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramIndicatorQuery.java
@@ -98,7 +98,7 @@ public class ProgramIndicatorQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public ProgramIndicatorQuery( @Qualifier( "readOnlyJdbcTemplate" )
-                                  final JdbcTemplate jdbcTemplate )
+    final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramIndicatorQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramIndicatorQuery.java
@@ -32,25 +32,29 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.hisp.dhis.common.DimensionItemType.PROGRAM_INDICATOR;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.dataitem.DataItem.builder;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
-import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiableTokenFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.programIdFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.skipValueType;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
-import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_UNION;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
@@ -82,7 +86,8 @@ public class ProgramIndicatorQuery implements DataItemQuery
 {
     private static final String COMMON_COLUMNS = "programindicator.name, programindicator.uid, programindicator.code,"
         + " program.name as program_name, program.uid as program_uid, program.sharing as program_sharing,"
-        + " programindicator.sharing as programindicator_sharing";
+        + " programindicator.sharing as programindicator_sharing,"
+        + " programindicator.shortname, program.shortname as program_shortname";
 
     private static final String COMMON_UIDS = "program.uid, programindicator.uid";
 
@@ -93,7 +98,7 @@ public class ProgramIndicatorQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public ProgramIndicatorQuery( @Qualifier( "readOnlyJdbcTemplate" )
-    final JdbcTemplate jdbcTemplate )
+                                  final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -120,13 +125,17 @@ public class ProgramIndicatorQuery implements DataItemQuery
         while ( rowSet.next() )
         {
             final String name = trimToEmpty( rowSet.getString( "name" ) );
-            final String displayName = defaultIfBlank( trimToEmpty( rowSet.getString( "pi_i18n_name" ) ),
+            final String displayName = defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_name" ) ),
                 name );
+            final String shortName = trimToNull( rowSet.getString( "shortname" ) );
+            final String displayShortName = defaultIfBlank( trimToNull( rowSet.getString( "i18n_shortname" ) ),
+                shortName );
 
             // Specific case where we have to force a vale type. Program
             // Indicators don't have a value type but they always evaluate to
             // numbers.
             dataItems.add( builder().name( name ).displayName( displayName ).id( rowSet.getString( "uid" ) )
+                .shortName( shortName ).displayShortName( displayShortName )
                 .code( rowSet.getString( "code" ) ).dimensionItemType( PROGRAM_INDICATOR )
                 .programId( rowSet.getString( "program_uid" ) ).valueType( NUMBER ).build() );
         }
@@ -171,44 +180,8 @@ public class ProgramIndicatorQuery implements DataItemQuery
 
         if ( hasStringNonBlankPresence( paramsMap, LOCALE ) )
         {
-            // Selecting only rows that contains both programs and program
-            // indicators translations at the same time.
-            sql.append( selectRowsContainingBothTranslatedNames( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated programs.
-                .append( selectRowsContainingOnlyTranslatedProgramNames( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated program indicators.
-                .append( selectRowsContainingOnlyTranslatedProgramIndicatorNames( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting ALL rows, not taking into consideration
-                // translations.
-                .append( selectAllRowsIgnoringAnyTranslation() )
-
-                /// AND excluding ALL translated rows previously selected
-                /// (translated programs and translated program indicators).
-                .append( SPACED_WHERE + "(" + COMMON_UIDS + ") not in (" )
-
-                .append( selectRowsContainingBothTranslatedNames( true ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated programs.
-                .append( selectRowsContainingOnlyTranslatedProgramNames( true ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated program indicators.
-                .append( selectRowsContainingOnlyTranslatedProgramIndicatorNames( true ) )
-
-                // Closing NOT IN exclusions.
-                .append( ")" );
+            // Selecting translated names.
+            sql.append( selectRowsContainingTranslatedName() );
         }
         else
         {
@@ -217,8 +190,9 @@ public class ProgramIndicatorQuery implements DataItemQuery
         }
 
         sql.append(
-            " group by program.name, programindicator.name, " + COMMON_UIDS
-                + ", programindicator.code, p_i18n_name, pi_i18n_name, program_sharing, programindicator_sharing" );
+            " group by program.name, program.shortname, programindicator.name, " + COMMON_UIDS
+                + ", programindicator.code, p_i18n_name, i18n_name, program_sharing, programindicator_sharing, programindicator.shortname,"
+                + " i18n_shortname, p_i18n_shortname" );
 
         // Closing the temp table.
         sql.append( " ) t" );
@@ -233,13 +207,15 @@ public class ProgramIndicatorQuery implements DataItemQuery
 
         // Optional filters, based on the current root junction.
         final OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );
-        optionalFilters.append( ifSet( displayFiltering( "t.pi_i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayNameFiltering( "t.i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayShortNameFiltering( "t.i18n_shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( nameFiltering( "t.name", paramsMap ) ) );
+        optionalFilters.append( ifSet( shortNameFiltering( "t.shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( programIdFiltering( "t.program_uid", paramsMap ) ) );
         optionalFilters.append( ifSet( uidFiltering( "t.uid", paramsMap ) ) );
         sql.append( ifAny( optionalFilters.toString() ) );
 
-        final String identifiableStatement = identifiableTokenFiltering( "t.uid", "t.code", "t.pi_i18n_name",
+        final String identifiableStatement = identifiableTokenFiltering( "t.uid", "t.code", "t.i18n_name",
             null, paramsMap );
 
         if ( isNotBlank( identifiableStatement ) )
@@ -248,8 +224,8 @@ public class ProgramIndicatorQuery implements DataItemQuery
             sql.append( identifiableStatement );
         }
 
-        sql.append( ifSet( ordering( "t.pi_i18n_name, t.uid",
-            "t.name, t.uid", paramsMap ) ) );
+        sql.append( ifSet( ordering( "t.i18n_name, t.uid",
+            "t.name, t.uid", "t.i18n_shortname, t.uid", "t.shortname, t.uid", paramsMap ) ) );
         sql.append( ifSet( maxLimit( paramsMap ) ) );
 
         final String fullStatement = sql.toString();
@@ -259,95 +235,22 @@ public class ProgramIndicatorQuery implements DataItemQuery
         return fullStatement;
     }
 
-    private String selectRowsContainingBothTranslatedNames( final boolean onlyUidColumns )
+    private String selectRowsContainingTranslatedName()
     {
-        final StringBuilder sql = new StringBuilder();
-
-        if ( onlyUidColumns )
-        {
-            sql.append( SPACED_SELECT + COMMON_UIDS );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", p_displayname.value as p_i18n_name, pi_displayname.value as pi_i18n_name" );
-        }
-
-        sql.append( SPACED_FROM_PROGRAM_INDICATOR )
+        return new StringBuilder()
+            .append( SPACED_SELECT + COMMON_COLUMNS )
+            .append( translationNamesColumnsFor( "programindicator", true ) )
+            .append( SPACED_FROM_PROGRAM_INDICATOR )
             .append( JOINS )
-            .append(
-                " join jsonb_to_recordset(program.translations) as p_displayname(value TEXT, locale TEXT, property TEXT) on p_displayname.locale = :"
-                    + LOCALE + " and p_displayname.property = 'NAME'" )
-            .append(
-                " join jsonb_to_recordset(programindicator.translations) as pi_displayname(value TEXT, locale TEXT, property TEXT) on pi_displayname.locale = :"
-                    + LOCALE + " and pi_displayname.property = 'NAME'" );
-
-        return sql.toString();
-    }
-
-    private String selectRowsContainingOnlyTranslatedProgramNames( final boolean onlyUidColumns )
-    {
-        final StringBuilder sql = new StringBuilder();
-
-        if ( onlyUidColumns )
-        {
-            sql.append( SPACED_SELECT + COMMON_UIDS );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", p_displayname.value as p_i18n_name, programindicator.name as pi_i18n_name" );
-        }
-
-        sql.append( SPACED_FROM_PROGRAM_INDICATOR )
-            .append( JOINS )
-            .append(
-                " join jsonb_to_recordset(program.translations) as p_displayname(value TEXT, locale TEXT, property TEXT) on p_displayname.locale = :"
-                    + LOCALE + " and p_displayname.property = 'NAME'" )
-            .append( SPACED_WHERE + "(" + COMMON_UIDS + ")" )
-            .append( " not in (" )
-
-            // Exclude rows already fully translated.
-            .append( selectRowsContainingBothTranslatedNames( true ) )
-            .append( ")" );
-
-        return sql.toString();
-    }
-
-    private String selectRowsContainingOnlyTranslatedProgramIndicatorNames( final boolean onlyUidColumns )
-    {
-        final StringBuilder sql = new StringBuilder();
-
-        if ( onlyUidColumns )
-        {
-            sql.append( SPACED_SELECT + COMMON_UIDS );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", program.name as p_i18n_name, pi_displayname.value as pi_i18n_name" );
-        }
-
-        sql.append( SPACED_FROM_PROGRAM_INDICATOR )
-            .append( JOINS )
-            .append(
-                " join jsonb_to_recordset(programindicator.translations) as pi_displayname(value TEXT, locale TEXT, property TEXT) on pi_displayname.locale = :"
-                    + LOCALE + " and pi_displayname.property = 'NAME'" )
-            .append( SPACED_WHERE + "(" + COMMON_UIDS + ")" )
-            .append( " not in (" )
-
-            // Exclude rows already fully translated.
-            .append( selectRowsContainingBothTranslatedNames( true ) )
-            .append( ")" );
-
-        return sql.toString();
+            .append( translationNamesJoinsOn( "programindicator", true ) ).toString();
     }
 
     private String selectAllRowsIgnoringAnyTranslation()
     {
         return new StringBuilder()
             .append( SPACED_SELECT + COMMON_COLUMNS )
-            .append( ", program.name as p_i18n_name, programindicator.name as pi_i18n_name" )
+            .append( ", program.name as p_i18n_name, programindicator.name as i18n_name," +
+                " program.shortname as p_i18n_shortname, programindicator.shortname as i18n_shortname" )
             .append( SPACED_FROM_PROGRAM_INDICATOR )
             .append( JOINS ).toString();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramStageDataElementQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramStageDataElementQuery.java
@@ -101,7 +101,7 @@ public class ProgramStageDataElementQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public ProgramStageDataElementQuery( @Qualifier( "readOnlyJdbcTemplate" )
-                                         final JdbcTemplate jdbcTemplate )
+    final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -124,14 +124,14 @@ public class ProgramStageDataElementQuery implements DataItemQuery
             final String displayName = defaultIfBlank( trimToEmpty( rowSet.getString( "p_i18n_name" ) ),
                 rowSet.getString( "program_name" ) ) + SPACE
                 + defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_name" ) ),
-                trimToEmpty( rowSet.getString( "name" ) ) );
+                    trimToEmpty( rowSet.getString( "name" ) ) );
 
             final String shortName = trimToEmpty(
                 rowSet.getString( "program_shortname" ) ) + SPACE + trimToEmpty( rowSet.getString( "shortname" ) );
             final String displayShortName = defaultIfBlank( trimToEmpty( rowSet.getString( "p_i18n_shortname" ) ),
                 rowSet.getString( "program_shortname" ) ) + SPACE
                 + defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_shortname" ) ),
-                trimToEmpty( rowSet.getString( "shortname" ) ) );
+                    trimToEmpty( rowSet.getString( "shortname" ) ) );
 
             final String uid = rowSet.getString( "program_uid" ) + "." + rowSet.getString( "uid" );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramStageDataElementQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramStageDataElementQuery.java
@@ -37,21 +37,24 @@ import static org.hisp.dhis.common.DimensionItemType.PROGRAM_DATA_ELEMENT;
 import static org.hisp.dhis.common.ValueType.fromString;
 import static org.hisp.dhis.dataitem.DataItem.builder;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
-import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiableTokenFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.programIdFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.valueTypeFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
-import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_UNION;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
 import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
@@ -84,7 +87,8 @@ public class ProgramStageDataElementQuery implements DataItemQuery
 {
     private static final String COMMON_COLUMNS = "program.name as program_name, program.uid as program_uid,"
         + " dataelement.uid, dataelement.name, dataelement.valuetype, dataelement.code,"
-        + " dataelement.sharing as dataelement_sharing, program.sharing as program_sharing";
+        + " dataelement.sharing as dataelement_sharing, program.sharing as program_sharing,"
+        + " dataelement.shortname, program.shortname as program_shortname";
 
     private static final String COMMON_UIDS = "program.uid, dataelement.uid";
 
@@ -97,7 +101,7 @@ public class ProgramStageDataElementQuery implements DataItemQuery
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public ProgramStageDataElementQuery( @Qualifier( "readOnlyJdbcTemplate" )
-    final JdbcTemplate jdbcTemplate )
+                                         final JdbcTemplate jdbcTemplate )
     {
         checkNotNull( jdbcTemplate );
 
@@ -119,11 +123,20 @@ public class ProgramStageDataElementQuery implements DataItemQuery
                 rowSet.getString( "program_name" ) ) + SPACE + trimToEmpty( rowSet.getString( "name" ) );
             final String displayName = defaultIfBlank( trimToEmpty( rowSet.getString( "p_i18n_name" ) ),
                 rowSet.getString( "program_name" ) ) + SPACE
-                + defaultIfBlank( trimToEmpty( rowSet.getString( "de_i18n_name" ) ),
-                    trimToEmpty( rowSet.getString( "name" ) ) );
+                + defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_name" ) ),
+                trimToEmpty( rowSet.getString( "name" ) ) );
+
+            final String shortName = trimToEmpty(
+                rowSet.getString( "program_shortname" ) ) + SPACE + trimToEmpty( rowSet.getString( "shortname" ) );
+            final String displayShortName = defaultIfBlank( trimToEmpty( rowSet.getString( "p_i18n_shortname" ) ),
+                rowSet.getString( "program_shortname" ) ) + SPACE
+                + defaultIfBlank( trimToEmpty( rowSet.getString( "i18n_shortname" ) ),
+                trimToEmpty( rowSet.getString( "shortname" ) ) );
+
             final String uid = rowSet.getString( "program_uid" ) + "." + rowSet.getString( "uid" );
 
             dataItems.add( builder().name( name ).displayName( displayName ).id( uid )
+                .shortName( shortName ).displayShortName( displayShortName )
                 .code( rowSet.getString( "code" ) ).dimensionItemType( PROGRAM_DATA_ELEMENT )
                 .programId( rowSet.getString( "program_uid" ) ).valueType( valueType ).build() );
         }
@@ -158,44 +171,8 @@ public class ProgramStageDataElementQuery implements DataItemQuery
 
         if ( hasStringNonBlankPresence( paramsMap, LOCALE ) )
         {
-            // Selecting only rows that contains both programs and data elements
-            // translations at the same time.
-            sql.append( selectRowsContainingBothTranslatedNames( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated programs.
-                .append( selectRowsContainingOnlyTranslatedProgramNames( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated data elements.
-                .append( selectRowsContainingOnlyTranslatedDataElementNames( false ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting ALL rows, not taking into consideration
-                // translations.
-                .append( selectAllRowsIgnoringAnyTranslation() )
-
-                /// AND excluding ALL translated rows previously selected
-                /// (translated programs and translated data elements).
-                .append( SPACED_WHERE + "(" + COMMON_UIDS + ") not in (" )
-
-                .append( selectRowsContainingBothTranslatedNames( true ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated programs.
-                .append( selectRowsContainingOnlyTranslatedProgramNames( true ) )
-
-                .append( SPACED_UNION )
-
-                // Selecting only rows with translated data elements.
-                .append( selectRowsContainingOnlyTranslatedDataElementNames( true ) )
-
-                // Closing NOT IN exclusions.
-                .append( ")" );
+            // Selecting translated names.
+            sql.append( selectRowsContainingTranslatedName() );
         }
         else
         {
@@ -204,8 +181,9 @@ public class ProgramStageDataElementQuery implements DataItemQuery
         }
 
         sql.append(
-            " group by program.name, dataelement.name, " + COMMON_UIDS
-                + ", dataelement.valuetype, dataelement.code, p_i18n_name, de_i18n_name, program_sharing, dataelement_sharing" );
+            " group by program.name, program.shortname, dataelement.name, " + COMMON_UIDS
+                + ", dataelement.valuetype, dataelement.code, p_i18n_name, i18n_name, program_sharing, dataelement_sharing, dataelement.shortname,"
+                + " i18n_shortname, p_i18n_shortname" );
 
         // Closing the temp table.
         sql.append( " ) t" );
@@ -222,13 +200,16 @@ public class ProgramStageDataElementQuery implements DataItemQuery
 
         // Optional filters, based on the current root junction.
         final OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );
-        optionalFilters.append( ifSet( displayFiltering( "t.p_i18n_name", "t.de_i18n_name", paramsMap ) ) );
+        optionalFilters.append( ifSet( displayNameFiltering( "t.p_i18n_name", "t.i18n_name", paramsMap ) ) );
+        optionalFilters
+            .append( ifSet( displayShortNameFiltering( "t.p_i18n_shortname", "t.i18n_shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( nameFiltering( "t.program_name", "t.name", paramsMap ) ) );
+        optionalFilters.append( ifSet( shortNameFiltering( "t.program_shortname", "t.shortname", paramsMap ) ) );
         optionalFilters.append( ifSet( programIdFiltering( "t.program_uid", paramsMap ) ) );
         optionalFilters.append( ifSet( uidFiltering( "t.uid", paramsMap ) ) );
         sql.append( ifAny( optionalFilters.toString() ) );
 
-        final String identifiableStatement = identifiableTokenFiltering( "t.uid", "t.code", "t.de_i18n_name",
+        final String identifiableStatement = identifiableTokenFiltering( "t.uid", "t.code", "t.i18n_name",
             "t.p_i18n_name", paramsMap );
 
         if ( isNotBlank( identifiableStatement ) )
@@ -237,8 +218,9 @@ public class ProgramStageDataElementQuery implements DataItemQuery
             sql.append( identifiableStatement );
         }
 
-        sql.append( ifSet( ordering( "t.p_i18n_name, t.de_i18n_name, t.uid",
-            "t.program_name, t.name, t.uid", paramsMap ) ) );
+        sql.append( ifSet( ordering( "t.p_i18n_name, t.i18n_name, t.uid",
+            "t.program_name, t.name, t.uid", "t.i18n_shortname, t.uid",
+            "t.shortname, t.uid", paramsMap ) ) );
         sql.append( ifSet( maxLimit( paramsMap ) ) );
 
         final String fullStatement = sql.toString();
@@ -248,95 +230,22 @@ public class ProgramStageDataElementQuery implements DataItemQuery
         return fullStatement;
     }
 
-    private String selectRowsContainingBothTranslatedNames( final boolean onlyUidColumns )
+    private String selectRowsContainingTranslatedName()
     {
-        final StringBuilder sql = new StringBuilder();
-
-        if ( onlyUidColumns )
-        {
-            sql.append( SPACED_SELECT + COMMON_UIDS );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", p_displayname.value as p_i18n_name, de_displayname.value as de_i18n_name" );
-        }
-
-        sql.append( SPACED_FROM_DATA_ELEMENT )
+        return new StringBuilder()
+            .append( SPACED_SELECT + COMMON_COLUMNS )
+            .append( translationNamesColumnsFor( "dataelement", true ) )
+            .append( SPACED_FROM_DATA_ELEMENT )
             .append( JOINS )
-            .append(
-                " join jsonb_to_recordset(program.translations) as p_displayname(value TEXT, locale TEXT, property TEXT) on p_displayname.locale = :"
-                    + LOCALE + " and p_displayname.property = 'NAME'" )
-            .append(
-                " join jsonb_to_recordset(dataelement.translations) as de_displayname(value TEXT, locale TEXT, property TEXT) on de_displayname.locale = :"
-                    + LOCALE + " and de_displayname.property = 'NAME'" );
-
-        return sql.toString();
-    }
-
-    private String selectRowsContainingOnlyTranslatedProgramNames( final boolean onlyUidColumns )
-    {
-        final StringBuilder sql = new StringBuilder();
-
-        if ( onlyUidColumns )
-        {
-            sql.append( SPACED_SELECT + COMMON_UIDS );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", p_displayname.value as p_i18n_name, dataelement.name as de_i18n_name" );
-        }
-
-        sql.append( SPACED_FROM_DATA_ELEMENT )
-            .append( JOINS )
-            .append(
-                " join jsonb_to_recordset(program.translations) as p_displayname(value TEXT, locale TEXT, property TEXT) on p_displayname.locale = :"
-                    + LOCALE + " and p_displayname.property = 'NAME'" )
-            .append( SPACED_WHERE + "(" + COMMON_UIDS + ")" )
-            .append( " not in (" )
-
-            // Exclude rows already fully translated.
-            .append( selectRowsContainingBothTranslatedNames( true ) )
-            .append( ")" );
-
-        return sql.toString();
-    }
-
-    private String selectRowsContainingOnlyTranslatedDataElementNames( final boolean onlyUidColumns )
-    {
-        final StringBuilder sql = new StringBuilder();
-
-        if ( onlyUidColumns )
-        {
-            sql.append( SPACED_SELECT + COMMON_UIDS );
-        }
-        else
-        {
-            sql.append( SPACED_SELECT + COMMON_COLUMNS )
-                .append( ", program.name as p_i18n_name, de_displayname.value as de_i18n_name" );
-        }
-
-        sql.append( SPACED_FROM_DATA_ELEMENT )
-            .append( JOINS )
-            .append(
-                " join jsonb_to_recordset(dataelement.translations) as de_displayname(value TEXT, locale TEXT, property TEXT) on de_displayname.locale = :"
-                    + LOCALE + " and de_displayname.property = 'NAME'" )
-            .append( SPACED_WHERE + "(" + COMMON_UIDS + ")" )
-            .append( " not in (" )
-
-            // Exclude rows already fully translated.
-            .append( selectRowsContainingBothTranslatedNames( true ) )
-            .append( ")" );
-
-        return sql.toString();
+            .append( translationNamesJoinsOn( "dataelement", true ) ).toString();
     }
 
     private String selectAllRowsIgnoringAnyTranslation()
     {
         return new StringBuilder()
             .append( SPACED_SELECT + COMMON_COLUMNS )
-            .append( ", program.name as p_i18n_name, dataelement.name as de_i18n_name" )
+            .append( ", program.name as p_i18n_name, dataelement.name as i18n_name," +
+                " program.shortname as p_i18n_shortname, dataelement.shortname as i18n_shortname" )
             .append( SPACED_FROM_DATA_ELEMENT )
             .append( JOINS ).toString();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/FilteringStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/FilteringStatement.java
@@ -35,10 +35,12 @@ import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasSetPre
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.DISPLAY_NAME;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.DISPLAY_SHORT_NAME;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.IDENTIFIABLE_TOKEN_COMPARISON;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.NAME;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.PROGRAM_ID;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.ROOT_JUNCTION;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.SHORT_NAME;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.UID;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.VALUE_TYPES;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_AND;
@@ -91,7 +93,7 @@ public class FilteringStatement
     }
 
     public static String nameFiltering( final String columnOne, final String columnTwo,
-        final MapSqlParameterSource paramsMap )
+                                        final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, NAME ) )
         {
@@ -102,7 +104,29 @@ public class FilteringStatement
         return EMPTY;
     }
 
-    public static String displayFiltering( final String column, final MapSqlParameterSource paramsMap )
+    public static String shortNameFiltering( final String column, final MapSqlParameterSource paramsMap )
+    {
+        if ( hasStringPresence( paramsMap, SHORT_NAME ) )
+        {
+            return SPACED_LEFT_PARENTHESIS + column + ILIKE + SHORT_NAME + SPACED_RIGHT_PARENTHESIS;
+        }
+
+        return EMPTY;
+    }
+
+    public static String shortNameFiltering( final String columnOne, final String columnTwo,
+                                             final MapSqlParameterSource paramsMap )
+    {
+        if ( hasStringPresence( paramsMap, SHORT_NAME ) )
+        {
+            return SPACED_LEFT_PARENTHESIS + columnOne + ILIKE + SHORT_NAME + " or " + columnTwo + ILIKE + SHORT_NAME
+                + SPACED_RIGHT_PARENTHESIS;
+        }
+
+        return EMPTY;
+    }
+
+    public static String displayNameFiltering( final String column, final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, DISPLAY_NAME ) )
         {
@@ -112,14 +136,35 @@ public class FilteringStatement
         return EMPTY;
     }
 
-    public static String displayFiltering( final String columnOne, final String columnTwo,
-        final MapSqlParameterSource paramsMap )
+    public static String displayNameFiltering( final String columnOne, final String columnTwo,
+                                               final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, DISPLAY_NAME ) )
         {
             return SPACED_LEFT_PARENTHESIS + columnOne + ILIKE + DISPLAY_NAME + " or " + columnTwo + ILIKE
-                + DISPLAY_NAME
-                + SPACED_RIGHT_PARENTHESIS;
+                + DISPLAY_NAME + SPACED_RIGHT_PARENTHESIS;
+        }
+
+        return EMPTY;
+    }
+
+    public static String displayShortNameFiltering( final String column, final MapSqlParameterSource paramsMap )
+    {
+        if ( hasStringPresence( paramsMap, DISPLAY_SHORT_NAME ) )
+        {
+            return SPACED_LEFT_PARENTHESIS + column + ILIKE + DISPLAY_SHORT_NAME + SPACED_RIGHT_PARENTHESIS;
+        }
+
+        return EMPTY;
+    }
+
+    public static String displayShortNameFiltering( final String columnOne, final String columnTwo,
+                                                    final MapSqlParameterSource paramsMap )
+    {
+        if ( hasStringPresence( paramsMap, DISPLAY_SHORT_NAME ) )
+        {
+            return SPACED_LEFT_PARENTHESIS + columnOne + ILIKE + DISPLAY_SHORT_NAME + " or " + columnTwo + ILIKE
+                + DISPLAY_SHORT_NAME + SPACED_RIGHT_PARENTHESIS;
         }
 
         return EMPTY;
@@ -161,7 +206,7 @@ public class FilteringStatement
     }
 
     public static String identifiableTokenFiltering( final String idColumn, final String codeColumn,
-        final String displayNameColumn, final String programNameColumn, final MapSqlParameterSource paramsMap )
+                                                     final String displayNameColumn, final String programNameColumn, final MapSqlParameterSource paramsMap )
     {
         if ( hasStringNonBlankPresence( paramsMap, IDENTIFIABLE_TOKEN_COMPARISON ) )
         {
@@ -187,7 +232,7 @@ public class FilteringStatement
     }
 
     private static String createRegexConditionForPhrase( final String column, final String[] filteringWords,
-        final String spacedAndOr, final String regexMatch )
+                                                         final String spacedAndOr, final String regexMatch )
     {
         if ( filteringWords != null && filteringWords.length > 0 && isNotBlank( column ) )
         {
@@ -212,7 +257,7 @@ public class FilteringStatement
     }
 
     private static String createRegexConditionForIdentifier( final String column, final String[] filteringWords,
-        final String spacedAndOr, final String regexMatch )
+                                                             final String spacedAndOr, final String regexMatch )
     {
         // Should only trigger when there is no more than one word in the
         // filtering.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/FilteringStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/FilteringStatement.java
@@ -93,7 +93,7 @@ public class FilteringStatement
     }
 
     public static String nameFiltering( final String columnOne, final String columnTwo,
-                                        final MapSqlParameterSource paramsMap )
+        final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, NAME ) )
         {
@@ -115,7 +115,7 @@ public class FilteringStatement
     }
 
     public static String shortNameFiltering( final String columnOne, final String columnTwo,
-                                             final MapSqlParameterSource paramsMap )
+        final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, SHORT_NAME ) )
         {
@@ -137,7 +137,7 @@ public class FilteringStatement
     }
 
     public static String displayNameFiltering( final String columnOne, final String columnTwo,
-                                               final MapSqlParameterSource paramsMap )
+        final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, DISPLAY_NAME ) )
         {
@@ -159,7 +159,7 @@ public class FilteringStatement
     }
 
     public static String displayShortNameFiltering( final String columnOne, final String columnTwo,
-                                                    final MapSqlParameterSource paramsMap )
+        final MapSqlParameterSource paramsMap )
     {
         if ( hasStringPresence( paramsMap, DISPLAY_SHORT_NAME ) )
         {
@@ -206,7 +206,7 @@ public class FilteringStatement
     }
 
     public static String identifiableTokenFiltering( final String idColumn, final String codeColumn,
-                                                     final String displayNameColumn, final String programNameColumn, final MapSqlParameterSource paramsMap )
+        final String displayNameColumn, final String programNameColumn, final MapSqlParameterSource paramsMap )
     {
         if ( hasStringNonBlankPresence( paramsMap, IDENTIFIABLE_TOKEN_COMPARISON ) )
         {
@@ -232,7 +232,7 @@ public class FilteringStatement
     }
 
     private static String createRegexConditionForPhrase( final String column, final String[] filteringWords,
-                                                         final String spacedAndOr, final String regexMatch )
+        final String spacedAndOr, final String regexMatch )
     {
         if ( filteringWords != null && filteringWords.length > 0 && isNotBlank( column ) )
         {
@@ -257,7 +257,7 @@ public class FilteringStatement
     }
 
     private static String createRegexConditionForIdentifier( final String column, final String[] filteringWords,
-                                                             final String spacedAndOr, final String regexMatch )
+        final String spacedAndOr, final String regexMatch )
     {
         // Should only trigger when there is no more than one word in the
         // filtering.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/NameTranslationStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/NameTranslationStatement.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataitem.query.shared;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
+
+/**
+ * Provides common statements related to name translation.
+ *
+ * @author maikel arabori
+ */
+public class NameTranslationStatement
+{
+    private NameTranslationStatement()
+    {
+    }
+
+    /**
+     * This method will join the translations column for the given table.
+     *
+     * @param table the table containing the translation columns
+     * @return the joins responsible to bring translated names
+     */
+    public static String translationNamesJoinsOn( final String table )
+    {
+        if ( isNotBlank( table ) )
+        {
+            return translationNamesJoinsOn( table, false );
+        }
+
+        return EMPTY;
+    }
+
+    /**
+     * This method will join the translations column for the given table.
+     * Depending on the program flag it will also join the program table.
+     *
+     * @param table the table containing the translation columns
+     * @param includeProgram if true, it will also join the program table
+     * @return the joins responsible to bring translated names
+     */
+    public static String translationNamesJoinsOn( final String table, final boolean includeProgram )
+    {
+        final StringBuilder joins = new StringBuilder();
+
+        if ( isNotBlank( table ) )
+        {
+            joins
+                .append(
+                    " left join jsonb_to_recordset(" + table + ".translations) as " + table
+                        + "_displayname(value TEXT, locale TEXT, property TEXT) on " + table + "_displayname.locale = :"
+                        + LOCALE + " and " + table + "_displayname.property = 'NAME'" )
+                .append(
+                    " left join jsonb_to_recordset(" + table + ".translations) as " + table
+                        + "_displayshortname(value TEXT, locale TEXT, property TEXT) on " + table
+                        + "_displayshortname.locale = :"
+                        + LOCALE + " and " + table + "_displayshortname.property = 'SHORT_NAME'" );
+
+            if ( includeProgram )
+            {
+                joins
+                    .append(
+                        " left join jsonb_to_recordset(program.translations) as p_displayname(value TEXT, locale TEXT, property TEXT) on p_displayname.locale = :"
+                            + LOCALE + " and p_displayname.property = 'NAME'" )
+                    .append(
+                        " left join jsonb_to_recordset(program.translations) as p_displayshortname(value TEXT, locale TEXT, property TEXT) on p_displayshortname.locale = :"
+                            + LOCALE + " and p_displayshortname.property = 'SHORT_NAME'" );
+            }
+        }
+
+        return joins.toString();
+    }
+
+    /**
+     * This method defines the values for the translatable columns, for the
+     * given table.
+     *
+     * @param table the table containing the translation columns
+     * @return the columns containing the translated names
+     */
+    public static String translationNamesColumnsFor( final String table )
+    {
+        if ( isNotBlank( table ) )
+        {
+            return translationNamesColumnsFor( table, false );
+        }
+
+        return EMPTY;
+    }
+
+    /**
+     * This method defines the values for the translatable columns, for the
+     * given table. Depending on the program flag it will also bring
+     * translatable columns from the program table.
+     *
+     * @param table the table containing the translation columns
+     * @param includeProgram if true, it will also bring program columns
+     * @return the columns containing the translated names
+     */
+    public static String translationNamesColumnsFor( final String table, final boolean includeProgram )
+    {
+        final StringBuilder columns = new StringBuilder();
+
+        if ( isNotBlank( table ) )
+        {
+            columns
+                .append(
+                    ", (case when " + table + "_displayname.value is not null then " + table
+                        + "_displayname.value else "
+                        + table + ".name end) as i18n_name" )
+                .append(
+                    ", (case when " + table + "_displayshortname.value is not null then " + table
+                        + "_displayshortname.value else " + table + ".shortname end) as i18n_shortname" );
+
+            if ( includeProgram )
+            {
+                columns
+                    .append(
+                        ", (case when p_displayname.value is not null then p_displayname.value else program.name end) as p_i18n_name" )
+                    .append(
+                        ", (case when p_displayshortname.value is not null then p_displayshortname.value else program.shortname end) as p_i18n_shortname" );
+            }
+        }
+
+        return columns.toString();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/OrderingStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/OrderingStatement.java
@@ -53,8 +53,8 @@ public class OrderingStatement
     }
 
     public static String ordering( final String displayNameOrderingColumns, final String nameOrderingColumns,
-                                   final String displayShortNameOrderingColumns, final String shortNameOrderingColumns,
-                                   final MapSqlParameterSource paramsMap )
+        final String displayShortNameOrderingColumns, final String shortNameOrderingColumns,
+        final MapSqlParameterSource paramsMap )
     {
         if ( hasStringNonBlankPresence( paramsMap, DISPLAY_NAME_ORDER ) && isNotBlank( displayNameOrderingColumns ) )
         {
@@ -80,7 +80,7 @@ public class OrderingStatement
     }
 
     private static String buildOrderByStatement( final String displayOrderingColumns,
-                                                 final String ascOrDesc )
+        final String ascOrDesc )
     {
         final StringBuilder orderBy = new StringBuilder();
         final String[] columns = trimToEmpty( displayOrderingColumns ).split( "," );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/OrderingStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/OrderingStatement.java
@@ -33,7 +33,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasStringNonBlankPresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.DISPLAY_NAME_ORDER;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.DISPLAY_SHORT_NAME_ORDER;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.NAME_ORDER;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.SHORT_NAME_ORDER;
 
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
@@ -50,23 +52,35 @@ public class OrderingStatement
     {
     }
 
-    public static String ordering( final String displayOrderingColumns, final String nameOrderingColumns,
-        final MapSqlParameterSource paramsMap )
+    public static String ordering( final String displayNameOrderingColumns, final String nameOrderingColumns,
+                                   final String displayShortNameOrderingColumns, final String shortNameOrderingColumns,
+                                   final MapSqlParameterSource paramsMap )
     {
-        if ( hasStringNonBlankPresence( paramsMap, DISPLAY_NAME_ORDER ) && isNotBlank( displayOrderingColumns ) )
+        if ( hasStringNonBlankPresence( paramsMap, DISPLAY_NAME_ORDER ) && isNotBlank( displayNameOrderingColumns ) )
         {
-            return buildOrderByStatement( displayOrderingColumns, (String) paramsMap.getValue( DISPLAY_NAME_ORDER ) );
+            return buildOrderByStatement( displayNameOrderingColumns,
+                (String) paramsMap.getValue( DISPLAY_NAME_ORDER ) );
         }
         else if ( hasStringNonBlankPresence( paramsMap, NAME_ORDER ) && isNotBlank( nameOrderingColumns ) )
         {
             return buildOrderByStatement( nameOrderingColumns, (String) paramsMap.getValue( NAME_ORDER ) );
+        }
+        else if ( hasStringNonBlankPresence( paramsMap, SHORT_NAME_ORDER ) && isNotBlank( nameOrderingColumns ) )
+        {
+            return buildOrderByStatement( shortNameOrderingColumns, (String) paramsMap.getValue( SHORT_NAME_ORDER ) );
+        }
+        else if ( hasStringNonBlankPresence( paramsMap, DISPLAY_SHORT_NAME_ORDER )
+            && isNotBlank( displayShortNameOrderingColumns ) )
+        {
+            return buildOrderByStatement( displayShortNameOrderingColumns,
+                (String) paramsMap.getValue( DISPLAY_SHORT_NAME_ORDER ) );
         }
 
         return EMPTY;
     }
 
     private static String buildOrderByStatement( final String displayOrderingColumns,
-        final String ascOrDesc )
+                                                 final String ascOrDesc )
     {
         final StringBuilder orderBy = new StringBuilder();
         final String[] columns = trimToEmpty( displayOrderingColumns ).split( "," );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/QueryParam.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/QueryParam.java
@@ -40,7 +40,11 @@ public class QueryParam
 
     public static final String NAME = "name";
 
+    public static final String SHORT_NAME = "shortName";
+
     public static final String DISPLAY_NAME = "displayName";
+
+    public static final String DISPLAY_SHORT_NAME = "displayShortName";
 
     public static final String LOCALE = "locale";
 
@@ -56,7 +60,11 @@ public class QueryParam
 
     public static final String NAME_ORDER = "nameOrder";
 
+    public static final String SHORT_NAME_ORDER = "shortNameOrder";
+
     public static final String DISPLAY_NAME_ORDER = "displayNameOrder";
+
+    public static final String DISPLAY_SHORT_NAME_ORDER = "displayShortNameOrder";
 
     public static final String UID = "uid";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/StatementUtil.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/StatementUtil.java
@@ -42,8 +42,6 @@ public class StatementUtil
 
     public static final String SPACED_SELECT = " select ";
 
-    public static final String SPACED_UNION = " union ";
-
     public static final String SPACED_WHERE = " where ";
 
     public static final String SPACED_OR = " or ";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/shared/NameTranslationStatementTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/shared/NameTranslationStatementTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataitem.query.shared;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
+import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for NameTranslationStatement.
+ *
+ * @author maikel arabori
+ */
+public class NameTranslationStatementTest
+{
+    @Test
+    public void testTranslationNamesJoinsOn()
+    {
+        // Given
+        final String table = "indicator";
+
+        // When
+        final String actualStatement = translationNamesJoinsOn( table );
+
+        // Then
+        assertThat( actualStatement,
+            containsString( "left join jsonb_to_recordset(indicator.translations) as indicator" ) );
+        assertThat( actualStatement,
+            containsString( "indicator_displayname(value TEXT, locale TEXT, property TEXT) on indicator" ) );
+        assertThat( actualStatement, not( containsString( "program" ) ) );
+    }
+
+    @Test
+    public void testTranslationNamesJoinsOnWhenTableIsNull()
+    {
+        // Given
+        final String nullTable = null;
+
+        // When
+        final String actualStatement = translationNamesJoinsOn( nullTable );
+
+        // Then
+        assertThat( actualStatement, containsString( EMPTY ) );
+    }
+
+    @Test
+    public void testTranslationNamesJoinsOnWhenTableIsBlank()
+    {
+        // Given
+        final String blankTable = " ";
+
+        // When
+        final String actualStatement = translationNamesJoinsOn( blankTable );
+
+        // Then
+        assertThat( actualStatement, containsString( EMPTY ) );
+    }
+
+    @Test
+    public void testTranslationNamesJoinsOnWithProgram()
+    {
+        // Given
+        final String table = "indicator";
+
+        // When
+        final String actualStatement = translationNamesJoinsOn( table, true );
+
+        // Then
+        assertThat( actualStatement,
+            containsString( "left join jsonb_to_recordset(indicator.translations) as indicator" ) );
+        assertThat( actualStatement,
+            containsString( "indicator_displayname(value TEXT, locale TEXT, property TEXT) on indicator" ) );
+        assertThat( actualStatement,
+            containsString(
+                "left join jsonb_to_recordset(program.translations) as p_displayname(value TEXT, locale TEXT, property TEXT)" ) );
+        assertThat( actualStatement,
+            containsString(
+                "left join jsonb_to_recordset(program.translations) as p_displayshortname(value TEXT, locale TEXT, property TEXT)" ) );
+    }
+
+    @Test
+    public void testTranslationNamesColumnsForWhenTableIsNull()
+    {
+        // Given
+        final String nullTable = null;
+
+        // When
+        final String actualStatement = translationNamesJoinsOn( null );
+
+        // Then
+        assertThat( actualStatement, containsString( EMPTY ) );
+    }
+
+    @Test
+    public void testTranslationNamesColumnsForWhenTableIsEmpty()
+    {
+        // Given
+        final String emptyTable = null;
+
+        // When
+        final String actualStatement = translationNamesJoinsOn( emptyTable );
+
+        // Then
+        assertThat( actualStatement, containsString( EMPTY ) );
+    }
+
+    @Test
+    public void testTranslationNamesColumnsFor()
+    {
+        // Given
+        final String table = "indicator";
+
+        // When
+        final String actualStatement = translationNamesColumnsFor( table );
+
+        // Then
+        assertThat( actualStatement,
+            containsString( "(case when indicator_displayname.value is not null then indicator_displayname.value" ) );
+        assertThat( actualStatement,
+            containsString(
+                "(case when indicator_displayshortname.value is not null then indicator_displayshortname.value" ) );
+        assertThat( actualStatement, not( containsString( "program" ) ) );
+    }
+
+    @Test
+    public void testTranslationNamesColumnsForWithProgram()
+    {
+        // Given
+        final String table = "indicator";
+
+        // When
+        final String actualStatement = translationNamesColumnsFor( table, true );
+
+        // Then
+        assertThat( actualStatement,
+            containsString( "(case when indicator_displayname.value is not null then indicator_displayname.value" ) );
+        assertThat( actualStatement,
+            containsString(
+                "(case when indicator_displayshortname.value is not null then indicator_displayshortname.value" ) );
+        assertThat( actualStatement, containsString(
+            "(case when p_displayname.value is not null then p_displayname.value else program.name end) as p_i18n_name" ) );
+        assertThat( actualStatement, containsString(
+            "(case when p_displayshortname.value is not null then p_displayshortname.value else program.shortname end) as p_i18n_shortname" ) );
+    }
+
+    @Test
+    public void testTranslationNamesColumnsForWithProgramWhenTableIsNull()
+    {
+        // Given
+        final String nullTable = null;
+
+        // When
+        final String actualStatement = translationNamesColumnsFor( nullTable, true );
+
+        // Then
+        assertThat( actualStatement, containsString( EMPTY ) );
+    }
+
+    @Test
+    public void testTranslationNamesColumnsForWithProgramWhenTableIsEmpty()
+    {
+        // Given
+        final String emptyTable = null;
+
+        // When
+        final String actualStatement = translationNamesColumnsFor( emptyTable, true );
+
+        // Then
+        assertThat( actualStatement, containsString( EMPTY ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/shared/OrderingStatementTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/shared/OrderingStatementTest.java
@@ -50,12 +50,14 @@ public class OrderingStatementTest
         // Given
         final String aGroupOfColumns = "anyColumn, otherColumn";
         final String otherGroupOfColumns = "anyColumn, otherColumn";
+        final String yetOtherColumns = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( DISPLAY_NAME_ORDER, "asc" );
         final String expectedStatement = " order by anyColumn asc, otherColumn asc";
 
         // When
-        final String actualStatement = ordering( aGroupOfColumns, otherGroupOfColumns, theParameterSource );
+        final String actualStatement = ordering( aGroupOfColumns, otherGroupOfColumns, yetOtherColumns, yetOtherColumns,
+            theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );
@@ -67,12 +69,14 @@ public class OrderingStatementTest
         // Given
         final String displayOrderingColumns = "anyColumn, anyColumn2";
         final String nameOrderingColumns = "otherColumn, otherColumn2";
+        final String yetOtherColumns = "yetAnotherColumn, otherColumn2";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( NAME_ORDER, "desc" );
         final String expectedStatement = " order by otherColumn desc, otherColumn2 desc";
 
         // When
-        final String actualStatement = ordering( displayOrderingColumns, nameOrderingColumns, theParameterSource );
+        final String actualStatement = ordering( displayOrderingColumns, nameOrderingColumns, yetOtherColumns,
+            yetOtherColumns, theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );
@@ -84,10 +88,12 @@ public class OrderingStatementTest
         // Given
         final String displayOrderingColumn = "anyColumn";
         final String nameOrderingColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource noParameterSource = new MapSqlParameterSource();
 
         // When
-        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, noParameterSource );
+        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, yetAnotherColumn,
+            yetAnotherColumn, noParameterSource );
 
         // Then
         assertThat( actualStatement, is( EMPTY ) );
@@ -99,10 +105,12 @@ public class OrderingStatementTest
         // Given
         final String displayOrderingColumn = "anyColumn";
         final String nameOrderingColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource nullParameterSource = null;
 
         // When
-        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, nullParameterSource );
+        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, yetAnotherColumn,
+            yetAnotherColumn, nullParameterSource );
 
         // Then
         assertThat( actualStatement, is( EMPTY ) );
@@ -114,11 +122,13 @@ public class OrderingStatementTest
         // Given
         final String displayOrderingColumn = "anyColumn";
         final String nameOrderingColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( NAME_ORDER, null );
 
         // When
-        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, theParameterSource );
+        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, yetAnotherColumn,
+            yetAnotherColumn, theParameterSource );
 
         // Then
         assertThat( actualStatement, is( EMPTY ) );
@@ -130,11 +140,13 @@ public class OrderingStatementTest
         // Given
         final String displayOrderingColumn = "anyColumn";
         final String nameOrderingColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( NAME_ORDER, EMPTY );
 
         // When
-        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, theParameterSource );
+        final String actualStatement = ordering( displayOrderingColumn, nameOrderingColumn, yetAnotherColumn,
+            yetAnotherColumn, theParameterSource );
 
         // Then
         assertThat( actualStatement, is( EMPTY ) );
@@ -146,12 +158,14 @@ public class OrderingStatementTest
         // Given
         final String aNullColumn = null;
         final String otherColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( NAME_ORDER, "desc" );
         final String expectedStatement = " order by otherColumn desc";
 
         // When
-        final String actualStatement = ordering( aNullColumn, otherColumn, theParameterSource );
+        final String actualStatement = ordering( aNullColumn, otherColumn, yetAnotherColumn, yetAnotherColumn,
+            theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );
@@ -163,12 +177,14 @@ public class OrderingStatementTest
         // Given
         final String anEmptyColumn = EMPTY;
         final String otherColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( NAME_ORDER, "desc" );
         final String expectedStatement = " order by otherColumn desc";
 
         // When
-        final String actualStatement = ordering( anEmptyColumn, otherColumn, theParameterSource );
+        final String actualStatement = ordering( anEmptyColumn, otherColumn, yetAnotherColumn, yetAnotherColumn,
+            theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );
@@ -180,12 +196,14 @@ public class OrderingStatementTest
         // Given
         final String aNullColumn = null;
         final String otherColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( DISPLAY_NAME_ORDER, "asc" );
         final String expectedStatement = EMPTY;
 
         // When
-        final String actualStatement = ordering( aNullColumn, otherColumn, theParameterSource );
+        final String actualStatement = ordering( aNullColumn, otherColumn, yetAnotherColumn, yetAnotherColumn,
+            theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );
@@ -197,12 +215,14 @@ public class OrderingStatementTest
         // Given
         final String anEmptyColumn = EMPTY;
         final String otherColumn = "otherColumn";
+        final String yetAnotherColumn = "yetAnotherColumn";
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( DISPLAY_NAME_ORDER, "asc" );
         final String expectedStatement = EMPTY;
 
         // When
-        final String actualStatement = ordering( anEmptyColumn, otherColumn, theParameterSource );
+        final String actualStatement = ordering( anEmptyColumn, otherColumn, yetAnotherColumn, yetAnotherColumn,
+            theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );
@@ -213,13 +233,13 @@ public class OrderingStatementTest
     {
         // Given
         final String aNullColumn = null;
-        final String anotherNullColumn = null;
         final MapSqlParameterSource theParameterSource = new MapSqlParameterSource()
             .addValue( NAME_ORDER, "desc" );
         final String expectedStatement = EMPTY;
 
         // When
-        final String actualStatement = ordering( aNullColumn, anotherNullColumn, theParameterSource );
+        final String actualStatement = ordering( aNullColumn, aNullColumn, aNullColumn, aNullColumn,
+            theParameterSource );
 
         // Then
         assertThat( actualStatement, is( expectedStatement ) );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryController.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.feedback.ErrorCode.E3012;
 import static org.hisp.dhis.node.NodeUtils.createMetadata;
 import static org.hisp.dhis.webapi.controller.dataitem.validator.FilterValidator.checkNamesAndOperators;
 import static org.hisp.dhis.webapi.controller.dataitem.validator.OrderValidator.checkOrderParams;
-import static org.hisp.dhis.webapi.controller.dataitem.validator.OrderValidator.checkOrderParamsAndFiltersAllowance;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
@@ -148,7 +147,6 @@ public class DataItemQueryController
 
         checkNamesAndOperators( filters );
         checkOrderParams( orderParams.getOrders() );
-        checkOrderParamsAndFiltersAllowance( orderParams.getOrders(), filters );
 
         // Extracting the target entities to be queried.
         final Set<Class<? extends BaseIdentifiableObject>> targetEntities = dataItemServiceFacade

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/Filter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/Filter.java
@@ -40,6 +40,8 @@ public class Filter
         VALUE_TYPE( "valueType" ),
         NAME( "name" ),
         DISPLAY_NAME( "displayName" ),
+        SHORT_NAME( "shortName" ),
+        DISPLAY_SHORT_NAME( "displayShortName" ),
         PROGRAM_ID( "programId" ),
         ID( "id" );
 
@@ -116,6 +118,8 @@ public class Filter
         VALUE_TYPE_EQUAL( "valueType:eq:" ),
         NAME_ILIKE( "name:ilike:" ),
         DISPLAY_NAME_ILIKE( "displayName:ilike:" ),
+        SHORT_NAME_ILIKE( "shortName:ilike:" ),
+        DISPLAY_SHORT_NAME_ILIKE( "displayShortName:ilike:" ),
         PROGRAM_ID_EQUAL( "programId:eq:" ),
         ID_EQUAL( "id:eq:" ),
         IDENTIFIABLE_TOKEN( "identifiable:token:" );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/Order.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/Order.java
@@ -37,7 +37,9 @@ public class Order
     public enum Attribute
     {
         NAME( "name" ),
-        DISPLAY_NAME( "displayName" );
+        DISPLAY_NAME( "displayName" ),
+        SHORT_NAME( "shortName" ),
+        DISPLAY_SHORT_NAME( "displayShortName" );
 
         private String name;
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelper.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/helper/FilteringHelper.java
@@ -46,11 +46,13 @@ import static org.hisp.dhis.common.UserContext.getUserSetting;
 import static org.hisp.dhis.common.ValueType.fromString;
 import static org.hisp.dhis.common.ValueType.getAggregatables;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.DISPLAY_NAME;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.DISPLAY_SHORT_NAME;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.IDENTIFIABLE_TOKEN_COMPARISON;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.NAME;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.PROGRAM_ID;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.ROOT_JUNCTION;
+import static org.hisp.dhis.dataitem.query.shared.QueryParam.SHORT_NAME;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.UID;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.USER_GROUP_UIDS;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.VALUE_TYPES;
@@ -63,10 +65,12 @@ import static org.hisp.dhis.user.UserSettingKey.UI_LOCALE;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.DIMENSION_TYPE_EQUAL;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.DIMENSION_TYPE_IN;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.DISPLAY_NAME_ILIKE;
+import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.DISPLAY_SHORT_NAME_ILIKE;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.IDENTIFIABLE_TOKEN;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.ID_EQUAL;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.NAME_ILIKE;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.PROGRAM_ID_EQUAL;
+import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.SHORT_NAME_ILIKE;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.VALUE_TYPE_EQUAL;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.VALUE_TYPE_IN;
 import static org.hisp.dhis.webapi.controller.dataitem.validator.FilterValidator.containsFilterWithAnyOfPrefixes;
@@ -301,6 +305,20 @@ public class FilteringHelper
         if ( StringUtils.isNotEmpty( ilikeDisplayName ) )
         {
             paramsMap.addValue( DISPLAY_NAME, wrap( addIlikeReplacingCharacters( ilikeDisplayName ), "%" ) );
+        }
+
+        final String ilikeShortName = extractValueFromFilter( filters, SHORT_NAME_ILIKE );
+
+        if ( StringUtils.isNotEmpty( ilikeShortName ) )
+        {
+            paramsMap.addValue( SHORT_NAME, wrap( addIlikeReplacingCharacters( ilikeShortName ), "%" ) );
+        }
+
+        final String ilikeDisplayShortName = extractValueFromFilter( filters, DISPLAY_SHORT_NAME_ILIKE );
+
+        if ( StringUtils.isNotEmpty( ilikeDisplayShortName ) )
+        {
+            paramsMap.addValue( DISPLAY_SHORT_NAME, wrap( addIlikeReplacingCharacters( ilikeDisplayShortName ), "%" ) );
         }
 
         final String equalId = extractValueFromFilter( filters, ID_EQUAL, true );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/validator/OrderValidator.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/validator/OrderValidator.java
@@ -30,18 +30,14 @@ package org.hisp.dhis.webapi.controller.dataitem.validator;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.hisp.dhis.feedback.ErrorCode.E2015;
-import static org.hisp.dhis.feedback.ErrorCode.E2036;
 import static org.hisp.dhis.feedback.ErrorCode.E2037;
 import static org.hisp.dhis.webapi.controller.dataitem.Order.Attribute.getNames;
 import static org.hisp.dhis.webapi.controller.dataitem.Order.Nature.getValues;
-import static org.hisp.dhis.webapi.controller.dataitem.validator.FilterValidator.FILTER_ATTRIBUTE_NAME;
 
 import java.util.Set;
 
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.feedback.ErrorMessage;
-import org.hisp.dhis.webapi.controller.dataitem.Filter;
-import org.hisp.dhis.webapi.controller.dataitem.Order;
 
 /**
  * Validator class responsible for validating order parameters.
@@ -98,61 +94,6 @@ public class OrderValidator
                 else
                 {
                     throw new IllegalQueryException( new ErrorMessage( E2015, orderParam ) );
-                }
-            }
-        }
-    }
-
-    /**
-     * Checks if the given of order params can be used in combination with the
-     * given filters. Currently the only valid combinations allowed when using
-     * "name" or "displayName" are:
-     *
-     * 1) "order=displayName:asc => filter=displayName:eq:something" 2)
-     * "order=name:asc => filter=name:eq:something"
-     *
-     * In the other hand these are NOT ALLOWED:
-     *
-     * 1) "order=displayName:asc => filter=name:eq:something" 2) "order=name:asc
-     * => filter=displayName:eq:something"
-     *
-     * In other words, if one filters by "name", it cannot be ordered by
-     * "displayName" and vice-versa.
-     *
-     * @param orderParams a set containing elements in the format
-     *        "attributeName:asc"
-     * @param filters the set of filters, where each element has the format
-     *        something like "attributeName:eq:value"
-     * @throws IllegalQueryException if some of the filters are not allowed with
-     *         any order param.
-     */
-    public static void checkOrderParamsAndFiltersAllowance( final Set<String> orderParams, final Set<String> filters )
-    {
-        if ( isNotEmpty( orderParams ) && isNotEmpty( filters ) )
-        {
-            for ( final String orderParam : orderParams )
-            {
-                final String[] orderAttributeValuePair = orderParam.split( ":" );
-                final String orderAttributeName = trimToEmpty( orderAttributeValuePair[ORDERING_ATTRIBUTE_NAME] );
-
-                for ( final String filter : filters )
-                {
-                    final String[] array = filter.split( ":" );
-
-                    final String filterAttributeName = trimToEmpty( array[FILTER_ATTRIBUTE_NAME] );
-
-                    if ( trimToEmpty( orderAttributeName ).equalsIgnoreCase( Order.Attribute.DISPLAY_NAME.getName() )
-                        && trimToEmpty( filterAttributeName ).equalsIgnoreCase( Filter.Attribute.NAME.getName() ) )
-                    {
-                        throw new IllegalQueryException( new ErrorMessage( E2036, orderParam + " + " + filter ) );
-                    }
-
-                    if ( trimToEmpty( orderAttributeName ).equalsIgnoreCase( Order.Attribute.NAME.getName() )
-                        && trimToEmpty( filterAttributeName )
-                            .equalsIgnoreCase( Filter.Attribute.DISPLAY_NAME.getName() ) )
-                    {
-                        throw new IllegalQueryException( new ErrorMessage( E2036, orderParam + " + " + filter ) );
-                    }
                 }
             }
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/validator/OrderValidatorTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/validator/OrderValidatorTest.java
@@ -31,7 +31,6 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.webapi.controller.dataitem.validator.OrderValidator.checkOrderParams;
-import static org.hisp.dhis.webapi.controller.dataitem.validator.OrderValidator.checkOrderParamsAndFiltersAllowance;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashSet;
@@ -101,52 +100,5 @@ public class OrderValidatorTest
 
         // Then
         assert (noExceptionIsThrown);
-    }
-
-    @Test( expected = Test.None.class ) /* no exception is expected */
-    public void testCheckOrderParamsAndFiltersAllowanceWithSuccess()
-    {
-        // Given
-        final Set<String> orderings = new HashSet<>( singletonList( "name:asc" ) );
-        final Set<String> filters = new HashSet<>( singletonList( "name:ilike:someName" ) );
-        final boolean noExceptionIsThrown = true;
-
-        // When
-        checkOrderParamsAndFiltersAllowance( orderings, filters );
-
-        // Then
-        assert (noExceptionIsThrown);
-    }
-
-    @Test
-    public void testCheckOrderParamsAndFiltersAllowanceUsingNameOnOrderAndDisplayNameOnFilter()
-    {
-        // Given
-        final Set<String> orderings = new HashSet<>( singletonList( "name:asc" ) );
-        final Set<String> filters = new HashSet<>( singletonList( "displayName:ilike:someName" ) );
-
-        // When throws
-        final IllegalQueryException thrown = assertThrows( IllegalQueryException.class,
-            () -> checkOrderParamsAndFiltersAllowance( orderings, filters ) );
-
-        // Then
-        assertThat( thrown.getMessage(),
-            containsString( "Combination not supported: `name:asc + displayName:ilike:someName`" ) );
-    }
-
-    @Test
-    public void testCheckOrderParamsAndFiltersAllowanceUsingDisplayNameOnOrderAndNameOnFilter()
-    {
-        // Given
-        final Set<String> orderings = new HashSet<>( singletonList( "displayName:asc" ) );
-        final Set<String> filters = new HashSet<>( singletonList( "name:ilike:someName" ) );
-
-        // When throws
-        final IllegalQueryException thrown = assertThrows( IllegalQueryException.class,
-            () -> checkOrderParamsAndFiltersAllowance( orderings, filters ) );
-
-        // Then
-        assertThat( thrown.getMessage(),
-            containsString( "Combination not supported: `displayName:asc + name:ilike:someName`" ) );
     }
 }


### PR DESCRIPTION
Now, shortName and displayShortName are supported in the URL filtering and also returned as part of the /dataItems response.

Some front-end applications relly on those attributes, so we had to support them as well.

With these changes, we will be able to filter and order by shortName and displayShortName.

**_This was already merged in 2.36, I'm just "forward" porting it to master._**