### PR TITLE
test: make JsonNode available in JsonValue access abstraction

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonArray.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonArray.java
@@ -115,12 +115,12 @@ public interface JsonArray extends JsonCollection
 
     default <E extends JsonValue> JsonList<E> getList( int index, Class<E> as )
     {
-        return asList( getArray( index ), as );
+        return JsonCollection.asList( getArray( index ), as );
     }
 
     default <E extends JsonValue> JsonMap<E> getMap( int index, Class<E> as )
     {
-        return asMap( getObject( index ), as );
+        return JsonCollection.asMap( getObject( index ), as );
     }
 
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonCollection.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonCollection.java
@@ -66,7 +66,7 @@ public interface JsonCollection extends JsonValue
      */
     int size();
 
-    default <E extends JsonValue> JsonList<E> asList( JsonArray array, Class<E> as )
+    static <E extends JsonValue> JsonList<E> asList( JsonArray array, Class<E> as )
     {
         class ListView extends CollectionView<JsonArray> implements JsonList<E>
         {
@@ -84,7 +84,7 @@ public interface JsonCollection extends JsonValue
         return new ListView( array );
     }
 
-    default <E extends JsonValue> JsonMap<E> asMap( JsonObject object, Class<E> as )
+    static <E extends JsonValue> JsonMap<E> asMap( JsonObject object, Class<E> as )
     {
         class MapView extends CollectionView<JsonObject> implements JsonMap<E>
         {
@@ -109,6 +109,12 @@ public interface JsonCollection extends JsonValue
         protected CollectionView( T viewed )
         {
             this.viewed = viewed;
+        }
+
+        @Override
+        public final JsonNode node()
+        {
+            return viewed.node();
         }
 
         @Override
@@ -151,6 +157,12 @@ public interface JsonCollection extends JsonValue
         public final <V extends JsonValue> V as( Class<V> as )
         {
             return viewed.as( as );
+        }
+
+        @Override
+        public final String toString()
+        {
+            return viewed.toString();
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonDocument.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonDocument.java
@@ -118,102 +118,6 @@ public final class JsonDocument implements Serializable
     }
 
     /**
-     * API of a JSON tree as it actually exist.
-     *
-     * Operations are lazily evaluated to make working with the JSON tree
-     * efficient.
-     */
-    public interface JsonNode extends Serializable
-    {
-        /**
-         * @return the type of the node as derived from the node beginning
-         */
-        JsonNodeType getType();
-
-        /**
-         * @return path within the overall content this node represents
-         */
-        String getPath();
-
-        /**
-         * @return the plain JSON of this node as defined in the overall content
-         */
-        String getDeclaration();
-
-        /**
-         * @return number of elements in an array or number of fields in an
-         *         object, otherwise undefined
-         * @throws UnsupportedOperationException when this node in neither an
-         *         array nor an object
-         */
-        default int size()
-        {
-            throw new UnsupportedOperationException( getType() + " node has no size property." );
-        }
-
-        /**
-         * @return true if an array or object has no elements/fields, otherwise
-         *         undefined
-         * @throws UnsupportedOperationException when this node in neither an
-         *         array nor an object
-         */
-        default boolean isEmpty()
-        {
-            throw new UnsupportedOperationException( getType() + " node has no empty property." );
-        }
-
-        /**
-         * The value depends on the {@link #getType()}:
-         * <ul>
-         * <li>{@link JsonNodeType#NULL} returns {@code null}</li>
-         * <li>{@link JsonNodeType#BOOLEAN} returns {@link Boolean}</li>
-         * <li>{@link JsonNodeType#STRING} returns {@link String}</li>
-         * <li>{@link JsonNodeType#NUMBER} returns either {@link Integer},
-         * {@link Long} or {@link Double}</li>
-         * <li>{@link JsonNodeType#ARRAY} returns an {@link java.util.List} of
-         * {@link JsonNode}</li>
-         * <li>{@link JsonNodeType#ARRAY} returns a {@link Map} or
-         * {@link String} keys and {@link JsonNode} values</li>
-         * </ul>
-         *
-         * @return the nodes values as described in the above table
-         */
-        Serializable value();
-
-        /**
-         * @return this {@link #value()} as as {@link Map} (only defined when
-         *         this node is of type {@link JsonNodeType#OBJECT}).
-         */
-        @SuppressWarnings( "unchecked" )
-        default Map<String, JsonNode> object()
-        {
-            return (Map<String, JsonNode>) value();
-        }
-
-        /**
-         * @return this {@link #value()} as as {@link List} (only defined when
-         *         this node is of type {@link JsonNodeType#ARRAY}).
-         */
-        @SuppressWarnings( "unchecked" )
-        default List<JsonNode> array()
-        {
-            return (List<JsonNode>) value();
-        }
-
-        /**
-         * @return offset or index in the overall content where this node starts
-         *         (inclusive, points to first index that belongs to the node)
-         */
-        int startIndex();
-
-        /**
-         * @return offset or index in the overall content where this node ends
-         *         (exclusive, points to first index after the node)
-         */
-        int endIndex();
-    }
-
-    /**
      * The main idea of lazy nodes is that at creation only the start index and
      * the path the node represents is known.
      *
@@ -335,6 +239,13 @@ public final class JsonDocument implements Serializable
             return JsonNodeType.OBJECT;
         }
 
+        @SuppressWarnings( "unchecked" )
+        @Override
+        public Map<String, JsonNode> members()
+        {
+            return (Map<String, JsonNode>) value();
+        }
+
         @Override
         public boolean isEmpty()
         {
@@ -346,7 +257,7 @@ public final class JsonDocument implements Serializable
         public int size()
         {
             // only compute value when needed
-            return isEmpty() ? 0 : object().size();
+            return isEmpty() ? 0 : members().size();
         }
 
         @Override
@@ -389,6 +300,13 @@ public final class JsonDocument implements Serializable
             return JsonNodeType.ARRAY;
         }
 
+        @SuppressWarnings( "unchecked" )
+        @Override
+        public List<JsonNode> elements()
+        {
+            return (List<JsonNode>) value();
+        }
+
         @Override
         public boolean isEmpty()
         {
@@ -400,7 +318,7 @@ public final class JsonDocument implements Serializable
         public int size()
         {
             // only compute value when needed
-            return isEmpty() ? 0 : array().size();
+            return isEmpty() ? 0 : elements().size();
         }
 
         @Override
@@ -569,7 +487,7 @@ public final class JsonDocument implements Serializable
         @Override
         Serializable parseValue()
         {
-            skipBoolean( json, start );
+            skipNull( json, start );
             return null;
         }
     }
@@ -619,19 +537,19 @@ public final class JsonDocument implements Serializable
             if ( pathToGo.startsWith( "[" ) )
             {
                 checkNodeIs( parent, JsonNodeType.ARRAY, path );
-                List<JsonNode> array = parent.array();
+                List<JsonNode> elements = parent.elements();
                 int index = parseInt( pathToGo.substring( 1, pathToGo.indexOf( ']' ) ) );
-                checkIndexExists( parent, array, index, path );
-                parent = array.get( index );
+                checkIndexExists( parent, elements, index, path );
+                parent = elements.get( index );
                 pathToGo = pathToGo.substring( pathToGo.indexOf( ']' ) + 1 );
             }
             else if ( pathToGo.startsWith( "." ) )
             {
                 checkNodeIs( parent, JsonNodeType.OBJECT, path );
-                Map<String, JsonNode> object = parent.object();
+                Map<String, JsonNode> members = parent.members();
                 String property = getHeadProperty( pathToGo );
-                checkFieldExists( parent, object, property, path );
-                parent = object.get( property );
+                checkFieldExists( parent, members, property, path );
+                parent = members.get( property );
                 pathToGo = pathToGo.substring( 1 + property.length() );
             }
             else

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonNode.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonNode.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.webapi.json.JsonDocument.JsonNodeType;
+
+/**
+ * API of a JSON tree as it actually exist in a HTTP response with a JSON
+ * payload.
+ * <p>
+ * Operations are lazily evaluated to make working with the JSON tree efficient.
+ *
+ * Trying use operations that are not supported for the {@link JsonNodeType},
+ * like access the {@link #members()} or {@link #elements()} of a node that is
+ * not an object or array respectively, will throw an
+ * {@link UnsupportedOperationException} error immediately.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonNode extends Serializable
+{
+    /**
+     * @return the type of the node as derived from the node beginning
+     */
+    JsonNodeType getType();
+
+    /**
+     * Size of an array of number of object members.
+     *
+     * This is preferable to calling {@link #value()} or {@link #members()} or
+     * {@link #elements()} when size is only property of interest as it might
+     * have better performance.
+     *
+     * @return number of elements in an array or number of fields in an object,
+     *         otherwise undefined
+     * @throws UnsupportedOperationException when this node in neither an array
+     *         nor an object
+     */
+    default int size()
+    {
+        throw new UnsupportedOperationException( getType() + " node has no size property." );
+    }
+
+    /**
+     * Whether or not an array or object has no elements or members.
+     *
+     * This is preferable to calling {@link #value()} or {@link #members()} or
+     * {@link #elements()} when emptiness is only property of interest as it
+     * might have better performance.
+     *
+     * @return true if an array or object has no elements/fields, otherwise
+     *         undefined
+     * @throws UnsupportedOperationException when this node in neither an array
+     *         nor an object
+     */
+    default boolean isEmpty()
+    {
+        throw new UnsupportedOperationException( getType() + " node has no empty property." );
+    }
+
+    /**
+     * The value depends on the {@link #getType()}:
+     * <ul>
+     * <li>{@link JsonNodeType#NULL} returns {@code null}</li>
+     * <li>{@link JsonNodeType#BOOLEAN} returns {@link Boolean}</li>
+     * <li>{@link JsonNodeType#STRING} returns {@link String}</li>
+     * <li>{@link JsonNodeType#NUMBER} returns either {@link Integer},
+     * {@link Long} or {@link Double}</li>
+     * <li>{@link JsonNodeType#ARRAY} returns an {@link java.util.List} of
+     * {@link JsonNode}</li>
+     * <li>{@link JsonNodeType#ARRAY} returns a {@link Map} or {@link String}
+     * keys and {@link JsonNode} values</li>
+     * </ul>
+     *
+     * @return the nodes values as described in the above table
+     */
+    Serializable value();
+
+    /**
+     * OBS! Only defined when this node is of type {@link JsonNodeType#OBJECT})
+     *
+     * @return this {@link #value()} as as {@link Map}
+     */
+    default Map<String, JsonNode> members()
+    {
+        throw new UnsupportedOperationException( getType() + " node has no members property." );
+    }
+
+    /**
+     * OBS! Only defined when this node is of type {@link JsonNodeType#ARRAY}).
+     *
+     * @return this {@link #value()} as as {@link List}
+     */
+    default List<JsonNode> elements()
+    {
+        throw new UnsupportedOperationException( getType() + " node has no elements property." );
+    }
+
+    /*
+     * API about this node in the context of the underlying JSON document
+     */
+
+    /**
+     * @return path within the overall content this node represents
+     */
+    String getPath();
+
+    /**
+     * @return the plain JSON of this node as defined in the overall content
+     */
+    String getDeclaration();
+
+    /**
+     * @return offset or index in the overall content where this node starts
+     *         (inclusive, points to first index that belongs to the node)
+     */
+    int startIndex();
+
+    /**
+     * @return offset or index in the overall content where this node ends
+     *         (exclusive, points to first index after the node)
+     */
+    int endIndex();
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
@@ -54,9 +54,12 @@ public interface JsonObject extends JsonCollection
     <T extends JsonValue> T get( String name, Class<T> as );
 
     /**
+     * Test an object for member names.
      *
-     * @param names a set of names that should exist
+     * @param names a set of member names that should exist
      * @return true if this object has (at least) all the given names
+     * @throws UnsupportedOperationException in case this value is not an JSON
+     *         object
      */
     boolean has( String... names );
 
@@ -92,12 +95,12 @@ public interface JsonObject extends JsonCollection
 
     default <E extends JsonValue> JsonList<E> getList( String name, Class<E> as )
     {
-        return asList( getArray( name ), as );
+        return JsonCollection.asList( getArray( name ), as );
     }
 
     default <E extends JsonValue> JsonMap<E> getMap( String name, Class<E> as )
     {
-        return asMap( getObject( name ), as );
+        return JsonCollection.asMap( getObject( name ), as );
     }
 
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonResponse.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonResponse.java
@@ -44,7 +44,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.hisp.dhis.webapi.json.JsonDocument.JsonFormatException;
-import org.hisp.dhis.webapi.json.JsonDocument.JsonNode;
 import org.hisp.dhis.webapi.json.JsonDocument.JsonNodeType;
 import org.hisp.dhis.webapi.json.JsonDocument.JsonPathException;
 
@@ -99,7 +98,8 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
             if ( node.getType() != expected )
             {
                 throw new UnsupportedOperationException(
-                    String.format( "Path %s does not contain a %s but %s", path, expected, node ) );
+                    String.format( "Path `%s` does not contain a %s but a(n) %s: %s",
+                        path, expected, node.getType(), node ) );
             }
             return get.apply( node );
         }
@@ -168,6 +168,12 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     }
 
     @Override
+    public JsonNode node()
+    {
+        return value();
+    }
+
+    @Override
     public boolean isEmpty()
     {
         return value().isEmpty();
@@ -176,7 +182,8 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     @Override
     public boolean has( String... names )
     {
-        return value( JsonNodeType.OBJECT, node -> node.object().keySet().containsAll( Arrays.asList( names ) ),
+        return value( JsonNodeType.OBJECT,
+            node -> node.members().keySet().containsAll( Arrays.asList( names ) ),
             ex -> false );
     }
 
@@ -203,7 +210,7 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     {
         return value( JsonNodeType.ARRAY, node -> {
             List<T> res = new ArrayList<>();
-            for ( JsonNode e : node.array() )
+            for ( JsonNode e : node.elements() )
             {
                 Object value = e.value();
                 if ( !elementType.isInstance( value ) )
@@ -294,7 +301,7 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
         }
         catch ( JsonPathException | JsonFormatException ex )
         {
-            return path + " in " + content;
+            return ex.getMessage();
         }
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonValue.java
@@ -59,10 +59,11 @@ package org.hisp.dhis.webapi.json;
  * implemented by this class are dynamically created using a
  * {@link java.lang.reflect.Proxy}.</li>
  * </ul>
+ *
+ * @author Jan Bernitt
  */
 public interface JsonValue
 {
-
     /**
      * A property exists when it is part of the JSON response. This means it can
      * be declared JSON {@code null}. Only a path that does not exist returns
@@ -75,7 +76,7 @@ public interface JsonValue
     /**
      * @return true if the value exists and is defined JSON {@code null}
      * @throws java.util.NoSuchElementException in case this value does not
-     *         exist in the content
+     *         exist in the JSON document
      */
     boolean isNull();
 
@@ -83,7 +84,7 @@ public interface JsonValue
      * @return true if the value exists and is a JSON array node (empty or not)
      *         but not JSON {@code null}
      * @throws java.util.NoSuchElementException in case this value does not
-     *         exist in the content
+     *         exist in the JSON document
      */
     boolean isArray();
 
@@ -91,7 +92,7 @@ public interface JsonValue
      * @return true if the value exists and is an JSON object node (empty or
      *         not) but not JSON {@code null}
      * @throws java.util.NoSuchElementException in case this value does not
-     *         exist in the content
+     *         exist in the JSON document
      */
     boolean isObject();
 
@@ -109,4 +110,42 @@ public interface JsonValue
      *         wrapped as the provided type or literally cast.
      */
     <T extends JsonValue> T as( Class<T> as );
+
+    /**
+     * This value as a list of uniform elements (view on JSON array).
+     *
+     * @param elementType assumed value element type
+     * @param <E> type of list elements
+     * @return list view of this value (assumes array)
+     */
+    default <E extends JsonValue> JsonList<E> asList( Class<E> elementType )
+    {
+        return JsonCollection.asList( as( JsonArray.class ), elementType );
+    }
+
+    /**
+     * This value as map of uniform values (view on JSON object).
+     *
+     * @param valueType assumed map value type
+     * @param <V> type of map values
+     * @return map view of this value (assumes object)
+     */
+    default <V extends JsonValue> JsonMap<V> asMap( Class<V> valueType )
+    {
+        return JsonCollection.asMap( as( JsonObject.class ), valueType );
+    }
+
+    /**
+     * Access the node in the JSON document. This can be the low level API that
+     * is concerned with extraction by path.
+     *
+     * This might be useful in test to access the
+     * {@link JsonNode#getDeclaration()} to modify and reuse it.
+     *
+     * @return the underlying {@link JsonNode} in the overall JSON document if
+     *         it exists
+     * @throws java.util.NoSuchElementException in case this value does not
+     *         exist in the JSON document
+     */
+    JsonNode node();
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonPath.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonPath.java
@@ -27,8 +27,7 @@
  */
 package org.hisp.dhis.webapi.json.domain;
 
-import static java.util.Arrays.asList;
-
+import java.util.Arrays;
 import java.util.List;
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -50,7 +49,7 @@ public interface JsonPath extends JsonString
 {
     default List<String> ids()
     {
-        return parsed( str -> asList( str.split( "/" ) ) );
+        return parsed( str -> Arrays.asList( str.split( "/" ) ) );
     }
 
     default boolean contains( String uid )

--- a/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonDocumentTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonDocumentTest.java
@@ -37,7 +37,6 @@ import java.util.HashSet;
 import java.util.Map;
 
 import org.hisp.dhis.webapi.json.JsonDocument.JsonFormatException;
-import org.hisp.dhis.webapi.json.JsonDocument.JsonNode;
 import org.hisp.dhis.webapi.json.JsonDocument.JsonNodeType;
 import org.hisp.dhis.webapi.json.JsonDocument.JsonPathException;
 import org.junit.Test;
@@ -50,7 +49,6 @@ import org.junit.Test;
  */
 public class JsonDocumentTest
 {
-
     @Test
     public void testStringNode()
     {
@@ -87,6 +85,10 @@ public class JsonDocumentTest
         assertEquals( "STRING node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
         assertEquals( "STRING node has no size property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::elements );
+        assertEquals( "STRING node has no elements property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::members );
+        assertEquals( "STRING node has no members property.", ex.getMessage() );
     }
 
     @Test
@@ -113,6 +115,10 @@ public class JsonDocumentTest
         assertEquals( "NUMBER node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
         assertEquals( "NUMBER node has no size property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::elements );
+        assertEquals( "NUMBER node has no elements property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::members );
+        assertEquals( "NUMBER node has no members property.", ex.getMessage() );
     }
 
     @Test
@@ -147,6 +153,10 @@ public class JsonDocumentTest
         assertEquals( "BOOLEAN node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
         assertEquals( "BOOLEAN node has no size property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::elements );
+        assertEquals( "BOOLEAN node has no elements property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::members );
+        assertEquals( "BOOLEAN node has no members property.", ex.getMessage() );
     }
 
     @Test
@@ -166,6 +176,20 @@ public class JsonDocumentTest
     }
 
     @Test
+    public void testNullNode_Unsupported()
+    {
+        JsonNode node = new JsonDocument( "null" ).get( "$" );
+        Exception ex = assertThrows( UnsupportedOperationException.class, node::isEmpty );
+        assertEquals( "NULL node has no empty property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::size );
+        assertEquals( "NULL node has no size property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::elements );
+        assertEquals( "NULL node has no elements property.", ex.getMessage() );
+        ex = assertThrows( UnsupportedOperationException.class, node::members );
+        assertEquals( "NULL node has no members property.", ex.getMessage() );
+    }
+
+    @Test
     public void testArray_Numbers()
     {
         JsonNode node = new JsonDocument( "[1, 2 ,3]" ).get( "$" );
@@ -175,14 +199,22 @@ public class JsonDocumentTest
     }
 
     @Test
+    public void testArray_Unsupported()
+    {
+        JsonNode node = new JsonDocument( "[]" ).get( "$" );
+        Exception ex = assertThrows( UnsupportedOperationException.class, node::members );
+        assertEquals( "ARRAY node has no members property.", ex.getMessage() );
+    }
+
+    @Test
     public void testObject_Flat()
     {
         JsonNode root = new JsonDocument( "{\"a\":1, \"bb\":true , \"ccc\":null }" ).get( "$" );
         assertEquals( JsonNodeType.OBJECT, root.getType() );
         assertFalse( root.isEmpty() );
         assertEquals( 3, root.size() );
-        Map<String, JsonNode> value = root.object();
-        assertEquals( new HashSet<>( asList( "a", "bb", "ccc" ) ), value.keySet() );
+        Map<String, JsonNode> members = root.members();
+        assertEquals( new HashSet<>( asList( "a", "bb", "ccc" ) ), members.keySet() );
     }
 
     @Test
@@ -246,6 +278,14 @@ public class JsonDocumentTest
     }
 
     @Test
+    public void testObject_Unsupported()
+    {
+        JsonNode node = new JsonDocument( "{}" ).get( "$" );
+        Exception ex = assertThrows( UnsupportedOperationException.class, node::elements );
+        assertEquals( "OBJECT node has no elements property.", ex.getMessage() );
+    }
+
+    @Test
     public void testObject_NoSuchProperty()
     {
         JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
@@ -293,5 +333,13 @@ public class JsonDocumentTest
         JsonFormatException ex = assertThrows( JsonFormatException.class, () -> doc.get( ".a" ) );
         assertEquals( "Unexpected character at position 6,\n" + "{\"a\": hello }\n" + "      ^ expected start of value",
             ex.getMessage() );
+    }
+
+    @Test
+    public void testNull()
+    {
+        JsonNode node = new JsonDocument( "null" ).get( "$" );
+        assertEquals( JsonNodeType.NULL, node.getType() );
+        assertNull( node.value() );
     }
 }


### PR DESCRIPTION
It dawned on me that we can now make the `JsonNode` available in `JsonValue` giving access to the actual document content during tests and also making for a nicer debugging experience. So this PR moves the `JsonNode` interface to a top level file and improves the consistency of the semantics and `toString()` as well as covering this with more tests.

This PR changes test code only and does not change any application code.