### PR TITLE
fix: [DHIS2-10022] event import fails idScheme=code

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/ProgramStagePreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/ProgramStagePreProcessor.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.events.importer.insert.preprocess;
 
+import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.importer.Processor;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
@@ -59,7 +60,9 @@ public class ProgramStagePreProcessor implements Processor
         }
         if ( programStage != null )
         {
-            event.setProgramStage( programStage.getUid() );
+            event.setProgramStage(
+                IdentifiableObjectUtils.getIdentifierBasedOnIdScheme( programStage,
+                    ctx.getImportOptions().getIdSchemes().getProgramStageIdScheme() ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportWithMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportWithMetadataTest.java
@@ -1,0 +1,90 @@
+package org.hisp.dhis.dxf2.events;
+
+import com.vividsolutions.jts.io.ParseException;
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.events.event.EventService;
+import org.hisp.dhis.dxf2.events.event.Events;
+import org.hisp.dhis.dxf2.events.event.csv.CsvEventService;
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
+import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
+import org.hisp.dhis.dxf2.metadata.MetadataImportService;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
+import org.hisp.dhis.feedback.Status;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.render.RenderFormat;
+import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.user.UserService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventImportWithMetadataTest extends DhisSpringTest
+{
+
+    @Autowired
+    private RenderService _renderService;
+
+    @Autowired
+    private CsvEventService csvEventService;
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private UserService _userService;
+
+    @Autowired
+    private MetadataImportService importService;
+
+    @Override
+    protected void setUpTest()
+        throws Exception
+    {
+        renderService = _renderService;
+        userService = _userService;
+    }
+
+    @Test
+    public void shouldImportCsv()
+        throws IOException,
+        ParseException
+    {
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource("dxf2/import/create_program_stages.json").getInputStream(), RenderFormat.JSON );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE );
+        params.setObjects( metadata );
+        params.setSkipSharing( true );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        ImportOptions importOptions = new ImportOptions();
+        IdSchemes idSchemes = new IdSchemes();
+        idSchemes.setDataElementIdScheme( "UID" );
+        idSchemes.setOrgUnitIdScheme( "CODE" );
+        idSchemes.setProgramStageIdScheme( "UID" );
+        idSchemes.setIdScheme( "CODE" );
+
+        importOptions.setIdSchemes( idSchemes );
+
+        Events events = csvEventService
+            .readEvents( new ClassPathResource( "dxf2/import/events-5b.csv" ).getInputStream(), true );
+        ImportSummaries importSummaries = eventService.addEvents( events.getEvents(), importOptions, null );
+
+        assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportWithMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportWithMetadataTest.java
@@ -104,7 +104,7 @@ public class EventImportWithMetadataTest extends DhisSpringTest
     }
 
     @Test
-    public void shouldSuccessCsvLookUpByCode()
+    public void shouldSuccessImportCsvLookUpByCode()
     {
         idSchemes.setIdScheme( "CODE" );
         ImportOptions importOptions = new ImportOptions();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportWithMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EventImportWithMetadataTest.java
@@ -1,6 +1,37 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.dxf2.events;
 
-import com.vividsolutions.jts.io.ParseException;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -23,12 +54,6 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-
 public class EventImportWithMetadataTest extends DhisSpringTest
 {
 
@@ -47,7 +72,7 @@ public class EventImportWithMetadataTest extends DhisSpringTest
     @Autowired
     private MetadataImportService importService;
 
-    private static IdSchemes idSchemes = new IdSchemes();
+    private static final IdSchemes idSchemes = new IdSchemes();
 
     private static Events events;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/create_program_stages.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/create_program_stages.json
@@ -69,37 +69,7 @@
     {
       "created": "2016-03-10T05:00:11.778+0000",
       "authorities": [
-        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
-        "ALL",
-        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
-        "F_TRACKED_ENTITY_INSTANCE_DELETE",
-        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
-        "F_MAP_PUBLIC_ADD",
-        "F_USER_ADD_WITHIN_MANAGED_GROUP",
-        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
-        "F_PROGRAM_ENROLLMENT",
-        "F_SQLVIEW_EXTERNAL",
-        "F_GIS_ADMIN",
-        "F_REPLICATE_USER",
-        "F_INSERT_CUSTOM_JS_CSS",
-        "F_DASHBOARD_PUBLIC_ADD",
-        "F_METADATA_IMPORT",
-        "F_VISUALIZATION_PUBLIC_ADD",
-        "F_VIEW_UNAPPROVED_DATA",
-        "F_VISUALIZATION_EXTERNAL",
-        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
-        "F_METADATA_EXPORT",
-        "F_PROGRAM_UNENROLLMENT",
-        "F_APPROVE_DATA",
-        "F_ACCEPT_DATA_LOWER_LEVELS",
-        "F_TRACKED_ENTITY_INSTANCE_ADD",
-        "F_USERGROUP_PUBLIC_ADD",
-        "F_OAUTH2_CLIENT_MANAGE",
-        "F_TRACKED_ENTITY_DATAVALUE_ADD",
-        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
-        "F_MAP_EXTERNAL",
-        "F_APPROVE_DATA_LOWER_LEVELS",
-        "F_TRACKED_ENTITY_DATAVALUE_DELETE"
+        "ALL"
       ],
       "userGroupAccesses": [],
       "dataSets": [],
@@ -197,38 +167,6 @@
       "notificationTemplates": [],
       "programStageDataElements": [
         {
-          "lastUpdated": "2016-12-06T16:37:46.077",
-          "id": "d9wIqlzSMgE",
-          "created": "2016-04-01T15:07:12.695",
-          "displayInReports": true,
-          "skipSynchronization": false,
-          "externalAccess": false,
-          "allowFutureDate": false,
-          "compulsory": true,
-          "allowProvidedElsewhere": false,
-          "sortOrder": 0,
-          "favorite": false,
-          "access": {
-            "read": true,
-            "update": true,
-            "externalize": false,
-            "delete": true,
-            "write": true,
-            "manage": true
-          },
-          "programStage": {
-            "id": "pTo4uMt3xur"
-          },
-          "dataElement": {
-            "id": "qrur9Dvnyt5"
-          },
-          "favorites": [],
-          "translations": [],
-          "userGroupAccesses": [],
-          "attributeValues": [],
-          "userAccesses": []
-        },
-        {
           "lastUpdated": "2016-12-06T16:37:46.104",
           "id": "FKHaErzkvEF",
           "created": "2016-04-01T15:07:12.723",
@@ -239,38 +177,6 @@
           "compulsory": true,
           "allowProvidedElsewhere": false,
           "sortOrder": 1,
-          "favorite": false,
-          "access": {
-            "read": true,
-            "update": true,
-            "externalize": false,
-            "delete": true,
-            "write": true,
-            "manage": true
-          },
-          "programStage": {
-            "id": "pTo4uMt3xur"
-          },
-          "dataElement": {
-            "id": "oZg33kd9taw"
-          },
-          "favorites": [],
-          "translations": [],
-          "userGroupAccesses": [],
-          "attributeValues": [],
-          "userAccesses": []
-        },
-        {
-          "lastUpdated": "2016-12-06T16:37:46.116",
-          "id": "Zrem1VAqA8r",
-          "created": "2016-12-06T16:37:46.115",
-          "displayInReports": false,
-          "skipSynchronization": false,
-          "externalAccess": false,
-          "allowFutureDate": false,
-          "compulsory": false,
-          "allowProvidedElsewhere": false,
-          "sortOrder": 2,
           "favorite": false,
           "access": {
             "read": true,
@@ -315,49 +221,9 @@
       "publicAccess": "rw------",
       "zeroIsSignificant": false,
       "userGroupAccesses": [],
-      "valueType": "COORDINATE",
+      "valueType": "TEXT",
       "created": "2016-03-10T05:02:18.868+0000",
       "domainType": "AGGREGATE"
-    },
-    {
-      "name": "DataElementB",
-      "code": "DataElementCodeB",
-      "user": {
-        "id": "VIkpd2KHCb1"
-      },
-      "lastUpdated": "2016-03-10T05:02:47.024+0000",
-      "id": "oZg33kd9taw",
-      "aggregationType": "SUM",
-      "aggregationLevels": [],
-      "zeroIsSignificant": false,
-      "publicAccess": "rw------",
-      "domainType": "AGGREGATE",
-      "created": "2016-03-10T05:02:47.023+0000",
-      "valueType": "TEXT",
-      "userGroupAccesses": [],
-      "description": "DataElementDescriptionB",
-      "attributeValues": [],
-      "shortName": "DataElementShortB"
-    },
-    {
-      "lastUpdated": "2016-03-10T05:04:44.334+0000",
-      "user": {
-        "id": "VIkpd2KHCb1"
-      },
-      "name": "DataElementC",
-      "code": "DataElementCodeC",
-      "aggregationLevels": [],
-      "id": "qrur9Dvnyt5",
-      "aggregationType": "SUM",
-      "publicAccess": "rw------",
-      "zeroIsSignificant": false,
-      "valueType": "NUMBER",
-      "userGroupAccesses": [],
-      "domainType": "AGGREGATE",
-      "created": "2016-03-10T05:04:44.329+0000",
-      "description": "DataElementDescriptionC",
-      "shortName": "DataElementShortC",
-      "attributeValues": []
     }
   ]
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/create_program_stages.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/create_program_stages.json
@@ -1,0 +1,363 @@
+{
+  "system": {
+    "id": "eed3d451-4ff5-4193-b951-ffcc68954299",
+    "rev": "4219a14",
+    "version": "2.35.0",
+    "date": "2020-11-24T07:46:15.538"
+  },
+  "organisationUnits": [
+    {
+      "path": "/y77LiPqLMoq",
+      "created": "2016-03-10T05:01:10.702+0000",
+      "attributeValues": [],
+      "shortName": "Country",
+      "name": "Country",
+      "uuid": "b8b03f02-6a01-4786-9343-937692400cec",
+      "openingDate": "2016-03-10",
+      "user": {
+        "id": "ZK1wkC59FCw"
+      },
+      "lastUpdated": "2016-03-10T05:01:10.717+0000",
+      "id": "y77LiPqLMoq",
+      "featureType": "NONE",
+      "description": "",
+      "code": "OU_559"
+    }
+  ],
+  "users": [
+    {
+      "lastUpdated": "2016-03-10T05:01:28.993+0000",
+      "surname": "admin",
+      "firstName": "admin",
+      "dataViewOrganisationUnits": [],
+      "id": "ZK1wkC59FCw",
+      "organisationUnits": [
+        {
+          "id": "y77LiPqLMoq"
+        }
+      ],
+      "teiSearchOrganisationUnits": [],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "selfRegistered": false,
+        "externalAuth": false,
+        "invitation": false,
+        "cogsDimensionConstraints": [],
+        "created": "2016-03-10T05:00:11.882+0000",
+        "username": "admin",
+        "disabled": false,
+        "passwordLastUpdated": "2016-03-10T05:00:11.791+0000",
+        "userInfo": {
+          "id": "ZK1wkC59FCw"
+        },
+        "catDimensionConstraints": [],
+        "lastLogin": "2016-03-10T05:00:11.791+0000",
+        "user": {
+          "id": "ZK1wkC59FCw"
+        },
+        "userRoles": [
+          {
+            "id": "VIkpd2KHCb1"
+          }
+        ]
+      },
+      "attributeValues": [],
+      "created": "2016-03-10T05:00:11.766+0000"
+    }
+  ],
+  "userRoles": [
+    {
+      "created": "2016-03-10T05:00:11.778+0000",
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_MAP_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_PROGRAM_ENROLLMENT",
+        "F_SQLVIEW_EXTERNAL",
+        "F_GIS_ADMIN",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_VISUALIZATION_PUBLIC_ADD",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_VISUALIZATION_EXTERNAL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_MAP_EXTERNAL",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE"
+      ],
+      "userGroupAccesses": [],
+      "dataSets": [],
+      "programs": [],
+      "publicAccess": "--------",
+      "id": "VIkpd2KHCb1",
+      "name": "Superuser",
+      "lastUpdated": "2016-03-10T05:00:11.778+0000"
+    }
+  ],
+  "programs": [
+    {
+      "lastUpdated": "2020-11-24T07:45:30.684",
+      "id": "VBqh0ynB2wv",
+      "created": "2016-03-30T20:18:31.020",
+      "name": "Malaria case registration",
+      "shortName": "Malaria case registration",
+      "code": "malaria_case",
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "enrollmentDateLabel": "Enrollment Date",
+      "onlyEnrollOnce": false,
+      "version": 3,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "incidentDateLabel": "Incident Date",
+      "selectEnrollmentDatesInFuture": false,
+      "useFirstStageDuringRegistration": false,
+      "completeEventsExpiryDays": 0,
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "programType": "WITHOUT_REGISTRATION",
+      "accessLevel": "OPEN",
+      "displayIncidentDate": false,
+      "expiryDays": 0,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "displayName": "John Traore",
+        "id": "ZK1wkC59FCw",
+        "username": "admin"
+      },
+      "style": {
+        "color": "#7c4dff",
+        "icon": "mosquito_positive"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "organisationUnits": [
+        {
+          "id": "y77LiPqLMoq"
+        }
+      ],
+      "programSections": [],
+      "programStages": [
+        {
+          "id": "pTo4uMt3xur"
+        }
+      ]
+    }
+  ],
+  "programStages": [
+    {
+      "lastUpdated": "2020-11-23T14:51:32.868",
+      "id": "pTo4uMt3xur",
+      "created": "2016-03-30T20:18:31.146",
+      "name": "Malaria case registration",
+      "code": "malaria_case",
+      "allowGenerateNextVisit": false,
+      "executionDateLabel": "Report date",
+      "preGenerateUID": false,
+      "openAfterEnrollment": false,
+      "repeatable": false,
+      "featureType": "POINT",
+      "remindCompleted": false,
+      "displayGenerateEventBox": false,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_UPDATE_AND_INSERT",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": true,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "VBqh0ynB2wv"
+      },
+      "lastUpdatedBy": {
+        "id": "ZK1wkC59FCw"
+      },
+      "notificationTemplates": [],
+      "programStageDataElements": [
+        {
+          "lastUpdated": "2016-12-06T16:37:46.077",
+          "id": "d9wIqlzSMgE",
+          "created": "2016-04-01T15:07:12.695",
+          "displayInReports": true,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "allowFutureDate": false,
+          "compulsory": true,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 0,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": false,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "pTo4uMt3xur"
+          },
+          "dataElement": {
+            "id": "qrur9Dvnyt5"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2016-12-06T16:37:46.104",
+          "id": "FKHaErzkvEF",
+          "created": "2016-04-01T15:07:12.723",
+          "displayInReports": true,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "allowFutureDate": false,
+          "compulsory": true,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": false,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "pTo4uMt3xur"
+          },
+          "dataElement": {
+            "id": "oZg33kd9taw"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2016-12-06T16:37:46.116",
+          "id": "Zrem1VAqA8r",
+          "created": "2016-12-06T16:37:46.115",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 2,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": false,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "pTo4uMt3xur"
+          },
+          "dataElement": {
+            "id": "F3ogKBuviRA"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        }
+      ],
+      "translations": [],
+      "attributeValues": [],
+      "programStageSections": []
+    }
+  ],
+  "dataElements": [
+    {
+      "description": "DataElementDescriptionA",
+      "shortName": "DataElementShortA",
+      "attributeValues": [],
+      "user": {
+        "id": "VIkpd2KHCb1"
+      },
+      "lastUpdated": "2016-03-10T05:02:18.871+0000",
+      "code": "DataElementCodeA",
+      "name": "DataElementA",
+      "aggregationLevels": [],
+      "aggregationType": "SUM",
+      "id": "F3ogKBuviRA",
+      "publicAccess": "rw------",
+      "zeroIsSignificant": false,
+      "userGroupAccesses": [],
+      "valueType": "COORDINATE",
+      "created": "2016-03-10T05:02:18.868+0000",
+      "domainType": "AGGREGATE"
+    },
+    {
+      "name": "DataElementB",
+      "code": "DataElementCodeB",
+      "user": {
+        "id": "VIkpd2KHCb1"
+      },
+      "lastUpdated": "2016-03-10T05:02:47.024+0000",
+      "id": "oZg33kd9taw",
+      "aggregationType": "SUM",
+      "aggregationLevels": [],
+      "zeroIsSignificant": false,
+      "publicAccess": "rw------",
+      "domainType": "AGGREGATE",
+      "created": "2016-03-10T05:02:47.023+0000",
+      "valueType": "TEXT",
+      "userGroupAccesses": [],
+      "description": "DataElementDescriptionB",
+      "attributeValues": [],
+      "shortName": "DataElementShortB"
+    },
+    {
+      "lastUpdated": "2016-03-10T05:04:44.334+0000",
+      "user": {
+        "id": "VIkpd2KHCb1"
+      },
+      "name": "DataElementC",
+      "code": "DataElementCodeC",
+      "aggregationLevels": [],
+      "id": "qrur9Dvnyt5",
+      "aggregationType": "SUM",
+      "publicAccess": "rw------",
+      "zeroIsSignificant": false,
+      "valueType": "NUMBER",
+      "userGroupAccesses": [],
+      "domainType": "AGGREGATE",
+      "created": "2016-03-10T05:04:44.329+0000",
+      "description": "DataElementDescriptionC",
+      "shortName": "DataElementShortC",
+      "attributeValues": []
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/csv/events_import_code.csv
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/csv/events_import_code.csv
@@ -1,0 +1,2 @@
+event,status,program,programStage,enrollment,orgUnit,eventDate,dueDate,latitude,longitude,dataElement,value,storedBy,providedElsewhere,completedDate,completedBy,geometry
+ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,F3ogKBuviRA,text,bjorn,false,,,'POINT (-11.4283223849698 8.06311527044516)'

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/events-5b.csv
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/events-5b.csv
@@ -1,0 +1,4 @@
+event,status,program,programStage,enrollment,orgUnit,eventDate,dueDate,latitude,longitude,dataElement,value,storedBy,providedElsewhere,completedDate,completedBy,geometry
+ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,F3ogKBuviRA,"[-11.4234147333302,8.04129958345372]",bjorn,false,,,"POINT (-11.4283223849698 8.06311527044516)"
+ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,oZg33kd9taw,Female,bjorn,false,,,"POINT (-11.4283223849698 8.06311527044516)"
+ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,qrur9Dvnyt5,23,bjorn,false,,,"POINT (-11.4283223849698 8.06311527044516)"

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/events-5b.csv
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/import/events-5b.csv
@@ -1,4 +1,0 @@
-event,status,program,programStage,enrollment,orgUnit,eventDate,dueDate,latitude,longitude,dataElement,value,storedBy,providedElsewhere,completedDate,completedBy,geometry
-ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,F3ogKBuviRA,"[-11.4234147333302,8.04129958345372]",bjorn,false,,,"POINT (-11.4283223849698 8.06311527044516)"
-ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,oZg33kd9taw,Female,bjorn,false,,,"POINT (-11.4283223849698 8.06311527044516)"
-ZjoPam9PF3O,ACTIVE,malaria_case,malaria_case,,OU_559,2020-08-24T00:00:00.000,2020-08-24,8.06311527044516,-11.4283223849698,qrur9Dvnyt5,23,bjorn,false,,,"POINT (-11.4283223849698 8.06311527044516)"


### PR DESCRIPTION
On 2.35 in ProgramStagePreProcessor we are checking about Idscheme but on the event we are not setting a program stage based on that.

- [x] During events import, updates event program stage based on idScheme  
- [x] adds tests 