### PR TITLE
test: Header support for WebClient API and JsonMultiMaps

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonArray.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonArray.java
@@ -123,4 +123,8 @@ public interface JsonArray extends JsonCollection
         return JsonCollection.asMap( getObject( index ), as );
     }
 
+    default <E extends JsonValue> JsonMultiMap<E> getMultiMap( int index, Class<E> as )
+    {
+        return JsonCollection.asMultiMap( getObject( index ), as );
+    }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonCollection.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonCollection.java
@@ -102,6 +102,24 @@ public interface JsonCollection extends JsonValue
         return new MapView( object );
     }
 
+    static <E extends JsonValue> JsonMultiMap<E> asMultiMap( JsonObject object, Class<E> as )
+    {
+        class MultiMapView extends CollectionView<JsonObject> implements JsonMultiMap<E>
+        {
+            MultiMapView( JsonObject viewed )
+            {
+                super( viewed );
+            }
+
+            @Override
+            public JsonList<E> get( String key )
+            {
+                return viewed.getList( key, as );
+            }
+        }
+        return new MultiMapView( object );
+    }
+
     abstract class CollectionView<T extends JsonCollection> implements JsonCollection
     {
         protected final T viewed;

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonMultiMap.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonMultiMap.java
@@ -25,32 +25,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi;
-
-import static org.hisp.dhis.webapi.utils.WebClientUtils.substitutePlaceholders;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+package org.hisp.dhis.webapi.json;
 
 /**
- * The purpose of this interface is to allow mixin style addition of the
- * convenience web API by implementing this interface's essential method
- * {@link #authWebRequest(String,MockHttpServletRequestBuilder)}.
+ * A {@link JsonMap} with {@link JsonList} of elements.
  *
- * @author Morten Svanæs
+ * This needs a dedicated type as we cannot pass a {@link JsonMap} {@link Class}
+ * with the generics of a {@link JsonList} of the element type otherwise.
+ *
+ * @author Jan Bernitt
+ *
+ * @param <E> type of the map list elements
  */
-@FunctionalInterface
-public interface AuthenticatedWebClient
+public interface JsonMultiMap<E extends JsonValue> extends JsonMap<JsonList<E>>
 {
-    WebClient.HttpResponse authWebRequest( String token, MockHttpServletRequestBuilder request );
-
-    default WebClient.HttpResponse GET( String token, String url, Object... args )
-    {
-        return baseWebRequest( token, get( substitutePlaceholders( url, args ) ), "" );
-    }
-
-    default WebClient.HttpResponse baseWebRequest( String token, MockHttpServletRequestBuilder request, String body )
-    {
-        return authWebRequest( token, request );
-    }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
@@ -103,4 +103,8 @@ public interface JsonObject extends JsonCollection
         return JsonCollection.asMap( getObject( name ), as );
     }
 
+    default <E extends JsonValue> JsonMultiMap<E> getMultiMap( String name, Class<E> as )
+    {
+        return JsonCollection.asMultiMap( getObject( name ), as );
+    }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonValue.java
@@ -136,6 +136,19 @@ public interface JsonValue
     }
 
     /**
+     * This value as map of list value with of uniform elements (view on JSON
+     * object).
+     *
+     * @param valueType assumed map value type
+     * @param <V> type of map values
+     * @return map view of this value (assumes object)
+     */
+    default <V extends JsonValue> JsonMultiMap<V> asMultiMap( Class<V> valueType )
+    {
+        return JsonCollection.asMultiMap( as( JsonObject.class ), valueType );
+    }
+
+    /**
      * Access the node in the JSON document. This can be the low level API that
      * is concerned with extraction by path.
      *

--- a/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
@@ -77,6 +77,17 @@ public class JsonResponseTest
     }
 
     @Test
+    public void testCustomObjectTypeMultiMap()
+    {
+        JsonMultiMap<JsonNumber> multiMap = createJSON( "{'foo':[1,23], 'bar':[34,56]}" )
+            .asMultiMap( JsonNumber.class );
+        assertFalse( multiMap.isEmpty() );
+        assertTrue( multiMap.isObject() );
+        assertEquals( 23, multiMap.get( "foo" ).get( 1 ).intValue() );
+        assertEquals( 34, multiMap.get( "bar" ).get( 0 ).intValue() );
+    }
+
+    @Test
     public void testObjectHas()
     {
         JsonObject response = createJSON( "{'users': {'foo':{'id':'foo'}, 'bar':[]}}" );

--- a/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
@@ -79,7 +79,7 @@ public class JsonResponseTest
     @Test
     public void testCustomObjectTypeMultiMap()
     {
-        JsonMultiMap<JsonNumber> multiMap = createJSON( "{'foo':[1,23], 'bar':[34,56]}" )
+        JsonMultiMap<JsonNumber> multiMap = createJSON( "{'foo':[1,23], 'bar': [34,56]}" )
             .asMultiMap( JsonNumber.class );
         assertFalse( multiMap.isEmpty() );
         assertTrue( multiMap.isObject() );

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
@@ -60,7 +60,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @ContextConfiguration( classes = { WebMvcConfig.class, WebTestConfigurationWithJwtTokenAuth.class } )
 @ActiveProfiles( "test-h2" )
 @Transactional
-public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenienceTest implements AuthenticatedWebClient
+public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenienceTest implements WebClient
 {
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -88,12 +88,10 @@ public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenience
         TestUtils.executeStartupRoutines( webApplicationContext );
     }
 
-    public WebClient.HttpResponse authWebRequest( String token, MockHttpServletRequestBuilder request )
+    @Override
+    public HttpResponse webRequest( MockHttpServletRequestBuilder request )
     {
         return failOnException(
-            () -> new WebClient.HttpResponse(
-                mvc.perform( request.header( "Authorization", "Bearer " + token ) )
-                    .andReturn()
-                    .getResponse() ) );
+            () -> new HttpResponse( mvc.perform( request ).andReturn().getResponse() ) );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/WebClientUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/WebClientUtils.java
@@ -29,11 +29,15 @@ package org.hisp.dhis.webapi.utils;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.webapi.WebClient.HttpResponse;
+import org.hisp.dhis.webapi.WebClient.RequestComponent;
 import org.hisp.dhis.webapi.json.JsonList;
 import org.hisp.dhis.webapi.json.JsonObject;
 import org.hisp.dhis.webapi.json.domain.JsonError;
@@ -163,9 +167,12 @@ public class WebClientUtils
 
     public static String substitutePlaceholders( String url, Object[] args )
     {
-        return args.length == 0
-            ? url
-            : String.format( url.replaceAll( "\\{[a-zA-Z]+}", "%s" ), (Object[]) args );
+        if ( args.length == 0 )
+        {
+            return url;
+        }
+        Object[] urlArgs = Arrays.stream( args ).filter( arg -> !(arg instanceof RequestComponent) ).toArray();
+        return String.format( url.replaceAll( "\\{[a-zA-Z]+}", "%s" ), (Object[]) urlArgs );
     }
 
     public static <T> T failOnException( Callable<T> op )
@@ -178,6 +185,32 @@ public class WebClientUtils
         {
             throw new AssertionError( ex );
         }
+    }
+
+    public static RequestComponent[] requestComponentsIn( Object... args )
+    {
+        List<RequestComponent> components = new ArrayList<>();
+        for ( Object arg : args )
+        {
+            if ( arg instanceof RequestComponent )
+            {
+                components.add( (RequestComponent) arg );
+            }
+        }
+        return components.toArray( new RequestComponent[0] );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public static <T extends RequestComponent> T getComponent( Class<T> type, RequestComponent[] components )
+    {
+        for ( RequestComponent c : components )
+        {
+            if ( c.getClass() == type )
+            {
+                return (T) c;
+            }
+        }
+        return null;
     }
 
     private WebClientUtils()


### PR DESCRIPTION
### Summary
PR adds 2 small additions to the  REST controller testing toolkit:
1. adds header support (which allowed to handle JWT tokens through standard API)
2. adds `JsonMultiMap` as a way to do `JsonMap<JsonList<E>>`

Note that this PR only changes tests and test support code. It does not change any application code.

### Header Support for REST Controller Tests
I had an idea how to make the REST controller testing toolkit more flexible and support the JWT token case that so far was solved as an extended API. The varargs version of the HTTP methods `GET`, `POST` etcetera now allows to use a mix of arguments that should be replaced in the URL pattern and arguments that configure the HTTP request. To distinguish the two a marker interface `RequestComponent` was introduced which is implemented by `Body` and `Header` classes. This now allows calls like:

```java
PUT("/userGroups/{id}/users", userid, JwtToken(token), Body("{....}");
//or
POST("/something/", Header("key","value"), Header("key2", "v2"), Body("..."));
```
The names of the static helpers to create headers and body intentionally do not follow Java naming conventions in favour of a more declarative appearance when used like in the above example.

### JSON MutiMaps
Here https://github.com/dhis2/dhis2-core/pull/7619/files#diff-6e0599b9980b7de8314076a0a3e91ca595028e86e8126efe9a7ad9586b658f38R114 I noticed that with `JsonMap` and `JsonList` one can not nest these like `JsonMap<JsonList<JsonString>>`. This would be the type for what is known as a multi-map in Java. A solution for this is the introduced type `JsonMultiMap`.