### PR TITLE
chore: Re-enable .war file compression

### DIFF
--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -158,7 +158,6 @@
         </configuration>
       </plugin>
 
-
     </plugins>
   </build>
 
@@ -197,11 +196,11 @@
 
   <properties>
     <rootDir>../</rootDir>
-    <useWarCompression>false</useWarCompression>
-    <maven-jetty-plugin.version>9.4.37.v20210219</maven-jetty-plugin.version>
+    <useWarCompression>true</useWarCompression>
+    <maven-jetty-plugin.version>9.4.38.v20210224</maven-jetty-plugin.version>
     <tomcat.version>8.5.47</tomcat.version>
     <jrebel-maven-plugin.version>1.1.6</jrebel-maven-plugin.version>
-    <maven-war-plugin.version>2.4</maven-war-plugin.version>
+    <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
     <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
     <cargo-maven2-plugin.version>1.7.7</cargo-maven2-plugin.version>
   </properties>


### PR DESCRIPTION
Disabling of .war file compression was accidentally committed, this commit re-enables the compression.

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>