### PR TITLE
perf: port tracker query sql rewrite to 2.35.2

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -223,6 +223,17 @@ public class TrackedEntityInstanceQueryParams
      * Indicates whether paging should be skipped.
      */
     private boolean skipPaging;
+    
+    /**
+     * Indicates if there is a maximum tei retrieval limit. 0 no limit.
+     */
+    private int maxTeiLimit;
+
+    /**
+     * Indicates if a count of records for this params is already calculated.
+     * Used to avoid redundant querying to find count.
+     */
+    private int count;
 
     /**
      * Indicates whether to include soft-deleted elements
@@ -1085,6 +1096,28 @@ public class TrackedEntityInstanceQueryParams
         this.skipPaging = skipPaging;
         return this;
     }
+    
+    public int getMaxTeiLimit()
+    {
+        return maxTeiLimit;
+    }
+
+    public TrackedEntityInstanceQueryParams setMaxTeiLimit( int maxTeiLimit )
+    {
+        this.maxTeiLimit = maxTeiLimit;
+        return this;
+    }
+
+    public int getCount()
+    {
+        return count;
+    }
+
+    public TrackedEntityInstanceQueryParams setCount( int count )
+    {
+        this.count = count;
+        return this;
+    }
 
     public boolean isIncludeDeleted()
     {
@@ -1203,5 +1236,11 @@ public class TrackedEntityInstanceQueryParams
     public void setTrackedEntityTypes( List<TrackedEntityType> trackedEntityTypes )
     {
         this.trackedEntityTypes = trackedEntityTypes;
+    }
+    
+    public boolean hasFilterForPrograms()
+    {
+        return hasProgramStatus() || hasFollowUp() || hasProgramEnrollmentStartDate() || hasProgramEnrollmentEndDate()
+            || hasProgramIncidentStartDate() || hasProgramIncidentEndDate() || hasFilterForEvents();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -251,7 +251,8 @@ public class DefaultTrackedEntityInstanceService
 
         params.handleCurrentUserSelectionMode();
 
-        return trackedEntityInstanceStore.countTrackedEntityInstances( params );
+        // leveraging the better performant sql for count
+        return trackedEntityInstanceStore.getTrackedEntityInstanceCountForGrid( params );
     }
 
     // TODO lower index on attribute value?
@@ -682,12 +683,13 @@ public class DefaultTrackedEntityInstanceService
                 }
             }
 
-            if ( maxTeiLimit > 0 &&
-                ((isGridSearch && trackedEntityInstanceStore.getTrackedEntityInstanceCountForGrid( params ) > maxTeiLimit) ||
-                    (!isGridSearch && trackedEntityInstanceStore.countTrackedEntityInstances( params ) > maxTeiLimit)) )
+            if ( maxTeiLimit > 0 && params.isPaging()
+                && params.getOffset() > 0 && (params.getOffset() + params.getPageSizeWithDefault()) > maxTeiLimit )
             {
-                throw new IllegalQueryException( "maxteicountreached" );
+                throw new IllegalQueryException(
+                    "maxteicountreached" );
             }
+            params.setMaxTeiLimit( maxTeiLimit );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -396,7 +396,7 @@ public class HibernateTrackedEntityInstanceStore
     @Override
     public List<Map<String, String>> getTrackedEntityInstancesGrid( TrackedEntityInstanceQueryParams params )
     {
-        String sql = getQuery( params );
+        String sql = getQuery( params, true );
         log.debug( "Tracked entity instance query SQL: " + sql );
 
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -34,9 +34,6 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getTokens;
-import static org.hisp.dhis.commons.util.TextUtils.removeLastAnd;
-import static org.hisp.dhis.commons.util.TextUtils.removeLastComma;
-import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.CREATED_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.DELETED;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.INACTIVE_ID;
@@ -55,7 +52,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -69,6 +65,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.query.Query;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -83,7 +82,6 @@ import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
@@ -105,6 +103,28 @@ public class HibernateTrackedEntityInstanceStore
     extends SoftDeleteHibernateObjectStore<TrackedEntityInstance>
     implements TrackedEntityInstanceStore
 {
+    private static final String AND_PSI_STATUS_EQUALS_SINGLE_QUOTE = "and psi.status = '";
+
+    private static final String OFFSET = "OFFSET";
+
+    private static final String LIMIT = "LIMIT";
+
+    private static final String PSI_EXECUTIONDATE = "PSI.executiondate";
+
+    private static final String PSI_DUEDATE = "PSI.duedate";
+
+    private static final String IS_NULL = "IS NULL";
+
+    private static final String IS_NOT_NULL = "IS NOT NULL";
+
+    private static final String SPACE = " ";
+
+    private static final String SINGLE_QUOTE = "'";
+
+    private static final String EQUALS = " = ";
+
+    private static final String PSI_STATUS = "PSI.status";
+    
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -212,7 +232,6 @@ public class HibernateTrackedEntityInstanceStore
 
             // Joining program owners and using that as tei ou source
             hql += "inner join fetch tei.programOwners as po ";
-            String teiOuSource = "po.organisationUnit";
 
             if ( params.hasFilterForEvents() )
             {
@@ -333,26 +352,26 @@ public class HibernateTrackedEntityInstanceStore
 
         if ( params.hasLastUpdatedDuration() )
         {
-            hql += hlp.whereAnd() + "tei.lastUpdated >= '" +
+            hql += hlp.whereAnd() + " tei.lastUpdated >= '" +
                 getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
         }
         else
         {
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> "tei.lastUpdated >= '" +
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> " tei.lastUpdated >= '" +
                 getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
 
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> "tei.lastUpdated < '" +
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> " tei.lastUpdated < '" +
                 getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );
         }
 
-        hql += addWhereConditionally( hlp, params.isSynchronizationQuery(), () -> "tei.lastUpdated > tei.lastSynchronized");
+        hql += addWhereConditionally( hlp, params.isSynchronizationQuery(), () ->  "tei.lastUpdated > tei.lastSynchronized");
         
         // Comparing milliseconds instead of always creating new Date( 0 )
 
         if ( params.getSkipChangedBefore() != null && params.getSkipChangedBefore().getTime() > 0 )
         {
             String skipChangedBefore = DateUtils.getLongDateString( params.getSkipChangedBefore() );
-            hql += hlp.whereAnd() + "tei.lastUpdated >= '" + skipChangedBefore + "'";
+            hql += hlp.whereAnd() + " tei.lastUpdated >= '" + skipChangedBefore + "'";
         }
 
         params.handleOrganisationUnits();
@@ -384,60 +403,12 @@ public class HibernateTrackedEntityInstanceStore
     @Override
     public List<Map<String, String>> getTrackedEntityInstancesGrid( TrackedEntityInstanceQueryParams params )
     {
-        SqlHelper hlp = new SqlHelper();
-
-        // ---------------------------------------------------------------------
-        // Select clause
-        // ---------------------------------------------------------------------
-
-        String sql =
-            "select tei.uid as " + TRACKED_ENTITY_INSTANCE_ID + ", " +
-                "tei.created as " + CREATED_ID + ", " +
-                "tei.lastupdated as " + LAST_UPDATED_ID + ", " +
-                "ou.uid as " + ORG_UNIT_ID + ", " +
-                "ou.name as " + ORG_UNIT_NAME + ", " +
-                "te.uid as " + TRACKED_ENTITY_ID + ", " +
-                (params.hasProgram() ? "en.status as enrollment_status, " : "") +
-                (params.isIncludeDeleted() ? "tei.deleted as " + DELETED + ", " : "") +
-                "tei.inactive as " + INACTIVE_ID + ", ";
-
-        for ( QueryItem item : params.getAttributes() )
-        {
-            String col = statementBuilder.columnQuote( item.getItemId() );
-
-            sql += item.isNumeric() ? "CAST( " + col + ".value AS NUMERIC ) as " : col + ".value as ";
-
-            sql += col + ", ";
-        }
-
-        sql = removeLastComma( sql ) + " ";
-
-        // ---------------------------------------------------------------------
-        // From and where clause
-        // ---------------------------------------------------------------------
-
-        sql += getFromWhereClause( params, hlp );
-
-        // ---------------------------------------------------------------------
-        // Order clause
-        // ---------------------------------------------------------------------
-
-        sql += getOrderClause( params );
-
-        // ---------------------------------------------------------------------
-        // Paging clause
-        // ---------------------------------------------------------------------
-
-        sql += addConditionally( params.isPaging(),
-            () -> " limit " + params.getPageSizeWithDefault() + " offset " + params.getOffset() );
-
-        // ---------------------------------------------------------------------
-        // Query
-        // ---------------------------------------------------------------------
+        String sql = getQuery( params );
+        log.debug( "Tracked entity instance query SQL: " + sql );
 
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
 
-        log.debug( "Tracked entity instance query SQL: " + sql );
+        checkMaxTeiCountReached( params, rowSet );
 
         List<Map<String, String>> list = new ArrayList<>();
 
@@ -458,11 +429,21 @@ public class HibernateTrackedEntityInstanceStore
                 map.put( DELETED, rowSet.getString( DELETED ) );
             }
 
-            for ( QueryItem item : params.getAttributes() )
+            if ( !params.getAttributesAndFilters().isEmpty() )
             {
-                map.put( item.getItemId(),
-                    isOrgUnit( item ) ? getOrgUnitNameByUid( rowSet.getString( item.getItemId() ) )
-                        : rowSet.getString( item.getItemId() ) );
+                HashMap<String, String> attributeValues = new HashMap<>();
+                String teavString = rowSet.getString( "tea_values" );
+
+                extractFromTeavAggregatedString( attributeValues, teavString );
+
+                for ( QueryItem item : params.getAttributes() )
+                {
+                    map.put( item.getItemId(),
+                        isOrgUnit( item ) && attributeValues.containsKey( item.getItemId() ) ?
+                            getOrgUnitNameByUid( attributeValues.get( item.getItemId() ) )
+                            :
+                            attributeValues.get( item.getItemId() ) );
+                }
             }
 
             list.add( map );
@@ -471,317 +452,1072 @@ public class HibernateTrackedEntityInstanceStore
         return list;
     }
 
+    private void extractFromTeavAggregatedString( HashMap<String, String> attributeValues, String teavString )
+    {
+        if ( teavString != null )
+        {
+            String[] pairs = teavString.split( ";" );
+
+            for ( String pair : pairs )
+            {
+                String[] teav = pair.split( ":" );
+
+                if ( teav.length == 2 )
+                {
+                    attributeValues.put( teav[0], teav[1] );
+                }
+            }
+        }
+    }
+
+    private void checkMaxTeiCountReached( TrackedEntityInstanceQueryParams params, SqlRowSet rowSet )
+    {
+        if ( params.getMaxTeiLimit() > 0 && rowSet.last() )
+        {
+            if ( rowSet.getRow() > params.getMaxTeiLimit() )
+            {
+                throw new IllegalQueryException( "maxteicountreached" );
+            }
+            rowSet.beforeFirst();
+        }
+    }
+
     @Override
     public int getTrackedEntityInstanceCountForGrid( TrackedEntityInstanceQueryParams params )
     {
-        SqlHelper hlp = new SqlHelper();
-
         // ---------------------------------------------------------------------
         // Select clause
         // ---------------------------------------------------------------------
 
-        String sql = "select count(tei.uid) as " + TRACKED_ENTITY_INSTANCE_ID + " ";
-
-        // ---------------------------------------------------------------------
-        // From and where clause
-        // ---------------------------------------------------------------------
-
-        sql += getFromWhereClause( params, hlp );
+        String sql = getCountQuery( params );
 
         // ---------------------------------------------------------------------
         // Query
         // ---------------------------------------------------------------------
 
-        Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
-
         log.debug( "Tracked entity instance count SQL: " + sql );
+
+        Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
 
         return count;
     }
 
     /**
-     * From, join and where clause. For attribute params, restriction is set in
-     * inner join. For query params, restriction is set in where clause.
+         * Generates SQL based on "params". The purpose of the SQL is to retrieve a list of
+     * tracked entity instances, and additionally any requested attributes (If defined in params).
+     *
+     * The params are validated before we generate the SQL, so the only access-related SQL is the inner join o
+     * organisation units.
+     *
+     * The general structure of the query is as follows:
+     *
+     * select (main_projection)
+     * from (constraint_subquery)
+     * left join (additional_information)
+     * group by (main_groupby)
+     * order by (order)
+     *
+     * The constraint_subquery looks as follows:
+     *
+     * select (subquery_projection)
+     * from (tracked entity instances)
+     * inner join (attribute_constraints)
+     * [inner join (program_owner)]
+     * inner join (organisation units)
+     * left join (attribute_orderby)
+     * where exist(program_constraint)
+     * order by (order)
+     * limit (limit_offset)
+     *
+     * main_projection:
+     *  Will have an aggregate string of attributevalues (uid:value) as well as basic tei-info.
+     * constraint_subquery:
+     *  Includes all SQL related to narrowing down the number of tei's we are looking for. We use inner join primarily
+     *  for this, as well as exists for program instances. Do make sure we get the right selection, we also use left
+     *  join on attributes, when we are sorting by attributes, before we sort and finally limit the selection.
+     * subquery_projection:
+     *  Has all the required information for knowing what teis to return and how to order them
+     * attribute_constraints:
+     *  We inner join the attributes, and add 3 conditions: tei id, tea id and value. This uses a
+     *  (tei, tea, lower(value)) index. For each attribute constraints, we add subsequent inner joins.
+     * program_owner:
+     *  Only included when a program is specified. If included, it will join on 3 columns: tei, program and ou. We
+     *  have an index for this (program, ou, tei) which allows a scan only lookup
+     * attribute_orderby:
+     *  When a user specified an attribute in the order param, we need to join that attribute (We do left join, in case
+     *  the value is not there. This join is not for removing resulting records). After joining it and projecting it,
+     *  we can order by it.
+     * program_constraint:
+     *  If a program is specified, it indicates the tei must be enrolled in that program. Since the relation between
+     *  tei and enrollments are not 1:1, but 1:many, we use exists to avoid duplicate rows of tei, allowing us to avoid
+     *  grouping the result before we order and limit. This saves a lot of time.
+     *  NOTE: Within the program_constraint, we also have a subquery to deal with any event-related constraints. These
+     *  can either be constraints on any static properties, or user assignment. For user assignment, we also join with
+     *  the userinfo table. For events, we have an index (status, executiondate) which speeds up the lookup
+     *  significantly
+     * order:
+     *  Order is used both in the subquery and the main query. The sort depends on the params (see more info on the
+     *  related method). We order the subquery to make sure we get correct results before we limit. We order the main
+     *  query since the aggregation mixes up the order, so to return a consistent order, we order again.
+     * limit_offset:
+     *  The limit and offset is set based on a combination of params: program and tet can have a maxtei limit, which
+     *  only applies during a search outside the users capture scope. If applied, it will throw an error if the number
+     *  of results exceeds the limit. Otherwise we use paging. If no paging is set, there is no limit.
+     * additional_information:
+     *  Here we do a left join with any relevant information needed for the result: tet name, any attributes to project,
+     *  etc. We left join, since we don't want to reduce the results, just add information.
+     * main_groupby:
+     *  The purpose of this group by, is to aggregate any attributes added in additional_information
+     *
+     *
+     * @param params params defining the query
+     * @return SQL string
      */
-    private String getFromWhereClause( TrackedEntityInstanceQueryParams params, SqlHelper hlp )
+    private String getQuery( TrackedEntityInstanceQueryParams params )
+    {
+        return new StringBuilder()
+            .append( getQuerySelect( params ) )
+            .append( "FROM " )
+            .append( getFromSubQuery( params, false ) )
+            .append( getQueryRelatedTables( params ) )
+            .append( getQueryGroupBy( params ) )
+            .append( getQueryOrderBy( false, params ) )
+            .toString();
+    }
+
+    /**
+     * Uses the same basis as the getQuery method, but replaces the projection with a count and ignores order and limit
+     * @param params params defining the query
+     * @return a count SQL query
+     */
+    private String getCountQuery( TrackedEntityInstanceQueryParams params )
+    {
+        return new StringBuilder()
+            .append( getQueryCountSelect( params ) )
+            .append( getQuerySelect( params ) )
+            .append( "FROM " )
+            .append( getFromSubQuery( params, true ) )
+            .append( getQueryRelatedTables( params ) )
+            .append( getQueryGroupBy( params ) )
+            .append( " ) teicount" )
+            .toString();
+    }
+
+    /**
+     * Generates the projection of the main query. Includes two optional columns, deleted and tea_values
+     * @param params
+     * @return an SQL projection
+     */
+    private String getQuerySelect( TrackedEntityInstanceQueryParams params )
+    {
+        return new StringBuilder()
+            .append( "SELECT TEI.uid AS " + TRACKED_ENTITY_INSTANCE_ID + ", " )
+            .append( "TEI.created AS " + CREATED_ID + ", " )
+            .append( "TEI.lastupdated AS " + LAST_UPDATED_ID + ", " )
+            .append( "TEI.ou AS " + ORG_UNIT_ID + ", " )
+            .append( "TEI.ouname AS " + ORG_UNIT_NAME + ", " )
+            .append( "TET.uid AS " + TRACKED_ENTITY_ID + ", " )
+            .append( "TEI.inactive AS " + INACTIVE_ID )
+            .append( (params.isIncludeDeleted() ? ", TEI.deleted AS " + DELETED : "") )
+            .append( (params.hasAttributes() ? ", string_agg(TEA.uid || ':' || TEAV.value, ';') AS tea_values" : "") )
+            .append( SPACE )
+            .toString();
+    }
+
+    /**
+     * Generates the projection of the main query when doing a count query.
+     * @param params
+     * @return an SQL projection
+     */
+    private String getQueryCountSelect( TrackedEntityInstanceQueryParams params )
+    {
+        return "SELECT count(instance) FROM ( ";
+    }
+
+    /**
+     * Generates the SQL of the subquery, used to find the correct subset of tracked entity instances to return.
+     * Orchestrates all the different segments of the SQL into a complete subquery.
+     * @param params
+     * @param isCountQuery indicates if the query is a count query. In that case we skip order and limit.
+     * @return an SQL subquery
+     */
+    private String getFromSubQuery( TrackedEntityInstanceQueryParams params, boolean isCountQuery )
+    {
+        SqlHelper whereAnd = new SqlHelper( true );
+        StringBuilder fromSubQuery = new StringBuilder()
+            .append( "(" )
+            .append( getFromSubQuerySelect( params ) )
+            .append( " FROM trackedentityinstance TEI " )
+
+            // The following segments are all INNER JOIN, attempting to reduce the number of teis to return
+            .append( getFromSubQueryJoinAttributeConditions( params ) )
+            .append( getFromSubQueryJoinProgramOwnerConditions( params ) )
+            .append( getFromSubQueryJoinOrgUnitConditions( params ) )
+
+            // LEFT JOIN attributes we need to sort on.
+            .append( getFromSubQueryJoinOrderByAttributes( params ) )
+
+            // WHERE segments for tei, and for program instance (and program stage instance)
+            .append( getFromSubQueryTrackedEntityConditions( whereAnd, params ) )
+            .append( getFromSubQueryProgramInstanceConditions( whereAnd, params ) );
+
+        // sorting is uneccesary and limit would return the wrong results for a count query.
+        if ( !isCountQuery )
+        {
+            // SORT
+            fromSubQuery
+                .append( getQueryOrderBy( true, params ) )
+
+                // LIMIT, OFFSET
+                .append( getFromSubQueryLimitAndOffset( params ) );
+        }
+
+        return fromSubQuery.append( ") TEI " )
+            .toString();
+    }
+
+    /**
+     * The subquery projection. If we are sorting by attribute, we need to include the value in the subquery
+     * projection.
+     * @param params
+     * @return a SQL projection
+     */
+    private String getFromSubQuerySelect( TrackedEntityInstanceQueryParams params )
+    {
+        return new StringBuilder()
+            .append( "SELECT " )
+            .append( "TEI.trackedentityinstanceid, " )
+            .append( "TEI.uid, " )
+            .append( "TEI.created, " )
+            .append( "TEI.lastupdated, " )
+            .append( "TEI.inactive, " )
+            .append( "TEI.trackedentitytypeid, " )
+            .append( "TEI.deleted, " )
+            .append( "OU.uid as ou, " )
+            .append( "OU.name as ouname " )
+            .append( getFromSubQueryOrderAttributes( params ) )
+            .toString();
+    }
+
+    /**
+     * Generates a list of columns for projections if we are ordering by attributes.
+     * @param params
+     * @return a list of columns to be used in the subquery SQL projection, or empty string if no attributes are used
+     * for ordering.
+     */
+    private String getFromSubQueryOrderAttributes( TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder orderAttributes = new StringBuilder();
+
+        for ( QueryItem orderAttribute : getOrderAttributes( params ) )
+        {
+            orderAttributes
+                .append( ", " )
+                .append( statementBuilder.columnQuote( orderAttribute.getItemId() ) )
+                .append( ".value AS " )
+                .append( statementBuilder.columnQuote( orderAttribute.getItemId() ) );
+        }
+
+        return orderAttributes.toString();
+    }
+
+    /**
+     * Generates the WHERE-clause of the subquery SQL related to tracked entity instances.
+     * @param whereAnd tracking if where has been invoked or not
+     * @param params
+     * @return a SQL segment for the WHERE clause used in the subquery
+     */
+    private String getFromSubQueryTrackedEntityConditions( SqlHelper whereAnd, TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder trackedEntity = new StringBuilder();
+
+        /*
+         * If the user has specified a tracked entity type, we only have one, if not, it will be a collection of all TET
+         * the user can access.
+         */
+        if ( params.hasTrackedEntityType() )
+        {
+            trackedEntity
+                .append( whereAnd.whereAnd() )
+                .append( "TEI.trackedentitytypeid = " )
+                .append( params.getTrackedEntityType().getId() )
+                .append( SPACE );
+        }
+        else
+        {
+            trackedEntity
+                .append( whereAnd.whereAnd() )
+                .append( "TEI.trackedentitytypeid IN (" )
+                .append( getCommaDelimitedString( getIdentifiers( params.getTrackedEntityTypes() ) ) )
+                .append( ") " );
+        }
+
+        if ( params.hasTrackedEntityInstances() )
+        {
+            trackedEntity
+                .append( whereAnd.whereAnd() )
+                .append( "TEI.uid IN (" )
+                .append( getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) )
+                .append( ") " );
+        }
+        
+        if ( params.hasLastUpdatedDuration() )
+        {
+            trackedEntity.append( whereAnd.whereAnd() )
+                .append( " TEI.lastupdated >= '" )
+                .append( getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) )
+                .append( SINGLE_QUOTE );
+        }
+        else
+        {
+            if ( params.hasLastUpdatedStartDate() )
+            {
+                trackedEntity.append( " TEI.lastupdated >= '" )
+                    .append( getMediumDateString( params.getLastUpdatedStartDate() ) ).append( SINGLE_QUOTE );
+            }
+            if ( params.hasLastUpdatedEndDate() )
+            {
+                trackedEntity.append( " TEI.lastupdated < '" )
+                    .append( getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) )
+                    .append( SINGLE_QUOTE );
+            }
+        }
+
+        if ( !params.isIncludeDeleted() )
+        {
+            trackedEntity
+                .append( whereAnd.whereAnd() )
+                .append( "TEI.deleted IS FALSE " );
+        }
+
+        return trackedEntity.toString();
+    }
+
+    /**
+     * Generates SQL for INNER JOINing attribute values. One INNER JOIN for each attribute to search for.
+     * @param params
+     * @return a series of 1 or more SQL INNER JOINs, or empty string if no query or attribute filters exists.
+     */
+    private String getFromSubQueryJoinAttributeConditions( TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder attributes = new StringBuilder();
+
+        List<QueryItem> filterItems = params.getAttributesAndFilters().stream()
+            .filter( QueryItem::hasFilter )
+            .collect( Collectors.toList() );
+
+        if ( !filterItems.isEmpty() || params.isOrQuery() )
+        {
+            if ( !params.isOrQuery() )
+            {
+                joinAttributeValueWithoutQueryParameter( attributes, filterItems );
+            }
+            else
+            {
+                joinAttributeValueWithQueryParameter( params, attributes );
+            }
+        }
+
+        return attributes.toString();
+    }
+
+    /**
+     * Generates a single INNER JOIN for searching for an attribute by query strings.
+     * Searches are done using lower() expression, since attribute values are case insensitive.
+     * The query search is extremely slow compared to alternatives.
+     * A query string (Can be multiple) has to match at least 1 attribute value for each attribute we have access to.
+     * We use Regex to search, allowing both exact match and with wildcards (EQ or LIKE).
+     * @param params
+     * @param attributes
+     */
+    private void joinAttributeValueWithQueryParameter( TrackedEntityInstanceQueryParams params,
+        StringBuilder attributes )
     {
         final String regexp = statementBuilder.getRegexpMatch();
         final String wordStart = statementBuilder.getRegexpWordStart();
         final String wordEnd = statementBuilder.getRegexpWordEnd();
         final String anyChar = "\\.*?";
+        final String start = params.getQuery().isOperator( QueryOperator.LIKE ) ? anyChar : wordStart;
+        final String end = params.getQuery().isOperator( QueryOperator.LIKE ) ? anyChar : wordEnd;
+        SqlHelper orHlp = new SqlHelper( true );
 
-        String sql = "from trackedentityinstance tei "
-            + "inner join trackedentitytype te on tei.trackedentitytypeid = te.trackedentitytypeid ";
+        List<Long> itemIds = params.getAttributesAndFilters().stream()
+            .map( QueryItem::getItem )
+            .map( DimensionalItemObject::getId )
+            .collect( Collectors.toList() );
 
-        String teiOuSource = "tei.organisationunitid";
+        attributes
+            .append( "INNER JOIN trackedentityattributevalue Q " )
+            .append( "ON Q.trackedentityinstanceid IN (" )
+            .append( getCommaDelimitedString( itemIds ) )
+            .append( ") AND (" );
 
-
-        if ( params.hasProgram() )
+        for ( String queryToken : getTokens( params.getQuery().getFilter() ) )
         {
-            //Using program owner OU instead of registration OU.
-            sql += "inner join (select trackedentityinstanceid, organisationunitid from trackedentityprogramowner where programid = ";
-            sql += params.getProgram().getId() + ") as tepo ON tei.trackedentityinstanceid = tepo.trackedentityinstanceid ";
-            teiOuSource = "tepo.organisationunitid";
+            final String query = statementBuilder.encode( queryToken, false );
 
-            sql += "inner join ("
-                + "select trackedentityinstanceid, min(case when status='ACTIVE' then 0 when status='COMPLETED' then 1 else 2 end) as status "
-                + "from programinstance pi ";
-
-            if ( params.hasFilterForEvents() )
-            {
-                sql += " inner join (select programinstanceid from programstageinstance psi ";
-
-                sql += addConditionally( params.hasAssignedUsers(), () -> "left join userinfo au on (psi.assigneduserid=au.userinfoid)" );
-
-                sql += getEventWhereClause( params );
-
-                sql += ") as psi on pi.programinstanceid = psi.programinstanceid ";
-            }
-
-            sql += " where pi.programid= " + params.getProgram().getId() + " ";
-
-            sql += addConditionally( params.hasProgramStatus(),
-                () -> "and status = '" + params.getProgramStatus() + "' " );
-
-            sql += addConditionally( params.hasFollowUp(), () -> "and pi.followup = " + params.getFollowUp() );
-
-            sql += addConditionally( params.hasProgramEnrollmentStartDate(), () -> "and pi.enrollmentdate >= '"
-                + getMediumDateString( params.getProgramEnrollmentStartDate() ) + "' " );
-
-            sql += addConditionally( params.hasProgramEnrollmentEndDate(), () -> "and pi.enrollmentdate <= '"
-                + getMediumDateString( params.getProgramEnrollmentEndDate() ) + "' " );
-
-            sql += addConditionally( params.hasProgramIncidentStartDate(),
-                () -> "and pi.incidentdate >= '" + getMediumDateString( params.getProgramIncidentStartDate() ) + "' " );
-
-            sql += addConditionally( params.hasProgramIncidentEndDate(),
-                () -> "and pi.incidentdate <= '" + getMediumDateString( params.getProgramIncidentEndDate() ) + "' " );
-
-            sql += addConditionally( params.isIncludeDeleted(),
-                () -> "and pi.deleted is false" );
-
-            sql += " group by trackedentityinstanceid ) as en on tei.trackedentityinstanceid = en.trackedentityinstanceid ";
+            attributes
+                .append( orHlp.or() )
+                .append( "lower(Q.value) " )
+                .append( regexp )
+                .append( " '" )
+                .append( start )
+                .append( StringUtils.lowerCase( query ) )
+                .append( end )
+                .append( SINGLE_QUOTE );
         }
 
-        sql += "inner join organisationunit ou on " + teiOuSource + " = ou.organisationunitid ";
+        attributes.append( ")" );
+    }
 
-        for ( QueryItem item : params.getAttributesAndFilters() )
+    /**
+     * Generates a single INNER JOIN for each attribute we are searching on. We can search by a range of operators.
+     * All searching is using lower() since attribute values are case insensitive.
+     * @param attributes
+     * @param filterItems
+     */
+    private void joinAttributeValueWithoutQueryParameter( StringBuilder attributes, List<QueryItem> filterItems )
+    {
+        for ( QueryItem queryItem : filterItems )
         {
-            final String col = statementBuilder.columnQuote( item.getItemId() );
+            String col = statementBuilder.columnQuote( queryItem.getItemId() );
+            String teaId = col + ".trackedentityattributeid";
+            String teav = "lower(" + col + ".value)";
+            String teiid = col + ".trackedentityinstanceid";
 
-            final String joinClause = item.hasFilter() ? "inner join" : "left join";
+            attributes
+                .append( " INNER JOIN trackedentityattributevalue " )
+                .append( col )
+                .append( " ON " )
+                .append( teaId )
+                .append( EQUALS )
+                .append( queryItem.getItem().getId() )
+                .append( " AND " )
+                .append( teiid )
+                .append( " = TEI.trackedentityinstanceid " );
 
-            sql += joinClause + " " + "trackedentityattributevalue as " + col + " " + "on " + col
-                + ".trackedentityinstanceid = tei.trackedentityinstanceid " + "and " + col
-                + ".trackedentityattributeid = " + item.getItem().getId() + " ";
-
-            if ( !params.isOrQuery() && item.hasFilter() )
+            for ( QueryFilter filter : queryItem.getFilters() )
             {
-                for ( QueryFilter filter : item.getFilters() )
-                {
-                    final String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
-
-                    final String queryCol = item.isNumeric() ? (col + ".value") : "lower(" + col + ".value)";
-
-                    sql += "and " + queryCol + " " + filter.getSqlOperator() + " "
-                        + StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) + " ";
-                }
+                attributes
+                    .append( "AND " )
+                    .append( teav )
+                    .append( SPACE )
+                    .append( filter.getSqlOperator() )
+                    .append( SPACE )
+                    .append( StringUtils.lowerCase( filter.getSqlFilter( filter.getFilter() ) ) );
             }
         }
-        
-        sql += addWhereConditionally( hlp, params.hasTrackedEntityInstances(),
-            () -> " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" );
+    }
 
-        if ( !params.hasTrackedEntityType() )
+    /**
+     * Generates the LEFT JOINs used for attributes we are ordering by (If any). We use LEFT JOIN to avoid removing any
+     * rows if there is no value for a given attribute and tei. The result of this LEFT JOIN is used in the subquery
+     * projection, and ordering in the subquery and main query.
+     * @param params
+     * @return a SQL LEFT JOIN for attributes used for ordering, or empty string if not attributes is used in order.
+     */
+    private String getFromSubQueryJoinOrderByAttributes( TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder joinOrderAttributes = new StringBuilder();
+
+        for ( QueryItem orderAttribute : getOrderAttributes( params ) )
         {
-            sql += hlp.whereAnd() + " tei.trackedentitytypeid in (" + params.getTrackedEntityTypes().stream()
-                .filter( Objects::nonNull )
-                .map( TrackedEntityType::getId )
-                .map( String::valueOf )
-                .collect( Collectors.joining(", ") ) + ") ";
+            if ( orderAttribute.hasFilter() ) // We already joined this if it is a filter.
+            {
+                continue;
+            }
+
+            joinOrderAttributes
+                .append( " LEFT JOIN trackedentityattributevalue AS " )
+                .append( statementBuilder.columnQuote( orderAttribute.getItemId() ) )
+                .append( " ON " )
+                .append( statementBuilder.columnQuote( orderAttribute.getItemId() ) )
+                .append( ".trackedentityinstanceid = TEI.trackedentityinstanceid " )
+                .append( "AND " )
+                .append( statementBuilder.columnQuote( orderAttribute.getItemId() ) )
+                .append( ".trackedentityattributeid = " )
+                .append( orderAttribute.getItem().getId() )
+                .append( SPACE );
         }
-        else
+
+        return joinOrderAttributes.toString();
+    }
+
+    /**
+     * Generates an INNER JOIN for program owner. This segment is only included if program is specified.
+     * @param params
+     * @return a SQL INNER JOIN for program owner, or empty string if no program is specified.
+     */
+    private String getFromSubQueryJoinProgramOwnerConditions( TrackedEntityInstanceQueryParams params )
+    {
+        if ( !params.hasProgram() )
         {
-            sql += hlp.whereAnd() + " tei.trackedentitytypeid = " + params.getTrackedEntityType().getId() + " ";
+            return "";
         }
+
+        return new StringBuilder()
+            .append( " INNER JOIN trackedentityprogramowner PO " )
+            .append( "ON PO.programid = " )
+            .append( params.getProgram().getId() )
+            .append( " AND PO.trackedentityinstanceid = TEI.trackedentityinstanceid " )
+            .toString();
+    }
+
+    /**
+     * Generates an INNER JOIN for organisation units. If a program is specified, we join on program ownership (PO), if
+     * not we join by tracked entity instance (TEI).
+     * Based on the ouMode, they will boil down to either DESCENDANTS (requiring matching on PATH), ALL (No constraints)
+     * or not DESCENDANTS or ALL (SELECTED) which will match against a collection of ids.
+     * @param params
+     * @return a SQL INNER JOIN for organisation units
+     */
+    private String getFromSubQueryJoinOrgUnitConditions( TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder orgUnits = new StringBuilder();
 
         params.handleOrganisationUnits();
 
-        if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.ALL ) )
-        {
-            // No restriction
-        }
-        else if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) )
-        {
-            String ouClause = " (";
+        orgUnits
+            .append( " INNER JOIN organisationunit OU " )
+            .append( "ON OU.organisationunitid = " )
+            .append( (params.hasProgram() ? "PO.organisationunitid " : "TEI.organisationunitid ") );
 
+        if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) )
+        {
             SqlHelper orHlp = new SqlHelper( true );
+
+            orgUnits.append( "AND (" );
 
             for ( OrganisationUnit organisationUnit : params.getOrganisationUnits() )
             {
-                ouClause += orHlp.or() + "ou.path like '" + organisationUnit.getPath() + "%'";
+                orgUnits
+                    .append( orHlp.or() )
+                    .append( "OU.path LIKE '" )
+                    .append( organisationUnit.getPath() )
+                    .append( "%'" );
             }
 
-            ouClause += ")";
-
-            sql += hlp.whereAnd() + ouClause;
+            orgUnits.append( ") " );
         }
-        else // SELECTED (default)
+        else if ( !params.isOrganisationUnitMode( OrganisationUnitSelectionMode.ALL ) )
         {
-            sql += hlp.whereAnd() + " " + teiOuSource + " in ("
-                + getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) ) + ") ";
+            orgUnits
+                .append( "AND OU.organisationunitid IN (" )
+                .append( getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) ) )
+                .append( ") " );
         }
 
-        if ( params.isOrQuery() && params.hasAttributesOrFilters() )
-        {
-            final String start = params.getQuery().isOperator( QueryOperator.LIKE ) ? anyChar : wordStart;
-            final String end = params.getQuery().isOperator( QueryOperator.LIKE ) ? anyChar : wordEnd;
-
-            sql += hlp.whereAnd() + " (";
-
-            List<String> queryTokens = getTokens( params.getQuery().getFilter() );
-
-            for ( String queryToken : queryTokens )
-            {
-                final String query = statementBuilder.encode( queryToken, false );
-
-                sql += "(";
-
-                for ( QueryItem item : params.getAttributesAndFilters() )
-                {
-                    final String col = statementBuilder.columnQuote( item.getItemId() );
-
-                    sql += col + ".value " + regexp + " '" + start + StringUtils.lowerCase( query ) + end + "' or ";
-                }
-
-                sql = removeLastOr( sql ) + ") and ";
-            }
-
-            sql = removeLastAnd( sql ) + ") ";
-        }
-
-        sql += addWhereConditionally( hlp, !params.isIncludeDeleted(), () -> " tei.deleted is false " );
-
-        return sql;
+        return orgUnits.toString();
     }
 
-    private String getOrderClause( TrackedEntityInstanceQueryParams params )
+    /**
+     * Generates an EXISTS condition for program instance (and program stage instance if specified). The EXIST will
+     * allow us to filter by enrollments with a low overhead. This condition only applies when a program is specified.
+     * @param whereAnd indicator tracking whether WHERE has been invoked or not
+     * @param params
+     * @return an SQL EXISTS clause for programinstance, or empty string if not program is specified.
+     */
+    private String getFromSubQueryProgramInstanceConditions( SqlHelper whereAnd,
+        TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder program = new StringBuilder();
+
+        if ( !params.hasProgram() )
+        {
+            return "";
+        }
+
+        program
+            .append( whereAnd.whereAnd() )
+            .append( "EXISTS (" )
+            .append( "SELECT PI.trackedentityinstanceid " )
+            .append( "FROM programinstance PI " );
+
+        /*
+         * Events depends on program, so we do the event filtering within the enrollment clause.
+         */
+        if ( params.hasFilterForEvents() )
+        {
+            program.append( getFromSubQueryProgramStageInstance( params ) );
+        }
+
+        program
+            .append( "WHERE PI.trackedentityinstanceid = TEI.trackedentityinstanceid " )
+            .append( "AND PI.programid = " )
+            .append( params.getProgram().getId() )
+            .append( SPACE );
+
+        if ( params.hasProgramStatus() )
+        {
+            program
+                .append( "AND PI.status = '" )
+                .append( params.getProgramStatus() )
+                .append( "' " );
+        }
+
+        if ( params.hasFollowUp() )
+        {
+            program
+                .append( "AND PI.followup IS " )
+                .append( params.getFollowUp() )
+                .append( SPACE );
+        }
+
+        if ( params.hasProgramEnrollmentStartDate() )
+        {
+            program
+                .append( "AND PI.enrollmentdate >= '" )
+                .append( getMediumDateString( params.getProgramEnrollmentStartDate() ) )
+                .append( "' " );
+        }
+
+        if ( params.hasProgramEnrollmentEndDate() )
+        {
+            program
+                .append( "AND PI.enrollmentdate <= '" )
+                .append( getMediumDateString( params.getProgramEnrollmentEndDate() ) )
+                .append( "' " );
+        }
+
+        if ( params.hasProgramIncidentStartDate() )
+        {
+            program
+                .append( "AND PI.incidentdate >= '" )
+                .append( getMediumDateString( params.getProgramIncidentStartDate() ) )
+                .append( "' " );
+        }
+
+        if ( params.hasProgramIncidentEndDate() )
+        {
+            program
+                .append( "AND PI.incidentdate <= '" )
+                .append( getMediumDateString( params.getProgramIncidentEndDate() ) )
+                .append( "' " );
+        }
+
+        if ( !params.isIncludeDeleted() )
+        {
+            program.append( "AND PI.deleted is false " );
+        }
+
+        program.append( ") " );
+
+        return program.toString();
+    }
+
+    /**
+     * Generates an INNER JOIN with the program instances if event-filters are specified. In the case of user assignment
+     * is part of the filter, we join with the userinfo table as well.
+     * @param params
+     * @return an SQL INNER JOIN for filtering on events.
+     */
+    private String getFromSubQueryProgramStageInstance( TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder events = new StringBuilder();
+        SqlHelper whereHlp = new SqlHelper( true );
+
+        events
+            .append( "INNER JOIN (" )
+            .append( "SELECT PSI.programinstanceid " )
+            .append( "FROM programstageinstance PSI " );
+
+        /*
+         * If filtering on assigned user, we join with the userinfo table to get users by uid.
+         */
+        if ( params.hasAssignedUsers() )
+        {
+            events
+                .append( "INNER JOIN (" )
+                .append( "SELECT userinfoid AS userid " )
+                .append( "FROM userinfo " )
+                .append( "WHERE uid IN (" )
+                .append( getQuotedCommaDelimitedString( params.getAssignedUsers() ) )
+                .append( ") " )
+                .append( ") AU ON AU.userid = PSI.assigneduserid" );
+        }
+
+        /*
+         * Each of the statuses has special conditions that needs to be met. The following code handles the different
+         * statuses and conditions.
+         */
+        if ( params.hasEventStatus() )
+        {
+            String start = getMediumDateString( params.getEventStartDate() );
+            String end = getMediumDateString( params.getEventEndDate() );
+            events.append( whereHlp.whereAnd() );
+
+            if ( params.isEventStatus( EventStatus.COMPLETED ) )
+            {
+                events.append( getQueryDateConditionBetween( whereHlp, PSI_EXECUTIONDATE, start, end ) )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_STATUS )
+                    .append( EQUALS )
+                    .append( SINGLE_QUOTE )
+                    .append( EventStatus.COMPLETED.name() )
+                    .append( SINGLE_QUOTE )
+                    .append( SPACE );
+            }
+            else if ( params.isEventStatus( EventStatus.VISITED ) || params.isEventStatus( EventStatus.ACTIVE ) )
+            {
+                events.append( getQueryDateConditionBetween( whereHlp, PSI_EXECUTIONDATE, start, end ) )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_STATUS )
+                    .append( EQUALS )
+                    .append( SINGLE_QUOTE )
+                    .append( EventStatus.ACTIVE.name() )
+                    .append( SINGLE_QUOTE )
+                    .append( SPACE );
+            }
+            else if ( params.isEventStatus( EventStatus.SCHEDULE ) )
+            {
+                events.append( getQueryDateConditionBetween( whereHlp, PSI_DUEDATE, start, end ) )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_STATUS )
+                    .append( SPACE )
+                    .append( IS_NOT_NULL )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_EXECUTIONDATE )
+                    .append( SPACE )
+                    .append( IS_NULL )
+                    .append( whereHlp.whereAnd() )
+                    .append( "date(now()) <= date(PSI.duedate) " );
+            }
+            else if ( params.isEventStatus( EventStatus.OVERDUE ) )
+            {
+                events.append( getQueryDateConditionBetween( whereHlp, PSI_DUEDATE, start, end ) )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_STATUS )
+                    .append( SPACE )
+                    .append( IS_NOT_NULL )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_EXECUTIONDATE )
+                    .append( SPACE )
+                    .append( IS_NULL )
+                    .append( whereHlp.whereAnd() )
+                    .append( "date(now()) > date(PSI.duedate) " );
+            }
+            else if ( params.isEventStatus( EventStatus.SKIPPED ) )
+            {
+                events.append( getQueryDateConditionBetween( whereHlp, PSI_DUEDATE, start, end ) )
+                    .append( whereHlp.whereAnd() )
+                    .append( PSI_STATUS )
+                    .append( EQUALS )
+                    .append( SINGLE_QUOTE )
+                    .append( EventStatus.SKIPPED.name() )
+                    .append( SINGLE_QUOTE )
+                    .append( SPACE );
+            }
+        }
+
+        if ( params.hasProgramStage() )
+        {
+            events
+                .append( whereHlp.whereAnd() )
+                .append( "PSI.programstageid = " )
+                .append( params.getProgramStage().getId() )
+                .append( SPACE );
+        }
+
+        if ( params.isIncludeOnlyUnassignedEvents() )
+        {
+            events
+                .append( whereHlp.whereAnd() )
+                .append( "PSI.assigneduserid IS NULL " );
+        }
+
+        if ( params.isIncludeOnlyAssignedEvents() )
+        {
+            events
+                .append( whereHlp.whereAnd() )
+                .append( "PSI.assigneduserid IS NOT NULL " );
+        }
+
+        if ( !params.isIncludeDeleted() )
+        {
+            events.append( whereHlp.whereAnd() )
+                .append( "PSI.deleted IS FALSE" );
+        }
+
+        events.append( ") PSI ON PSI.programinstanceid = PI.programinstanceid " );
+
+        return events.toString();
+    }
+
+    /**
+     * Helper method for making a date condition. The format is "[WHERE|AND] date >= start AND date <= end".
+     *
+     * @param whereHelper tracking whether WHERE has been invoked or not
+     * @param column the column for filter on
+     * @param start the start date
+     * @param end the end date
+     * @return a SQL filter for finding dates between two dates.
+     */
+    private String getQueryDateConditionBetween( SqlHelper whereHelper, String column, String start, String end )
+    {
+        StringBuilder dateBetween = new StringBuilder();
+
+        dateBetween
+            .append( whereHelper.whereAnd() )
+            .append( column )
+            .append( " >= '" )
+            .append( start )
+            .append( SINGLE_QUOTE )
+            .append( whereHelper.whereAnd() )
+            .append( column )
+            .append( " <= '" )
+            .append( end )
+            .append( "' " );
+
+        return dateBetween.toString();
+    }
+
+    /**
+     * Generates SQL for LEFT JOINing relevant tables with the teis we have in our result. After the subquery, we know
+     * which teis we are returning, but these LEFT JOINs will add any extra information we need. For example attribute
+     * values, tet uid, tea uid, etc.
+     * @param params
+     * @return a SQL with several LEFT JOINS, one for each relevant table to retrieve information from.
+     */
+    private String getQueryRelatedTables( TrackedEntityInstanceQueryParams params )
+    {
+        List<QueryItem> attributes = params.getAttributes();
+        StringBuilder relatedTables = new StringBuilder();
+
+        // We always get TET uid
+        relatedTables.append( "LEFT JOIN trackedentitytype TET ON TET.trackedentitytypeid = TEI.trackedentitytypeid " );
+
+        // As long as we have any attributes, we join them in to get their value, as well as the TEA for the TEA uid.
+        if ( !attributes.isEmpty() )
+        {
+            String attributeString = getCommaDelimitedString( attributes.stream()
+                .map( QueryItem::getItem )
+                .map( IdentifiableObject::getId )
+                .collect( Collectors.toList() ) );
+
+            relatedTables.append( "LEFT JOIN trackedentityattributevalue TEAV " )
+                .append( "ON TEAV.trackedentityinstanceid = TEI.trackedentityinstanceid " )
+                .append( "AND TEAV.trackedentityattributeid IN (" )
+                .append( attributeString )
+                .append( ") " );
+
+            relatedTables.append( "LEFT JOIN trackedentityattribute TEA " )
+                .append( "ON TEA.trackedentityattributeid = TEAV.trackedentityattributeid " );
+        }
+
+        return relatedTables.toString();
+    }
+
+    /**
+     * Generates the GROUP BY clause of the query. This is only needed when we are projecting any attributes. If any
+     * attributes are present we are aggregating them into a string. In case we are ordering by an attribute, we also
+     * need to include that column in the group by.
+     * @param params
+     * @return a SQL GROUP BY clause, or empty string if no attributes are specified.
+     */
+    private String getQueryGroupBy( TrackedEntityInstanceQueryParams params )
+    {
+        if ( params.getAttributes().isEmpty() )
+        {
+            return "";
+        }
+
+        StringBuilder groupBy = new StringBuilder()
+            .append( "GROUP BY TEI.trackedentityinstanceid, " )
+            .append( "TEI.uid, " )
+            .append( "TEI.created, " )
+            .append( "TEI.lastupdated, " )
+            .append( "TEI.ou, " )
+            .append( "TEI.ouname, " )
+            .append( "TET.uid, " )
+            .append( "TEI.inactive " )
+            .append( (params.isIncludeDeleted() ? ", TEI.deleted " : "") );
+
+        if ( !getOrderAttributes( params ).isEmpty() )
+        {
+
+            for ( QueryItem orderAttribute : getOrderAttributes( params ) )
+            {
+                groupBy
+                    .append( ", TEI." )
+                    .append( statementBuilder.columnQuote( orderAttribute.getItemId() ) )
+                    .append( SPACE );
+            }
+
+        }
+
+        return groupBy.toString();
+    }
+
+    /**
+     * Generates the ORDER BY clause. This clause is used both in the subquery and main query. When using it in the
+     * subquery, we want to make sure we get the right teis. When we order in the main query, it's to make sure we return
+     * the results in the correct order, since order might be mixed after GROUP BY.
+     * @param innerOrder indicates whether this is the subquery order by or main query order by
+     * @param params
+     * @return a SQL ORDER BY clause.
+     */
+    private String getQueryOrderBy( boolean innerOrder, TrackedEntityInstanceQueryParams params )
     {
         List<String> cols = getStaticGridColumns();
 
-        if ( params.getOrders() != null && params.getAttributes() != null && !params.getAttributes().isEmpty()
-            && !cols.isEmpty() )
+        if ( params.getOrders() != null && params.getAttributes() != null && !params.getAttributes().isEmpty() && !cols
+            .isEmpty() )
         {
-            ArrayList<String> orderFields = new ArrayList<>();
+            ArrayList<String> orderFields = new ArrayList<String>();
 
             for ( String order : params.getOrders() )
             {
-                String[] prop = order.split( ":" );
-
-                if ( prop.length == 2 && (prop[1].equals( "desc" ) || prop[1].equals( "asc" )) )
-                {
-                    if ( cols.contains( prop[0] ) )
-                    {
-                        orderFields.add( prop[0] + " " + prop[1] );
-                    }
-                    else
-                    {
-
-                        for ( QueryItem item : params.getAttributes() )
-                        {
-                            if ( prop[0].equals( item.getItemId() ) )
-                            {
-                                orderFields.add( statementBuilder.columnQuote( prop[0] ) + " " + prop[1] );
-                                break;
-                            }
-                        }
-                    }
-                }
+                extractOrderField( innerOrder, params, cols, orderFields, order );
 
             }
 
             if ( !orderFields.isEmpty() )
             {
-                return "order by " + StringUtils.join( orderFields, ',' );
+                return "ORDER BY " + StringUtils.join( orderFields, ',' ) + SPACE;
             }
         }
 
-        if ( params.hasProgram() )
+        if ( params.getAttributesAndFilters().stream().noneMatch( qi -> qi.hasFilter() && qi.isUnique() ) )
         {
-            return "order by en.status asc, lastUpdated desc ";
+            return "ORDER BY TEI.trackedentityinstanceid ASC ";
+        }
+        else
+        {
+            return "";
+        }
+    }
+
+    private void extractOrderField( boolean innerOrder, TrackedEntityInstanceQueryParams params, List<String> cols,
+        ArrayList<String> orderFields, String order )
+    {
+        String[] prop = order.split( ":" );
+
+        if ( prop.length == 2 && (prop[1].equals( "desc" ) || prop[1].equals( "asc" )) )
+        {
+            if ( cols.contains( prop[0] ) )
+            {
+                orderFields.add( prop[0] + SPACE + prop[1] );
+            }
+            else
+            {
+                extractDynamicOrderField( innerOrder, params, orderFields, prop );
+            }
+        }
+    }
+
+    private void extractDynamicOrderField( boolean innerOrder, TrackedEntityInstanceQueryParams params,
+        ArrayList<String> orderFields, String[] prop )
+    {
+        for ( QueryItem item : params.getAttributes() )
+        {
+            if ( prop[0].equals( item.getItemId() ) )
+            {
+                if ( innerOrder )
+                {
+                    orderFields.add( statementBuilder.columnQuote( prop[0] ) + ".value " + prop[1] );
+                }
+                else
+                {
+                    orderFields.add( "TEI." + statementBuilder.columnQuote( prop[0] ) + SPACE + prop[1] );
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Helper method for getting all attributes with a filter.
+     * @param params
+     * @return a list of QueryItem, each representing an attribute with 1 or more filters.
+     */
+    private List<QueryItem> getOrderAttributes( TrackedEntityInstanceQueryParams params )
+    {
+        if ( params.getOrders() != null )
+        {
+            List<String> ordersIdentifier = params.getOrders().stream()
+                .map( order -> order.split( ":" )[0] )
+                .collect( Collectors.toList() );
+
+            return params.getAttributesAndFilters().stream()
+                .filter( queryItem -> ordersIdentifier.contains( queryItem.getItemId() ) )
+                .collect( Collectors.toList() );
         }
 
-        return "order by lastUpdated desc ";
+        return Lists.newArrayList();
+    }
+
+    /**
+     * Generates the LIMIT and OFFSET part of the subquery. The limit is decided by several factors:
+     * 1. maxteilimit in a TET or Program
+     * 2. PageSize and Offset
+     * 3. No paging
+     *
+     * If maxteilimit is not 0, it means this is the hard limit of the number of results. In the case where there
+     * exists more results than maxteilimit, we should return an error to the user (This prevents snooping outside the
+     * users capture scope to some degree). 0 means no maxteilimit, or it's not applicable.
+     *
+     * If we have maxteilimit and paging on, we set the limit to maxteilimit.
+     *
+     * If we dont have maxteilimit, and paging on, we set normal paging parameters
+     *
+     * If neither maxteilimit or paging is set, we have no limit.
+     *
+     * The limit is set in the subquery, so the latter joins have fewer rows to consider.
+     *
+     * @param params
+     * @return a SQL LIMIT and OFFSET clause, or empty string if no LIMIT can be deducted.
+     */
+    private String getFromSubQueryLimitAndOffset( TrackedEntityInstanceQueryParams params )
+    {
+        StringBuilder limitOffset = new StringBuilder();
+        int limit = params.getMaxTeiLimit();
+
+        if ( limit == 0 && !params.isPaging() )
+        {
+            return "";
+        }
+        else if ( limit == 0 && params.isPaging() )
+        {
+            return limitOffset
+                .append( LIMIT )
+                .append( SPACE )
+                .append( params.getPageSizeWithDefault() )
+                .append( SPACE )
+                .append( OFFSET )
+                .append( SPACE )
+                .append( params.getOffset() )
+                .append( SPACE )
+                .toString();
+        }
+        else if ( params.isPaging() )
+        {
+            return limitOffset
+                .append( LIMIT )
+                .append( SPACE )
+                .append( Math.min( limit + 1, params.getPageSizeWithDefault() ) )
+                .append( SPACE )
+                .append( OFFSET )
+                .append( SPACE )
+                .append( params.getOffset() )
+                .append( SPACE )
+                .toString();
+        }
+        else
+        {
+            return limitOffset
+                .append( LIMIT )
+                .append( SPACE )
+                .append( limit + 1 ) // We add +1, since we use this limit to restrict a user to search to wide.
+                .append( SPACE )
+                .toString();
+        }
     }
 
     private List<String> getStaticGridColumns()
     {
 
-        return Arrays.asList( TRACKED_ENTITY_INSTANCE_ID, CREATED_ID, LAST_UPDATED_ID, ORG_UNIT_ID, ORG_UNIT_NAME, TRACKED_ENTITY_ID, INACTIVE_ID );
-    }
-
-    private String getEventWhereClause( TrackedEntityInstanceQueryParams params )
-    {
-        String sql = " where ";
-
-        if ( params.hasEventStatus() )
-        {
-            String start = getMediumDateString( params.getEventStartDate() );
-            String end = getMediumDateString( params.getEventEndDate() );
-
-            if ( params.isEventStatus( EventStatus.COMPLETED ) )
-            {
-                sql += " psi.executiondate >= '" + start + "' and psi.executiondate <= '" + end + "' " + "and psi.status = '" + EventStatus.COMPLETED.name()
-                    + "' and ";
-            }
-            else if ( params.isEventStatus( EventStatus.VISITED ) || params.isEventStatus( EventStatus.ACTIVE ) )
-            {
-                sql += " psi.executiondate >= '" + start + "' and psi.executiondate <= '" + end + "' " + "and psi.status = '" + EventStatus.ACTIVE.name()
-                    + "' and ";
-            }
-            else if ( params.isEventStatus( EventStatus.SCHEDULE ) )
-            {
-                sql += " psi.executiondate is null and psi.duedate >= '" + start + "' and psi.duedate <= '" + end + "' "
-                    + "and psi.status is not null and date(now()) <= date(psi.duedate) and ";
-            }
-            else if ( params.isEventStatus( EventStatus.OVERDUE ) )
-            {
-                sql += " psi.executiondate is null and psi.duedate >= '" + start + "' and psi.duedate <= '" + end + "' "
-                    + "and psi.status is not null and date(now()) > date(psi.duedate) and ";
-            }
-            else if ( params.isEventStatus( EventStatus.SKIPPED ) )
-            {
-                sql += " psi.duedate >= '" + start + "' and psi.duedate <= '" + end + "' " + "and psi.status = '" + EventStatus.SKIPPED.name() + "' and ";
-            }
-        }
-        
-        if ( params.hasProgramStage() )
-        {
-            sql += " psi.programstageid = " + params.getProgramStage().getId() + " and ";
-        }
-
-        if ( params.hasAssignedUsers() )
-        {
-            sql += " (au.uid in (" + getQuotedCommaDelimitedString( params.getAssignedUsers() ) + ")) and ";
-        }
-
-        if ( params.isIncludeOnlyUnassignedEvents() )
-        {
-            sql += " (psi.assigneduserid is null) and ";
-        }
-        if ( params.isIncludeOnlyUnassignedEvents() )
-        {
-            sql += " (psi.assigneduserid is null) and ";
-        }
-
-        if ( params.isIncludeOnlyAssignedEvents() )
-        {
-            sql += " (psi.assigneduserid is not null) and ";
-        }
-
-        sql += " psi.deleted is false ";
-
-        return sql;
+        return Arrays.asList( TRACKED_ENTITY_INSTANCE_ID, CREATED_ID, LAST_UPDATED_ID, ORG_UNIT_ID, ORG_UNIT_NAME,
+            TRACKED_ENTITY_ID, INACTIVE_ID );
     }
 
     private String getEventWhereClauseHql( TrackedEntityInstanceQueryParams params )
@@ -795,12 +1531,12 @@ public class HibernateTrackedEntityInstanceStore
 
             if ( params.isEventStatus( EventStatus.COMPLETED ) )
             {
-                hql += " psi.executionDate >= '" + start + "' and psi.executionDate <= '" + end + "' " + "and psi.status = '" + EventStatus.COMPLETED.name()
+                hql += " psi.executionDate >= '" + start + "' and psi.executionDate <= '" + end + "' " + AND_PSI_STATUS_EQUALS_SINGLE_QUOTE + EventStatus.COMPLETED.name()
                     + "' and ";
             }
             else if ( params.isEventStatus( EventStatus.VISITED ) || params.isEventStatus( EventStatus.ACTIVE ) )
             {
-                hql += " psi.executionDate >= '" + start + "' and psi.executionDate <= '" + end + "' " + "and psi.status = '" + EventStatus.ACTIVE.name()
+                hql += " psi.executionDate >= '" + start + "' and psi.executionDate <= '" + end + "' " + AND_PSI_STATUS_EQUALS_SINGLE_QUOTE + EventStatus.ACTIVE.name()
                     + "' and ";
             }
             else if ( params.isEventStatus( EventStatus.SCHEDULE ) )
@@ -815,7 +1551,7 @@ public class HibernateTrackedEntityInstanceStore
             }
             else if ( params.isEventStatus( EventStatus.SKIPPED ) )
             {
-                hql += " psi.dueDate >= '" + start + "' and psi.dueDate <= '" + end + "' " + "and psi.status = '" + EventStatus.SKIPPED.name() + "' and ";
+                hql += " psi.dueDate >= '" + start + "' and psi.dueDate <= '" + end + "' " + AND_PSI_STATUS_EQUALS_SINGLE_QUOTE + EventStatus.SKIPPED.name() + "' and ";
             }
         }
         

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_32__Add_index_in_tracker_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.35/V2_35_32__Add_index_in_tracker_tables.sql
@@ -1,0 +1,4 @@
+create unique index if not exists in_unique_trackedentityprogramowner_teiid_programid_ouid on trackedentityprogramowner using btree (trackedentityinstanceid, programid, organisationunitid);
+create index if not exists in_programinstance_programid on programinstance using btree (programid);
+create unique index if not exists in_trackedentityinstance_trackedentityattribute_value on trackedentityattributevalue using btree (trackedentityinstanceid, trackedentityattributeid, lower(value));
+create index if not exists in_programstageinstance_status_executiondate on programstageinstance using btree (status,executiondate);

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.cache.CacheStrategy;
@@ -205,6 +206,13 @@ public class TrackedEntityInstanceController
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
         
         int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
+        
+        // Validating here to avoid further querying
+        if ( queryParams.getMaxTeiLimit() > 0 && count > 0
+            && count > queryParams.getMaxTeiLimit() )
+        {
+            throw new IllegalQueryException( "maxteicountreached" );
+        }
 
         if ( criteria.isUseLegacy() || (count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging()) )
         {


### PR DESCRIPTION
this is a forward port of the tracker tei get sql rewrite from 2.34 to 2.35.2 patch version. 
The extra change from 2.34 is that, the api/trackedEntityInstance endpoint also uses the same refactored sql. 