### PR TITLE
fix: change translation properties key same to 2.36 [2.35]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/chart/BaseChart.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/chart/BaseChart.java
@@ -256,7 +256,7 @@ public abstract class BaseChart
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayDomainAxisLabel()
     {
-        return getTranslation( TranslationProperty.CHART_DOMAIN_AXIS_LABEL, getDomainAxisLabel() );
+        return getTranslation( TranslationProperty.domainAxisLabel, getDomainAxisLabel() );
     }
 
     public void setDomainAxisLabel( String domainAxisLabel )
@@ -275,7 +275,7 @@ public abstract class BaseChart
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayRangeAxisLabel()
     {
-        return getTranslation( TranslationProperty.CHART_RANGE_AXIS_LABEL, getRangeAxisLabel() );
+        return getTranslation( TranslationProperty.rangeAxisLabel, getRangeAxisLabel() );
     }
 
     public void setRangeAxisLabel( String rangeAxisLabel )
@@ -356,7 +356,7 @@ public abstract class BaseChart
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayTargetLineLabel()
     {
-        return getTranslation( TranslationProperty.CHART_TARGET_LINE_LABEL, getTargetLineLabel() );
+        return getTranslation( TranslationProperty.targetLineLabel, getTargetLineLabel() );
     }
 
     public void setTargetLineLabel( String targetLineLabel )
@@ -387,7 +387,7 @@ public abstract class BaseChart
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayBaseLineLabel()
     {
-        return getTranslation( TranslationProperty.CHART_BASE_LINE_LABEL, getBaseLineLabel() );
+        return getTranslation( TranslationProperty.baseLineLabel, getBaseLineLabel() );
     }
 
     public void setBaseLineLabel( String baseLineLabel )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -1123,7 +1123,7 @@ public abstract class BaseAnalyticalObject
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayTitle()
     {
-        return getTranslation( TranslationProperty.TITLE, getTitle() );
+        return getTranslation( TranslationProperty.title, getTitle() );
     }
 
     public void setTitle( String title )
@@ -1142,7 +1142,7 @@ public abstract class BaseAnalyticalObject
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplaySubtitle()
     {
-        return getTranslation( TranslationProperty.SUBTITLE, getSubtitle() );
+        return getTranslation( TranslationProperty.subtitle, getSubtitle() );
     }
 
     public void setSubtitle( String subtitle )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/TranslationProperty.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/TranslationProperty.java
@@ -42,12 +42,12 @@ public enum TranslationProperty
     RELATIONSHIP_TO_FROM_NAME( "toFromName" ),
     INSTRUCTION( "instruction" ),
     CONTENT( "content" ),
-    CHART_DOMAIN_AXIS_LABEL( "domainAxisLabel" ),
-    CHART_RANGE_AXIS_LABEL( "rangeAxisLabel" ),
-    CHART_TARGET_LINE_LABEL( "targetLineLabel" ),
-    CHART_BASE_LINE_LABEL( "baseLineLabel" ),
-    TITLE( "title" ),
-    SUBTITLE( "subtitle" );
+    domainAxisLabel( "domainAxisLabel" ),
+    rangeAxisLabel( "rangeAxisLabel" ),
+    targetLineLabel( "targetLineLabel" ),
+    baseLineLabel( "baseLineLabel" ),
+    title( "title" ),
+    subtitle( "subtitle" );
 
     private String name;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -841,7 +841,7 @@ public class Visualization
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayDomainAxisLabel()
     {
-        return getTranslation( TranslationProperty.CHART_DOMAIN_AXIS_LABEL, getDomainAxisLabel() );
+        return getTranslation( TranslationProperty.domainAxisLabel, getDomainAxisLabel() );
     }
 
     public void setDomainAxisLabel( String domainAxisLabel )
@@ -860,7 +860,7 @@ public class Visualization
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayRangeAxisLabel()
     {
-        return getTranslation( TranslationProperty.CHART_RANGE_AXIS_LABEL, getRangeAxisLabel() );
+        return getTranslation( TranslationProperty.rangeAxisLabel, getRangeAxisLabel() );
     }
 
     public void setRangeAxisLabel( String rangeAxisLabel )
@@ -915,7 +915,7 @@ public class Visualization
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayBaseLineLabel()
     {
-        return getTranslation( TranslationProperty.CHART_BASE_LINE_LABEL, getBaseLineLabel() );
+        return getTranslation( TranslationProperty.baseLineLabel, getBaseLineLabel() );
     }
 
     public void setBaseLineLabel( String baseLineLabel )
@@ -934,7 +934,7 @@ public class Visualization
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDisplayTargetLineLabel()
     {
-        return getTranslation( TranslationProperty.CHART_TARGET_LINE_LABEL, getTargetLineLabel() );
+        return getTranslation( TranslationProperty.targetLineLabel, getTargetLineLabel() );
     }
 
     public void setTargetLineLabel( String targetLineLabel )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -250,17 +250,17 @@ public class TranslationServiceTest
         manager.save( ecA );
 
         Set<Translation> translations = new HashSet<>();
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_BASE_LINE_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.baseLineLabel,
             "translated BaseLineLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_DOMAIN_AXIS_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.domainAxisLabel,
             "translated DomainAxisLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_RANGE_AXIS_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.rangeAxisLabel,
             "translated RangeAxisLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_TARGET_LINE_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.targetLineLabel,
             "translated TargetLineLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.TITLE,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.title,
             "translated Title" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.SUBTITLE,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.subtitle,
             "translated SubTitle" ) );
 
         manager.updateTranslations( ecA, translations );
@@ -289,17 +289,17 @@ public class TranslationServiceTest
         manager.save( visualization );
 
         Set<Translation> translations = new HashSet<>();
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_BASE_LINE_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.baseLineLabel,
             "translated BaseLineLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_DOMAIN_AXIS_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.domainAxisLabel,
             "translated DomainAxisLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_RANGE_AXIS_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.rangeAxisLabel,
             "translated RangeAxisLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.CHART_TARGET_LINE_LABEL,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.targetLineLabel,
             "translated TargetLineLabel" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.TITLE,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.title,
             "translated Title" ) );
-        translations.add( new Translation( locale.getLanguage(), TranslationProperty.SUBTITLE,
+        translations.add( new Translation( locale.getLanguage(), TranslationProperty.subtitle,
             "translated SubTitle" ) );
 
         manager.updateTranslations( visualization, translations );


### PR DESCRIPTION

from 2.36 we define translation property like below 

``` @JsonProperty
    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
    @Translatable( propertyName = "rangeAxisLabel" )
    public String getDisplayRangeAxisLabel()
    {
        return getTranslation( "rangeAxisLabel", getRangeAxisLabel() );
    }
```
The translationKey is the same as propertyName = rangeAxisLabel;

So we need to change translations property keys to match with version 2.36+