### PR TITLE
feat: adds a multi-region capped local heap cache

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheInfo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheInfo.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * REST API data structures for local cache information.
+ *
+ * @author Jan Bernitt
+ */
+@Getter
+@AllArgsConstructor
+public final class CacheInfo
+{
+
+    @JsonProperty
+    private final CacheCapInfo cap;
+
+    @JsonProperty
+    private final CacheBurdenInfo burden;
+
+    @JsonProperty
+    private final CacheGroupInfo total;
+
+    @JsonProperty
+    private final List<CacheGroupInfo> regions;
+
+    @Getter
+    @Setter
+    @RequiredArgsConstructor
+    public static final class CacheGroupInfo
+    {
+        @JsonProperty
+        private final String name;
+
+        @JsonProperty
+        private final int entries;
+
+        @JsonProperty
+        private final long hints;
+
+        @JsonProperty
+        private final long misses;
+
+        @JsonProperty
+        private final long size;
+
+        @JsonProperty
+        private final double burden;
+
+        @JsonProperty
+        private int highBurdenEntries;
+
+        @JsonProperty
+        public String getSizeHumanReadable()
+        {
+            return humanReadableSize( size );
+        }
+
+        @JsonProperty
+        public long getAverageEntrySize()
+        {
+            return entries == 0 ? 0L : size / entries;
+        }
+
+        @JsonProperty
+        public String getAverageEntrySizeHumanReadable()
+        {
+            return humanReadableSize( getAverageEntrySize() );
+        }
+
+        @JsonProperty
+        public float getHitsMissesRatio()
+        {
+            return misses == 0 ? Float.MAX_VALUE : hints / (float) misses;
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static final class CacheCapInfo
+    {
+        @JsonProperty
+        private final int capPercentage;
+
+        @JsonProperty
+        private final int softCapPercentage;
+
+        @JsonProperty
+        private final int hardCapPercentage;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static final class CacheBurdenInfo
+    {
+
+        @JsonProperty
+        private final int entries;
+
+        @JsonProperty
+        private final long size;
+
+        @JsonProperty
+        private final double threshold;
+
+        @JsonProperty
+        public String getSizeHumanReadable()
+        {
+            return humanReadableSize( size );
+        }
+
+        @JsonProperty
+        public long getAverageEntrySize()
+        {
+            return entries == 0 ? 0L : size / entries;
+        }
+
+        @JsonProperty
+        public String getAverageEntrySizeHumanReadable()
+        {
+            return humanReadableSize( getAverageEntrySize() );
+        }
+    }
+
+    /**
+     * Returns a human readable form of the passed size in bytes. As this is
+     * used in the context of estimated sizes the returned human readable form
+     * is also giving a approximation.
+     *
+     * @param size number of bytes
+     * @return a human readable form of the passed size in bytes.
+     */
+    public static String humanReadableSize( long size )
+    {
+        if ( size == 0L )
+        {
+            return "0";
+        }
+        if ( size > 1024L * 1024L )
+        {
+            return String.format( "~%.1fMB", (size / 1024L / 1024d) );
+        }
+        if ( size > 1024L )
+        {
+            return String.format( "~%.1fkB", (size / 1024d) );
+        }
+        return "< 1kB";
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheInfo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheInfo.java
@@ -70,7 +70,7 @@ public final class CacheInfo
         private final int entries;
 
         @JsonProperty
-        private final long hints;
+        private final long hits;
 
         @JsonProperty
         private final long misses;
@@ -105,7 +105,7 @@ public final class CacheInfo
         @JsonProperty
         public float getHitsMissesRatio()
         {
-            return misses == 0 ? Float.MAX_VALUE : hints / (float) misses;
+            return misses == 0 ? Float.MAX_VALUE : hits / (float) misses;
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/GenericSizeof.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/GenericSizeof.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility to efficiently as possible estimate the memory usage of an object
+ * similar to the {@code sizeof} operator in C.
+ *
+ * @author Jan Bernitt
+ */
+@Slf4j
+public final class GenericSizeof implements Sizeof
+{
+
+    /**
+     * Size of any primitive except long and double.
+     */
+    private static final Sizeof WORD = Sizeof.constant( 4 );
+
+    /**
+     * Size of long and double
+     */
+    private static final Sizeof DOUBLE_WORD = Sizeof.constant( 8 );
+
+    /**
+     * The number of bytes we assume each {@link Object} requires for JVM object
+     * headers which are not visible to reflection.
+     */
+    private final long objectHeaderSize;
+
+    private final UnaryOperator<Object> unwrap;
+
+    /**
+     * A cache to remember the SizeofOperator that can compute the size of an
+     * object of the key type.
+     */
+    private final Map<Type, Sizeof> sizeofByType = new ConcurrentHashMap<>();
+
+    /**
+     * A cache to remember the constant size values of the key type have. If a
+     * type does not have a constant size its value is {@code <= 0}.
+     */
+    private final Map<Class<?>, Long> fixedSizeOfType = new ConcurrentHashMap<>();
+
+    public GenericSizeof( long objectHeaderSize, UnaryOperator<Object> unwrap )
+    {
+        this.objectHeaderSize = objectHeaderSize;
+        this.unwrap = unwrap;
+        fixedSizeOfType.put( Class.class, 0L );
+        fixedSizeOfType.put( Constructor.class, 0L );
+        fixedSizeOfType.put( Method.class, 0L );
+        fixedSizeOfType.put( Field.class, 0L );
+        fixedSizeOfType.put( Pattern.class, 0L );
+    }
+
+    @Override
+    public long sizeof( Object obj )
+    {
+        if ( obj == null )
+        {
+            return 0L;
+        }
+        Class<?> type = unwrap.apply( obj ).getClass();
+        Sizeof sizeof = getSizeof( type );
+        if ( sizeof == this )
+        {
+            log.warn( "sizeof: resolution of " + type + " has cycles." );
+            return objectHeaderSize; // give ip;
+        }
+        return sizeof.sizeof( obj );
+    }
+
+    private Sizeof getSizeof( Class<?> type )
+    {
+        return getSizeof( type, type );
+    }
+
+    private Sizeof getSizeof( Class<?> type, Type genericType )
+    {
+        Sizeof sizeof = sizeofByType.get( type );
+        if ( sizeof != null )
+        {
+            return sizeof;
+        }
+        try
+        {
+            // OBS! we cannot use computeIfAbsent because this could cause
+            // recursive
+            // updates where computation of the value includes putting the key
+            sizeof = computeSizeof( type, genericType );
+            sizeofByType.putIfAbsent( genericType, sizeof );
+            return sizeof;
+        }
+        catch ( Throwable t )
+        {
+            log.error( "sizeof: Failed to compute function for " + type + ": ", t );
+            return Sizeof.constant( objectHeaderSize ); // give up
+        }
+    }
+
+    private Sizeof getSizeof( Type keyType )
+    {
+        return keyType instanceof Class
+            ? getSizeof( (Class<?>) keyType, keyType )
+            : getSizeof( (Class<?>) ((ParameterizedType) keyType).getRawType(), keyType );
+    }
+
+    private Sizeof computeSizeof( Class<?> type, Type genericType )
+    {
+        if ( type.isPrimitive() )
+        {
+            return isDoubleWord( type ) ? DOUBLE_WORD : WORD;
+        }
+        if ( type.isArray() )
+        {
+            return computeArraySizeof( type );
+        }
+        long fixedSize = getFixedSize( type );
+        if ( fixedSize >= 0 )
+        {
+            return Sizeof.constant( fixedSize );
+        }
+        if ( Collection.class.isAssignableFrom( type ) )
+        {
+            return computeCollectionSizeof( genericType );
+        }
+        if ( Map.class.isAssignableFrom( type ) )
+        {
+            return computeMapSizeof( genericType );
+        }
+        if ( type == Object.class || isNotStaticallyDeterminedInSize( type ) )
+        {
+            // we have to find out dynamically when we have the actual object
+            return this;
+        }
+        return computeFieldBasedSize( type );
+    }
+
+    private Sizeof computeArraySizeof( Class<?> type )
+    {
+        Class<?> elementType = type.getComponentType();
+        if ( elementType.isPrimitive() )
+        {
+            return Sizeof.arrayOfPrimitive( objectHeaderSize );
+        }
+        long elementSize = getFixedSize( elementType );
+        if ( elementSize >= 0 )
+        {
+            return Sizeof.arrayOfFixed( objectHeaderSize, elementSize );
+        }
+        return Sizeof.arrayOfDynamic( objectHeaderSize, getSizeof( elementType ) );
+    }
+
+    private Sizeof computeCollectionSizeof( Type collectionType )
+    {
+        Type elementType = getTypeParameter( 0, collectionType );
+        if ( elementType instanceof Class )
+        {
+            long elementSize = computeFixedSizeof( (Class<?>) elementType );
+            if ( elementSize > 0L )
+            {
+                return Sizeof.collectionOfFixed( objectHeaderSize, elementSize );
+            }
+        }
+        return Sizeof.collectionOfDynamic( objectHeaderSize, getSizeof( elementType ) );
+    }
+
+    private Sizeof computeMapSizeof( Type mapType )
+    {
+        return Sizeof.mapOfDynamic( objectHeaderSize,
+            getSizeof( getTypeParameter( 0, mapType ) ),
+            getSizeof( getTypeParameter( 1, mapType ) ) );
+    }
+
+    private Type getTypeParameter( int index, Type genericType )
+    {
+        if ( genericType instanceof ParameterizedType )
+        {
+            ParameterizedType type = (ParameterizedType) genericType;
+            return type.getActualTypeArguments()[index];
+        }
+        return Object.class; // we give up => dynamic analysis based on object
+    }
+
+    private boolean isDoubleWord( Class<?> type )
+    {
+        return type == long.class || type == double.class;
+    }
+
+    private Sizeof computeFieldBasedSize( Class<?> type )
+    {
+        long constantSizeSum = objectHeaderSize;
+        List<Sizeof> parts = new ArrayList<>();
+        Class<?> t = type;
+        while ( t != null )
+        {
+            for ( Field field : t.getDeclaredFields() )
+            {
+                if ( isInstanceField( field ) )
+                {
+                    long fixedSize = getFixedSize( field.getType() );
+                    if ( fixedSize >= 0 )
+                    {
+                        constantSizeSum += fixedSize;
+                    }
+                    else
+                    {
+                        parts.add(
+                            Sizeof.fieldSizeof( field, unwrap, getSizeof( field.getType(), field.getGenericType() ) ) );
+                    }
+                }
+            }
+            t = t.getSuperclass();
+        }
+        if ( constantSizeSum > 0 )
+        {
+            if ( parts.isEmpty() )
+            {
+                return Sizeof.constant( constantSizeSum );
+            }
+            parts.add( Sizeof.constant( constantSizeSum ) );
+        }
+        return Sizeof.sum( parts.toArray( new Sizeof[0] ) );
+    }
+
+    private boolean isInstanceField( Field f )
+    {
+        return !Modifier.isStatic( f.getModifiers() );
+    }
+
+    private long getFixedSize( Class<?> type )
+    {
+        Long size = fixedSizeOfType.get( type );
+        if ( size != null )
+        {
+            return size;
+        }
+        long fixedSize = computeFixedSizeof( type );
+        // OBS! we cannot use computeIfAbsent because this could cause recursive
+        // updates where computation of the value includes putting the key
+        fixedSizeOfType.putIfAbsent( type, fixedSize );
+        return fixedSize;
+    }
+
+    private long computeFixedSizeof( Class<?> type )
+    {
+        if ( type.isPrimitive() )
+        {
+            return isDoubleWord( type ) ? 8L : 4L;
+        }
+        if ( isRuntimeType( type ) )
+        {
+            return 0L; // no extra costs
+        }
+        if ( Proxy.isProxyClass( type ) )
+        {
+            log.info( "sizeof: Ignoring proxy: " + type );
+            return 0L; // some bad design referencing services in data objects
+        }
+        if ( isNotStaticallyDeterminedInSize( type ) )
+        {
+            return -1L; // certainly not constant in size
+        }
+        return computedFixedSizeofFields( type );
+    }
+
+    private long computedFixedSizeofFields( Class<?> type )
+    {
+        long sum = 0L;
+        for ( Field field : type.getDeclaredFields() )
+        {
+            if ( isInstanceField( field ) )
+            {
+                long fieldSize = getFixedSize( field.getType() );
+                if ( fieldSize < 0L )
+                {
+                    return -1L; // meh, not a constant type
+                }
+                sum += fieldSize;
+            }
+        }
+        // now also add supertypes
+        Class<?> base = type.getSuperclass();
+        while ( base != null )
+        {
+            long baseSize = getFixedSize( base );
+            if ( baseSize < 0L )
+            {
+                return -1L; // meh, not constant size type
+            }
+            sum += baseSize;
+            base = base.getSuperclass();
+        }
+        return sum;
+    }
+
+    private boolean isNotStaticallyDeterminedInSize( Class<?> type )
+    {
+        return type.isInterface()
+            || type.isArray()
+            || Modifier.isAbstract( type.getModifiers() );
+    }
+
+    private boolean isRuntimeType( Class<?> type )
+    {
+        return type == Class.class || type == Constructor.class || type == Method.class || type == Field.class
+            || ClassLoader.class.isAssignableFrom( type ) || type.getName().contains( "lambda" );
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Sizeof.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Sizeof.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.UnaryOperator;
+
+/**
+ * {@link Sizeof} is a operator that given an object returns the estimated size
+ * of this object in bytes. Can estimate the size of a particular type.
+ *
+ * To be efficient in the estimation of objects a {@link Sizeof} is composed
+ * based on the {@link Class} metadata available for given object type. This
+ * composed operator will have a part that is determined once when statically
+ * analysing a certain {@link Class} and might have a dynamic part for those
+ * parts of an object that do not allow static analysis. An example would be a
+ * field of type {@link Object} which could hold any actual object. In such a
+ * case the analysis would resolve the {@link Sizeof} operator dynamically for
+ * the actual {@link Class} of the present value.
+ *
+ * @author Jan Bernitt
+ */
+@FunctionalInterface
+interface Sizeof
+{
+
+    /**
+     * Estimates the total size of the given java object in the heap memory in
+     * number of bytes. This includes all objects referenced by fields of this
+     * objects recursively.
+     *
+     * It cannot be emphasised enough that this size is an estimation based on
+     * assumptions such as the size of the java object header or the size of a
+     * java reference pointer. Also this estimation uses a simplified
+     * perspective where details such additional size for array object headers
+     * are neglected.
+     *
+     * At times the estimation is deliberately pessimistic. For example for
+     * fields of a type of fixed know size (like an {@link Integer}) the
+     * estimation will assume the field does hold a value independent of the
+     * actual passed object pointing to {@code null} for that field or not. This
+     * is simply to allow efficient estimation of complex and deeply
+     * hierarchical object structures.
+     *
+     * @param obj an arbitrary java object
+     * @return number of bytes of memory used by the object
+     */
+    long sizeof( Object obj );
+
+    /**
+     * Creates a {@link Sizeof} operator that simply returns a constant size.
+     * This size has been a result of static analysis. Like the size of an a
+     * primitive or the sum of multiple of those and or the java object header.
+     *
+     * @param size number of bytes
+     * @return a {@link Sizeof} operator that simply returns the given fixed
+     *         size
+     */
+    static Sizeof constant( long size )
+    {
+        return obj -> size;
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator that sums up different parts of the
+     * analysis. Usually this is a {@link #constant(long)} part and one or more
+     * {@link #fieldSizeof(Field, UnaryOperator, Sizeof)} parts.
+     *
+     * @param parts parts of object sizeof analysis to sum
+     * @return a {@link Sizeof} operator that sums up all given parts
+     */
+    static Sizeof sum( Sizeof... parts )
+    {
+        return obj -> {
+            long sum = 0L;
+            for ( Sizeof part : parts )
+            {
+                sum += part.sizeof( obj );
+            }
+            return sum;
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} for fields which size value needs to be
+     * evaluated based on the actual value given the provided {@link Sizeof}
+     * operator.
+     *
+     * @param f field to extract.
+     * @param unwrap operator to unwrap the field value
+     * @param operator {@link Sizeof} operator to apply to the field value
+     * @return A {@link Sizeof} that extracts the given field from the object
+     *         and estimates it size given the provided {@link Sizeof} operator
+     */
+    static Sizeof fieldSizeof( Field f, UnaryOperator<Object> unwrap, Sizeof operator )
+    {
+        f.setAccessible( true );
+        return obj -> {
+            if ( obj == null )
+            {
+                return 4L; // this field
+            }
+            try
+            {
+                // 4 is for the field itself
+                // this would not be used for primitives
+                Object value = unwrap.apply( f.get( obj ) );
+                return 4L + operator.sizeof( value );
+            }
+            catch ( IllegalAccessException e )
+            {
+                return 8L; // very, very optimistic guess
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator for primitive arrays. It will assume it
+     * is only applied to objects that are arrays of primitives.
+     */
+    static Sizeof arrayOfPrimitive( long objectHeaderSize )
+    {
+        return obj -> {
+            if ( obj == null )
+            {
+                return 0L;
+            }
+            int length = Array.getLength( obj );
+            if ( obj instanceof byte[] )
+            {
+                return objectHeaderSize + length;
+            }
+            if ( obj instanceof char[] )
+            {
+                return objectHeaderSize + length * 2L;
+            }
+            if ( obj instanceof long[] || obj instanceof double[] )
+            {
+                return objectHeaderSize + length * 8L;
+            }
+            // all others we assume the worst implementation
+            return objectHeaderSize + length * 4L;
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator for reference arrays of element types
+     * with a fixed size. Like an array if {@link Integer}
+     */
+    static Sizeof arrayOfFixed( long objectHeaderSize, long elementSize )
+    {
+        return obj -> {
+            if ( obj == null )
+            {
+                return 0L;
+            }
+            Object[] array = (Object[]) obj;
+            return objectHeaderSize + array.length * (4L + elementSize);
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator for reference arrays of element types
+     * with a size that is not statically known. Like an array of {@link String}
+     * (as each value might have unpredictable length) or other more complex
+     * types with array or complex fields.
+     */
+    static Sizeof arrayOfDynamic( long objectHeaderSize, Sizeof elementSize )
+    {
+        return obj -> {
+            if ( obj == null )
+            {
+                return 0L;
+            }
+            Object[] array = (Object[]) obj;
+            long sum = objectHeaderSize + array.length * 4L; // the array itself
+            for ( Object e : array )
+            {
+                sum += elementSize.sizeof( e );
+            }
+            return sum;
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator for {@link Collection}s with an element
+     * type that has a fixed statically known size. Like a
+     * {@link java.util.List} of {@link Integer}.
+     */
+    static Sizeof collectionOfFixed( long objectHeaderSize, long elementSize )
+    {
+        return obj -> {
+            if ( obj == null )
+            {
+                return 0L;
+            }
+            return objectHeaderSize + ((Collection<?>) obj).size() * (8L + elementSize);
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator for {@link Collection}s with an element
+     * type with a size that is not statically known and that needs to be
+     * estimated by the provided {@link Sizeof} operator for elements.
+     */
+    static Sizeof collectionOfDynamic( long objectHeaderSize, Sizeof elementSize )
+    {
+        return obj -> {
+            if ( obj == null )
+            {
+                return 0L;
+            }
+            // for the root ref and state in the collection
+            long sum = objectHeaderSize;
+            for ( Object e : (Collection<?>) obj )
+            {
+                // assume at least 2 reference per element need to organise
+                sum += 8L + elementSize.sizeof( e );
+            }
+            return sum;
+        };
+    }
+
+    /**
+     * Creates a {@link Sizeof} operator for {@link Map}s. This is used for both
+     * maps with keys and/or values of fixed size and statically unknown size.
+     *
+     * In case a key or value has a fixed size the provided operator will simply
+     * return a {@link #constant(long)} size.
+     */
+    static Sizeof mapOfDynamic( long objectHeaderSize, Sizeof keySize, Sizeof valueSize )
+    {
+        return obj -> {
+            if ( obj == null )
+            {
+                return 0L;
+            }
+            long sum = objectHeaderSize;
+            for ( Entry<?, ?> e : ((Map<?, ?>) obj).entrySet() )
+            {
+                sum += keySize.sizeof( e.getKey() );
+                sum += valueSize.sizeof( e.getValue() );
+                sum += objectHeaderSize + 12L; // for the entry
+            }
+            return sum;
+        };
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Sizeof.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Sizeof.java
@@ -127,14 +127,17 @@ interface Sizeof
         return obj -> {
             if ( obj == null )
             {
-                return 4L; // this field
+                return 0L; // this field
             }
             try
             {
-                // 4 is for the field itself
                 // this would not be used for primitives
                 Object value = unwrap.apply( f.get( obj ) );
-                return 4L + operator.sizeof( value );
+                if ( value == null )
+                {
+                    return 0L;
+                }
+                return operator.sizeof( value );
             }
             catch ( IllegalAccessException e )
             {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/cache/SizeofTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/cache/SizeofTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.hisp.dhis.period.PeriodType;
+import org.junit.Test;
+
+/**
+ * Tests the {@link Sizeof} and {@link GenericSizeof} implementation.
+ *
+ * @author Jan Bernitt
+ */
+public class SizeofTest
+{
+
+    public static class PrimitiveAndWrapperBean
+    {
+        int a;
+
+        long b;
+
+        Integer c;
+    }
+
+    public static class CollectionBean
+    {
+        List<Integer> a;
+
+        List<List<Long>> b;
+
+        CollectionBean()
+        {
+            this( null, null );
+        }
+
+        CollectionBean( List<Integer> a, List<List<Long>> b )
+        {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    private final Sizeof sizeof = new GenericSizeof( 20L, obj -> obj );
+
+    @Test
+    public void testSizeofNull()
+    {
+        assertEquals( 0L, sizeof.sizeof( null ) );
+    }
+
+    @Test
+    public void testSizeofPrimitives()
+    {
+        assertEquals( 24L, sizeof.sizeof( 3 ) );
+        assertEquals( 28L, sizeof.sizeof( 3L ) );
+        assertEquals( 28L, sizeof.sizeof( 3d ) );
+    }
+
+    @Test
+    public void testSizeofPrimitiveArray()
+    {
+        assertEquals( 40L, sizeof.sizeof( new byte[20] ) );
+    }
+
+    @Test
+    public void testSizeofFixedArray()
+    {
+        // sizeof(Integer) = 24 * 10 for each Integer object
+        // + 20 for array object header
+        // + 10 * 4 for the reference array itself
+        assertEquals( 24L * 10 + 20L + 10 * 4L, sizeof.sizeof( new Integer[10] ) );
+    }
+
+    @Test
+    public void testSizeofString()
+    {
+        // base costs are: 20 + 20 + 8 = 48
+        assertEquals( 64L, sizeof.sizeof( "hello world!" ) );
+        assertEquals( 58L, sizeof.sizeof( "hello!" ) );
+    }
+
+    @Test
+    public void testSizeofRecord()
+    {
+        // 20 object header of BeanA
+        // + 4 int
+        // + 8 long
+        // + 4 ref => + 24 Integer
+        assertEquals( 60L, sizeof.sizeof( new PrimitiveAndWrapperBean() ) );
+    }
+
+    @Test
+    public void testSizeofList()
+    {
+        // just the object header
+        assertEquals( 20L, sizeof.sizeof( emptyList() ) );
+        // dynamic list as we do not have a generic type
+        // 20 object header wrapper
+        // 20 object header size
+        // + 3 * 24 Integer objects
+        // + 3 * 8 for references and list structure
+        assertEquals( 116, sizeof.sizeof( asList( 1, 2, 3 ) ) );
+    }
+
+    @Test
+    public void testSizeofListFields()
+    {
+        // 20 object header + 4 + 4 for ref fields
+        assertEquals( 28L, sizeof.sizeof( new CollectionBean() ) );
+        // 20 object header + 4 + 4 ref fields
+        // + 20 object header of the list
+        // + 3 * 24 Integer's + 3 * 8 for list structure
+        // + 20 object header empty list
+        assertEquals( 164L, sizeof.sizeof( new CollectionBean( asList( 1, 2, 3 ), emptyList() ) ) );
+    }
+
+    @Test
+    public void testSizeofPeriodType()
+    {
+        for ( PeriodType t : PeriodType.PERIOD_TYPES )
+        {
+            assertTrue( sizeof.sizeof( t ) > 0L );
+        }
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/cache/SizeofTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/cache/SizeofTest.java
@@ -29,10 +29,15 @@ package org.hisp.dhis.cache;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.hisp.dhis.period.PeriodType;
 import org.junit.Test;
@@ -66,6 +71,19 @@ public class SizeofTest
         }
 
         CollectionBean( List<Integer> a, List<List<Long>> b )
+        {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public static class MapBean
+    {
+        Map<String, Integer> a;
+
+        Map<String, Map<Integer, Long>> b;
+
+        public MapBean( Map<String, Integer> a, Map<String, Map<Integer, Long>> b )
         {
             this.a = a;
             this.b = b;
@@ -122,10 +140,15 @@ public class SizeofTest
     }
 
     @Test
-    public void testSizeofList()
+    public void testSizeofEmptyList()
     {
         // just the object header
         assertEquals( 20L, sizeof.sizeof( emptyList() ) );
+    }
+
+    @Test
+    public void testSizeofUnknownElementTypeList()
+    {
         // dynamic list as we do not have a generic type
         // 20 object header wrapper
         // 20 object header size
@@ -144,6 +167,54 @@ public class SizeofTest
         // + 3 * 24 Integer's + 3 * 8 for list structure
         // + 20 object header empty list
         assertEquals( 164L, sizeof.sizeof( new CollectionBean( asList( 1, 2, 3 ), emptyList() ) ) );
+    }
+
+    @Test
+    public void testSizeofListOfListFields()
+    {
+        CollectionBean listOfLists = new CollectionBean( emptyList(),
+            asList( asList( 1L, 2L ), asList( 3L, 4L ), asList( 5L, 6L ) ) );
+        assertEquals( 368L, sizeof.sizeof( listOfLists ) );
+    }
+
+    @Test
+    public void testSizeofEmptyMapFields()
+    {
+        assertEquals( 28L, sizeof.sizeof( new MapBean( null, null ) ) );
+    }
+
+    @Test
+    public void testSizeofSingletonMapFields()
+    {
+        assertEquals( 159L, sizeof.sizeof( new MapBean( singletonMap( "key", 1 ), null ) ) );
+    }
+
+    @Test
+    public void testSizeofHashMapFields()
+    {
+        Map<String, Integer> map = new HashMap<>();
+        map.put( "a", 1 );
+        map.put( "b", 2 );
+        assertEquals( 266L, sizeof.sizeof( new MapBean( map, null ) ) );
+    }
+
+    @Test
+    public void testSizeofTreeMapFields()
+    {
+        Map<String, Integer> map = new TreeMap<>();
+        map.put( "a", 1 );
+        map.put( "b", 2 );
+        assertEquals( 266L, sizeof.sizeof( new MapBean( map, null ) ) );
+    }
+
+    @Test
+    public void testSizeofMapOfMapsFields()
+    {
+        Map<String, Map<Integer, Long>> map = new HashMap<>();
+        map.put( "tree", new TreeMap<>() );
+        map.put( "singleton", singletonMap( 1, 42L ) );
+        map.put( "empty", emptyMap() );
+        assertEquals( 462L, sizeof.sizeof( new MapBean( null, map ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -45,6 +45,7 @@ public enum ConfigurationKey
     SYSTEM_SQL_VIEW_TABLE_PROTECTION( "system.sql_view_table_protection", Constants.ON, false ),
     SYSTEM_PROGRAM_RULE_SERVER_EXECUTION( "system.program_rule.server_execution", Constants.ON, false ),
     SYSTEM_CACHE_MAX_SIZE_FACTOR( "system.cache.max_size.factor", "0.5", false ),
+    SYSTEM_CACHE_CAP_PERCENTAGE( "system.cache.cap.percentage", "50", false ),
     NODE_ID( "node.id", "", false ),
     ENCRYPTION_PASSWORD( "encryption.password", "", true ),
     CONNECTION_DIALECT( "connection.dialect", "", false ),

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -45,7 +45,7 @@ public enum ConfigurationKey
     SYSTEM_SQL_VIEW_TABLE_PROTECTION( "system.sql_view_table_protection", Constants.ON, false ),
     SYSTEM_PROGRAM_RULE_SERVER_EXECUTION( "system.program_rule.server_execution", Constants.ON, false ),
     SYSTEM_CACHE_MAX_SIZE_FACTOR( "system.cache.max_size.factor", "0.5", false ),
-    SYSTEM_CACHE_CAP_PERCENTAGE( "system.cache.cap.percentage", "50", false ),
+    SYSTEM_CACHE_CAP_PERCENTAGE( "system.cache.cap.percentage", "0", false ),
     NODE_ID( "node.id", "", false ),
     ENCRYPTION_PASSWORD( "encryption.password", "", true ),
     CONNECTION_DIALECT( "connection.dialect", "", false ),

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
@@ -1,0 +1,747 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.Math.max;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.UnaryOperator;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.hibernate.Hibernate;
+import org.hisp.dhis.cache.CacheInfo.CacheBurdenInfo;
+import org.hisp.dhis.cache.CacheInfo.CacheCapInfo;
+import org.hisp.dhis.cache.CacheInfo.CacheGroupInfo;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The {@link CappedLocalCache} is a multi-region cache that tries to estimate
+ * the memory usage of cache entries and prevent all cache regions from together
+ * use over a configured cap limit.
+ *
+ * The cap is in relation to the maximum heap memory available to the JVM.
+ *
+ * Main configuration is the heap cap percentage. This is how much of the heap
+ * the cache is going to use at most. One has to remember that this is based on
+ * estimated sizes of cached objects.
+ *
+ * Secondary cap settings are the soft and hard caps which are in relation to
+ * the maximum memory the cache is using.
+ *
+ * When entries occupy memory beyond the hard cap the cache aggressively tries
+ * to free memory by invalidating the entries it deems the most burden (the
+ * least useful).
+ *
+ * When entries occupy memory beyond the soft cap the cache tries to free memory
+ * each time a new entry is added by invalidating some entries deemed a burden.
+ *
+ * The cache is organised by a map of regions, each having a map of entries.
+ * Both regions and entries record metadata to distinguish entries that are a
+ * burden from those that are useful.
+ *
+ * A watcher thread uses the metadata to compose a list of high burden entries
+ * in a regular interval. This list is used in case memory should be freed after
+ * entries are inserted or overall memory of the JVM is reaching its maximum.
+ *
+ * @author Jan Bernitt
+ */
+@Slf4j
+@Component
+public class CappedLocalCache
+{
+    /**
+     * Only used to measure the {@link Sizeof} overhead of the
+     * {@link CacheEntry} itself.
+     */
+    public static final Object EMPTY = new CacheEntry<>( null, null, null, 0L, 0L, 0L );
+
+    /**
+     * A {@link CacheRegion} works like a {@link Cache} facade for the
+     * underlying {@link CappedLocalCache} where all values share a single
+     * space.
+     *
+     * @param <V> type of values stored.
+     */
+    private static final class CacheRegion<V> implements Cache<V>
+    {
+        private final String region;
+
+        private final V defaultValue;
+
+        private final long defaultTtlInSeconds;
+
+        private final ConcurrentMap<String, CacheEntry<V>> entries = new ConcurrentHashMap<>();
+
+        private final LongConsumer sizeDeltaListener;
+
+        private final Sizeof sizeof;
+
+        private final long emptyEntrySize;
+
+        private final AtomicLong totalRegionSize = new AtomicLong();
+
+        private final AtomicLong hits = new AtomicLong();
+
+        private final AtomicLong misses = new AtomicLong();
+
+        CacheRegion( final CacheBuilder<V> builder, Sizeof sizeof, LongConsumer sizeDeltaListener )
+        {
+            this.region = builder.getRegion();
+            log.info( "Local capped cache instance created for region: '{}'", region );
+            this.defaultValue = builder.getDefaultValue();
+            this.defaultTtlInSeconds = builder.getExpiryInSeconds();
+            this.sizeof = sizeof;
+            this.emptyEntrySize = sizeof.sizeof( EMPTY );
+            this.sizeDeltaListener = sizeDeltaListener;
+        }
+
+        long getHits()
+        {
+            return hits.get();
+        }
+
+        long getMisses()
+        {
+            return misses.get();
+        }
+
+        @Override
+        public Optional<V> getIfPresent( String key )
+        {
+            return getOrDefault( key, value -> value );
+        }
+
+        @Override
+        public Optional<V> get( String key )
+        {
+            return getOrDefault( key, value -> value == null ? defaultValue : value );
+        }
+
+        private Optional<V> getOrDefault( String key, UnaryOperator<V> value )
+        {
+            CacheEntry<V> entry = entries.get( key );
+            if ( entry == null )
+            {
+                misses.incrementAndGet();
+                return Optional.empty();
+            }
+            hits.incrementAndGet();
+            return Optional.ofNullable( value.apply( entry.read() ) );
+        }
+
+        @Override
+        public Optional<V> get( String key, Function<String, V> fetcher )
+        {
+            if ( null == fetcher )
+            {
+                throw new IllegalArgumentException( "MappingFunction cannot be null" );
+            }
+            CacheEntry<V> entry = entries.get( key );
+            V value = entry == null ? null : entry.read();
+            if ( value != null )
+            {
+                hits.incrementAndGet();
+                return Optional.of( value );
+            }
+            misses.incrementAndGet();
+            value = fetcher.apply( key );
+            if ( value == null && entry != null )
+            {
+                // still null, no entry update needed
+                return Optional.ofNullable( defaultValue );
+            }
+            // need new entry...
+            put( key, value );
+            return Optional.ofNullable( value == null ? defaultValue : value );
+        }
+
+        @Override
+        public Collection<V> getAll()
+        {
+            return entries.values().stream().map( CacheEntry::read ).collect( toList() );
+        }
+
+        @Override
+        public void put( String key, V value )
+        {
+            put( key, value, defaultTtlInSeconds );
+        }
+
+        @Override
+        public void put( String key, V value, long ttlInSeconds )
+        {
+            long entrySize = emptyEntrySize + sizeof.sizeof( key ) + sizeof.sizeof( value );
+            long now = currentTimeMillis();
+            CacheEntry<V> oldEntry = entries.put( key,
+                new CacheEntry<>( region, key, value, now, now + (ttlInSeconds * 1000L), entrySize ) );
+            long sizeDelta = entrySize - (oldEntry == null ? 0L : oldEntry.size);
+            totalRegionSize.addAndGet( sizeDelta );
+            sizeDeltaListener.accept( sizeDelta );
+        }
+
+        @Override
+        public void invalidate( String key )
+        {
+            invalidate( entries.remove( key ), false );
+        }
+
+        /**
+         * @param entry the entry to invalidate
+         * @param remove true, if the entry needs removing, false if the passed
+         *        entry already was removed
+         * @return true, if the entry wasn't already removed, else false
+         */
+        boolean invalidate( CacheEntry<?> entry, boolean remove )
+        {
+            if ( entry == null )
+            {
+                return false; // already removed by another thread
+            }
+            if ( remove && entries.remove( entry.key ) != entry )
+            {
+                return false; // already removed
+            }
+            long sizeDelta = -entry.size;
+            totalRegionSize.addAndGet( sizeDelta );
+            sizeDeltaListener.accept( sizeDelta );
+            return true;
+        }
+
+        @Override
+        public void invalidateAll()
+        {
+            long sizeDelta = -totalRegionSize.get();
+            entries.clear();
+            totalRegionSize.set( 0L );
+            sizeDeltaListener.accept( sizeDelta );
+        }
+
+        @Override
+        public CacheType getCacheType()
+        {
+            return CacheType.IN_MEMORY;
+        }
+
+        @Override
+        public String toString()
+        {
+            return region + "[" + CacheInfo.humanReadableSize( totalRegionSize.get() ) + " for " + entries.size()
+                + " entries]";
+        }
+    }
+
+    private static final class CacheEntry<V>
+    {
+
+        final String region;
+
+        final String key;
+
+        private final V value;
+
+        /**
+         * System time when this entry was cached
+         */
+        final long created;
+
+        /**
+         * System time when this entry expires
+         */
+        final long expires;
+
+        /**
+         * Number of bytes this entry is estimated to use in memory
+         */
+        final long size;
+
+        /**
+         * Number of read accesses since creation
+         */
+        private int reads;
+
+        CacheEntry( String region, String key, V value, long created, long expires, long size )
+        {
+            this.region = region;
+            this.key = key;
+            this.value = value;
+            this.created = created;
+            this.expires = expires;
+            this.size = size;
+        }
+
+        V read()
+        {
+            reads++;
+            return value;
+        }
+
+        public boolean isExpired( long now )
+        {
+            return now >= expires;
+        }
+
+        /**
+         * Is a number that expresses how much an entry contributes to memory
+         * usage. Higher is worse. Lower is better.
+         * <p>
+         * We want to get rid of the entries with highest burden.
+         * <p>
+         * Burden increases the less a value is accessed and the closer it gets
+         * to the end of it maximum lifespan - its expiry.
+         *
+         * @param now what to consider system time of now
+         * @return burden this entry causes for memory
+         */
+        public long burden( long now )
+        {
+            if ( isExpired( now ) )
+            {
+                return Long.MAX_VALUE;
+            }
+            long avgAccessTime = (now - created) / max( 1, reads );
+            double avgReadsPerSec = 1000d / avgAccessTime;
+            double lifespanLeftRatio = getRelativeBurden( expires - now, expires - created );
+            return (long) (size / avgReadsPerSec / (lifespanLeftRatio == 0d ? 0.0001 : lifespanLeftRatio));
+        }
+
+        @Override
+        public String toString()
+        {
+            return region + ":" + key + "[" + CacheInfo.humanReadableSize( size ) + "]";
+        }
+    }
+
+    private final ConcurrentMap<String, CacheRegion<?>> regions = new ConcurrentHashMap<>();
+
+    private final Sizeof sizeof;
+
+    private final AtomicLong totalSize = new AtomicLong();
+
+    private final AtomicReference<Deque<CacheEntry<?>>> highBurdenEntries = new AtomicReference<>(
+        new ConcurrentLinkedDeque<>() );
+
+    private final AtomicBoolean watcherStarted = new AtomicBoolean();
+
+    private final Runtime runtime;
+    /*
+     * Settings and Statistics
+     */
+
+    private final AtomicReference<CacheInfo> info = new AtomicReference<>();
+
+    private volatile long highBurdenThreshold = Long.MAX_VALUE;
+
+    /**
+     * In reference to the JVM max heap that is the absolute cap for the memory
+     * used by this cache. For example 50 means half the JVM heap is used max.
+     */
+    private volatile int capPercent;
+
+    /**
+     * {@link #capPercent} of the {@link Runtime#maxMemory()}.
+     */
+    private volatile long capSize;
+
+    /**
+     * In reference to {@link #capSize}. If more than this percentage of the
+     * reference size is used entries are freed aggressively.
+     */
+    private volatile int hardCapPercentage = 80;
+
+    /**
+     * {@link #hardCapPercentage} of {@link #capSize}
+     */
+    private volatile long hardCapSize;
+
+    /**
+     * In reference to {@link #capSize}. If more than this percentage of the
+     * reference size is used adding entries tries to compensate by freeing
+     * burden entries of the same or larger size.
+     */
+    private volatile int softCapPercentage = 60;
+
+    /**
+     * {@link #softCapPercentage} of {@link #capSize}
+     */
+    private volatile long softCapSize;
+
+    @Autowired
+    public CappedLocalCache( DhisConfigurationProvider config )
+    {
+        this( new GenericSizeof( 20L, Hibernate::unproxy ),
+            parseInt( config.getPropertyOrDefault( ConfigurationKey.SYSTEM_CACHE_CAP_PERCENTAGE, "50" ) ) );
+    }
+
+    public CappedLocalCache( Sizeof sizeof, int capPercent )
+    {
+        this.sizeof = sizeof;
+        this.runtime = Runtime.getRuntime();
+        setCapPercent( capPercent );
+    }
+
+    public CacheInfo getInfo()
+    {
+        return info.get();
+    }
+
+    public Set<String> getRegions()
+    {
+        return unmodifiableSet( regions.keySet() );
+    }
+
+    public void setCapPercent( int capPercent )
+    {
+        this.capPercent = capPercent;
+        this.capSize = Runtime.getRuntime().maxMemory() / 100 * capPercent;
+        setHardCapPercentage( hardCapPercentage );
+        setSoftCapPercentage( softCapPercentage );
+    }
+
+    public void setHardCapPercentage( int hardCapPercentage )
+    {
+        this.hardCapPercentage = hardCapPercentage;
+        this.hardCapSize = capSize / 100 * hardCapPercentage;
+    }
+
+    public void setSoftCapPercentage( int softCapPercentage )
+    {
+        this.softCapPercentage = softCapPercentage;
+        this.softCapSize = capSize / 100 * softCapPercentage;
+    }
+
+    public void invalidate()
+    {
+        regions.values().forEach( CacheRegion::invalidateAll );
+    }
+
+    public void invalidateRegion( String region )
+    {
+        CacheRegion<?> cacheRegion = regions.get( region );
+        if ( cacheRegion != null )
+        {
+            cacheRegion.invalidateAll();
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public <V> Cache<V> createRegion( CacheBuilder<V> builder )
+    {
+        ensureWatcherThreadStarted();
+        return (Cache<V>) regions.computeIfAbsent( builder.getRegion(),
+            region -> new CacheRegion<>( builder, sizeof, this::sizeUpdate ) );
+    }
+
+    /**
+     * We do start the thread lazily by intention so that it is only active if
+     * this cache is actually used with at least one {@link CacheRegion}.
+     */
+    private void ensureWatcherThreadStarted()
+    {
+        if ( watcherStarted.compareAndSet( false, true ) )
+        {
+            Thread watcher = new Thread( this::runCacheWatcher );
+            watcher.setDaemon( true );
+            watcher.setName( "Local Cache Watcher" );
+            watcher.start();
+        }
+    }
+
+    private void sizeUpdate( long sizeDelta )
+    {
+        long newTotalSize = totalSize.addAndGet( sizeDelta );
+        if ( sizeDelta > 0L && newTotalSize > softCapSize )
+        {
+            free( sizeDelta ); // try compensate
+        }
+    }
+
+    private void freeProtectRuntime()
+    {
+        // remember: this can be off as `sizeof` is only an estimate
+        long estimatedUsedSize = totalSize.get();
+        if ( estimatedUsedSize > hardCapSize )
+        {
+            long overflow = free( estimatedUsedSize - hardCapSize );
+            if ( overflow > 0L )
+            {
+                log.info( "Cache overflew {}.", CacheInfo.humanReadableSize( overflow ) );
+            }
+        }
+
+        // this is about actual memory
+        // if there is little actual memory left cache should free entries
+        long freeHeapSize = runtime.freeMemory();
+        // less then 10% heap left?
+        long tenthHeapSize = runtime.maxMemory() / 10;
+        if ( freeHeapSize < tenthHeapSize && estimatedUsedSize > tenthHeapSize )
+        {
+            free( tenthHeapSize );
+        }
+    }
+
+    /**
+     * @param freeSize number of bytes to try to free by invalidating high
+     *        burden entries
+     * @return the size that could not be freed
+     */
+    private long free( long freeSize )
+    {
+        if ( freeSize <= 0L )
+        {
+            return 0L; // we freed memory :)
+        }
+        Deque<CacheEntry<?>> highBurdens = highBurdenEntries.get();
+        if ( highBurdens.isEmpty() )
+        {
+            return 0L;
+        }
+        long now = currentTimeMillis();
+        List<CacheEntry<?>> secondQualityHighBurdens = new ArrayList<>();
+        long sizeLeft = free( freeSize, highBurdens, secondQualityHighBurdens );
+        // do we still want to free memory?
+        if ( sizeLeft <= 0L )
+        {
+            return 0;
+        }
+        // only sort if numbers aren't to high, otherwise we just take first
+        if ( secondQualityHighBurdens.size() < 500 )
+        {
+            secondQualityHighBurdens.sort( ( a, b ) -> Long.compare( b.burden( now ), a.burden( now ) ) );
+        }
+        long burdenThreshold = highBurdenThreshold;
+        for ( CacheEntry<?> e : secondQualityHighBurdens )
+        {
+            if ( sizeLeft <= 0L )
+            {
+                return 0; // done
+            }
+            if ( e.burden( now ) > burdenThreshold && regions.get( e.region ).invalidate( e, true ) )
+            {
+                sizeLeft -= e.size;
+            }
+        }
+        return freeSize - sizeLeft;
+    }
+
+    /**
+     * Tries to free memory by invalidating
+     *
+     * @param freeSize number of bytes to try to free by invalidating high
+     *        burden entries
+     * @param highBurdens a list of candidates to invalidate
+     * @param secondQualityHighBurdens a target (output) list of those entries
+     *        in highBurdens list that were skipped so far
+     * @return the number of bytes left to free after invalidating first quality
+     *         entries in high burden list
+     */
+    private long free( long freeSize, Deque<CacheEntry<?>> highBurdens, List<CacheEntry<?>> secondQualityHighBurdens )
+    {
+        long now = currentTimeMillis();
+        long sizeLeft = freeSize;
+        long burdenThreshold = highBurdenThreshold;
+        while ( sizeLeft > 0L && !highBurdens.isEmpty() )
+        {
+            CacheEntry<?> e = highBurdens.removeFirst();
+            if ( e.burden( now ) > burdenThreshold )
+            {
+                if ( regions.get( e.region ).invalidate( e, true ) )
+                {
+                    sizeLeft -= e.size;
+                }
+            }
+            else
+            {
+                secondQualityHighBurdens.add( e );
+            }
+        }
+        return sizeLeft;
+    }
+
+    private void runCacheWatcher()
+    {
+        try
+        {
+            while ( true )
+            {
+                long start = currentTimeMillis();
+                long duration = currentTimeMillis() - start;
+                updateHighBurdenState();
+                freeProtectRuntime();
+                long delay = 10_000L - duration;
+                if ( delay > 0 )
+                {
+                    waitFor( delay );
+                }
+            }
+        }
+        catch ( RuntimeException ex )
+        {
+            log.error( "Cache watcher threw exception", ex );
+        }
+    }
+
+    private void updateHighBurdenState()
+    {
+        int totalEntryCount = 0;
+        long totalBurden = 0L;
+        long now = currentTimeMillis();
+        List<CacheGroupInfo> regionsInfo = new ArrayList<>();
+        for ( CacheRegion<?> region : regions.values() )
+        {
+            int regionEntryCount = 0;
+            long regionBurden = 0L;
+            long regionSize = 0L;
+            for ( CacheEntry<?> e : region.entries.values() )
+            {
+                if ( !e.isExpired( now ) )
+                {
+                    regionEntryCount++;
+                    regionBurden += e.burden( now );
+                    regionSize += e.size;
+                }
+            }
+            regionsInfo.add( new CacheGroupInfo( region.region, region.entries.size(), region.getHits(),
+                region.getMisses(), regionSize, getRelativeBurden( regionBurden, regionSize ) ) );
+            totalEntryCount += regionEntryCount;
+            totalBurden += regionBurden;
+        }
+
+        long avgBurden = totalEntryCount == 0 ? 0L : totalBurden / totalEntryCount;
+        // upper third entries are considered high burden
+        long newHighBurdenThreshold = avgBurden * 2 / 3;
+
+        Deque<CacheEntry<?>> newHighBurdenEntries = new ConcurrentLinkedDeque<>();
+
+        CacheGroupInfo total = findHighBurdens( regionsInfo, newHighBurdenEntries, newHighBurdenThreshold,
+            totalBurden );
+        info.set( new CacheInfo( new CacheCapInfo( capPercent, softCapPercentage, hardCapPercentage ),
+            new CacheBurdenInfo( newHighBurdenEntries.size(),
+                newHighBurdenEntries.stream().mapToLong( e -> e.size ).sum(),
+                getRelativeBurden( newHighBurdenThreshold, newHighBurdenEntries.size() ) ),
+            total, regionsInfo ) );
+
+        highBurdenThreshold = newHighBurdenThreshold;
+        highBurdenEntries.set( newHighBurdenEntries );
+    }
+
+    private CacheGroupInfo findHighBurdens( List<CacheGroupInfo> regionsInfo, Deque<CacheEntry<?>> newHighBurdenEntries,
+        long newHighBurdenThreshold, long totalBurden )
+    {
+        // OBS! we want to process regions high => low burden
+        regionsInfo.sort( ( a, b ) -> Double.compare( b.getBurden(), a.getBurden() ) );
+        for ( CacheGroupInfo regionInfo : regionsInfo )
+        {
+            findHighBurdensInRegion( regions.get( regionInfo.getName() ), regionInfo, newHighBurdenEntries,
+                newHighBurdenThreshold );
+        }
+        long totalNonExpiredSize = regionsInfo.stream().mapToLong( CacheGroupInfo::getSize ).sum();
+        CacheGroupInfo total = new CacheGroupInfo( "total",
+            regionsInfo.stream().mapToInt( CacheGroupInfo::getEntries ).sum(),
+            regionsInfo.stream().mapToLong( CacheGroupInfo::getHints ).sum(),
+            regionsInfo.stream().mapToLong( CacheGroupInfo::getMisses ).sum(),
+            totalNonExpiredSize,
+            getRelativeBurden( totalBurden, totalNonExpiredSize ) );
+        total.setHighBurdenEntries( regionsInfo.stream().mapToInt( CacheGroupInfo::getHighBurdenEntries ).sum() );
+        return total;
+    }
+
+    private void findHighBurdensInRegion( CacheRegion<?> region, CacheGroupInfo info,
+        Deque<CacheEntry<?>> newHighBurdenEntries, long currentHighBurdenThreshold )
+    {
+        long now = currentTimeMillis();
+        int regionHighBurdenCount = 0;
+        for ( CacheEntry<?> e : region.entries.values() )
+        {
+            if ( e.isExpired( now ) )
+            {
+                region.invalidate( e, true );
+            }
+            else
+            {
+                long burden = e.burden( now );
+                if ( burden > currentHighBurdenThreshold )
+                {
+                    if ( newHighBurdenEntries.isEmpty() || burden >= newHighBurdenEntries.peekFirst().burden( now ) )
+                    {
+                        newHighBurdenEntries.addFirst( e );
+                    }
+                    else
+                    {
+                        newHighBurdenEntries.addLast( e );
+                    }
+                    regionHighBurdenCount++;
+                }
+            }
+        }
+        info.setHighBurdenEntries( regionHighBurdenCount );
+    }
+
+    private static double getRelativeBurden( long burden, long size )
+    {
+        return round( size == 0 ? 0d : burden / (double) size );
+    }
+
+    private static double round( double value )
+    {
+        return Math.round( value * 100d ) / 100d;
+    }
+
+    public static void waitFor( long ms )
+    {
+        try
+        {
+            Thread.sleep( ms );
+        }
+        catch ( InterruptedException ex )
+        {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
@@ -692,7 +692,7 @@ public class CappedLocalCache
         long totalNonExpiredSize = regionsInfo.stream().mapToLong( CacheGroupInfo::getSize ).sum();
         CacheGroupInfo total = new CacheGroupInfo( "total",
             regionsInfo.stream().mapToInt( CacheGroupInfo::getEntries ).sum(),
-            regionsInfo.stream().mapToLong( CacheGroupInfo::getHints ).sum(),
+            regionsInfo.stream().mapToLong( CacheGroupInfo::getHits ).sum(),
             regionsInfo.stream().mapToLong( CacheGroupInfo::getMisses ).sum(),
             totalNonExpiredSize,
             getRelativeBurden( totalBurden, totalNonExpiredSize ) );

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheBuilderProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheBuilderProvider.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.cache;
 
+import java.util.function.Function;
+
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -51,7 +53,10 @@ public class DefaultCacheBuilderProvider implements CacheBuilderProvider
     @Override
     public <V> CacheBuilder<V> newCacheBuilder()
     {
-        return new ExtendedCacheBuilder<>( redisTemplate, configurationProvider, cappedLocalCache::createRegion );
+        Function<CacheBuilder<V>, Cache<V>> capCacheFactory = cappedLocalCache != null
+            ? cappedLocalCache::createRegion
+            : builder -> new NoOpCache<>();
+        return new ExtendedCacheBuilder<>( redisTemplate, configurationProvider, capCacheFactory );
     }
 
     @Autowired

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/CacheControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/CacheControllerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the {@link CacheController}.
+ *
+ * Mostly that only users with proper authority can use it.
+ *
+ * @author Jan Bernitt
+ */
+public class CacheControllerTest extends DhisControllerConvenienceTest
+{
+
+    @Test
+    public void testInvalidate()
+    {
+        switchToNewUser( "no-special-authority-user" );
+        assertStatus( HttpStatus.FORBIDDEN, POST( "/caches/invalidate" ) );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.cache.CacheInfo.CacheGroupInfo;
 import org.hisp.dhis.cache.CappedLocalCache;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,6 +57,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Controller
 @RequestMapping( value = "/caches" )
 @RequiredArgsConstructor
+@PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
 public class CacheController
 {
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.cache.CacheInfo;
+import org.hisp.dhis.cache.CacheInfo.CacheCapInfo;
+import org.hisp.dhis.cache.CacheInfo.CacheGroupInfo;
+import org.hisp.dhis.cache.CappedLocalCache;
+import org.hisp.dhis.webapi.controller.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Gives insights into the {@link CappedLocalCache} state and allows to
+ * invalidate entries as well as configure the cap settings.
+ *
+ * @author Jan Bernitt
+ */
+@Controller
+@RequestMapping( value = "/caches" )
+@RequiredArgsConstructor
+public class CacheController
+{
+
+    private final CappedLocalCache cache;
+
+    @RequestMapping( method = RequestMethod.GET, produces = "application/json" )
+    public @ResponseBody CacheInfo getInfo( @RequestParam( value = "condensed", required = false ) Boolean condensed )
+    {
+        CacheInfo info = getCacheInfo();
+        if ( condensed == null || !condensed )
+        {
+            return info;
+        }
+        return new CacheInfo( info.getCap(), info.getBurden(), info.getTotal(),
+            info.getRegions().stream()
+                .filter( r -> r.getEntries() > 0 )
+                .sorted( ( a, b ) -> Long.compare( b.getSize(), a.getSize() ) )
+                .collect( Collectors.toList() ) );
+    }
+
+    @RequestMapping( value = "/regions", method = RequestMethod.GET, produces = "application/json" )
+    public @ResponseBody Set<String> getRegions()
+    {
+        // sort alphabetically
+        return new TreeSet<>( cache.getRegions() );
+    }
+
+    @RequestMapping( value = "/regions/{region}", method = RequestMethod.GET, produces = "application/json" )
+    public @ResponseBody CacheGroupInfo getRegionInfo( @PathVariable( "region" ) String region )
+        throws NotFoundException
+    {
+        CacheInfo info = getCacheInfo();
+        for ( CacheGroupInfo groupInfo : info.getRegions() )
+        {
+            if ( groupInfo.getName().equals( region ) )
+            {
+                return groupInfo;
+            }
+        }
+        throw new NotFoundException( region );
+    }
+
+    @RequestMapping( value = "/cap", method = RequestMethod.GET, produces = "application/json" )
+    public @ResponseBody CacheCapInfo getCapInfo()
+    {
+        return getCacheInfo().getCap();
+    }
+
+    @RequestMapping( value = "/cap", method = RequestMethod.PUT )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
+    public void updateCap( @RequestParam( value = "heap", required = false ) Integer heap,
+        @RequestParam( value = "hard", required = false ) Integer hard,
+        @RequestParam( value = "soft", required = false ) Integer soft )
+    {
+        if ( heap != null )
+        {
+            cache.setCapPercent( heap );
+        }
+        if ( hard != null )
+        {
+            cache.setHardCapPercentage( hard );
+        }
+        if ( soft != null )
+        {
+            cache.setSoftCapPercentage( soft );
+        }
+    }
+
+    @RequestMapping( value = "/invalidate", method = RequestMethod.POST )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
+    public void invalidate()
+    {
+        cache.invalidate();
+    }
+
+    @RequestMapping( value = "/regions/{region}/invalidate", method = RequestMethod.POST )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
+    public void invalidateRegion( @PathVariable( "region" ) String region )
+    {
+        cache.invalidateRegion( region );
+    }
+
+    private CacheInfo getCacheInfo()
+    {
+        CacheInfo info = cache.getInfo();
+        if ( info == null )
+        {
+            throw new IllegalStateException( "Capped local cache is not used." );
+        }
+        return info;
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds a heap memory cache implementation with eager invalidation and memory cap over all caches (here regions).
This implementation is an alternative to the existing `LocalCache` based on cache2k. 
The main purpose is to gain insight about cache usage and see if eager invalidation as implemented can solve the cache problems.

To provide a cap over all local caches the `CappedLocalCache` is not a single cache but a cache cluster containing all local `Cache`s. These are called `CacheRegion` as each implements a single `region`.

To only consume up to a certain size of the available heap memory of the JVM the cache has a cap setting.
Apart from the TTL and default value settings of the cache builder the cache ignores the other builder settings as it has its own strategy to manage cache entries.

To know how much space entries take a `Sizeof` operator was created that **estimates** the size of any given java object in heap memory which is one of the metadata values each cache entry tracks.

The cache performs an assessment of cache entries in an interval. For each entry a number is computed, called burden, which represents how relevant or irrelevant the cache deems the entry. 

* The less read access the more burden. 
* The less TTL left the more burden. 
* The larger the entry size the more burden. 

From this a list of high burden entries is maintained. This list is used if the cache deems it is time to free memory by invalidating entries.

 Reasons to free memory can be: 
* another entry was added and space is nearing the cap (soft cap)
* overall size of cache entries is nearing the cap (hard cap)
* the overall free heap memory is low

### Configuration
A new configuration `ConfigurationKey.SYSTEM_CACHE_CAP_PERCENTAGE` was added that holds the percentage of the heap that all local caches together should use at maximum. Default is `50`%.
If this value is zero or below the capped local cache is disabled and the `LocalCache` based on cache2k is used instead.

### REST API
A controller was added that allows insight into the cache state. This is represented as `CacheInfo` record.
The main purpose of this is to learn what is going on in the caches without having to analyse a heap dump.
The `CacheInfo` record is maintained as apart of the burden list computation that happens in intervals in as a background task.

In addition the RESR API can be used to invalidate all local caches or a particular cache by region.
Also the cap settings of the capped local cache can be changed.

### Automatic Testing
The main implementations of `CappedLocalCache` and the `Sizeof` operator got new unit tests.