### PR TITLE
test: Adds toolbox for easy Web API testing

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
@@ -28,14 +28,15 @@ package org.hisp.dhis.actions;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.gson.JsonObject;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+
 import org.hisp.dhis.TestRunStorage;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
 
-import java.util.List;
-
-import static org.hamcrest.Matchers.equalTo;
+import com.google.gson.JsonObject;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -68,7 +69,7 @@ public class UserActions
 
         ApiResponse response = this.post( user );
 
-        response.validate().statusCode( 200 );
+        response.validate().statusCode( 201 );
 
         TestRunStorage.addCreatedEntity( endpoint, id );
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonArray.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonArray.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.util.List;
+
+/**
+ * Represents a JSON array node.
+ *
+ * As all nodes are mere views or virtual index access will never throw an
+ * {@link ArrayIndexOutOfBoundsException}. Whether or not an element at an index
+ * exists is determined first when {@link JsonValue#exists()} or other value
+ * accessing operations are performed on a node.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonArray extends JsonCollection
+{
+
+    /**
+     * Index access to the array.
+     *
+     * Note that this will neither check index nor element type.
+     *
+     * @param index index to access (>= 0)
+     * @param as assumed type of the element
+     * @param <T> type of the returned element
+     * @return element at the given index
+     */
+    <T extends JsonValue> T get( int index, Class<T> as );
+
+    /**
+     * @return the array elements as a uniform list of {@link String}
+     * @throws IllegalArgumentException in case the node is not an array or the
+     *         array has mixed elements
+     */
+    List<String> stringValues();
+
+    /**
+     * @return the array elements as a uniform list of {@link Number}
+     * @throws IllegalArgumentException in case the node is not an array or the
+     *         array has mixed elements
+     */
+    List<Number> numberValues();
+
+    /**
+     * @return the array elements as a uniform list of {@link Boolean}
+     * @throws IllegalArgumentException in case the node is not an array or the
+     *         array has mixed elements
+     */
+    List<Boolean> boolValues();
+
+    default JsonValue get( int index )
+    {
+        return get( index, JsonValue.class );
+    }
+
+    default JsonNumber getNumber( int index )
+    {
+        return get( index, JsonNumber.class );
+    }
+
+    default JsonArray getArray( int index )
+    {
+        return get( index, JsonArray.class );
+    }
+
+    default JsonString getString( int index )
+    {
+        return get( index, JsonString.class );
+    }
+
+    default JsonBoolean getBoolean( int index )
+    {
+        return get( index, JsonBoolean.class );
+    }
+
+    default JsonObject getObject( int index )
+    {
+        return get( index, JsonObject.class );
+    }
+
+    default <E extends JsonValue> JsonList<E> getList( int index, Class<E> as )
+    {
+        return asList( getArray( index ), as );
+    }
+
+    default <E extends JsonValue> JsonMap<E> getMap( int index, Class<E> as )
+    {
+        return asMap( getObject( index ), as );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonBoolean.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonBoolean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+/**
+ * Represents a boolean JSON node.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonBoolean extends JsonPrimitive
+{
+
+    /**
+     * @return boolean value of the property or {@code null} when this property
+     *         is undefined or defined as JSON {@code null}.
+     */
+    Boolean bool();
+
+    /**
+     * Same as {@link #bool()} except that this throws an
+     * {@link java.util.NoSuchElementException} in case the value is not
+     * defined.
+     *
+     * @return true of false, nothing else
+     * @throws java.util.NoSuchElementException when this value is not defined
+     *         in the JSON content or defined JSON {@code null}.
+     */
+    default boolean booleanValue()
+    {
+        return mapNonNull( bool(), Boolean::booleanValue );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonCollection.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonCollection.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+/**
+ * Common base class for JSON nodes that have children.
+ *
+ * These are their
+ * <ul>
+ * <li>{@link JsonArray}s, or</li>
+ * <li>{@link JsonObject}s</li>
+ * </ul>
+ *
+ * Each has their typed wrapper type:
+ * <ul>
+ * <li>{@link JsonList}</li>
+ * <li>{@link JsonMap}</li>
+ * </ul>
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonCollection extends JsonValue
+{
+
+    /**
+     * @return true, in case the collection exists but has no elements and is
+     *         not {@code null}
+     * @throws java.util.NoSuchElementException in case this value does not
+     *         exist in the content
+     * @throws IllegalArgumentException in case the value does exist but is not
+     *         a collection
+     */
+    boolean isEmpty();
+
+    /**
+     * @return the number of elements in the collection
+     * @throws java.util.NoSuchElementException in case this value does not
+     *         exist in the content
+     * @throws IllegalArgumentException in case the value does exist but is not
+     *         a collection
+     */
+    int size();
+
+    default <E extends JsonValue> JsonList<E> asList( JsonArray array, Class<E> as )
+    {
+        class ListView extends CollectionView<JsonArray> implements JsonList<E>
+        {
+            ListView( JsonArray viewed )
+            {
+                super( viewed );
+            }
+
+            @Override
+            public E get( int index )
+            {
+                return array.get( index, as );
+            }
+        }
+        return new ListView( array );
+    }
+
+    default <E extends JsonValue> JsonMap<E> asMap( JsonObject object, Class<E> as )
+    {
+        class MapView extends CollectionView<JsonObject> implements JsonMap<E>
+        {
+            MapView( JsonObject viewed )
+            {
+                super( viewed );
+            }
+
+            @Override
+            public E get( String key )
+            {
+                return viewed.get( key, as );
+            }
+        }
+        return new MapView( object );
+    }
+
+    abstract class CollectionView<T extends JsonCollection> implements JsonCollection
+    {
+        protected final T viewed;
+
+        protected CollectionView( T viewed )
+        {
+            this.viewed = viewed;
+        }
+
+        @Override
+        public final boolean isEmpty()
+        {
+            return viewed.isEmpty();
+        }
+
+        @Override
+        public final int size()
+        {
+            return viewed.size();
+        }
+
+        @Override
+        public final boolean exists()
+        {
+            return viewed.exists();
+        }
+
+        @Override
+        public final boolean isNull()
+        {
+            return viewed.isNull();
+        }
+
+        @Override
+        public final boolean isArray()
+        {
+            return viewed.isArray();
+        }
+
+        @Override
+        public final boolean isObject()
+        {
+            return viewed.isObject();
+        }
+
+        @Override
+        public final <V extends JsonValue> V as( Class<V> as )
+        {
+            return viewed.as( as );
+        }
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonDate.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonDate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * A {@link JsonDate} is a {@link JsonString} with a special format.
+ *
+ * The {@link #date()} utility allows to access the date as
+ * {@link LocalDateTime} instead of {@link String}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonDate extends JsonString
+{
+    default LocalDateTime date()
+    {
+        return parsed( str -> LocalDateTime.parse( str, DateTimeFormatter.ISO_LOCAL_DATE_TIME ) );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonList.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonList.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * A {@link JsonList} is nothing else then a {@link JsonArray} with "typed"
+ * uniform elements.
+ *
+ * @author Jan Bernitt
+ *
+ * @param <E> type of the list elements
+ */
+public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<E>
+{
+    /**
+     * A typed variant of {@link JsonArray#get(int)}, equivalent to
+     * {@link JsonArray#get(int, Class)} where 2nd parameter is the type
+     * parameter E.
+     *
+     * @param index index to access
+     * @return element at the provided index
+     */
+    E get( int index );
+
+    @Override
+    @NotNull
+    default Iterator<E> iterator()
+    {
+        int size = size();
+        return new Iterator<E>()
+        {
+            int index = 0;
+
+            @Override
+            public boolean hasNext()
+            {
+                return index < size;
+            }
+
+            @Override
+            public E next()
+            {
+                E e = get( index++ );
+                if ( !e.exists() )
+                {
+                    throw new NoSuchElementException();
+                }
+                return e;
+            }
+        };
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonMap.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonMap.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+/**
+ * {@link JsonMap}s are a special form of a {@link JsonObject} where all
+ * properties have a common uniform value type.
+ *
+ * @author Jan Bernitt
+ *
+ * @param <E> type of the uniform map values
+ */
+public interface JsonMap<E extends JsonValue> extends JsonCollection
+{
+    /**
+     * A typed variant of {@link JsonObject#get(String)}, equivalent to
+     * {@link JsonObject#get(String, Class)} where 2nd parameter is the type
+     * parameter E.
+     *
+     * @param key property to access
+     * @return value at the provided property
+     */
+    E get( String key );
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonNumber.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonNumber.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+/**
+ * Represents a numeric JSON node.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonNumber extends JsonPrimitive
+{
+
+    /**
+     * @return numeric value of the property or {@code null} when this property
+     *         is undefined or defined as JSON {@code null}.
+     */
+    Number number();
+
+    default int intValue()
+    {
+        return mapNonNull( number(), Number::intValue );
+    }
+
+    default long longValue()
+    {
+        return mapNonNull( number(), Number::longValue );
+    }
+
+    default float floatValue()
+    {
+        return mapNonNull( number(), Number::floatValue );
+    }
+
+    default double doubleValue()
+    {
+        return mapNonNull( number(), Number::doubleValue );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+/**
+ * Represents a JSON object node.
+ *
+ * As all nodes are mere views or virtual field access will never throw a
+ * {@link java.util.NoSuchElementException}. Whether or not a field with a given
+ * name exists is determined first when {@link JsonValue#exists()} or other
+ * value accessing operations are performed on a node.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonObject extends JsonCollection
+{
+
+    /**
+     * Name access to object fields.
+     *
+     * Note that this neither checks if a field exist nor if it has the assumed
+     * type.
+     *
+     * @param name field name
+     * @param as assumed type of the field
+     * @param <T> returned field type
+     * @return field value for the given name
+     */
+    <T extends JsonValue> T get( String name, Class<T> as );
+
+    /**
+     *
+     * @param names a set of names that should exist
+     * @return true if this object has (at least) all the given names
+     */
+    boolean has( String... names );
+
+    default JsonValue get( String name )
+    {
+        return get( name, JsonValue.class );
+    }
+
+    default JsonObject getObject( String name )
+    {
+        return get( name, JsonObject.class );
+    }
+
+    default JsonNumber getNumber( String name )
+    {
+        return get( name, JsonNumber.class );
+    }
+
+    default JsonArray getArray( String name )
+    {
+        return get( name, JsonArray.class );
+    }
+
+    default JsonString getString( String name )
+    {
+        return get( name, JsonString.class );
+    }
+
+    default JsonBoolean getBoolean( String name )
+    {
+        return get( name, JsonBoolean.class );
+    }
+
+    default <E extends JsonValue> JsonList<E> getList( String name, Class<E> as )
+    {
+        return asList( getArray( name ), as );
+    }
+
+    default <E extends JsonValue> JsonMap<E> getMap( String name, Class<E> as )
+    {
+        return asMap( getObject( name ), as );
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonPrimitive.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonPrimitive.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.util.function.Function;
+
+/**
+ * A common base type for the primitive nodes in a JSON tree.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonPrimitive extends JsonValue
+{
+    /**
+     * A helper function that converts non-{@code null} values which are assumed
+     * to represent the raw primitive value of this JSON value.
+     *
+     * @param from should represent the raw primitive value of this JSON value
+     * @param to conversion {@link Function} to use
+     * @param <A> input type
+     * @param <B> output type
+     * @return input value of type A converted to type B by using the provided
+     *         {@link Function}
+     * @throws java.util.NoSuchElementException in case input is {@code null}
+     *         (which means this value was not defined)
+     */
+    <A, B> B mapNonNull( A from, Function<A, B> to );
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonString.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonString.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.util.function.Function;
+
+/**
+ * Represents a string JSON node.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonString extends JsonPrimitive
+{
+
+    /**
+     * @return string value of the property or {@code null} when this property
+     *         is undefined or defined as JSON {@code null}.
+     */
+    String string();
+
+    /**
+     * In contrast to {@link #mapNonNull(Object, Function)} this function simply
+     * returns {@code null} when {@link #string()} is {@code null}. This
+     * includes the case that this value is not defined in the JSON content.
+     *
+     * @param parser function that parses a given {@link String} to the returned
+     *        type.
+     * @param <T> return type
+     * @return {@code null} when {@link #string()} returns {@code null}
+     *         otherwise the result of calling provided parser with result of
+     *         {@link #string()}.
+     */
+    default <T> T parsed( Function<String, T> parser )
+    {
+        String value = string();
+        return value == null ? null : parser.apply( value );
+    }
+
+    default Class<?> parsedClass()
+    {
+        try
+        {
+            return Class.forName( string() );
+        }
+        catch ( ClassNotFoundException ex )
+        {
+            throw new IllegalArgumentException( ex );
+        }
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonValue.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+/**
+ * The {@link JsonValue} is a virtual read-only view for JSON responses.
+ *
+ * As usual there are specific node types for the JSON building blocks:
+ * <ul>
+ * <li>{@link JsonObject}</li>
+ * <li>{@link JsonArray}</li>
+ * <li>{@link JsonString}</li>
+ * <li>{@link JsonNumber}</li>
+ * <li>{@link JsonBoolean}</li>
+ * </ul>
+ * In addition there is {@link JsonCollection} as a common base type of
+ * {@link JsonObject} and {@link JsonArray} and {@link JsonPrimitive} as common
+ * base type of {@link JsonString}, {@link JsonNumber} and {@link JsonBoolean}.
+ *
+ * In addition {@link JsonList} is a typed JSON array of uniform elements (which
+ * can be understood as a typed wrapper around a {@link JsonArray}.
+ *
+ * Similarly {@link JsonMap} is a typed JSON object map of uniform values (which
+ * can be understood as a typed wrapper around a {@link JsonObject}.
+ *
+ * The API is designed to:
+ * <ul>
+ * <li>be extended by further types extending {@link JsonValue}, such as
+ * {@link JsonDate} but also further specific object types</li>
+ * <li>fail at point of assertion. This means traversing the virtual tree does
+ * not cause errors unless explicitly provoked.</li>
+ * <li>be implemented by a single class which only builds a lookup path and
+ * checks or provides the leaf values on demand. Interfaces not directly
+ * implemented by this class are dynamically created using a
+ * {@link java.lang.reflect.Proxy}.</li>
+ * </ul>
+ */
+public interface JsonValue
+{
+
+    /**
+     * A property exists when it is part of the JSON response. This means it can
+     * be declared JSON {@code null}. Only a path that does not exist returns
+     * false.
+     *
+     * @return true, if the value exists, else false
+     */
+    boolean exists();
+
+    /**
+     * @return true if the value exists and is defined JSON {@code null}
+     * @throws java.util.NoSuchElementException in case this value does not
+     *         exist in the content
+     */
+    boolean isNull();
+
+    /**
+     * @return true if the value exists and is a JSON array node (empty or not)
+     *         but not JSON {@code null}
+     * @throws java.util.NoSuchElementException in case this value does not
+     *         exist in the content
+     */
+    boolean isArray();
+
+    /**
+     * @return true if the value exists and is an JSON object node (empty or
+     *         not) but not JSON {@code null}
+     * @throws java.util.NoSuchElementException in case this value does not
+     *         exist in the content
+     */
+    boolean isObject();
+
+    /**
+     * "Cast" this JSON value to a more specific type. Note that any type can be
+     * switched to any other type. Types here are just what we believe to be
+     * true. They are only here to guide us, not assert existence.
+     *
+     * Whether or not assumptions are actually true is determined when leaf
+     * values are accessed.
+     *
+     * @param as assumed value type
+     * @param <T> value type returned
+     * @return this object as the provided type, this might mean this object is
+     *         wrapped as the provided type or literally cast.
+     */
+    <T extends JsonValue> T as( Class<T> as );
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonAccess.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonAccess.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonString;
+
+/**
+ * Web API equivalent of a 8 character access pattern as used in
+ * {@link org.hisp.dhis.user.sharing.Sharing} JSON.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonAccess extends JsonString
+{
+
+    default boolean isMetadataRead()
+    {
+        return string().charAt( 0 ) == 'r';
+    }
+
+    default boolean isMetadataWrite()
+    {
+        return string().charAt( 1 ) == 'w';
+    }
+
+    default boolean iDataRead()
+    {
+        return string().charAt( 2 ) == 'r';
+    }
+
+    default boolean isDataWrite()
+    {
+        return string().charAt( 3 ) == 'w';
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonConstant.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonConstant.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.constant.Constant}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonConstant extends JsonNameableObject
+{
+    default double getValue()
+    {
+        return getNumber( "value" ).doubleValue();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDashboard.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDashboard.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.util.List;
+
+import org.hisp.dhis.webapi.json.JsonList;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.dashboard.Dashboard}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonDashboard extends JsonNameableObject
+{
+
+    default int getItemCount()
+    {
+        return getNumber( "itemCount" ).intValue();
+    }
+
+    default boolean isRestrictFilters()
+    {
+        return getBoolean( "restrictFilters" ).booleanValue();
+    }
+
+    default List<String> getAllowedFilters()
+    {
+        return getArray( "allowedFilters" ).stringValues();
+    }
+
+    default JsonList<JsonDashboardItem> getDashboardItems()
+    {
+        return getList( "dashboardItems", JsonDashboardItem.class );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDashboardItem.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDashboardItem.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.dashboard.DashboardItemShape;
+import org.hisp.dhis.dashboard.DashboardItemType;
+import org.hisp.dhis.webapi.json.JsonList;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.dashboard.DashboardItem}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonDashboardItem extends JsonIdentifiableObject
+{
+    default DashboardItemType getType()
+    {
+        return getString( "type" ).parsed( DashboardItemType::valueOf );
+    }
+
+    default int getInterpretationCount()
+    {
+        return getNumber( "interpretationCount" ).intValue();
+    }
+
+    default int getInterpretationLikeCount()
+    {
+        return getNumber( "interpretationLikeCount" ).intValue();
+    }
+
+    default int getContentCount()
+    {
+        return getNumber( "contentCount" ).intValue();
+    }
+
+    default String getText()
+    {
+        return getString( "text" ).string();
+    }
+
+    default Boolean getMessages()
+    {
+        return getBoolean( "messages" ).bool();
+    }
+
+    default String getAppKey()
+    {
+        return getString( "appKey" ).string();
+    }
+
+    default DashboardItemShape getShape()
+    {
+        return getString( "shape" ).parsed( DashboardItemShape::valueOf );
+    }
+
+    default Number getX()
+    {
+        return getNumber( "x" ).number();
+    }
+
+    default Number getY()
+    {
+        return getNumber( "y" ).number();
+    }
+
+    default Number getHeight()
+    {
+        return getNumber( "height" ).number();
+    }
+
+    default Number getWidth()
+    {
+        return getNumber( "width" ).number();
+    }
+
+    default JsonIdentifiableObject getVisualization()
+    {
+        return get( "visualization", JsonIdentifiableObject.class );
+    }
+
+    default JsonIdentifiableObject getChart()
+    {
+        return get( "chart", JsonIdentifiableObject.class );
+    }
+
+    default JsonIdentifiableObject getReportTable()
+    {
+        return get( "reportTable", JsonIdentifiableObject.class );
+    }
+
+    default JsonIdentifiableObject getEventChart()
+    {
+        return get( "eventChart", JsonIdentifiableObject.class );
+    }
+
+    default JsonIdentifiableObject getMap()
+    {
+        return get( "map", JsonIdentifiableObject.class );
+    }
+
+    default JsonIdentifiableObject getEventReport()
+    {
+        return get( "eventReport", JsonIdentifiableObject.class );
+    }
+
+    default JsonList<JsonUser> getUsers()
+    {
+        return getList( "users", JsonUser.class );
+    }
+
+    default JsonList<JsonIdentifiableObject> getReports()
+    {
+        return getList( "reports", JsonIdentifiableObject.class );
+    }
+
+    default JsonList<JsonIdentifiableObject> getResources()
+    {
+        return getList( "resources", JsonIdentifiableObject.class );
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonError.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonError.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.util.function.Consumer;
+
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * A generic error JSON as usually returned by DHIS2.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonError extends JsonObject
+{
+    default String getHttpStatus()
+    {
+        return getString( "httpStatus" ).string();
+    }
+
+    default int getHttpStatusCode()
+    {
+        return getNumber( "httpStatusCode" ).intValue();
+    }
+
+    default String getStatus()
+    {
+        return getString( "status" ).string();
+    }
+
+    default String getMessage()
+    {
+        return getString( "message" ).string();
+    }
+
+    /**
+     * OBS! This property only exists in some error responses.
+     */
+    default JsonTypeReport getTypeReport()
+    {
+        return get( "response", JsonTypeReport.class );
+    }
+
+    /**
+     * OBS! This is not a getter for a property in the response but a helper to
+     * extract a summary description based on the error response.
+     *
+     * @return a error summary suitable to be used as assert message.
+     */
+    default String summary()
+    {
+        StringBuilder str = new StringBuilder();
+        Consumer<JsonList<JsonErrorReport>> printer = errors -> {
+            if ( errors.exists() )
+            {
+                for ( JsonErrorReport error : errors )
+                {
+                    str.append( "\n  " ).append( error.getErrorCode() ).append( ' ' ).append( error.getMessage() );
+                }
+            }
+        };
+        str.append( getMessage() );
+        if ( getTypeReport().exists() )
+        {
+            printer.accept( getTypeReport().getErrorReports() );
+            if ( getTypeReport().getObjectReports().exists() )
+            {
+                for ( JsonObjectReport report : getTypeReport().getObjectReports() )
+                {
+                    str.append( "\n* " ).append( report.getKlass() );
+                    printer.accept( report.getErrorReports() );
+                }
+            }
+        }
+        return str.toString();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonErrorReport.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonErrorReport.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.util.List;
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.feedback.ErrorReport}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonErrorReport extends JsonObject
+{
+    default String getMessage()
+    {
+        return getString( "message" ).string();
+    }
+
+    default Class<?> getMainKlass()
+    {
+        return getString( "mainKlass" ).parsedClass();
+    }
+
+    default ErrorCode getErrorCode()
+    {
+        return getString( "errorCode" ).parsed( ErrorCode::valueOf );
+    }
+
+    default Class<?> getErrorKlass()
+    {
+        return getString( "errorKlass" ).parsedClass();
+    }
+
+    default List<String> getErrorProperties()
+    {
+        return getArray( "errorProperties" ).stringValues();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonGeoMap.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonGeoMap.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.util.List;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.mapping.Map}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonGeoMap extends JsonNameableObject
+{
+    default Number getLongitude()
+    {
+        return getNumber( "longitude" ).number();
+    }
+
+    default Number getLatitude()
+    {
+        return getNumber( "latitude" ).number();
+    }
+
+    default Number getZoom()
+    {
+        return getNumber( "zoom" ).number();
+    }
+
+    default String getBasemap()
+    {
+        return getString( "basemap" ).string();
+    }
+
+    default String getTitle()
+    {
+        return getString( "title" ).string();
+    }
+
+    default List<String> getSubscribers()
+    {
+        return getArray( "subscribers" ).stringValues();
+    }
+
+    default boolean isSubscribed()
+    {
+        return getBoolean( "subscribed" ).booleanValue();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonIdentifiableObject.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonIdentifiableObject.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hisp.dhis.webapi.json.JsonDate;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.common.BaseIdentifiableObject}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonIdentifiableObject extends JsonObject
+{
+    default String getId()
+    {
+        return getString( "id" ).string();
+    }
+
+    default String getName()
+    {
+        return getString( "name" ).string();
+    }
+
+    default String getDisplayName()
+    {
+        return getString( "displayName" ).string();
+    }
+
+    default String getHref()
+    {
+        return getString( "href" ).string();
+    }
+
+    default String getCode()
+    {
+        return getString( "code" ).string();
+    }
+
+    default JsonUser getLastUpdatedBy()
+    {
+        return get( "lastUpdatedBy", JsonUser.class );
+    }
+
+    default LocalDateTime getLastUpdated()
+    {
+        return get( "lastUpdated", JsonDate.class ).date();
+    }
+
+    default JsonUser getCreatedBy()
+    {
+        return get( "createdBy", JsonUser.class );
+    }
+
+    default LocalDateTime getCreated()
+    {
+        return get( "created", JsonDate.class ).date();
+    }
+
+    default boolean getExternalAccess()
+    {
+        return getBoolean( "externalAccess" ).booleanValue();
+    }
+
+    default List<String> getFavorites()
+    {
+        return getArray( "favorites" ).stringValues();
+    }
+
+    default boolean isFavorite()
+    {
+        return getBoolean( "favorite" ).booleanValue();
+    }
+
+    default JsonSharing getSharing()
+    {
+        return get( "sharing", JsonSharing.class );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonNameableObject.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonNameableObject.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.common.BaseNameableObject}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonNameableObject extends JsonIdentifiableObject
+{
+
+    default String getShortName()
+    {
+        return getString( "shortName" ).string();
+    }
+
+    default String getDisplayShortName()
+    {
+        return getString( "displayShortName" ).string();
+    }
+
+    default String getDescription()
+    {
+        return getString( "description" ).string();
+    }
+
+    default String getDisplayDescription()
+    {
+        return getString( "displayDescription" ).string();
+    }
+
+    default String getFormName()
+    {
+        return getString( "formName" ).string();
+    }
+
+    default String getDisplayFormName()
+    {
+        return getString( "displayFormName" ).string();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonObjectAccess.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonObjectAccess.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.user.sharing.UserAccess} and
+ * {@link org.hisp.dhis.user.sharing.UserGroupAccess}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonObjectAccess extends JsonObject
+{
+    default JsonAccess getAccess()
+    {
+        return get( "access", JsonAccess.class );
+    }
+
+    default String getId()
+    {
+        return getString( "id" ).string();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonObjectReport.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonObjectReport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.feedback.ObjectReport}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonObjectReport extends JsonObject
+{
+    default Class<?> getKlass()
+    {
+        return getString( "klass" ).parsedClass();
+    }
+
+    default int getIndex()
+    {
+        return getNumber( "index" ).intValue();
+    }
+
+    default JsonList<JsonErrorReport> getErrorReports()
+    {
+        return getList( "errorReports", JsonErrorReport.class );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonOrganisationUnit.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonOrganisationUnit.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.time.LocalDateTime;
+
+import org.hisp.dhis.webapi.json.JsonDate;
+import org.hisp.dhis.webapi.json.JsonList;
+
+/**
+ * Web API equivalent of a
+ * {@link org.hisp.dhis.organisationunit.OrganisationUnit}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonOrganisationUnit extends JsonIdentifiableObject
+{
+    default boolean isLeaf()
+    {
+        return getBoolean( "leaf" ).booleanValue();
+    }
+
+    default int getLevel()
+    {
+        return getNumber( "level" ).intValue();
+    }
+
+    default JsonPath getPath()
+    {
+        return get( "path", JsonPath.class );
+    }
+
+    default LocalDateTime getOpeningDate()
+    {
+        return get( "openingDate", JsonDate.class ).date();
+    }
+
+    default LocalDateTime getClosedDate()
+    {
+        return get( "closedDate", JsonDate.class ).date();
+    }
+
+    default JsonOrganisationUnit getParent()
+    {
+        return get( "parent", JsonOrganisationUnit.class );
+    }
+
+    default JsonList<JsonOrganisationUnit> getChildren()
+    {
+        return getList( "children", JsonOrganisationUnit.class );
+    }
+
+    default JsonList<JsonOrganisationUnit> getAncestors()
+    {
+        return getList( "ancestors", JsonOrganisationUnit.class );
+    }
+
+    default JsonList<JsonUser> getUsers()
+    {
+        return getList( "users", JsonUser.class );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonPath.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonPath.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.webapi.json.JsonString;
+
+/**
+ * A utility for an {@link OrganisationUnit#getPath()} value.
+ *
+ * Values use the format (starting with the root):
+ *
+ * <pre>
+ * /{uid}/{uid}
+ * /{uid}/{uid}/{uid}
+ * </pre>
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonPath extends JsonString
+{
+    default List<String> ids()
+    {
+        return parsed( str -> asList( str.split( "/" ) ) );
+    }
+
+    default boolean contains( String uid )
+    {
+        return ids().contains( uid );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonSharing.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonSharing.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonMap;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.user.sharing.Sharing}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonSharing extends JsonObject
+{
+    default String getOwner()
+    {
+        return getString( "owner" ).string();
+    }
+
+    default JsonAccess getPublic()
+    {
+        return get( "public", JsonAccess.class );
+    }
+
+    default boolean isExternal()
+    {
+        return getBoolean( "external" ).booleanValue();
+    }
+
+    default JsonMap<JsonObjectAccess> getUsers()
+    {
+        return getMap( "users", JsonObjectAccess.class );
+    }
+
+    default JsonMap<JsonObjectAccess> getUserGroups()
+    {
+        return getMap( "userGroups", JsonObjectAccess.class );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonStats.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonStats.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.feedback.Stats}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonStats extends JsonObject
+{
+    default int getCreated()
+    {
+        return getNumber( "created" ).intValue();
+    }
+
+    default int getUpdated()
+    {
+        return getNumber( "updated" ).intValue();
+    }
+
+    default int getDeleted()
+    {
+        return getNumber( "deleted" ).intValue();
+    }
+
+    default int getIgnored()
+    {
+        return getNumber( "ignored" ).intValue();
+    }
+
+    default int getTotal()
+    {
+        return getNumber( "total" ).intValue();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonTranslation.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonTranslation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.translation.Translation}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonTranslation extends JsonObject
+{
+
+    default String getLocale()
+    {
+        return getString( "locale" ).string();
+    }
+
+    default String getProperty()
+    {
+        return getString( "property" ).string();
+    }
+
+    default String getValue()
+    {
+        return getString( "value" ).string();
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonTypeReport.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonTypeReport.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.feedback.TypeReport}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonTypeReport extends JsonObject
+{
+    default String getResponseType()
+    {
+        return getString( "responseType" ).string();
+    }
+
+    default JsonStats getStats()
+    {
+        return get( "stats", JsonStats.class );
+    }
+
+    default JsonList<JsonObjectReport> getObjectReports()
+    {
+        return getList( "objectReports", JsonObjectReport.class );
+    }
+
+    default JsonList<JsonErrorReport> getErrorReports()
+    {
+        return getList( "errorReports", JsonErrorReport.class );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUser.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUser.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonList;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.user.User}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonUser extends JsonIdentifiableObject
+{
+    default String getSurname()
+    {
+        return getString( "surname" ).string();
+    }
+
+    default String getFirstName()
+    {
+        return getString( "firstName" ).string();
+    }
+
+    default JsonUserCredentials getUserCredentials()
+    {
+        return get( "userCredentials", JsonUserCredentials.class );
+    }
+
+    default JsonList<JsonUserGroup> getUserGroups()
+    {
+        return getList( "userGroups", JsonUserGroup.class );
+    }
+
+    default JsonList<JsonOrganisationUnit> getOrganisationUnits()
+    {
+        return getList( "organisationUnits", JsonOrganisationUnit.class );
+    }
+
+    default JsonList<JsonOrganisationUnit> getDataViewOrganisationUnits()
+    {
+        return getList( "dataViewOrganisationUnits", JsonOrganisationUnit.class );
+    }
+
+    default JsonList<JsonOrganisationUnit> getTeiSearchOrganisationUnits()
+    {
+        return getList( "teiSearchOrganisationUnits", JsonOrganisationUnit.class );
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserCredentials.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserCredentials.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.time.LocalDateTime;
+
+import org.hisp.dhis.webapi.json.JsonDate;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.user.UserCredentials}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonUserCredentials extends JsonIdentifiableObject
+{
+
+    default LocalDateTime getLastLogin()
+    {
+        return get( "lastLogin", JsonDate.class ).date();
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserGroup.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserGroup.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.webapi.json.JsonList;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.user.UserGroup}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonUserGroup extends JsonIdentifiableObject
+{
+    default JsonList<JsonUser> getUsers()
+    {
+        return getList( "users", JsonUser.class );
+    }
+
+    default JsonList<JsonUserGroup> getManagedGroups()
+    {
+        return getList( "managedGroups", JsonUserGroup.class );
+    }
+
+    default JsonList<JsonUserGroup> getManagedByGroups()
+    {
+        return getList( "managedByGroups", JsonUserGroup.class );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -27,26 +27,17 @@
  */
 package org.hisp.dhis.webapi;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 
 import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
+import org.hisp.dhis.webapi.json.JsonResponse;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.restdocs.JUnitRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.snippet.Snippet;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.test.context.ActiveProfiles;
@@ -54,94 +45,75 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Base class for convenient testing of the web API on basis of
+ * {@link JsonResponse}.
+ *
+ * @author Jan Bernitt
  */
 @RunWith( SpringRunner.class )
 @WebAppConfiguration
 @ContextConfiguration( classes = { MvcTestConfig.class, WebTestConfiguration.class } )
 @ActiveProfiles( "test-h2" )
 @Transactional
-public abstract class DhisWebSpringTest extends DhisConvenienceTest
+public abstract class DhisControllerConvenienceTest extends DhisConvenienceTest implements WebClient
 {
     @Autowired
-    protected WebApplicationContext webApplicationContext;
+    private WebApplicationContext webApplicationContext;
 
     @Autowired
-    protected IdentifiableObjectManager manager;
+    private UserService _userService;
 
-    @Autowired
-    protected RenderService renderService;
+    private MockMvc mvc;
 
-    @Autowired
-    protected UserService _userService;
+    private MockHttpSession session;
 
-    protected MockMvc mvc;
-
-    @Autowired
-    protected SchemaService schemaService;
-
-    @Rule
-    public JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation( "target/generated-snippets" );
+    private User currentUser;
 
     @Before
-    public void setup()
+    public final void setup()
         throws Exception
     {
         userService = _userService;
         CharacterEncodingFilter characterEncodingFilter = new CharacterEncodingFilter();
         characterEncodingFilter.setEncoding( "UTF-8" );
         characterEncodingFilter.setForceEncoding( true );
-        mvc = MockMvcBuilders.webAppContextSetup( webApplicationContext )
-            .apply( documentationConfiguration( this.restDocumentation ) )
-            .build();
-
+        mvc = MockMvcBuilders.webAppContextSetup( webApplicationContext ).build();
         TestUtils.executeStartupRoutines( webApplicationContext );
-
-        setUpTest();
+        switchToNewUser( null, "ALL" );
     }
 
-    protected void setUpTest()
-        throws Exception
+    protected final User getCurrentUser()
     {
+        return currentUser;
     }
 
-    // -------------------------------------------------------------------------
-    // Supportive methods
-    // -------------------------------------------------------------------------
-
-    public MockHttpSession getSession( String... authorities )
+    protected final User switchToNewUser( String username, String... authorities )
     {
-        createAndInjectAdminUser( authorities );
+        currentUser = currentUser == null
+            ? createAdminUser( authorities )
+            : createUser( username, authorities );
 
-        MockHttpSession session = new MockHttpSession();
+        injectSecurityContext( currentUser );
+
+        session = new MockHttpSession();
         session.setAttribute( HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
             SecurityContextHolder.getContext() );
-        return session;
+
+        return currentUser;
     }
 
-    public RestDocumentationResultHandler documentPrettyPrint( String useCase, Snippet... snippets )
+    @Override
+    public HttpResponse webRequest( MockHttpServletRequestBuilder request )
     {
-        return document( useCase, preprocessRequest( prettyPrint() ), preprocessResponse( prettyPrint() ), snippets );
+        return failOnException(
+            () -> new HttpResponse( mvc.perform( request.session( session ) ).andReturn().getResponse() ) );
     }
 
-    public SchemaService getSchemaService()
-    {
-        return schemaService;
-    }
-
-    public MockMvc getMvc()
-    {
-        return mvc;
-    }
-
-    public IdentifiableObjectManager getManager()
-    {
-        return manager;
-    }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.node.DefaultNodeService;
 import org.hisp.dhis.node.NodeService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.UserSettingService;
+import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
 import org.hisp.dhis.webapi.mvc.DhisApiVersionHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
@@ -86,6 +87,9 @@ public class MvcTestConfig implements WebMvcConfigurer
 
     @Autowired
     private UserSettingService userSettingService;
+
+    @Autowired
+    private CurrentUserHandlerMethodArgumentResolver currentUserHandlerMethodArgumentResolver;
 
     @Bean
     public CustomRequestMappingHandlerMapping requestMappingHandlerMapping()
@@ -187,6 +191,7 @@ public class MvcTestConfig implements WebMvcConfigurer
     public void addArgumentResolvers( List<HandlerMethodArgumentResolver> resolvers )
     {
         resolvers.add( dhisApiVersionHandlerMethodArgumentResolver() );
+        resolvers.add( currentUserHandlerMethodArgumentResolver );
     }
 
     @Bean

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebClient.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebClient.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi;
+
+import static org.hisp.dhis.webapi.documentation.common.TestUtils.APPLICATION_JSON_UTF8;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertSeries;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.plainTextOrJson;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.startWithMediaType;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.substitutePlaceholders;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.hisp.dhis.webapi.json.JsonResponse;
+import org.hisp.dhis.webapi.json.domain.JsonError;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.shaded.com.google.common.io.ByteStreams;
+
+/**
+ * The purpose of this interface is to allow mixin style addition of the
+ * convenience web API by implementing this interface's essential method
+ * {@link #webRequest(MockHttpServletRequestBuilder)}.
+ *
+ * @author Jan Bernitt
+ */
+@FunctionalInterface
+public interface WebClient
+{
+
+    HttpResponse webRequest( MockHttpServletRequestBuilder request );
+
+    default HttpResponse GET( String url, Object... args )
+    {
+        return webRequest( get( substitutePlaceholders( url, args ) ), "" );
+    }
+
+    default HttpResponse POST( String url, Object... args )
+    {
+        return POST( substitutePlaceholders( url, args ), "" );
+    }
+
+    default HttpResponse POST( String url, String body )
+    {
+        return webRequest( post( url ), body );
+    }
+
+    default HttpResponse PATCH( String url, Object... args )
+    {
+        return PATCH( substitutePlaceholders( url, args ), "" );
+    }
+
+    default HttpResponse PATCH( String url, String body )
+    {
+        return webRequest( patch( url ), body );
+    }
+
+    default HttpResponse PUT( String url, Object... args )
+    {
+        return PUT( substitutePlaceholders( url, args ), "" );
+    }
+
+    default HttpResponse PUT( String url, String body )
+    {
+        return webRequest( put( url ), body );
+    }
+
+    default HttpResponse DELETE( String url, Object... args )
+    {
+        return DELETE( substitutePlaceholders( url, args ), "" );
+    }
+
+    default HttpResponse DELETE( String url, String body )
+    {
+        return webRequest( delete( url ), body );
+    }
+
+    default HttpResponse webRequest( MockHttpServletRequestBuilder request, String body )
+    {
+        if ( body != null && body.endsWith( ".json" ) )
+        {
+            return failOnException( () -> webRequest( request
+                .contentType( APPLICATION_JSON_UTF8 )
+                .content( ByteStreams.toByteArray( new ClassPathResource( body ).getInputStream() ) ) ) );
+        }
+        if ( startWithMediaType( body ) )
+        {
+            return webRequest( request
+                .contentType( body.substring( 0, body.indexOf( ':' ) ) )
+                .content( body.substring( body.indexOf( ':' ) + 1 ) ) );
+        }
+        return body == null || body.isEmpty()
+            ? webRequest( request )
+            : webRequest( request
+                .contentType( APPLICATION_JSON )
+                .content( plainTextOrJson( body ) ) );
+    }
+
+    default <T> T run( Function<WebClient, ? extends WebSnippet<T>> snippet )
+    {
+        return snippet.apply( this ).run();
+    }
+
+    default <A, B> B run( BiFunction<WebClient, A, ? extends WebSnippet<B>> snippet, A argument )
+    {
+        return snippet.apply( this, argument ).run();
+    }
+
+    final class HttpResponse
+    {
+        private final MockHttpServletResponse response;
+
+        public HttpResponse( MockHttpServletResponse response )
+        {
+            this.response = response;
+        }
+
+        public HttpStatus status()
+        {
+            return HttpStatus.resolve( response.getStatus() );
+        }
+
+        public HttpStatus.Series series()
+        {
+            return status().series();
+        }
+
+        public boolean success()
+        {
+            return series() == Series.SUCCESSFUL;
+        }
+
+        public JsonResponse content()
+        {
+            return content( Series.SUCCESSFUL );
+        }
+
+        public JsonResponse content( Series expected )
+        {
+            assertSeries( expected, this );
+            return contentUnchecked();
+        }
+
+        public JsonResponse content( HttpStatus expected )
+        {
+            assertStatus( expected, this );
+            return contentUnchecked();
+        }
+
+        public JsonError error()
+        {
+            assertTrue( "not a client or server error", series().value() >= 4 );
+            return contentUnchecked().as( JsonError.class );
+        }
+
+        public JsonError error( Series expected )
+        {
+            // OBS! cannot use assertSeries as it uses this method
+            assertEquals( expected, series() );
+            return contentUnchecked().as( JsonError.class );
+        }
+
+        public JsonResponse contentUnchecked()
+        {
+            return failOnException( () -> new JsonResponse( response.getContentAsString( StandardCharsets.UTF_8 ) ) );
+        }
+
+        public String location()
+        {
+            return header( ContextUtils.HEADER_LOCATION );
+        }
+
+        public String header( String name )
+        {
+            return response.getHeader( name );
+        }
+    }
+
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebSnippet.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebSnippet.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi;
+
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Base class to create context free reusable snippets.
+ *
+ * The purpose of {@link WebSnippet}s is to allow definition of sequences of
+ * {@link WebClient} usage that become reusable building blocks to create more
+ * complex scenarios.
+ *
+ * @author Jan Bernitt
+ *
+ * @param <T> optional return type of the snippet to send information back to
+ *        the caller, like IDs, or {@link org.hisp.dhis.webapi.json.JsonValue}s
+ */
+public abstract class WebSnippet<T> implements WebClient
+{
+
+    private final WebClient client;
+
+    public WebSnippet( WebClient client )
+    {
+        this.client = client;
+    }
+
+    @Override
+    public final HttpResponse webRequest( MockHttpServletRequestBuilder request )
+    {
+        return client.webRequest( request );
+    }
+
+    /**
+     * Runs the snippet.
+     *
+     * @return a optional result value, like an ID or a
+     *         {@link org.hisp.dhis.webapi.json.JsonValue} that can be used by
+     *         the caller to continue working with data created or used in this
+     *         snippet.
+     */
+    protected abstract T run();
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertError;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertSeries;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonArray;
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.domain.JsonGeoMap;
+import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
+import org.hisp.dhis.webapi.json.domain.JsonTranslation;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
+import org.hisp.dhis.webapi.snippets.SomeUserId;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+
+/**
+ * Tests the generic operations offered by the {@link AbstractCrudController}
+ * using specific endpoints.
+ *
+ * @author Jan Bernitt
+ */
+public class AbstractCrudControllerTest extends DhisControllerConvenienceTest
+{
+    @Test
+    public void testGetObjectList()
+    {
+        JsonList<JsonUser> users = GET( "/users/" )
+            .content( HttpStatus.OK ).getList( "users", JsonUser.class );
+
+        assertEquals( 1, users.size() );
+        JsonUser user = users.get( 0 );
+        assertEquals( "admin admin", user.getDisplayName() );
+    }
+
+    @Test
+    public void testGetObject()
+    {
+        String id = run( SomeUserId::new );
+        JsonUser userById = GET( "/users/{id}", id )
+            .content( HttpStatus.OK ).as( JsonUser.class );
+
+        assertEquals( id, userById.getId() );
+        assertTrue( userById.getUserCredentials().exists() );
+    }
+
+    @Test
+    public void testGetObjectProperty()
+    {
+        // response will look like: { "surname": <name> }
+        JsonUser userProperty = GET( "/users/{id}/surname", run( SomeUserId::new ) )
+            .content( HttpStatus.OK ).as( JsonUser.class );
+
+        assertEquals( "admin", userProperty.getSurname() );
+        assertEquals( 1, userProperty.size() );
+    }
+
+    @Test
+    public void testPartialUpdateObject()
+    {
+        String id = run( SomeUserId::new );
+        assertStatus( HttpStatus.NO_CONTENT, PATCH( "/users/" + id, "{'surname':'Peter'}" ) );
+
+        assertEquals( "Peter", GET( "/users/{id}", id ).content().as( JsonUser.class ).getSurname() );
+    }
+
+    @Test
+    public void replaceTranslations()
+    {
+        String id = getCurrentUser().getUid();
+        JsonArray translations = GET( "/users/{id}/translations", id )
+            .content().getArray( "translations" );
+
+        assertTrue( translations.isEmpty() );
+
+        PUT( "/users/" + id + "/translations",
+            "{'translations': [{'locale':'sv', 'property':'name', 'value':'namn'}]}" )
+                .content( HttpStatus.NO_CONTENT );
+
+        translations = GET( "/users/{id}/translations", id )
+            .content().getArray( "translations" );
+        assertEquals( 1, translations.size() );
+        JsonTranslation translation = translations.get( 0, JsonTranslation.class );
+        assertEquals( "sv", translation.getLocale() );
+        assertEquals( "name", translation.getProperty() );
+        assertEquals( "namn", translation.getValue() );
+    }
+
+    @Test
+    public void replaceTranslations_MissingValue()
+    {
+        String id = getCurrentUser().getUid();
+        String translations = "{'translations': [{'locale':'sv', 'property':'name'}]}";
+        assertError( ErrorCode.E4000, "Missing required property `value`.",
+            PUT( "/users/" + id + "/translations", translations ).error() );
+    }
+
+    @Test
+    public void replaceTranslations_MissingProperty()
+    {
+        String id = getCurrentUser().getUid();
+        assertError( ErrorCode.E4000, "Missing required property `property`.",
+            PUT( "/users/" + id + "/translations",
+                "{'translations': [{'locale':'sv', 'value':'namn'}]}" ).error() );
+    }
+
+    @Test
+    public void replaceTranslations_MissingLocale()
+    {
+        String id = getCurrentUser().getUid();
+        String translations = "{'translations': [{'property':'name', 'value':'namn'}]}";
+        assertError( ErrorCode.E4000, "Missing required property `locale`.",
+            PUT( "/users/" + id + "/translations", translations ).error() );
+    }
+
+    @Test
+    public void testUpdateObjectProperty()
+    {
+        String id = getCurrentUser().getUid();
+        assertStatus( HttpStatus.NO_CONTENT,
+            PATCH( "/users/" + id + "/firstName", "{'firstName':'Fancy Mike'}" ) );
+        assertEquals( "Fancy Mike", GET( "/users/{id}", id )
+            .content().as( JsonUser.class ).getFirstName() );
+    }
+
+    @Test
+    public void testUpdateObjectProperty_ReadOnlyProperty()
+    {
+        String id = getCurrentUser().getUid();
+        assertStatus( HttpStatus.FORBIDDEN,
+            PATCH( "/users/" + id + "/displayName", "{'displayName':'Fancy Mike'}" ) );
+    }
+
+    @Test
+    public void testPostJsonObject()
+    {
+        assertStatus( HttpStatus.CREATED,
+            POST( "/constants/", "{'name':'answer', 'value': 42}" ) );
+    }
+
+    @Test
+    public void testSetAsFavorite()
+    {
+        // first we need to create an entity that can be marked as favorite
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
+
+        assertStatus( HttpStatus.OK, POST( "/maps/" + mapId + "/favorite" ) );
+        JsonGeoMap map = GET( "/maps/{uid}", mapId ).content().as( JsonGeoMap.class );
+        assertEquals( singletonList( getCurrentUser().getUid() ), map.getFavorites() );
+    }
+
+    @Test
+    public void testRemoveAsFavorite()
+    {
+        // first we need to create an entity that can be marked as favorite
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
+        // make it a favorite
+        assertStatus( HttpStatus.OK, POST( "/maps/" + mapId + "/favorite" ) );
+
+        assertStatus( HttpStatus.OK, DELETE( "/maps/" + mapId + "/favorite" ) );
+        assertEquals( emptyList(), GET( "/maps/{uid}", mapId )
+            .content().as( JsonGeoMap.class ).getFavorites() );
+    }
+
+    @Test
+    public void testSubscribe()
+    {
+        // first we need to create an entity that can be subscribed to
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
+
+        assertStatus( HttpStatus.OK, POST( "/maps/" + mapId + "/subscriber" ) );
+        JsonGeoMap map = GET( "/maps/{uid}", mapId ).content().as( JsonGeoMap.class );
+        assertEquals( singletonList( getCurrentUser().getUid() ), map.getSubscribers() );
+    }
+
+    @Test
+    public void testUnsubscribe()
+    {
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
+        assertStatus( HttpStatus.OK, POST( "/maps/" + mapId + "/subscriber" ) );
+
+        assertStatus( HttpStatus.OK, DELETE( "/maps/" + mapId + "/subscriber" ) );
+        JsonGeoMap map = GET( "/maps/{uid}", mapId ).content().as( JsonGeoMap.class );
+        assertEquals( emptyList(), map.getSubscribers() );
+    }
+
+    @Test
+    public void testPutJsonObject()
+    {
+        // first the updated entity needs to be created
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
+
+        assertStatus( HttpStatus.NO_CONTENT, PUT( "/maps/" + mapId, "{'name':'Europa'}" ) );
+        assertEquals( "Europa", GET( "/maps/{id}", mapId )
+            .content().as( JsonGeoMap.class ).getName() );
+    }
+
+    @Test
+    public void testDeleteObject()
+    {
+        // first the deleted entity needs to be created
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
+
+        assertStatus( HttpStatus.OK, DELETE( "/maps/" + mapId ) );
+        assertEquals( 0, GET( "/maps" ).content().getArray( "maps" ).size() );
+    }
+
+    @Test
+    public void testGetCollectionItem()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which has a collection
+        String groupId = assertStatus( HttpStatus.CREATED, POST( "/userGroups/", "{'name':'testers'}" ) );
+        // add an item to the collection
+        assertSeries( Series.SUCCESSFUL, POST( "/userGroups/" + groupId + "/users/" + userId ) );
+
+        assertUserGroupHasOnlyUser( groupId, userId );
+    }
+
+    @Test
+    public void testAddCollectionItemsJson()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which has a collection
+        String groupId = assertStatus( HttpStatus.CREATED, POST( "/userGroups/", "{'name':'testers'}" ) );
+
+        assertStatus( HttpStatus.NO_CONTENT,
+            POST( "/userGroups/" + groupId + "/users", "{'additions': [{'id':'" + userId + "'}]}" ) );
+
+        assertUserGroupHasOnlyUser( groupId, userId );
+    }
+
+    @Test
+    public void testReplaceCollectionItemsJson()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which has a collection
+        String groupId = assertStatus( HttpStatus.CREATED,
+            POST( "/userGroups/", "{'name':'testers', 'users':[{'id':'" + userId + "'}]}" ) );
+        String peter = "{'name': 'Peter', 'firstName':'Peter', 'surname':'Pan', 'userCredentials':{'username':'peter47'}}";
+        String peterUserId = assertStatus( HttpStatus.CREATED, POST( "/users", peter ) );
+
+        assertStatus( HttpStatus.NO_CONTENT,
+            PUT( "/userGroups/" + groupId + "/users", "{'identifiableObjects':[{'id':'" + peterUserId + "'}]}" ) );
+
+        assertUserGroupHasOnlyUser( groupId, peterUserId );
+    }
+
+    @Test
+    public void testAddCollectionItem()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which has a collection
+        String groupId = assertStatus( HttpStatus.CREATED, POST( "/userGroups/", "{'name':'testers'}" ) );
+
+        assertStatus( HttpStatus.NO_CONTENT, POST( "/userGroups/{uid}/users/{itemId}", groupId, userId ) );
+        assertUserGroupHasOnlyUser( groupId, userId );
+    }
+
+    @Test
+    public void testDeleteCollectionItemsJson()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which has a collection
+        String groupId = assertStatus( HttpStatus.CREATED,
+            POST( "/userGroups/", "{'name':'testers', 'users':[{'id':'" + userId + "'}]}" ) );
+
+        assertStatus( HttpStatus.NO_CONTENT,
+            DELETE( "/userGroups/" + groupId + "/users", "{'identifiableObjects':[{'id':'" + userId + "'}]}" ) );
+        assertEquals( 0, GET( "/userGroups/{uid}/users/", groupId ).content().getArray( "users" ).size() );
+    }
+
+    @Test
+    public void testSetSharing()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which can be shared
+        String programId = assertStatus( HttpStatus.CREATED,
+            POST( "/programs/", "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION'}" ) );
+
+        String sharing = "{'owner':'" + userId + "', 'public':'rwrw----', 'external': true }";
+        assertStatus( HttpStatus.NO_CONTENT, PUT( "/programs/" + programId + "/sharing", sharing ) );
+
+        JsonIdentifiableObject program = GET( "/programs/{id}", programId )
+            .content().as( JsonIdentifiableObject.class );
+        assertTrue( program.exists() );
+        assertEquals( "rwrw----", program.getSharing().getPublic().string() );
+        assertFalse( "programs cannot be external", program.getSharing().isExternal() );
+    }
+
+    private void assertUserGroupHasOnlyUser( String groupId, String userId )
+    {
+        JsonList<JsonUser> usersInGroup = GET( "/userGroups/{uid}/users/{itemId}", groupId, userId ).content()
+            .getList( "users", JsonUser.class );
+        assertEquals( 1, usersInGroup.size() );
+        assertEquals( userId, usersInGroup.get( 0 ).getId() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static java.util.Collections.singletonList;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertSeries;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonArray;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+
+/**
+ * Tests the {@link org.hisp.dhis.webapi.controller.user.MeController} API.
+ *
+ * @author Jan Bernitt
+ */
+public class MeControllerTest extends DhisControllerConvenienceTest
+{
+    @Test
+    public void testGetCurrentUser()
+    {
+        assertEquals( getCurrentUser().getUid(), GET( "/me" ).content().as( JsonUser.class ).getId() );
+    }
+
+    @Test
+    public void testGetCurrentUserDataApprovalWorkflows()
+    {
+        JsonArray workflows = GET( "/me/dataApprovalWorkflows" ).content().getArray( "dataApprovalWorkflows" );
+        assertTrue( workflows.isArray() );
+        assertTrue( workflows.isEmpty() );
+    }
+
+    @Test
+    public void testGetAuthorities()
+    {
+        assertEquals( singletonList( "ALL" ), GET( "/me/authorities" ).content().stringValues() );
+    }
+
+    @Test
+    public void testUpdateCurrentUser()
+    {
+        assertSeries( Series.SUCCESSFUL, PUT( "/me", "{'surname':'Lars'}" ) );
+        assertEquals( "Lars", GET( "/me" ).content().as( JsonUser.class ).getSurname() );
+    }
+
+    @Test
+    public void testHasAuthority()
+    {
+        assertTrue( GET( "/me/authorities/ALL" ).content().booleanValue() );
+
+        switchToNewUser( "Kalle" ); // with no authorities
+        assertFalse( GET( "/me/authorities/missing" ).content().booleanValue() );
+    }
+
+    @Test
+    public void testGetSettings()
+    {
+        JsonObject settings = GET( "/me/settings" ).content();
+
+        assertTrue( settings.isObject() );
+        assertFalse( settings.isEmpty() );
+        assertTrue( settings.get( "keyMessageSmsNotification" ).exists() );
+        assertEquals( "en", settings.getString( "keyUiLocale" ).string() );
+    }
+
+    @Test
+    public void testGetSetting()
+    {
+        assertEquals( "en", GET( "/me/settings/{key}", "keyUiLocale" ).content().string() );
+    }
+
+    @Test
+    public void testGetSetting_Missing()
+    {
+        assertEquals( "Key is not supported: missing",
+            GET( "/me/settings/missing" ).error( Series.CLIENT_ERROR ).getMessage() );
+    }
+
+    @Test
+    public void testChangePassword()
+    {
+        assertStatus( HttpStatus.ACCEPTED,
+            PUT( "/me/changePassword", "{'oldPassword':'district','newPassword':'$ecrEt42'}" ) );
+    }
+
+    @Test
+    public void testChangePassword_WrongNew()
+    {
+        assertEquals( "Password must have at least 8, and at most 40 characters",
+            PUT( "/me/changePassword", "{'oldPassword':'district','newPassword':'secret'}" )
+                .error( Series.CLIENT_ERROR ).getMessage() );
+    }
+
+    @Test
+    public void testChangePassword_WrongOld()
+    {
+        assertEquals( "OldPassword is incorrect",
+            PUT( "/me/changePassword", "{'oldPassword':'wrong','newPassword':'secret'}" )
+                .error( Series.CLIENT_ERROR ).getMessage() );
+    }
+
+    @Test
+    public void testVerifyPasswordText()
+    {
+        assertTrue( POST( "/me/verifyPassword", "text/plain:district" )
+            .content().getBoolean( "isCorrectPassword" ).booleanValue() );
+        assertFalse( POST( "/me/verifyPassword", "text/plain:wrong" )
+            .content().getBoolean( "isCorrectPassword" ).booleanValue() );
+    }
+
+    @Test
+    public void testVerifyPasswordJson()
+    {
+        assertTrue( POST( "/me/verifyPassword", "{'password':'district'}" )
+            .content().getBoolean( "isCorrectPassword" ).booleanValue() );
+        assertFalse( POST( "/me/verifyPassword", "{'password':'wrong'}" )
+            .content().getBoolean( "isCorrectPassword" ).booleanValue() );
+    }
+
+    public interface JsonPasswordValidation extends JsonObject
+    {
+        default boolean isValidPassword()
+        {
+            return getBoolean( "isValidPassword" ).booleanValue();
+        }
+
+        default String getErrorMessage()
+        {
+            return getString( "errorMessage" ).string();
+        }
+    }
+
+    @Test
+    public void testValidatePasswordText()
+    {
+        JsonPasswordValidation result = POST( "/me/validatePassword", "text/plain:$ecrEt42" )
+            .content().as( JsonPasswordValidation.class );
+        assertTrue( result.isValidPassword() );
+        assertNull( result.getErrorMessage() );
+    }
+
+    @Test
+    public void testValidatePasswordText_NoDigits()
+    {
+        JsonPasswordValidation result = POST( "/me/validatePassword", "text/plain:secret" )
+            .content().as( JsonPasswordValidation.class );
+        assertFalse( result.isValidPassword() );
+        assertEquals( "Password must have at least 8, and at most 40 characters", result.getErrorMessage() );
+    }
+
+    @Test
+    public void testGetDashboard()
+    {
+        JsonObject dashboard = GET( "/me/dashboard" ).content();
+        assertEquals( 0, dashboard.getNumber( "unreadInterpretations" ).intValue() );
+        assertEquals( 0, dashboard.getNumber( "unreadMessageConversations" ).intValue() );
+    }
+
+    @Test
+    public void testUpdateInterpretationsLastRead()
+    {
+        assertStatus( HttpStatus.NO_CONTENT, POST( "/me/dashboard/interpretations/read" ) );
+    }
+
+    @Test
+    public void testGetApprovalLevels()
+    {
+        assertTrue( GET( "/me/dataApprovalLevels" ).content().isArray() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponse.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponse.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Function;
+
+import net.minidev.json.JSONArray;
+
+import org.springframework.util.ObjectUtils;
+
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.PathNotFoundException;
+
+/**
+ * Implements the {@link JsonValue} read-only access abstraction for JSON
+ * responses.
+ *
+ * The way this works is that internally when navigating the JSON object the
+ * {@link #expression} is extended. The returned value is always either a
+ * {@link JsonResponse} or a {@link Proxy} calling all default methods on the
+ * declaring interface and all implemented by {@link JsonResponse} on a
+ * "wrapped" {@link JsonResponse} instance.
+ *
+ * When values are accessed the {@link #expression} path is extracted from the
+ * {@link #content} and eventually converted and checked against expectations.
+ * Exceptions are eventually converted to provide a consistent behaviour.
+ *
+ * It is crucial to understand that the complete JSON object model is purely a
+ * typed convenience layer expressing what could or is expected to exist.
+ * Whether or not something actually exist is first evaluated when leaf values
+ * are accessed or existence is explicitly checked using {@link #exists()}.
+ *
+ * This also means specific {@link JsonObject}s are modelled by extending the
+ * interface and implementing {@code default} methods. No other implementation
+ * class is ever written except {@link JsonResponse}.
+ *
+ * @author Jan Bernitt
+ */
+public final class JsonResponse implements JsonObject, JsonArray, JsonString, JsonNumber, JsonBoolean, Serializable
+{
+
+    private final String content;
+
+    private final String expression;
+
+    /**
+     * A simple "cache" so that multiple asserts working on the same path do not
+     * extract the actual value multiple times.
+     */
+    private transient Object valueCache;
+
+    public JsonResponse( String content )
+    {
+        this( content, "$" );
+    }
+
+    private JsonResponse( String content, String expression )
+    {
+        this.content = content;
+        this.expression = expression;
+    }
+
+    private JsonPath path()
+    {
+        return JsonPath.compile( expression );
+    }
+
+    private Object value( Function<JsonPathException, Object> orElse )
+    {
+        if ( valueCache != null )
+        {
+            return valueCache;
+        }
+        try
+        {
+            Object value = path().read( content );
+            valueCache = value;
+            return value;
+        }
+        catch ( PathNotFoundException ex )
+        {
+            Object res = orElse.apply( ex );
+            if ( res instanceof RuntimeException )
+            {
+                throw (RuntimeException) res;
+            }
+            return res;
+        }
+    }
+
+    @Override
+    public <T extends JsonValue> T get( int index, Class<T> as )
+    {
+        return asType( as, new JsonResponse( content, expression + "[" + index + "]" ) );
+    }
+
+    @Override
+    public <T extends JsonValue> T get( String name, Class<T> as )
+    {
+        return asType( as, new JsonResponse( content, expression + "." + name ) );
+    }
+
+    @Override
+    public <T extends JsonValue> T as( Class<T> as )
+    {
+        return asType( as, this );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private <T extends JsonValue> T asType( Class<T> as, JsonValue res )
+    {
+        return isExtended( as ) ? createProxy( as, res ) : (T) res;
+    }
+
+    @Override
+    public Boolean bool()
+    {
+        return (Boolean) value( ex -> null );
+    }
+
+    @Override
+    public <A, B> B mapNonNull( A from, Function<A, B> to )
+    {
+        if ( from == null )
+        {
+            throw noSuchValue( null );
+        }
+        return to.apply( from );
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return ObjectUtils.isEmpty( value( this::noSuchValue ) );
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public boolean has( String... names )
+    {
+        Object value = value( this::noSuchValue );
+        if ( value instanceof Map )
+        {
+            return ((Map<String, ?>) value).keySet().containsAll( Arrays.asList( names ) );
+        }
+        return false;
+    }
+
+    @Override
+    public List<String> stringValues()
+    {
+        return arrayList( String.class );
+    }
+
+    @Override
+    public List<Number> numberValues()
+    {
+        return arrayList( Number.class );
+    }
+
+    @Override
+    public List<Boolean> boolValues()
+    {
+        return arrayList( Boolean.class );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private <T> List<T> arrayList( Class<T> elementType )
+    {
+        Object value = value( this::noSuchValue );
+        if ( value instanceof JSONArray )
+        {
+            for ( Object e : (JSONArray) value )
+            {
+                if ( !elementType.isInstance( e ) )
+                {
+                    throw new IllegalArgumentException( "element is not a " + elementType );
+                }
+            }
+            return (List<T>) value;
+        }
+        throw new IllegalArgumentException( "not an array: " + expression );
+    }
+
+    @Override
+    public int size()
+    {
+        Object value = value( this::noSuchValue );
+        if ( value instanceof String )
+        {
+            return ((String) value).length();
+        }
+        if ( value instanceof Collection )
+        {
+            return ((Collection<?>) value).size();
+        }
+        if ( value instanceof Object[] )
+        {
+            return ((Object[]) value).length;
+        }
+        if ( value instanceof Map )
+        {
+            return ((Map<?, ?>) value).size();
+        }
+        throw new UnsupportedOperationException( "Size of " + value + " not supported!" );
+    }
+
+    @Override
+    public boolean isArray()
+    {
+        Object value = value( this::noSuchValue );
+        return value instanceof JSONArray || value instanceof Object[];
+    }
+
+    @Override
+    public boolean isObject()
+    {
+        return value( this::noSuchValue ) instanceof Map;
+    }
+
+    @Override
+    public Number number()
+    {
+        return (Number) value( ex -> null );
+    }
+
+    @Override
+    public String string()
+    {
+        return (String) value( ex -> null );
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return value( ex -> null ) != null;
+    }
+
+    @Override
+    public boolean isNull()
+    {
+        return value( this::noSuchValue ) == null;
+    }
+
+    private NoSuchElementException noSuchValue( JsonPathException ex )
+    {
+        NoSuchElementException res = new NoSuchElementException(
+            "expected: <" + expression + "> \nbut found: \n" + content );
+        if ( ex != null )
+        {
+            res.initCause( ex );
+        }
+        return res;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        return obj instanceof JsonResponse
+            && expression.equals( ((JsonResponse) obj).expression )
+            && content.equals( ((JsonResponse) obj).content );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( content, expression );
+    }
+
+    @Override
+    public String toString()
+    {
+        return expression + " in " + content + (valueCache == null ? "" : " => " + valueCache.toString());
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static <E extends JsonValue> E createProxy( Class<E> as, JsonValue inner )
+    {
+        return (E) Proxy.newProxyInstance(
+            Thread.currentThread().getContextClassLoader(), new Class[] { as },
+            ( proxy, method, args ) -> {
+                // are we dealing with a default method in the extending class?
+                Class<?> declaringClass = method.getDeclaringClass();
+                if ( method.isDefault() && isExtended( declaringClass ) )
+                {
+                    // call the default method of the proxied type itself
+                    if ( !isJava8() )
+                    {
+                        return MethodHandles.lookup()
+                            .findSpecial( declaringClass, method.getName(),
+                                MethodType.methodType( method.getReturnType(), method.getParameterTypes() ),
+                                declaringClass )
+                            .bindTo( proxy ).invokeWithArguments();
+                    }
+                    return MethodHandles.lookup()
+                        .in( declaringClass )
+                        .unreflectSpecial( method, declaringClass )
+                        .bindTo( proxy ).invokeWithArguments( args );
+                }
+                // call the same method on the wrapped object (assuming it has
+                // it)
+                try
+                {
+                    return method.invoke( inner, args );
+                }
+                catch ( InvocationTargetException ex )
+                {
+                    throw ex.getTargetException();
+                }
+            } );
+    }
+
+    private static boolean isExtended( Class<?> declaringClass )
+    {
+        return !declaringClass.isAssignableFrom( JsonResponse.class );
+    }
+
+    private static boolean isJava8()
+    {
+        String javaVersion = System.getProperty( "java.version" );
+        boolean javaVersionIsBlank = javaVersion.trim().isEmpty();
+        return !javaVersionIsBlank && javaVersion.startsWith( "1.8" );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+import org.hisp.dhis.webapi.json.domain.JsonError;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
+import org.junit.Test;
+
+/**
+ * Tests the basic correctness of {@link JsonResponse} which is the
+ * implementation of all core interfaces of the {@link JsonValue} utility.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonResponseTest
+{
+
+    @Test
+    public void testCustomObjectType()
+    {
+        JsonObject response = new JsonResponse( "{'user': {'id':'foo'}}" );
+
+        assertEquals( "foo", response.get( "user", JsonUser.class ).getId() );
+    }
+
+    @Test
+    public void testCustomObjectTypeList()
+    {
+        JsonObject response = new JsonResponse( "{'users': [ {'id':'foo'} ]}" );
+
+        JsonList<JsonUser> users = response.getList( "users", JsonUser.class );
+        assertEquals( "foo", users.get( 0 ).getId() );
+    }
+
+    @Test
+    public void testCustomObjectTypeMap()
+    {
+        JsonObject response = new JsonResponse( "{'users': {'foo':{'id':'foo'}, 'bar':{'id':'bar'}}}" );
+        JsonMap<JsonUser> usersById = response.getMap( "users", JsonUser.class );
+        assertFalse( usersById.isEmpty() );
+        assertEquals( 2, usersById.size() );
+        assertEquals( "foo", usersById.get( "foo" ).getId() );
+    }
+
+    @Test
+    public void testDateType()
+    {
+        JsonObject response = new JsonResponse( "{'user': {'lastUpdated': '2021-01-21T15:14:54.000'}}" );
+
+        JsonUser user = response.get( "user", JsonUser.class );
+        assertEquals( LocalDateTime.of( 2021, 1, 21, 15, 14, 54 ),
+            user.getLastUpdated() );
+        assertNull( user.getCreated() );
+    }
+
+    @Test
+    public void testNumber()
+    {
+        JsonObject response = new JsonResponse( "{'number': 13, 'fraction': 4.2}" );
+
+        assertEquals( 13, response.getNumber( "number" ).number() );
+        assertEquals( 4.2f, response.getNumber( "fraction" ).number().floatValue(), 0.001f );
+        assertTrue( response.getNumber( "number" ).exists() );
+        assertNull( response.getNumber( "missing" ).number() );
+    }
+
+    @Test
+    public void testIntValue()
+    {
+        JsonObject response = new JsonResponse( "{'number':13}" );
+        assertEquals( 13, response.getNumber( "number" ).intValue() );
+        JsonNumber missing = response.getNumber( "missing" );
+        assertThrows( NoSuchElementException.class, missing::intValue );
+    }
+
+    @Test
+    public void testString()
+    {
+        JsonObject response = new JsonResponse( "{'text': 'plain'}" );
+
+        assertEquals( "plain", response.getString( "text" ).string() );
+        assertTrue( response.getString( "text" ).exists() );
+        assertNull( response.getString( "missing" ).string() );
+    }
+
+    @Test
+    public void testBool()
+    {
+        JsonObject response = new JsonResponse( "{'flag': true}" );
+
+        assertTrue( response.getBoolean( "flag" ).bool() );
+        assertTrue( response.getBoolean( "flag" ).exists() );
+        assertNull( response.getBoolean( "missing" ).bool() );
+    }
+
+    @Test
+    public void testBooleanValue()
+    {
+        JsonObject response = new JsonResponse( "{'flag': true}" );
+
+        assertTrue( response.getBoolean( "flag" ).booleanValue() );
+        JsonBoolean missing = response.getBoolean( "missing" );
+        assertThrows( NoSuchElementException.class, missing::booleanValue );
+    }
+
+    @Test
+    public void testNotExists()
+    {
+        JsonObject response = new JsonResponse( "{'flag': true}" );
+
+        assertFalse( response.getString( "no" ).exists() );
+    }
+
+    @Test
+    public void testSizeArray()
+    {
+        JsonObject response = new JsonResponse( "{'numbers': [1,2,3,4]}" );
+
+        assertEquals( 4, response.getArray( "numbers" ).size() );
+        assertFalse( response.getArray( "numbers" ).isNull() );
+    }
+
+    @Test
+    public void testStringValues()
+    {
+        JsonObject response = new JsonResponse( "{'letters': ['a','b','c']}" );
+
+        assertEquals( asList( "a", "b", "c" ), response.getArray( "letters" ).stringValues() );
+    }
+
+    @Test
+    public void testNumberValues()
+    {
+        JsonObject response = new JsonResponse( "{'digits': [1,2,3]}" );
+
+        assertEquals( asList( 1, 2, 3 ), response.getArray( "digits" ).numberValues() );
+    }
+
+    @Test
+    public void testBoolValues()
+    {
+        JsonObject response = new JsonResponse( "{'flags': [true, false, true]}" );
+
+        assertEquals( asList( true, false, true ), response.getArray( "flags" ).boolValues() );
+    }
+
+    @Test
+    public void testIsNull()
+    {
+        JsonObject response = new JsonResponse( "{'optional': null }" );
+
+        assertTrue( response.getArray( "optional" ).isNull() );
+    }
+
+    @Test
+    public void testIsArray()
+    {
+        JsonObject response = new JsonResponse( "{'array': [], notAnArray: 42 }" );
+
+        assertTrue( new JsonResponse( "[]" ).isArray() );
+        assertTrue( response.getArray( "array" ).isArray() );
+        assertFalse( response.getArray( "notAnArray" ).isArray() );
+        JsonArray missing = response.getArray( "missing" );
+        assertThrows( NoSuchElementException.class, missing::isArray );
+    }
+
+    @Test
+    public void testIsObject()
+    {
+        JsonObject response = new JsonResponse( "{'object': {}, notAnObject: 42 }" );
+
+        assertTrue( response.isObject() );
+        assertTrue( response.getArray( "object" ).isObject() );
+        assertFalse( response.getArray( "notAnObject" ).isObject() );
+        JsonArray missing = response.getArray( "missing" );
+        assertThrows( NoSuchElementException.class, missing::isObject );
+    }
+
+    @Test
+    public void testErrorSummary_MessageOnly()
+    {
+        JsonObject response = new JsonResponse( "{'message':'my message'}" );
+        assertEquals( "my message", response.as( JsonError.class ).summary() );
+    }
+
+    @Test
+    public void testErrorSummary_MessageAndErrorReports()
+    {
+        JsonObject response = new JsonResponse(
+            "{'message':'my message','response':{'errorReports': [{'errorCode':'E4000','message':'m1'}]}}" );
+        assertEquals( "my message\n" + "  E4000 m1", response.as( JsonError.class ).summary() );
+    }
+
+    @Test
+    public void testErrorSummary_MessageAndObjectReports()
+    {
+        JsonObject response = new JsonResponse(
+            "{'message':'my message','response':{'objectReports':[{'klass':'java.lang.String','errorReports': [{'errorCode':'E4000','message':'m1'}]}]}}" );
+        assertEquals( "my message\n" + "* class java.lang.String\n" + "  E4000 m1",
+            response.as( JsonError.class ).summary() );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/snippets/SomeUserId.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/snippets/SomeUserId.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.snippets;
+
+import org.hisp.dhis.webapi.WebClient;
+import org.hisp.dhis.webapi.WebSnippet;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
+
+/**
+ * A simple {@link WebSnippet} that returns a "random" users ID. This is most
+ * likely the admin user, as this is the only existing users in many test
+ * scenarios.
+ *
+ * @author Jan Bernitt
+ */
+public class SomeUserId extends WebSnippet<String>
+{
+    public SomeUserId( WebClient client )
+    {
+        super( client );
+    }
+
+    @Override
+    protected String run()
+    {
+        return GET( "/users/" ).content().getList( "users", JsonUser.class ).get( 0 ).getId();
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/WebClientUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/WebClientUtils.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.webapi.WebClient.HttpResponse;
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.hisp.dhis.webapi.json.domain.JsonError;
+import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
+import org.hisp.dhis.webapi.json.domain.JsonObjectReport;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+
+/**
+ * Helpers needed when testing with {@link org.hisp.dhis.webapi.WebClient} and
+ * {@link org.springframework.test.web.servlet.MockMvc}.
+ *
+ * @author Jan Bernitt
+ */
+public class WebClientUtils
+{
+
+    private static final Pattern IS_MEDIA_TYPE = Pattern.compile( "^[-a-z]+/[-a-z]+:" );
+
+    public static String plainTextOrJson( String body )
+    {
+        if ( startWithMediaType( body ) )
+        {
+            return body.substring( body.indexOf( ':' ) + 1 );
+        }
+        return body.replace( '\'', '"' );
+    }
+
+    public static boolean startWithMediaType( String body )
+    {
+        return body != null && IS_MEDIA_TYPE.matcher( body ).find();
+    }
+
+    /**
+     * Asserts that the {@link HttpResponse} has the expected
+     * {@link HttpStatus}.
+     *
+     * If status is {@link HttpStatus#CREATED} the method returns the UID of the
+     * created object in case it is provided by the response. This is based on a
+     * convention used in DHIS2.
+     *
+     * @param expected status we should get
+     * @param actual the response we actually got
+     * @return UID of the created object (if available) or {@code null}
+     */
+    public static String assertStatus( HttpStatus expected, HttpResponse actual )
+    {
+        HttpStatus actualStatus = actual.status();
+        if ( expected != actualStatus )
+        {
+            if ( expected.series() == actualStatus.series() )
+            {
+                assertEquals( expected, actualStatus );
+            }
+            else
+            {
+                // OBS! we use the actual state to not fail the check in error
+                String msg = actual.error( actualStatus.series() ).summary();
+                assertEquals( msg, expected, actualStatus );
+            }
+        }
+        return getCreatedId( actual );
+    }
+
+    /**
+     * Asserts that the {@link HttpResponse} has the expected
+     * {@link HttpStatus.Series}. This is useful on cases where it only matters
+     * that operation was {@link Series#SUCCESSFUL} or say
+     * {@link Series#CLIENT_ERROR} but not which exact code of the series.
+     *
+     * If status is {@link HttpStatus#CREATED} the method returns the UID of the
+     * created object in case it is provided by the response. This is based on a
+     * convention used in DHIS2.
+     *
+     * @param expected status {@link Series} we should get
+     * @param actual the response we actually got
+     * @return UID of the created object (if available) or {@code null}
+     */
+    public static String assertSeries( HttpStatus.Series expected, HttpResponse actual )
+    {
+        Series actualSeries = actual.series();
+        if ( expected != actualSeries )
+        {
+            // OBS! we use the actual state to not fail the check in error
+            String msg = actual.error( actualSeries ).summary();
+            assertEquals( msg, expected, actualSeries );
+        }
+        return getCreatedId( actual );
+    }
+
+    private static String getCreatedId( HttpResponse response )
+    {
+        HttpStatus actual = response.status();
+        if ( actual == HttpStatus.CREATED )
+        {
+            JsonObject report = response.contentUnchecked().getObject( "response" );
+            if ( report.exists() )
+            {
+                return report.getString( "uid" ).string();
+            }
+            String location = response.location();
+            return location == null ? null : location.substring( location.lastIndexOf( '/' ) + 1 );
+        }
+        return null;
+    }
+
+    /**
+     * Assumes the {@link org.hisp.dhis.webapi.json.domain.JsonError} has a
+     * {@link org.hisp.dhis.webapi.json.domain.JsonTypeReport} containing a
+     * single {@link org.hisp.dhis.webapi.json.domain.JsonErrorReport} with the
+     * expected properties.
+     *
+     * @param expectedCode The code the single error is expected to have
+     * @param expectedMessage The message the single error is expected to have
+     * @param actual the actual error from the {@link HttpResponse}
+     */
+    public static void assertError( ErrorCode expectedCode, String expectedMessage, JsonError actual )
+    {
+        JsonList<JsonObjectReport> reports = actual.getTypeReport().getObjectReports();
+        assertEquals( 1, reports.size() );
+        JsonList<JsonErrorReport> errors = reports.get( 0 ).getErrorReports();
+        assertEquals( 1, errors.size() );
+        JsonErrorReport error = errors.get( 0 );
+        assertEquals( expectedCode, error.getErrorCode() );
+        assertEquals( expectedMessage, error.getMessage() );
+    }
+
+    public static String substitutePlaceholders( String url, Object[] args )
+    {
+        return args.length == 0
+            ? url
+            : String.format( url.replaceAll( "\\{[a-zA-Z]+}", "%s" ), (Object[]) args );
+    }
+
+    public static <T> T failOnException( Callable<T> op )
+    {
+        try
+        {
+            return op.call();
+        }
+        catch ( Exception ex )
+        {
+            throw new AssertionError( ex );
+        }
+    }
+
+    private WebClientUtils()
+    {
+        throw new UnsupportedOperationException( "util" );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -454,7 +454,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         validateAndThrowErrors( () -> schemaValidator.validate( persistedObject ) );
         manager.updateTranslations( persistedObject, object.getTranslations() );
-        manager.update( persistedObject );
 
         response.setStatus( HttpServletResponse.SC_NO_CONTENT );
     }
@@ -504,7 +503,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return patchService.diff( new PatchParams( mapper.readTree( request.getInputStream() ) ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )
+    @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PATCH } )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void updateObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
@@ -624,48 +623,17 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     public void postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
-        User user = currentUserService.getCurrentUser();
-
-        if ( !aclService.canCreate( user, getEntityClass() ) )
-        {
-            throw new CreateAccessDeniedException( "You don't have the proper permissions to create this object." );
-        }
-
-        T parsed = deserializeJsonEntity( request, response );
-        parsed.getTranslations().clear();
-
-        preCreateEntity( parsed );
-
-        MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() )
-            .setImportReportMode( ImportReportMode.FULL )
-            .setUser( user )
-            .setImportStrategy( ImportStrategy.CREATE )
-            .addObject( parsed );
-
-        ImportReport importReport = importService.importMetadata( params );
-        ObjectReport objectReport = getObjectReport( importReport );
-        WebMessage webMessage = WebMessageUtils.objectReport( objectReport );
-
-        if ( objectReport != null && webMessage.getStatus() == Status.OK )
-        {
-            String location = contextService.getApiPath() + getSchema().getRelativeApiEndpoint() + "/"
-                + objectReport.getUid();
-
-            webMessage.setHttpStatus( HttpStatus.CREATED );
-            response.setHeader( ContextUtils.HEADER_LOCATION, location );
-            T entity = manager.get( getEntityClass(), objectReport.getUid() );
-            postCreateEntity( entity );
-        }
-        else
-        {
-            webMessage.setStatus( Status.ERROR );
-        }
-
-        webMessageService.send( webMessage, response, request );
+        postObject( request, response, deserializeJsonEntity( request, response ) );
     }
 
     @RequestMapping( method = RequestMethod.POST, consumes = { "application/xml", "text/xml" } )
     public void postXmlObject( HttpServletRequest request, HttpServletResponse response )
+        throws Exception
+    {
+        postObject( request, response, deserializeXmlEntity( request ) );
+    }
+
+    private void postObject( HttpServletRequest request, HttpServletResponse response, T parsed )
         throws Exception
     {
         User user = currentUserService.getCurrentUser();
@@ -675,19 +643,20 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             throw new CreateAccessDeniedException( "You don't have the proper permissions to create this object." );
         }
 
-        T parsed = deserializeXmlEntity( request );
         parsed.getTranslations().clear();
 
         preCreateEntity( parsed );
 
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() )
-            .setImportReportMode( ImportReportMode.FULL )
-            .setUser( user )
-            .setImportStrategy( ImportStrategy.CREATE )
+            .setImportReportMode( ImportReportMode.FULL ).setUser( user ).setImportStrategy( ImportStrategy.CREATE )
             .addObject( parsed );
 
-        ImportReport importReport = importService.importMetadata( params );
-        ObjectReport objectReport = getObjectReport( importReport );
+        postObject( request, response, getObjectReport( importService.importMetadata( params ) ) );
+    }
+
+    protected final void postObject( HttpServletRequest request, HttpServletResponse response,
+        ObjectReport objectReport )
+    {
         WebMessage webMessage = WebMessageUtils.objectReport( objectReport );
 
         if ( objectReport != null && webMessage.getStatus() == Status.OK )


### PR DESCRIPTION
### Summary
This PR adds a new base test class `DhisControllerConvenienceTest` and a utility `JsonResponse` to make testing web API controller classes in spring integration tests easy and readable.

The principle is based on JSON path extraction identical to what is used by spring mock MVC under the hood.
In contrast to sping mock MVC the path isn't provided as `String` but is build up using a extendible API that gives the illusion of working with a JSON object tree. 

Asserts are not made by providing matchers to spring mock MVC but by extracting leaf values or properties from the virtual JSON tree and making vanilla JUnit asserts. 

This approach is both way more readable and easier to debug as it isn't any different from usual "object oriented" test code.
At the same time we keep the benefit of only extracting and checking relevant sub-paths from the JSON response.
The type extensibility of the virtual JSON tree provides a nice place to capture the names in our APIs in one place and make that information reusable and avoid string composition in test code.

### Virtual JSON Tree
There is only a single class `JsonResponse` that implements arbitrary JSON trees including those using user defined types.
This works because all the tree is, is a view on the complete response. When we navigate the tree using the tree methods all that actually happens is that we compose a path that drills down to an **existing or non existing** node in the response JSON. 

So `JsonResponse` implements all JSON node types at the same time as it can act as any of them. 
Which role it has is limited by the Java types. This includes the basic node types: `JsonObject`, `JsonArray`, `JsonNumber`, `JsonString`, `JsonBoolean` but also extensions of these types. This works because the tree is virtual anyway and any operation can be expressed as a combination of basic operations which just manipulate the path we look at. 

When users extend the basic JSON node types with custom types, such as DHIS2 domain types these are also interfaces which are implemented using `default` methods that call the fundamental methods. These interface are implemented by dynamic proxies which call `default` methods of the interface using method handles and virtual methods by calling that method on the underlying `JsonResponse` (which manipulates the path).

So while this PR has a lot of these JSON tree types all these do is capture the naming and structural conventions our API(s) have. Functionally they are implemented by `JsonResponse`.

### Examples
This PR contains two example tests 
* [`MeControllerTest`](https://github.com/dhis2/dhis2-core/pull/7475/files#diff-7880a4220fe15ab1a6ec47768c5a73cf7560fa21f81a7d3665ce73fc023fffd8): Testing all methods of the `MeController`
* [`AbstractCrudControllerTest`](https://github.com/dhis2/dhis2-core/pull/7475/files#diff-2223dc3e120b85d93051823922217512d002bf195a578aecd7d0723852f910f0): Testing all methods of the `AbstractCrudController`

These demonstrate that with this utility controller API tests can be written in a readable and concise manner.

### Found Issues
Testing the two controllers has revealed a few issues:
* `PUT` was mapped twice for identical path, removed at the "loosing" occurrence which also allowed `PATCH`
* since the `UserController` would override `postObject` it would not return a `201` `CREATED` as the overridden method would but a `200` `OK` instead. More seriously it would even return `OK` when the request was not successful since parts of the proper result handling were missing in the overridden method. This was fixed by extracting common parts which then can be called both in case of `AbstractCrudController` and `UserController`. This means it now also returns `201` `CREATED` when successful.

(cherry picked from commit e93c6628ceed027392cb44aa95477a92be03c253)