### PR TITLE
fix: Correctly cast the size of the caches in the cache provider

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -134,7 +134,7 @@ public class DefaultCacheProvider
 
     private long getActualSize( long size )
     {
-        return Math.max( (long) this.cacheFactor * size, 1 );
+        return (long) Math.max( this.cacheFactor * size, 1 );
     }
 
     @Override


### PR DESCRIPTION
A silly mistake on cast precedence was making all the cache to have size 1.