### PR TITLE
fix: Prediction test timeouts for CI [DHIS2-9317]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
@@ -340,7 +340,7 @@ public class PredictionDataValueFetcherTest
             fetcher.setSemaphoreTimeout( 2, TimeUnit.MILLISECONDS );
 
             when( dataValueService.getDeflatedDataValues( any() ) ).thenAnswer( p -> {
-                Thread.sleep( 3 );
+                Thread.sleep( 100 );
                 return null;
             } );
 
@@ -367,7 +367,7 @@ public class PredictionDataValueFetcherTest
 
             fetcher.getDataValues( orgUnitA );
 
-            Thread.sleep( 3 );
+            Thread.sleep( 100 );
         }
         catch ( Exception ex )
         {
@@ -494,6 +494,6 @@ public class PredictionDataValueFetcherTest
             throw new RuntimeException( "Could not acquire semaphore." );
         }
 
-        Thread.sleep( 10 ); // Milliseconds.
+        Thread.sleep( 200 ); // Milliseconds.
     }
 }


### PR DESCRIPTION
This is an additional commit for [DHIS2-9317](https://jira.dhis2.org/browse/DHIS2-9317), extending some of the timeouts and sleep times in PredictionDataValueFetcherTest that were causing problems in slow CI environments:

- In _testTimeoutWaitingForProducer_ and _testTimeoutWaitingForConsumer_, increase the sleep time from 3 ms to 100 ms. The only requirement for this time is that the sleeping thread must sleep longer than the other thread, which is polling for a semaphore with a timeout of 2 ms. In tests on faster servers the 2 ms timeout always timed out before the 3 second sleep, but on a CI server it sometimes did not. Hopefully the 2 ms timeout will always time out before the 100 ms sleep. This will add 97 ms to each of these 2 tests.
- In _waitForTheOtherThread_, increase the sleep from 10 ms to 200 ms. This is the time required for the other thread to call a method after releasing the semaphore (just a couple of Java statements). On faster servers 10 ms was always sufficient, but on a CI server sometimes not. This method is called twice by _testGetDataValuesWithFastDb_ and twice by _testGetDataValuesWithSlowDb_, so this will add 190 * 2 = 380 ms to each of these two tests.

We could lengthen these sleeps even more, but it would add even more to the test every time it is run.