### PR TITLE
fix: Adjust preheat caches for new tracker importer

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionComboStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionComboStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = CategoryOptionCombo.class, mapper = CategoryOptionComboMapper.class, cache = true, ttl = 30 )
+@StrategyFor( value = CategoryOptionCombo.class, mapper = CategoryOptionComboMapper.class, cache = true, ttl = 5 )
 public class CatOptionComboStrategy extends AbstractSchemaStrategy
 {
     public CatOptionComboStrategy( SchemaService schemaService, QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/CatOptionStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = CategoryOption.class, mapper = CategoryOptionMapper.class, cache = true, ttl = 30 )
+@StrategyFor( value = CategoryOption.class, mapper = CategoryOptionMapper.class, cache = true, ttl = 30, capacity = 5 )
 public class CatOptionStrategy extends AbstractSchemaStrategy
 {
     public CatOptionStrategy( SchemaService schemaService, QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/OrgUnitStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/OrgUnitStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = OrganisationUnit.class, mapper = OrganisationUnitMapper.class, cache = true, ttl = 30, capacity = 2000 )
+@StrategyFor( value = OrganisationUnit.class, mapper = OrganisationUnitMapper.class, cache = true, ttl = 30, capacity = 100 )
 public class OrgUnitStrategy extends AbstractSchemaStrategy
 {
     public OrgUnitStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStageStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStageStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = ProgramStage.class, mapper = ProgramStageMapper.class, cache = true, ttl = 20 )
+@StrategyFor( value = ProgramStage.class, mapper = ProgramStageMapper.class, cache = true, ttl = 20, capacity = 30 )
 public class ProgramStageStrategy extends AbstractSchemaStrategy
 {
     public ProgramStageStrategy( SchemaService schemaService, QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/ProgramStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = Program.class, mapper = ProgramMapper.class, cache = true, ttl = 20 )
+@StrategyFor( value = Program.class, mapper = ProgramMapper.class, cache = true, ttl = 20, capacity = 10 )
 public class ProgramStrategy extends AbstractSchemaStrategy
 {
     public ProgramStrategy( SchemaService schemaService, QueryService queryService, IdentifiableObjectManager manager,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/RelationshipTypeStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/RelationshipTypeStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = RelationshipType.class, mapper = RelationshipTypeMapper.class, cache = true, ttl = 10 )
+@StrategyFor( value = RelationshipType.class, mapper = RelationshipTypeMapper.class, cache = true, ttl = 10, capacity = 10 )
 public class RelationshipTypeStrategy extends AbstractSchemaStrategy
 {
     public RelationshipTypeStrategy( SchemaService schemaService, QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
@@ -62,7 +62,10 @@ public @interface StrategyFor
 
     /**
      * The maximum number of entries hold by the cache. Defaults to
-     * Long.MAX_VALUE
+     * 5. The reason for the low default, is that certain objects can contain
+     * a lot of references and quickly consume memory. For most metadata, a
+     * capacity of 5 is not neccesarily small either. We should always specify
+     * capacity for each strategy, on not rely on the default.
      */
-    long capacity() default Long.MAX_VALUE;
+    long capacity() default 5;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/StrategyFor.java
@@ -61,11 +61,11 @@ public @interface StrategyFor
     int ttl() default 5;
 
     /**
-     * The maximum number of entries hold by the cache. Defaults to
-     * 5. The reason for the low default, is that certain objects can contain
-     * a lot of references and quickly consume memory. For most metadata, a
-     * capacity of 5 is not neccesarily small either. We should always specify
-     * capacity for each strategy, on not rely on the default.
+     * The maximum number of entries hold by the cache. Defaults to 5. The
+     * reason for the low default, is that certain objects can contain a lot of
+     * references and quickly consume memory. For most metadata, a capacity of 5
+     * is not necessarily small either. We should always specify capacity for
+     * each strategy, on not rely on the default.
      */
     long capacity() default 5;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/TrackedEntityTypeStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/TrackedEntityTypeStrategy.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
  * @author Luciano Fiandesio
  */
 @Component
-@StrategyFor( value = TrackedEntityType.class, mapper = TrackedEntityTypeMapper.class, cache = true, ttl = 10 )
+@StrategyFor( value = TrackedEntityType.class, mapper = TrackedEntityTypeMapper.class, cache = true, ttl = 10, capacity = 5 )
 public class TrackedEntityTypeStrategy extends AbstractSchemaStrategy
 {
     public TrackedEntityTypeStrategy( SchemaService schemaService, QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategyCachingTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/AbstractSchemaStrategyCachingTest.java
@@ -114,7 +114,7 @@ public class AbstractSchemaStrategyCachingTest
 
         verify( cache, times( 1 ) ).hasKey( "RelationshipType" );
 
-        verify( cache, times( 5 ) ).put( eq( "RelationshipType" ), anyString(), any(), eq( 10 ), eq( Long.MAX_VALUE ) );
+        verify( cache, times( 5 ) ).put( eq( "RelationshipType" ), anyString(), any(), eq( 10 ), eq( 10L ) );
     }
 
     @Test
@@ -162,7 +162,7 @@ public class AbstractSchemaStrategyCachingTest
         // Then
         assertThat( preheat.getAll( Program.class ), hasSize( 1 ) );
 
-        verify( cache, times( 1 ) ).put( eq( "Program" ), anyString(), any(), eq( 20 ), eq( Long.MAX_VALUE ) );
+        verify( cache, times( 1 ) ).put( eq( "Program" ), anyString(), any(), eq( 20 ), eq( 10L ) );
     }
 
 }


### PR DESCRIPTION
After some discussion with Markus and my own evaluations, we set a specific capacity for each cache we use in the tracker importer preheat.
The default was also lowered, just so we don't end up in a bad situation down the line.
