### PR TITLE
fix: Fixing 'access' for charts and report tables [DHIS2-10674]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/ConversionHelper.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/ConversionHelper.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.visualization;
 
 import static java.util.Arrays.asList;
@@ -21,7 +48,7 @@ import org.hisp.dhis.reporttable.ReportTable;
  * Such conversions are needed to keep backward compatibility across
  * ReportTable, Chart and Visualization. It's just a temporary class an should
  * be removed as soon as ReportTable and Chart are remove from the codebase.
- * 
+ *
  * @author maikel arabori
  */
 @Deprecated

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/ConversionHelper.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/ConversionHelper.java
@@ -1,0 +1,213 @@
+package org.hisp.dhis.visualization;
+
+import static java.util.Arrays.asList;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
+import static org.hisp.dhis.visualization.VisualizationType.valueOf;
+import static org.springframework.beans.BeanUtils.copyProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.chart.Chart;
+import org.hisp.dhis.chart.ChartType;
+import org.hisp.dhis.chart.Series;
+import org.hisp.dhis.reporttable.ReportParams;
+import org.hisp.dhis.reporttable.ReportTable;
+
+/**
+ * This is just a helper class responsible for converting from/to Visualization.
+ * Such conversions are needed to keep backward compatibility across
+ * ReportTable, Chart and Visualization. It's just a temporary class an should
+ * be removed as soon as ReportTable and Chart are remove from the codebase.
+ * 
+ * @author maikel arabori
+ */
+@Deprecated
+public class ConversionHelper
+{
+    public static List<Chart> convertToChartList( List<Visualization> entities )
+    {
+        final List<Chart> charts = new ArrayList<>();
+
+        if ( isNotEmpty( entities ) )
+        {
+            for ( final Visualization visualization : entities )
+            {
+                final Chart chart = new Chart();
+                copyProperties( visualization, chart, "type" );
+
+                // Consider only Visualization type that is a Chart
+                if ( visualization.getType() != null )
+                {
+                    // Set the correct type
+                    chart.setType( ChartType.valueOf( visualization.getType().name() ) );
+
+                    // Copy seriesItems
+                    if ( isNotEmpty( visualization.getOptionalAxes() ) )
+                    {
+                        final List<Series> seriesItems = new ArrayList<>();
+                        final List<Axis> axes = visualization.getOptionalAxes();
+
+                        for ( final Axis axis : axes )
+                        {
+                            final Series series = new Series();
+                            series.setSeries( axis.getDimensionalItem() );
+                            series.setAxis( axis.getAxis() );
+                            series.setId( axis.getId() );
+
+                            seriesItems.add( series );
+                        }
+                        chart.setSeriesItems( seriesItems );
+                    }
+
+                    // Copy column into series
+                    if ( isNotEmpty( visualization.getColumnDimensions() ) )
+                    {
+                        final List<String> columns = visualization.getColumnDimensions();
+                        chart.setSeries( columns.get( 0 ) );
+                    }
+
+                    // Copy rows into category
+                    if ( isNotEmpty( visualization.getRowDimensions() ) )
+                    {
+                        final List<String> rows = visualization.getRowDimensions();
+                        chart.setCategory( rows.get( 0 ) );
+                    }
+
+                    chart.setCumulativeValues( visualization.isCumulativeValues() );
+                    charts.add( chart );
+                }
+            }
+        }
+
+        return charts;
+    }
+
+    public static Visualization convertToVisualization( final Chart chart )
+    {
+        final Visualization visualization = new Visualization();
+
+        if ( chart != null )
+        {
+            copyProperties( chart, visualization );
+
+            if ( chart.getType() != null )
+            {
+                visualization.setType( valueOf( chart.getType().name() ) );
+            }
+
+            // Copy seriesItems
+            if ( isNotEmpty( chart.getSeriesItems() ) )
+            {
+                final List<Series> seriesItems = chart.getSeriesItems();
+                final List<Axis> axes = visualization.getOptionalAxes();
+
+                for ( final Series seriesItem : seriesItems )
+                {
+                    final Axis axis = new Axis();
+                    axis.setDimensionalItem( seriesItem.getSeries() );
+                    axis.setAxis( seriesItem.getAxis() );
+                    axis.setId( seriesItem.getId() );
+
+                    axes.add( axis );
+                }
+                visualization.setOptionalAxes( axes );
+            }
+
+            // Add series into columns
+            if ( !StringUtils.isEmpty( chart.getSeries() ) )
+            {
+                if ( visualization.getColumnDimensions() != null )
+                {
+                    visualization.getColumnDimensions().add( chart.getSeries() );
+                }
+                else
+                {
+                    visualization.setColumnDimensions( asList( chart.getSeries() ) );
+                }
+            }
+
+            // Add category into rows
+            if ( !StringUtils.isEmpty( chart.getCategory() ) )
+            {
+                if ( visualization.getRowDimensions() != null )
+                {
+                    visualization.getRowDimensions().add( chart.getCategory() );
+                }
+                else
+                {
+                    visualization.setRowDimensions( asList( chart.getCategory() ) );
+                }
+            }
+
+            visualization.setCumulativeValues( chart.isCumulativeValues() );
+        }
+
+        return visualization;
+    }
+
+    public static List<ReportTable> convertToReportTableList( List<Visualization> entities )
+    {
+        List<ReportTable> reportTables = new ArrayList<>();
+
+        if ( isNotEmpty( entities ) )
+        {
+            for ( final Visualization visualization : entities )
+            {
+                if ( visualization.getType() != null )
+                {
+                    final ReportTable reportTable = new ReportTable();
+                    copyProperties( visualization, reportTable );
+
+                    // Copy report params
+                    if ( visualization.hasReportingParams() )
+                    {
+                        final ReportingParams reportingParams = visualization.getReportingParams();
+                        final ReportParams reportParams = new ReportParams();
+
+                        reportParams
+                            .setParamGrandParentOrganisationUnit( reportingParams.isGrandParentOrganisationUnit() );
+                        reportParams.setParamOrganisationUnit( reportingParams.isOrganisationUnit() );
+                        reportParams.setParamParentOrganisationUnit( reportingParams.isParentOrganisationUnit() );
+                        reportParams.setParamReportingMonth( reportingParams.isReportingPeriod() );
+
+                        reportTable.setReportParams( reportParams );
+                    }
+
+                    reportTables.add( reportTable );
+                }
+            }
+        }
+
+        return reportTables;
+    }
+
+    public static Visualization convertToVisualization( final ReportTable reportTable )
+    {
+        final Visualization visualization = new Visualization();
+
+        if ( reportTable != null )
+        {
+            copyProperties( reportTable, visualization );
+            visualization.setType( PIVOT_TABLE );
+
+            // Copy report params
+            if ( reportTable.hasReportParams() )
+            {
+                final ReportingParams reportingParams = new ReportingParams();
+                final ReportParams reportParams = reportTable.getReportParams();
+
+                reportingParams.setGrandParentOrganisationUnit( reportParams.isParamGrandParentOrganisationUnit() );
+                reportingParams.setOrganisationUnit( reportParams.isParamOrganisationUnit() );
+                reportingParams.setParentOrganisationUnit( reportParams.isParamParentOrganisationUnit() );
+                reportingParams.setReportingPeriod( reportParams.isParamReportingMonth() );
+
+                visualization.setReportingParams( reportingParams );
+            }
+        }
+
+        return visualization;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.fieldfilter;
 
 import static java.beans.Introspector.decapitalize;
+import static org.hisp.dhis.visualization.ConversionHelper.convertToVisualization;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -47,14 +48,13 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.chart.Chart;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -68,6 +68,7 @@ import org.hisp.dhis.node.types.ComplexNode;
 import org.hisp.dhis.node.types.SimpleNode;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.reporttable.ReportTable;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.PropertyTransformer;
 import org.hisp.dhis.schema.Schema;
@@ -81,6 +82,7 @@ import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserGroupAccess;
 import org.hisp.dhis.user.UserGroupService;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.visualization.Visualization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -89,6 +91,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -381,8 +385,29 @@ public class DefaultFieldFilterService implements FieldFilterService
         updateFields( fieldMap, schema.getKlass() );
 
         if ( fieldMap.containsKey( "access" ) && schema.isIdentifiableObject() )
-        {
-            ((BaseIdentifiableObject) object).setAccess( aclService.getAccess( (IdentifiableObject) object, user ) );
+        {   
+            // These checks for Chart and ReportTable are needed to keep the
+            // backward compatibility with Visualization. Should be removed once
+            // Chart and ReportTable are gone.
+            if ( object instanceof Chart )
+            {
+                final Visualization visualization = convertToVisualization( (Chart) object );
+
+                ((BaseIdentifiableObject) object)
+                    .setAccess( aclService.getAccess( visualization, user ) );
+            }
+            else if ( object instanceof ReportTable )
+            {
+                final Visualization visualization = convertToVisualization( (ReportTable) object );
+
+                ((BaseIdentifiableObject) object)
+                    .setAccess( aclService.getAccess( visualization, user ) );
+            }
+            else
+            {
+                ((BaseIdentifiableObject) object)
+                    .setAccess( aclService.getAccess( (IdentifiableObject) object, user ) );
+            }
         }
 
         if ( fieldMap.containsKey( "attribute" ) && AttributeValue.class.isAssignableFrom( object.getClass() ) )

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -48,6 +48,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
@@ -91,8 +93,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -385,7 +385,7 @@ public class DefaultFieldFilterService implements FieldFilterService
         updateFields( fieldMap, schema.getKlass() );
 
         if ( fieldMap.containsKey( "access" ) && schema.isIdentifiableObject() )
-        {   
+        {
             // These checks for Chart and ReportTable are needed to keep the
             // backward compatibility with Visualization. Should be removed once
             // Chart and ReportTable are gone.

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -27,9 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.visualization.ConversionHelper.convertToReportTableList;
+import static org.hisp.dhis.visualization.ConversionHelper.convertToVisualization;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 import static org.hisp.dhis.webapi.utils.PaginationUtils.getPaginationData;
-import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -97,7 +98,6 @@ import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.reporttable.ReportParams;
 import org.hisp.dhis.reporttable.ReportTable;
 import org.hisp.dhis.schema.MergeService;
 import org.hisp.dhis.schema.Property;
@@ -109,7 +109,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
-import org.hisp.dhis.visualization.ReportingParams;
 import org.hisp.dhis.visualization.Visualization;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
@@ -118,7 +117,6 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.CacheControl;
@@ -1230,67 +1228,6 @@ public abstract class ReportTableFacadeController
         }
 
         return null;
-    }
-
-    private Visualization convertToVisualization( final ReportTable reportTable )
-    {
-        final Visualization visualization = new Visualization();
-
-        if ( reportTable != null )
-        {
-            copyProperties( reportTable, visualization );
-            visualization.setType( PIVOT_TABLE );
-
-            // Copy report params
-            if ( reportTable.hasReportParams() )
-            {
-                final ReportingParams reportingParams = new ReportingParams();
-                final ReportParams reportParams = reportTable.getReportParams();
-
-                reportingParams.setGrandParentOrganisationUnit( reportParams.isParamGrandParentOrganisationUnit() );
-                reportingParams.setOrganisationUnit( reportParams.isParamOrganisationUnit() );
-                reportingParams.setParentOrganisationUnit( reportParams.isParamParentOrganisationUnit() );
-                reportingParams.setReportingPeriod( reportParams.isParamReportingMonth() );
-
-                visualization.setReportingParams( reportingParams );
-            }
-        }
-        return visualization;
-    }
-
-    private List<ReportTable> convertToReportTableList( List<Visualization> entities )
-    {
-        List<ReportTable> reportTables = new ArrayList<>();
-
-        if ( CollectionUtils.isNotEmpty( entities ) )
-        {
-            for ( final Visualization visualization : entities )
-            {
-                if ( visualization.getType() != null )
-                {
-                    final ReportTable reportTable = new ReportTable();
-                    BeanUtils.copyProperties( visualization, reportTable );
-
-                    // Copy report params
-                    if ( visualization.hasReportingParams() )
-                    {
-                        final ReportingParams reportingParams = visualization.getReportingParams();
-                        final ReportParams reportParams = new ReportParams();
-
-                        reportParams
-                            .setParamGrandParentOrganisationUnit( reportingParams.isGrandParentOrganisationUnit() );
-                        reportParams.setParamOrganisationUnit( reportingParams.isOrganisationUnit() );
-                        reportParams.setParamParentOrganisationUnit( reportingParams.isParentOrganisationUnit() );
-                        reportParams.setParamReportingMonth( reportingParams.isReportingPeriod() );
-
-                        reportTable.setReportParams( reportParams );
-                    }
-
-                    reportTables.add( reportTable );
-                }
-            }
-        }
-        return reportTables;
     }
 
     protected List<Visualization> getEntity( String uid, WebOptions options )


### PR DESCRIPTION
As we have to still support Chart and ReportTable, but behind the scenes, all rules and tables are tight to Visualization, we need to add a "special condition" in order to load the "access" for the Visualization associated with the legacy object returned (Chart or Visualization).
Otherwise, we end up with a different/invalid "access" for Chart and ReportTable.

This PR will ensure the "access" is consistent across all those three entities.
This code must be removed once we completely drop the support for Chart and ReportTable.

