### PR TITLE
ci: run api tests unless explicitly skipped

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -1,8 +1,6 @@
 name: Run api tests
 
-on:
-  pull_request:
-    types: [ synchronize ]
+on: [ pull_request ]
 jobs:
   api-test:
     env:

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -1,7 +1,17 @@
 name: Run api tests
 
-on: [ pull_request ]
+on:
+  pull_request: 
+    types: [ labeled, synchronize ]
 jobs:
+  cleanup-runs:
+   runs-on: ubuntu-latest
+   steps:
+   - uses: rokroskar/workflow-run-cleanup-action@master
+     env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+     
   api-test:
     env:
       CORE_IMAGE_NAME: "dhis2/core:local"

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -2,14 +2,14 @@ name: Run api tests
 
 on:
   pull_request:
-    types: [labeled, synchronize ]
+    types: [ synchronize ]
 jobs:
   api-test:
     env:
       CORE_IMAGE_NAME: "dhis2/core:local"
       TEST_IMAGE_NAME: "dhis2/tests:local"
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'run-api-tests')
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-api-tests')"
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11


### PR DESCRIPTION
Until now, we ran the API tests only when label run-api-tests was added. It's easy to forget about the label, so this would sometimes lead to tests broken on master. 

This PR changes that behavior and now API tests will run on all PRs unless label [skip-api-tests] is added.  When the label is added, workflows that were already running will be canceled. 