### PR TITLE
perf: rewrite TEI get SQL for better performance (2.36)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1326,24 +1325,10 @@ public class TrackedEntityInstanceQueryParams
         TRACKEDENTITY( "trackedEntity", "tei.uid" ),
         CREATED( CREATED_ID, "tei.created" ),
         CREATED_AT( "createdAt", "tei.created" ),
-        CREATED_AT_CLIENT( "createdAtClient", "tei.createdAtClient" ),
         UPDATED_AT( "updatedAt", "tei.lastUpdated" ),
-        UPDATED_AT_CLIENT( "updatedAtClient", "tei.lastUpdatedAtClient" ),
-        ENROLLED_AT( "enrolledAt", "pi.enrollmentDate" ),
         // this works only for the new endpoint
         // ORGUNIT_NAME( "orgUnitName", "tei.organisationUnit.name" ),
-        INACTIVE( INACTIVE_ID, "tei.inactive" ),
-        ENROLLMENT_OCCURED_AT( "enrollmentOccurredAt", "pi.incidentDate" ),
-        ENROLLMENT_CREATED_AT( "enrollmentCreatedAt", "pi.created" ),
-        ENROLLMENT_CREATED_AT_CLIENT( "enrollmentCreatedAtClient", "pi.createdAtClient" ),
-        ENROLLMENT_UPDATED_AT( "enrollmentUpdatedAt", "pi.lastUpdated" ),
-        ENROLLMENT_UPDATED_AT_CLIENT( "enrollmentUpdatedAtClient", "pi.lastUpdatedAtClient" ),
-        ENROLLMENT_STATUS( "status",
-            "(case when pi.status = 'ACTIVE' then 1 when pi.status = 'COMPLETED' then 2 else 3 end)" );
-
-        private static final EnumSet<OrderColumn> enrollmentOrderColumns = EnumSet.of( ENROLLED_AT,
-            ENROLLMENT_OCCURED_AT, ENROLLMENT_CREATED_AT, ENROLLMENT_CREATED_AT_CLIENT,
-            ENROLLMENT_UPDATED_AT, ENROLLMENT_UPDATED_AT_CLIENT, ENROLLMENT_STATUS );
+        INACTIVE( INACTIVE_ID, "tei.inactive" );
 
         private final String propName;
 
@@ -1352,12 +1337,6 @@ public class TrackedEntityInstanceQueryParams
         public static boolean isStaticColumn( String propName )
         {
             return Arrays.stream( OrderColumn.values() )
-                .anyMatch( orderColumn -> orderColumn.getPropName().equals( propName ) );
-        }
-
-        public static boolean isEnrollmentColumn( String propName )
-        {
-            return OrderColumn.enrollmentOrderColumns.stream()
                 .anyMatch( orderColumn -> orderColumn.getPropName().equals( propName ) );
         }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -248,12 +248,6 @@ public class TrackedEntityInstanceQueryParams
     private int maxTeiLimit;
 
     /**
-     * Indicates if a count of records for this params is already calculated.
-     * Used to avoid redundant querying to find count.
-     */
-    private int count;
-
-    /**
      * Indicates whether to include soft-deleted elements
      */
     private boolean includeDeleted;
@@ -1162,17 +1156,6 @@ public class TrackedEntityInstanceQueryParams
     public TrackedEntityInstanceQueryParams setMaxTeiLimit( int maxTeiLimit )
     {
         this.maxTeiLimit = maxTeiLimit;
-        return this;
-    }
-
-    public int getCount()
-    {
-        return count;
-    }
-
-    public TrackedEntityInstanceQueryParams setCount( int count )
-    {
-        this.count = count;
         return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -249,6 +249,12 @@ public class TrackedEntityInstanceQueryParams
     private int maxTeiLimit;
 
     /**
+     * Indicates if a count of records for this params is already calculated.
+     * Used to avoid redundant querying to find count.
+     */
+    private int count;
+
+    /**
      * Indicates whether to include soft-deleted elements
      */
     private boolean includeDeleted;
@@ -1157,6 +1163,17 @@ public class TrackedEntityInstanceQueryParams
     public TrackedEntityInstanceQueryParams setMaxTeiLimit( int maxTeiLimit )
     {
         this.maxTeiLimit = maxTeiLimit;
+        return this;
+    }
+
+    public int getCount()
+    {
+        return count;
+    }
+
+    public TrackedEntityInstanceQueryParams setCount( int count )
+    {
+        this.count = count;
         return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -244,6 +244,11 @@ public class TrackedEntityInstanceQueryParams
     private boolean skipPaging;
 
     /**
+     * Indicates if there is a maximum tei retrieval limit. 0 no limit.
+     */
+    private int maxTeiLimit;
+
+    /**
      * Indicates whether to include soft-deleted elements
      */
     private boolean includeDeleted;
@@ -1144,6 +1149,17 @@ public class TrackedEntityInstanceQueryParams
         return skipPaging;
     }
 
+    public int getMaxTeiLimit()
+    {
+        return maxTeiLimit;
+    }
+
+    public TrackedEntityInstanceQueryParams setMaxTeiLimit( int maxTeiLimit )
+    {
+        this.maxTeiLimit = maxTeiLimit;
+        return this;
+    }
+
     public TrackedEntityInstanceQueryParams setSkipPaging( boolean skipPaging )
     {
         this.skipPaging = skipPaging;
@@ -1278,6 +1294,12 @@ public class TrackedEntityInstanceQueryParams
     public void setTrackedEntityTypes( List<TrackedEntityType> trackedEntityTypes )
     {
         this.trackedEntityTypes = trackedEntityTypes;
+    }
+
+    public boolean hasFilterForPrograms()
+    {
+        return hasProgramStatus() || hasFollowUp() || hasProgramEnrollmentStartDate() || hasProgramEnrollmentEndDate()
+            || hasProgramIncidentStartDate() || hasProgramIncidentEndDate() || hasFilterForEvents();
     }
 
     @Getter

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -742,13 +742,16 @@ public class DefaultTrackedEntityInstanceService
                 }
             }
 
-            if ( maxTeiLimit > 0 &&
-                ((isGridSearch
-                    && trackedEntityInstanceStore.getTrackedEntityInstanceCountForGrid( params ) > maxTeiLimit) ||
-                    (!isGridSearch && trackedEntityInstanceStore.countTrackedEntityInstances( params ) > maxTeiLimit)) )
+            if ( maxTeiLimit > 0 && ((isGridSearch && params.isPaging()
+                && params.getOffset() > 0 && (params.getOffset() + params.getPageSizeWithDefault()) > maxTeiLimit)
+                || ((!isGridSearch
+                    && trackedEntityInstanceStore.countTrackedEntityInstances( params ) > maxTeiLimit))) )
             {
-                throw new IllegalQueryException( "maxteicountreached" );
+                throw new IllegalQueryException(
+                    "maxteicountreached" );
             }
+
+            params.setMaxTeiLimit( maxTeiLimit );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -188,6 +188,11 @@ public class DefaultTrackedEntityInstanceService
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceStore
             .getTrackedEntityInstances( params );
 
+        if ( params.getMaxTeiLimit() > 0 && trackedEntityInstances.size() > params.getMaxTeiLimit() )
+        {
+            throw new IllegalQueryException( "maxteicountreached" );
+        }
+
         trackedEntityInstances = trackedEntityInstances.stream()
             .filter( ( tei ) -> aclService.canDataRead( user, tei.getTrackedEntityType() ) )
             .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -290,7 +290,9 @@ public class DefaultTrackedEntityInstanceService
 
         params.handleCurrentUserSelectionMode();
 
-        return trackedEntityInstanceStore.countTrackedEntityInstances( params );
+        // using countForGrid here to leverage the better performant rewritten
+        // sql query
+        return trackedEntityInstanceStore.getTrackedEntityInstanceCountForGrid( params );
     }
 
     // TODO lower index on attribute value?
@@ -742,10 +744,8 @@ public class DefaultTrackedEntityInstanceService
                 }
             }
 
-            if ( maxTeiLimit > 0 && ((isGridSearch && params.isPaging()
-                && params.getOffset() > 0 && (params.getOffset() + params.getPageSizeWithDefault()) > maxTeiLimit)
-                || ((!isGridSearch
-                    && trackedEntityInstanceStore.countTrackedEntityInstances( params ) > maxTeiLimit))) )
+            if ( maxTeiLimit > 0 && params.isPaging()
+                && params.getOffset() > 0 && (params.getOffset() + params.getPageSizeWithDefault()) > maxTeiLimit )
             {
                 throw new IllegalQueryException(
                     "maxteicountreached" );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -188,11 +188,6 @@ public class DefaultTrackedEntityInstanceService
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceStore
             .getTrackedEntityInstances( params );
 
-        if ( params.getMaxTeiLimit() > 0 && trackedEntityInstances.size() > params.getMaxTeiLimit() )
-        {
-            throw new IllegalQueryException( "maxteicountreached" );
-        }
-
         trackedEntityInstances = trackedEntityInstances.stream()
             .filter( ( tei ) -> aclService.canDataRead( user, tei.getTrackedEntityType() ) )
             .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -414,10 +414,6 @@ public class HibernateTrackedEntityInstanceStore
         String sql = getQuery( params, true );
         log.debug( "Tracked entity instance query SQL: " + sql );
 
-        // ---------------------------------------------------------------------
-        // Query
-        // ---------------------------------------------------------------------
-
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
 
         checkMaxTeiCountReached( params, rowSet );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -583,7 +583,7 @@ public class HibernateTrackedEntityInstanceStore
             .append( getFromSubQuery( params, false ) )
             .append( getQueryRelatedTables( params ) )
             .append( getQueryGroupBy( params ) )
-            .append( getQueryOrderBy( false, params, isGridQuery ) )
+            .append( getQueryOrderBy( false, params ) )
             .toString();
     }
 
@@ -681,7 +681,7 @@ public class HibernateTrackedEntityInstanceStore
         {
             // SORT
             fromSubQuery
-                .append( getQueryOrderBy( true, params, true ) )
+                .append( getQueryOrderBy( true, params ) )
 
                 // LIMIT, OFFSET
                 .append( getFromSubQueryLimitAndOffset( params ) );
@@ -1425,7 +1425,7 @@ public class HibernateTrackedEntityInstanceStore
      * @param params
      * @return a SQL ORDER BY clause.
      */
-    private String getQueryOrderBy( boolean innerOrder, TrackedEntityInstanceQueryParams params, boolean gridQuery )
+    private String getQueryOrderBy( boolean innerOrder, TrackedEntityInstanceQueryParams params )
     {
         if ( params.getOrders() != null && params.getAttributes() != null && !params.getAttributes().isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -796,9 +796,8 @@ public class HibernateTrackedEntityInstanceStore
 
         for ( QueryItem orderAttribute : getOrderAttributes( params ) )
         {
-            if ( orderAttribute.hasFilter() ) // We already joined this if it is
-                                              // a filter.
-            {
+            if ( orderAttribute.hasFilter() )
+            { // We already joined this if it is a filter.
                 continue;
             }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -201,6 +201,13 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     private List<TrackedEntityInstance> getTrackedEntityInstancesLegacy( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityInstanceParams params, boolean skipAccessValidation )
     {
+        if ( queryParams.getMaxTeiLimit() > 0 && queryParams.getCount() > 0
+            && queryParams.getCount() > queryParams.getMaxTeiLimit() )
+        {
+            // For legacy fetch, we add this check here.
+            throw new IllegalQueryException( "maxteicountreached" );
+        }
+
         List<org.hisp.dhis.trackedentity.TrackedEntityInstance> daoTEIs = teiService
             .getTrackedEntityInstances( queryParams, skipAccessValidation );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -201,13 +201,6 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     private List<TrackedEntityInstance> getTrackedEntityInstancesLegacy( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityInstanceParams params, boolean skipAccessValidation )
     {
-        if ( queryParams.getMaxTeiLimit() > 0 && queryParams.getCount() > 0
-            && queryParams.getCount() > queryParams.getMaxTeiLimit() )
-        {
-            // For legacy fetch, we add this check here.
-            throw new IllegalQueryException( "maxteicountreached" );
-        }
-
         List<org.hisp.dhis.trackedentity.TrackedEntityInstance> daoTEIs = teiService
             .getTrackedEntityInstances( queryParams, skipAccessValidation );
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_34__Add_index_in_tracker_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_34__Add_index_in_tracker_tables.sql
@@ -1,0 +1,4 @@
+create unique index if not exists in_unique_trackedentityprogramowner_teiid_programid_ouid on trackedentityprogramowner using btree (trackedentityinstanceid, programid, organisationunitid);
+create index if not exists in_programinstance_programid on programinstance using btree (programid);
+create unique index if not exists in_trackedentityinstance_trackedentityattribute_value on trackedentityattributevalue using btree (trackedentityinstanceid, trackedentityattributeid, lower(value));
+create index if not exists in_programstageinstance_status_executiondate on programstageinstance using btree (status,executiondate);

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -47,6 +47,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.cache.CacheStrategy;
@@ -160,10 +161,16 @@ public class TrackedEntityInstanceController
 
         int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
 
+        //Adding this check here to avoid further querying if teicount is already exceeded
+        if ( queryParams.getMaxTeiLimit() > 0 && count > 0
+            && count > queryParams.getMaxTeiLimit() )
+        {
+            throw new IllegalQueryException( "maxteicountreached" );
+        }
+        
         if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
         {
             queryParams.setUseLegacy( true );
-            queryParams.setCount( count );
         }
 
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances(

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -161,13 +161,13 @@ public class TrackedEntityInstanceController
 
         int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
 
-        //Adding this check here to avoid further querying if teicount is already exceeded
+        // Validating here to avoid further querying
         if ( queryParams.getMaxTeiLimit() > 0 && count > 0
             && count > queryParams.getMaxTeiLimit() )
         {
             throw new IllegalQueryException( "maxteicountreached" );
         }
-        
+
         if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
         {
             queryParams.setUseLegacy( true );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -163,6 +163,7 @@ public class TrackedEntityInstanceController
         if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
         {
             queryParams.setUseLegacy( true );
+            queryParams.setCount( count );
         }
 
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances(

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.event.mapper;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.isEnrollmentColumn;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.isStaticColumn;
 
 import java.util.Collections;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
@@ -385,12 +385,7 @@ public class TrackedEntityCriteriaMapper
         {
             for ( OrderParam orderParam : orderParams )
             {
-                if ( isEnrollmentColumn( orderParam.getField() ) && Objects.isNull( program ) )
-                {
-                    throw new IllegalQueryException(
-                        "Invalid order property, program should be present: " + orderParam.getField() );
-                }
-                else if ( !isStaticColumn( orderParam.getField() ) && !attributes.containsKey( orderParam.getField() ) )
+                if ( !isStaticColumn( orderParam.getField() ) && !attributes.containsKey( orderParam.getField() ) )
                 {
                     throw new IllegalQueryException( "Invalid order property: " + orderParam.getField() );
                 }


### PR DESCRIPTION
Forward port of grid query sql rewrite. 

Additional change in 2.36 is that, we use the same sql to fetch the trackedentityinstanceid (the primary key) for the api/trackedEntityInstance and the api/tracker/trackedEntity endpoints as well. 