### PR TITLE
perf: Create a configuration to correctly size the caches [DHIS2-10629]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -69,6 +69,8 @@ import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.util.InputUtils;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
@@ -181,6 +183,9 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
     private CachingMap<String, CategoryOptionCombo> aocCache;
 
     @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Mock
     private Environment environment;
 
     @Mock
@@ -201,9 +206,11 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
         user = new User();
 
         when( environment.getActiveProfiles() ).thenReturn( new String[] { "test" } );
+        when( dhisConfigurationProvider.getProperty( ConfigurationKey.CACHE_MULTIPLICATOR_FACTOR ) ).thenReturn( "1" );
         CacheBuilderProvider cacheBuilderProvider = new DefaultCacheBuilderProvider();
 
-        DefaultCacheProvider cacheContext = new DefaultCacheProvider( cacheBuilderProvider, environment );
+        DefaultCacheProvider cacheContext = new DefaultCacheProvider( cacheBuilderProvider, environment,
+            dhisConfigurationProvider );
         InputUtils inputUtils = new InputUtils( categoryService, idObjManager, cacheContext );
 
         DefaultAggregateAccessManager aggregateAccessManager = new DefaultAggregateAccessManager( aclService,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -30,13 +30,7 @@ package org.hisp.dhis.dxf2.dataset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hisp.dhis.DhisConvenienceTest.assertIllegalQueryEx;
-import static org.hisp.dhis.DhisConvenienceTest.createCategoryCombo;
-import static org.hisp.dhis.DhisConvenienceTest.createCategoryOption;
-import static org.hisp.dhis.DhisConvenienceTest.createCategoryOptionCombo;
-import static org.hisp.dhis.DhisConvenienceTest.createDataSet;
-import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
-import static org.hisp.dhis.DhisConvenienceTest.createPeriod;
+import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -206,7 +200,8 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
         user = new User();
 
         when( environment.getActiveProfiles() ).thenReturn( new String[] { "test" } );
-        when( dhisConfigurationProvider.getProperty( ConfigurationKey.CACHE_MULTIPLICATOR_FACTOR ) ).thenReturn( "1" );
+        when( dhisConfigurationProvider.getProperty( ConfigurationKey.SYSTEM_CACHE_MAX_SIZE_FACTOR ) )
+            .thenReturn( "1" );
         CacheBuilderProvider cacheBuilderProvider = new DefaultCacheBuilderProvider();
 
         DefaultCacheProvider cacheContext = new DefaultCacheProvider( cacheBuilderProvider, environment,

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -44,6 +44,7 @@ public enum ConfigurationKey
     SYSTEM_MONITORING_PASSWORD( "system.monitoring.password" ),
     SYSTEM_SQL_VIEW_TABLE_PROTECTION( "system.sql_view_table_protection", Constants.ON, false ),
     SYSTEM_PROGRAM_RULE_SERVER_EXECUTION( "system.program_rule.server_execution", Constants.ON, false ),
+    SYSTEM_CACHE_MAX_SIZE_FACTOR( "system.cache.max_size.factor", "0.5", false ),
     NODE_ID( "node.id", "", false ),
     ENCRYPTION_PASSWORD( "encryption.password", "", true ),
     CONNECTION_DIALECT( "connection.dialect", "", false ),
@@ -145,8 +146,7 @@ public enum ConfigurationKey
     DB_POOL_TYPE( "db.pool.type", "c3p0", false ),
     ACTIVE_READ_REPLICAS( "active.read.replicas", "0", false ),
     AUDIT_ENABLED( "system.audit.enabled", Constants.TRUE, false ),
-    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false ),
-    CACHE_MULTIPLICATOR_FACTOR( "system.cache.factor", "0.5", false );
+    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false );
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -145,7 +145,8 @@ public enum ConfigurationKey
     DB_POOL_TYPE( "db.pool.type", "c3p0", false ),
     ACTIVE_READ_REPLICAS( "active.read.replicas", "0", false ),
     AUDIT_ENABLED( "system.audit.enabled", Constants.TRUE, false ),
-    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false );
+    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false ),
+    CACHE_MULTIPLICATOR_FACTOR( "system.cache.factor", "0.5", false );
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -73,7 +73,8 @@ public class DefaultCacheProvider
     {
         this.cacheBuilderProvider = cacheBuilderProvider;
         this.environment = environment;
-        this.cacheFactor = Double.parseDouble( dhisConfig.getProperty( ConfigurationKey.CACHE_MULTIPLICATOR_FACTOR ) );
+        this.cacheFactor = Double
+            .parseDouble( dhisConfig.getProperty( ConfigurationKey.SYSTEM_CACHE_MAX_SIZE_FACTOR ) );
     }
 
     /**
@@ -131,7 +132,7 @@ public class DefaultCacheProvider
         return cache;
     }
 
-    private long getSize( long size )
+    private long getActualSize( long size )
     {
         return Math.max( (long) this.cacheFactor * size, 1 );
     }
@@ -142,7 +143,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.analyticsResponse.name() )
             .expireAfterWrite( initialExpirationTime.toMillis(), MILLISECONDS )
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -165,9 +166,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.defaultObjectCache.name() )
             .expireAfterAccess( 12, TimeUnit.HOURS )
-            .withInitialCapacity( 4 )
+            .withInitialCapacity( (int) getActualSize( 4 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_100 ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_100 ) ) )
             .build() );
     }
 
@@ -177,7 +178,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.isDataApproved.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -187,9 +188,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.allConstantsCache.name() )
             .expireAfterWrite( 2, TimeUnit.MINUTES )
-            .withInitialCapacity( 1 )
+            .withInitialCapacity( (int) getActualSize( 1 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1 ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1 ) ) )
             .build() );
     }
 
@@ -199,9 +200,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.inUserOuHierarchy.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -211,9 +212,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.inUserSearchOuHierarchy.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -223,9 +224,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.userCaptureOuCountThreshold.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -235,9 +236,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.periodIdCache.name() )
             .expireAfterWrite( 24, TimeUnit.HOURS )
-            .withInitialCapacity( 200 )
+            .withInitialCapacity( (int) getActualSize( 200 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -267,7 +268,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.programOwner.name() )
             .expireAfterWrite( 5, TimeUnit.MINUTES )
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -277,7 +278,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.programTempOwner.name() )
             .expireAfterWrite( 30, TimeUnit.MINUTES )
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -287,9 +288,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.userIdCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
-            .withInitialCapacity( 200 )
+            .withInitialCapacity( (int) getActualSize( 200 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -300,7 +301,7 @@ public class DefaultCacheProvider
             .forRegion( Region.currentUserGroupInfoCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -310,7 +311,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.userSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -320,9 +321,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.attrOptionComboIdCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -332,7 +333,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.systemSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -356,9 +357,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.dataItemsPagination.name() )
             .expireAfterWrite( 5, MINUTES )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -369,7 +370,7 @@ public class DefaultCacheProvider
             .forRegion( Region.metadataAttributes.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -379,9 +380,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.canDataWriteCocCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -391,9 +392,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.analyticsSql.name() )
             .expireAfterWrite( 10, TimeUnit.HOURS )
-            .withInitialCapacity( 10000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -403,9 +404,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.dataElementCache.name() )
             .expireAfterWrite( 60, TimeUnit.MINUTES )
-            .withInitialCapacity( 1000 )
+            .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -415,9 +416,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.propertyTransformerCache.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withInitialCapacity( 20 )
+            .withInitialCapacity( (int) getActualSize( 20 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -427,9 +428,9 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.programRulesCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 20 )
+            .withInitialCapacity( (int) getActualSize( 20 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -445,9 +446,9 @@ public class DefaultCacheProvider
         return this.<V> newBuilder()
             .forRegion( Region.userGroupNameCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 20 )
+            .withInitialCapacity( (int) getActualSize( 20 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( 1000 ) )
+            .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1K ) ) )
             .build();
     }
 
@@ -457,9 +458,9 @@ public class DefaultCacheProvider
         return this.<V> newBuilder()
             .forRegion( Region.userDisplayNameCache.name() )
             .expireAfterWrite( 3, TimeUnit.HOURS )
-            .withInitialCapacity( 20 )
+            .withInitialCapacity( (int) getActualSize( 20 ) )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( 500000 ) )
+            .withMaximumSize( orZeroInTestRun( SIZE_10K ) )
             .build();
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -54,6 +54,14 @@ import com.google.api.client.util.Lists;
 public class DefaultCacheProvider
     implements CacheProvider
 {
+    private static final long SIZE_1 = 1;
+
+    private static final long SIZE_100 = 100;
+
+    private static final long SIZE_1K = 1_000;
+
+    private static final long SIZE_10K = 10_000;
+
     private final double cacheFactor;
 
     private final CacheBuilderProvider cacheBuilderProvider;
@@ -123,24 +131,9 @@ public class DefaultCacheProvider
         return cache;
     }
 
-    private long getSize1()
+    private long getSize( long size )
     {
-        return 1;
-    }
-
-    private long getSize100()
-    {
-        return (long) this.cacheFactor * 100;
-    }
-
-    private long getSize1k()
-    {
-        return (long) this.cacheFactor * 1_000;
-    }
-
-    private long getSize10k()
-    {
-        return (long) this.cacheFactor * 10_000;
+        return Math.max( (long) this.cacheFactor * size, 1 );
     }
 
     @Override
@@ -149,7 +142,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.analyticsResponse.name() )
             .expireAfterWrite( initialExpirationTime.toMillis(), MILLISECONDS )
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -174,7 +167,7 @@ public class DefaultCacheProvider
             .expireAfterAccess( 12, TimeUnit.HOURS )
             .withInitialCapacity( 4 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize100() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_100 ) ) )
             .build() );
     }
 
@@ -184,7 +177,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.isDataApproved.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -196,7 +189,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 2, TimeUnit.MINUTES )
             .withInitialCapacity( 1 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize1() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1 ) ) )
             .build() );
     }
 
@@ -208,7 +201,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -220,7 +213,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -232,7 +225,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -244,7 +237,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 24, TimeUnit.HOURS )
             .withInitialCapacity( 200 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -274,7 +267,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.programOwner.name() )
             .expireAfterWrite( 5, TimeUnit.MINUTES )
-            .withMaximumSize( orZeroInTestRun( getSize1k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -284,7 +277,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.programTempOwner.name() )
             .expireAfterWrite( 30, TimeUnit.MINUTES )
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -296,7 +289,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .withInitialCapacity( 200 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -307,7 +300,7 @@ public class DefaultCacheProvider
             .forRegion( Region.currentUserGroupInfoCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -317,7 +310,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.userSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -329,7 +322,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -339,7 +332,7 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.systemSetting.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
-            .withMaximumSize( orZeroInTestRun( getSize1k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -365,7 +358,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 5, MINUTES )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -376,7 +369,7 @@ public class DefaultCacheProvider
             .forRegion( Region.metadataAttributes.name() )
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize1k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
             .build() );
     }
 
@@ -388,7 +381,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -400,7 +393,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 10, TimeUnit.HOURS )
             .withInitialCapacity( 10000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -412,7 +405,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 60, TimeUnit.MINUTES )
             .withInitialCapacity( 1000 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -424,7 +417,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 12, TimeUnit.HOURS )
             .withInitialCapacity( 20 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize10k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_10K ) ) )
             .build() );
     }
 
@@ -436,7 +429,7 @@ public class DefaultCacheProvider
             .expireAfterWrite( 3, TimeUnit.HOURS )
             .withInitialCapacity( 20 )
             .forceInMemory()
-            .withMaximumSize( orZeroInTestRun( getSize1k() ) )
+            .withMaximumSize( orZeroInTestRun( getSize( SIZE_1K ) ) )
             .build() );
     }
 


### PR DESCRIPTION
This PR is a first attempt to reduce the impact of the cache on the JVM Heap.
A configuration has been created to tune the size of the caches in the system. For now I am guessing a default value, I think that when we have time we should understand how much memory space on the heap the caches are actually using and having this configuration based on the size of the memory used for the JVM.
For example, if the system runs with a JVM with 10G the value would be 10 and so on.
To arrive there we will need to perform some tests that will require time that at the moment we don't have before the hard freeze of the 2.36.

Any suggestion for a better name for the configuration is appreciated.