### PR TITLE
fix: hibernate cache error for user.getDisplayName

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccess.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccess.java
@@ -48,6 +48,8 @@ public class UserAccess
 {
     private String access;
 
+    private transient User user;
+
     private String uid;
 
     private String displayName;
@@ -58,6 +60,7 @@ public class UserAccess
 
     public UserAccess( User user, String access )
     {
+        this.user = user;
         this.uid = user.getUid();
         this.displayName = user.getDisplayName();
         this.access = access;
@@ -91,7 +94,7 @@ public class UserAccess
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getUserUid()
     {
-        return uid;
+        return user != null ? user.getUid() : null;
     }
 
     @JsonProperty( "id" )
@@ -99,7 +102,7 @@ public class UserAccess
     @Property( required = Property.Value.TRUE )
     public String getUid()
     {
-        return uid;
+        return uid != null ? uid : (user != null ? user.getUid() : null);
     }
 
     public void setUid( String uid )
@@ -122,16 +125,20 @@ public class UserAccess
     @JsonIgnore
     public User getUser()
     {
-        User user = new User();
-        user.setUid( uid );
+        if ( user == null )
+        {
+            User user = new User();
+            user.setUid( uid );
+            return user;
+        }
+
         return user;
     }
 
     @JsonProperty
     public void setUser( User user )
     {
-        this.uid = user.getUid();
-        this.displayName = user.getDisplayName();
+        this.user = user;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupAccess.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupAccess.java
@@ -48,6 +48,8 @@ public class UserGroupAccess
 {
     private String access;
 
+    private transient UserGroup userGroup;
+
     private String uid;
 
     private String displayName;
@@ -58,8 +60,7 @@ public class UserGroupAccess
 
     public UserGroupAccess( UserGroup userGroup, String access )
     {
-        this.uid = userGroup.getUid();
-        this.displayName = userGroup.getDisplayName();
+        this.userGroup = userGroup;
         this.access = access;
     }
 
@@ -91,7 +92,7 @@ public class UserGroupAccess
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getUserGroupUid()
     {
-        return uid;
+        return userGroup != null ? userGroup.getUid() : null;
     }
 
     @JsonProperty( "id" )
@@ -99,7 +100,7 @@ public class UserGroupAccess
     @Property( required = Property.Value.TRUE )
     public String getUid()
     {
-        return uid;
+        return uid != null ? uid : (userGroup != null ? userGroup.getUid() : null);
     }
 
     public void setUid( String uid )
@@ -122,16 +123,20 @@ public class UserGroupAccess
     @JsonIgnore
     public UserGroup getUserGroup()
     {
-        UserGroup userGroup = new UserGroup();
-        userGroup.setUid( uid );
+        if ( userGroup == null )
+        {
+            UserGroup userGroup = new UserGroup();
+            userGroup.setUid( uid );
+            return userGroup;
+        }
+
         return userGroup;
     }
 
     @JsonProperty
     public void setUserGroup( UserGroup userGroup )
     {
-        this.setUid( userGroup.getUid() );
-        this.displayName = userGroup.getDisplayName();
+        this.userGroup = userGroup;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/UserAccess.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/UserAccess.java
@@ -77,6 +77,14 @@ public class UserAccess
 
     public org.hisp.dhis.user.UserAccess toDtoObject()
     {
-        return new org.hisp.dhis.user.UserAccess( this.id, this.access );
+        org.hisp.dhis.user.UserAccess userAccess = new org.hisp.dhis.user.UserAccess();
+        userAccess.setUid( this.id );
+        userAccess.setAccess( this.access );
+        User user = new User();
+        user.setUid( this.id );
+        userAccess.setUser( user );
+        userAccess.setUid( this.id );
+
+        return userAccess;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/UserGroupAccess.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/UserGroupAccess.java
@@ -77,6 +77,14 @@ public class UserGroupAccess
 
     public org.hisp.dhis.user.UserGroupAccess toDtoObject()
     {
-        return new org.hisp.dhis.user.UserGroupAccess( this );
+        org.hisp.dhis.user.UserGroupAccess userGroupAccess = new org.hisp.dhis.user.UserGroupAccess();
+        userGroupAccess.setUid( this.id );
+        userGroupAccess.setAccess( this.access );
+        UserGroup userGroup = new UserGroup();
+        userGroup.setUid( this.id );
+        userGroupAccess.setUserGroup( userGroup );
+        userGroupAccess.setUid( this.id );
+
+        return userGroupAccess;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -27,66 +27,33 @@
  */
 package org.hisp.dhis.preheat;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.attribute.AttributeService;
-import org.hisp.dhis.category.CategoryDimension;
-import org.hisp.dhis.common.AnalyticalObject;
-import org.hisp.dhis.common.BaseAnalyticalObject;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.common.DataDimensionItem;
-import org.hisp.dhis.common.EmbeddedObject;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.commons.collection.CollectionUtils;
-import org.hisp.dhis.commons.timer.SystemTimer;
+import static com.google.common.base.Preconditions.*;
+import com.google.common.collect.*;
+import lombok.extern.slf4j.*;
+import org.apache.commons.lang3.*;
+import org.hisp.dhis.attribute.*;
+import org.hisp.dhis.category.*;
+import org.hisp.dhis.common.*;
+import org.hisp.dhis.commons.collection.*;
 import org.hisp.dhis.commons.timer.Timer;
-import org.hisp.dhis.dataelement.DataElementOperand;
-import org.hisp.dhis.dataset.DataSetElement;
-import org.hisp.dhis.hibernate.HibernateProxyUtils;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodService;
-import org.hisp.dhis.period.PeriodStore;
-import org.hisp.dhis.query.Query;
-import org.hisp.dhis.query.QueryService;
-import org.hisp.dhis.query.Restrictions;
-import org.hisp.dhis.schema.MergeParams;
-import org.hisp.dhis.schema.MergeService;
-import org.hisp.dhis.schema.Property;
-import org.hisp.dhis.schema.PropertyType;
-import org.hisp.dhis.schema.Schema;
-import org.hisp.dhis.schema.SchemaService;
-import org.hisp.dhis.system.util.ReflectionUtils;
-import org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension;
-import org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension;
-import org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserAuthorityGroup;
-import org.hisp.dhis.user.UserCredentials;
-import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.commons.timer.*;
+import org.hisp.dhis.dataelement.*;
+import org.hisp.dhis.dataset.*;
+import org.hisp.dhis.hibernate.*;
+import org.hisp.dhis.period.*;
+import org.hisp.dhis.query.*;
+import org.hisp.dhis.schema.*;
+import org.hisp.dhis.system.util.*;
+import org.hisp.dhis.trackedentity.*;
+import org.hisp.dhis.user.*;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.annotation.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
-import com.google.common.collect.Lists;
+import java.util.*;
+import java.util.stream.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -323,6 +290,7 @@ public class DefaultPreheatService implements PreheatService
 
                 if ( user != null )
                 {
+                    ua.setUser( user );
                     ua.setUid( user.getUid() );
                     ua.setDisplayName( user.getDisplayName() );
                 }
@@ -336,6 +304,7 @@ public class DefaultPreheatService implements PreheatService
 
                 if ( userGroup != null )
                 {
+                    uga.setUserGroup( userGroup );
                     uga.setUid( userGroup.getUid() );
                     uga.setDisplayName( userGroup.getDisplayName() );
                 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -28,15 +28,19 @@
 package org.hisp.dhis.preheat;
 
 import static com.google.common.base.Preconditions.*;
-import com.google.common.collect.*;
+
+import java.util.*;
+import java.util.stream.*;
+
 import lombok.extern.slf4j.*;
+
 import org.apache.commons.lang3.*;
 import org.hisp.dhis.attribute.*;
 import org.hisp.dhis.category.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.*;
-import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.commons.timer.*;
+import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.dataelement.*;
 import org.hisp.dhis.dataset.*;
 import org.hisp.dhis.hibernate.*;
@@ -52,8 +56,7 @@ import org.springframework.context.annotation.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
 
-import java.util.*;
-import java.util.stream.*;
+import com.google.common.collect.*;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -27,18 +27,13 @@
  */
 package org.hisp.dhis.user;
 
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.cache.HibernateCacheManager;
-import org.hisp.dhis.security.acl.AclService;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import static com.google.common.base.Preconditions.*;
+import org.hisp.dhis.cache.*;
+import org.hisp.dhis.security.acl.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.*;
 
 /**
  * @author Lars Helge Overland
@@ -268,6 +263,6 @@ public class DefaultUserGroupService
     public String getDisplayName( String uid )
     {
          return userGroupNameCache.get( uid,
-            n -> userGroupStore.getByUid( uid ).getDisplayName() ).orElse( null );
+            n -> userGroupStore.getByUidNoAcl( uid ).getDisplayName() ).orElse( null );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -28,12 +28,13 @@
 package org.hisp.dhis.user;
 
 import static com.google.common.base.Preconditions.*;
+
+import java.util.*;
+
 import org.hisp.dhis.cache.*;
 import org.hisp.dhis.security.acl.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
-
-import java.util.*;
 
 /**
  * @author Lars Helge Overland
@@ -262,7 +263,7 @@ public class DefaultUserGroupService
     @Transactional( readOnly = true )
     public String getDisplayName( String uid )
     {
-         return userGroupNameCache.get( uid,
+        return userGroupNameCache.get( uid,
             n -> userGroupStore.getByUidNoAcl( uid ).getDisplayName() ).orElse( null );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -27,19 +27,18 @@
  */
 package org.hisp.dhis.user;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -268,8 +267,7 @@ public class DefaultUserGroupService
     @Transactional( readOnly = true )
     public String getDisplayName( String uid )
     {
-        Optional<String> displayName = userGroupNameCache.get( uid,
-            n -> userGroupStore.getByUidNoAcl( uid ).getDisplayName() );
-        return displayName.isPresent() ? displayName.get() : null;
+         return userGroupNameCache.get( uid,
+            n -> userGroupStore.getByUid( uid ).getDisplayName() ).orElse( null );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -27,27 +27,8 @@
  */
 package org.hisp.dhis.user;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.time.ZoneId.systemDefault;
-import static java.time.ZonedDateTime.now;
-import static org.hisp.dhis.common.CodeGenerator.isValidUid;
-import static org.hisp.dhis.system.util.ValidationUtils.usernameIsValid;
-import static org.hisp.dhis.system.util.ValidationUtils.uuidIsValid;
-
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
+import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -70,7 +51,22 @@ import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.collect.Lists;
+import javax.annotation.Nullable;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.time.ZoneId.systemDefault;
+import static java.time.ZonedDateTime.now;
+import static org.hisp.dhis.common.CodeGenerator.isValidUid;
+import static org.hisp.dhis.system.util.ValidationUtils.usernameIsValid;
+import static org.hisp.dhis.system.util.ValidationUtils.uuidIsValid;
 
 /**
  * @author Chau Thu Tran
@@ -820,7 +816,6 @@ public class DefaultUserService
     @Override
     public String getDisplayName( String userUid )
     {
-        Optional<String> displayName = userDisplayNameCache.get( userUid, c -> userStore.getDisplayName( userUid ) );
-        return displayName.isPresent() ? displayName.get() : null;
+        return userDisplayNameCache.get( userUid, c -> userStore.getDisplayName( userUid ) ).orElse( null );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -27,8 +27,26 @@
  */
 package org.hisp.dhis.user;
 
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.time.ZoneId.systemDefault;
+import static java.time.ZonedDateTime.now;
+import static org.hisp.dhis.common.CodeGenerator.isValidUid;
+import static org.hisp.dhis.system.util.ValidationUtils.usernameIsValid;
+import static org.hisp.dhis.system.util.ValidationUtils.uuidIsValid;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -51,22 +69,7 @@ import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.annotation.Nullable;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.time.ZoneId.systemDefault;
-import static java.time.ZonedDateTime.now;
-import static org.hisp.dhis.common.CodeGenerator.isValidUid;
-import static org.hisp.dhis.system.util.ValidationUtils.usernameIsValid;
-import static org.hisp.dhis.system.util.ValidationUtils.uuidIsValid;
+import com.google.common.collect.Lists;
 
 /**
  * @author Chau Thu Tran

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -497,7 +497,6 @@ public class HibernateUserStore
         String sql = "select concat(firstname, ' ', surname) from userinfo where uid =:uid";
         Query<String> query = getSession().createNativeQuery( sql );
         query.setParameter( "uid", userUid );
-        query.setHint( QueryHints.CACHEABLE, true );
         return query.getSingleResult();
     }
 }


### PR DESCRIPTION
This is to fix the e2e test error `[ERROR]   TrackedEntityInstanceAclReadTests.before:78->setupUser:111->setupAccessMap:137->lambda$setupAccessMap$1:144 » IllegalState`

Issue: 
Hibernate query cache doesn't support native SQL
Cache for this query throw error `aliases expected length is 0; actual length is 1`
`String sql = "select concat(firstname, ' ', surname) from userinfo where uid =:uid";`

Fixed: 
- Turn off the query cache for that for now. The result is already cached with `Cache<String> userDisplayNameCache;` in `DefaultUserService` so should be fine.
- Also added few minor fixes for the legacy access objects to make it work with the e2e tests

*** Same fix is merged to 2.36 and all e2e tests passed there. https://github.com/dhis2/dhis2-core/pull/7578
There is still an e2e test error on master that seems not related to my fix, so we can merge this first. Then look at that error later.