### PR TITLE
feat: Add support for using JWT tokens

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentialsStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentialsStore.java
@@ -63,7 +63,7 @@ public interface UserCredentialsStore
      * open ID.
      *
      * @param openId open ID.
-     * @return the UserCredentials.
+     * @return the UserCredentials or null if there is no match.
      */
     UserCredentials getUserCredentialsByOpenId( String openId );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -267,7 +267,7 @@ public interface UserService
      * OpenID.
      *
      * @param openId the openId of the User.
-     * @return the UserCredentials.
+     * @return the UserCredentials or null if there is no match
      */
     UserCredentials getUserCredentialsByOpenId( String openId );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
@@ -42,6 +42,7 @@ import org.springframework.security.web.authentication.session.SessionFixationPr
 import org.springframework.util.ClassUtils;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
@@ -117,8 +118,9 @@ public class AuthenticationLoggerListener
             }
         }
 
-        log.warn( eventClassName + "; username: " + authName + ipAddress + sessionId + exceptionMessage );
+        String userNamePrefix = Strings.isNullOrEmpty( authName ) ? "" : authName;
 
+        log.warn( eventClassName + userNamePrefix + authName + ipAddress + sessionId + exceptionMessage );
     }
 
     private String hashSessionId( String sessionId )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationManagerResolver.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.jwt;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
+import org.hisp.dhis.user.UserCredentials;
+import org.hisp.dhis.user.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.stereotype.Component;
+
+import com.nimbusds.jwt.JWTParser;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Slf4j
+@Component
+public class DhisJwtAuthenticationManagerResolver implements AuthenticationManagerResolver<HttpServletRequest>
+{
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private DhisOidcProviderRepository clientRegistrationRepository;
+
+    private final Map<String, AuthenticationManager> authenticationManagers = new ConcurrentHashMap<>();
+
+    private final Converter<HttpServletRequest, String> issuerConverter = new JwtClaimIssuerConverter();
+
+    private JwtDecoder jwtDecoder;
+
+    public void setJwtDecoder( JwtDecoder jwtDecoder )
+    {
+        this.jwtDecoder = jwtDecoder;
+    }
+
+    @Override
+    public AuthenticationManager resolve( HttpServletRequest request )
+    {
+        String issuer = this.issuerConverter.convert( request );
+        if ( issuer == null )
+        {
+            throw new InvalidBearerTokenException( "Missing issuer" );
+        }
+
+        return getAuthenticationManager( issuer );
+    }
+
+    private AuthenticationManager getAuthenticationManager( String issuer )
+    {
+        return this.authenticationManagers.computeIfAbsent( issuer, s -> {
+
+            DhisOidcClientRegistration clientRegistration = clientRegistrationRepository.findByIssuerUri( issuer );
+            if ( clientRegistration == null )
+            {
+                throw new InvalidBearerTokenException( "Invalid issuer" );
+            }
+
+            return new DhisJwtAuthenticationProvider(
+                getDecoder( issuer ),
+                getConverter( clientRegistration ) )::authenticate;
+        } );
+    }
+
+    private JwtDecoder getDecoder( String issuer )
+    {
+        if ( jwtDecoder != null )
+        {
+            return jwtDecoder;
+        }
+
+        return JwtDecoders.fromIssuerLocation( issuer );
+    }
+
+    private Converter<Jwt, DhisJwtAuthenticationToken> getConverter( DhisOidcClientRegistration clientRegistration )
+    {
+        return jwt -> {
+            List<String> audience = jwt.getAudience();
+
+            Collection<String> clientIds = clientRegistration.getClientIds();
+
+            Set<String> matchedClientIds = clientIds.stream()
+                .filter( audience::contains )
+                .collect( Collectors.toSet() );
+
+            if ( matchedClientIds.isEmpty() )
+            {
+                throw new InvalidBearerTokenException( "Invalid audience" );
+            }
+
+            String mappingClaimKey = clientRegistration.getMappingClaimKey();
+            String mappingValue = jwt.getClaim( mappingClaimKey );
+
+            UserCredentials userCredentials = userService.getUserCredentialsByOpenId( mappingValue );
+            if ( userCredentials == null )
+            {
+                throw new InvalidBearerTokenException( String.format(
+                    "Found no matching DHIS2 user for the mapping claim:'%s' with the value:'%s'",
+                    mappingClaimKey, mappingValue ) );
+            }
+
+            Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+
+            return new DhisJwtAuthenticationToken( jwt, grantedAuthorities, mappingValue, userCredentials );
+        };
+    }
+
+    private static class DhisJwtAuthenticationProvider implements AuthenticationProvider
+    {
+        private final JwtDecoder jwtDecoder;
+
+        private final Converter<Jwt, DhisJwtAuthenticationToken> jwtAuthenticationConverter;
+
+        public DhisJwtAuthenticationProvider( JwtDecoder jwtDecoder,
+            Converter<Jwt, DhisJwtAuthenticationToken> jwtAuthenticationConverter )
+        {
+            checkNotNull( jwtDecoder );
+            checkNotNull( jwtAuthenticationConverter );
+
+            this.jwtDecoder = jwtDecoder;
+            this.jwtAuthenticationConverter = jwtAuthenticationConverter;
+        }
+
+        @Override
+        public Authentication authenticate( Authentication authentication )
+            throws AuthenticationException
+        {
+            BearerTokenAuthenticationToken bearer = (BearerTokenAuthenticationToken) authentication;
+
+            Jwt jwt = getJwt( bearer );
+
+            DhisJwtAuthenticationToken token = this.jwtAuthenticationConverter.convert( jwt );
+            if ( token == null )
+            {
+                throw new InvalidBearerTokenException( "Invalid token" );
+            }
+
+            token.setDetails( bearer.getDetails() );
+
+            return token;
+        }
+
+        private Jwt getJwt( BearerTokenAuthenticationToken bearer )
+        {
+            try
+            {
+                return this.jwtDecoder.decode( bearer.getToken() );
+            }
+            catch ( BadJwtException failed )
+            {
+                throw new InvalidBearerTokenException( failed.getMessage(), failed );
+            }
+            catch ( JwtException failed )
+            {
+                throw new AuthenticationServiceException( failed.getMessage(), failed );
+            }
+        }
+
+        @Override
+        public boolean supports( Class<?> authentication )
+        {
+            return BearerTokenAuthenticationToken.class.isAssignableFrom( authentication );
+        }
+    }
+
+    private static class JwtClaimIssuerConverter implements Converter<HttpServletRequest, String>
+    {
+        private final BearerTokenResolver resolver = new DefaultBearerTokenResolver();
+
+        @Override
+        public String convert( HttpServletRequest request )
+        {
+            String token = this.resolver.resolve( request );
+
+            try
+            {
+                String issuer = JWTParser.parse( token ).getJWTClaimsSet().getIssuer();
+                if ( issuer != null )
+                {
+                    return issuer;
+                }
+            }
+            catch ( Exception ex )
+            {
+                throw new InvalidBearerTokenException( ex.getMessage(), ex );
+            }
+
+            throw new InvalidBearerTokenException( "Missing issuer" );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/OAuth2AuthorizationServerEnabledCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/OAuth2AuthorizationServerEnabledCondition.java
@@ -25,52 +25,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.security.oidc;
+package org.hisp.dhis.security.oauth2;
 
-import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.CLIENT_ID;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import lombok.Builder;
-import lombok.Data;
-
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.hisp.dhis.condition.PropertiesAwareConfigurationCondition;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
-@Builder
-public class DhisOidcClientRegistration
+public class OAuth2AuthorizationServerEnabledCondition extends PropertiesAwareConfigurationCondition
 {
-    private final ClientRegistration clientRegistration;
-
-    private final String mappingClaimKey;
-
-    private final String loginIcon;
-
-    private final String loginIconPadding;
-
-    private final String loginText;
-
-    @Builder.Default
-    private final Map<String, Map<String, String>> externalClients = new HashMap<>();
-
-    public Collection<String> getClientIds()
+    @Override
+    public boolean matches( ConditionContext context, AnnotatedTypeMetadata metadata )
     {
-        Set<String> allExternalClientIds = externalClients.entrySet()
-            .stream()
-            .flatMap( e -> e.getValue().entrySet().stream() )
-            .filter( e -> e.getKey().contains( CLIENT_ID ) )
-            .map( Map.Entry::getValue )
-            .collect( Collectors.toSet() );
+        if ( isTestRun( context ) )
+        {
+            return false;
+        }
 
-        allExternalClientIds.add( clientRegistration.getClientId() );
-        return Collections.unmodifiableSet( allExternalClientIds );
+        return getConfiguration().isEnabled( ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER );
+    }
+
+    @Override
+    public ConfigurationPhase getConfigurationPhase()
+    {
+        return ConfigurationPhase.PARSE_CONFIGURATION;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisCustomAuthorizationRequestResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisCustomAuthorizationRequestResolver.java
@@ -59,7 +59,7 @@ public class DhisCustomAuthorizationRequestResolver implements OAuth2Authorizati
     public static final String HASH_DIGEST_ALGORITHM = "SHA-256";
 
     @Autowired
-    private DhisClientRegistrationRepository clientRegistrationRepository;
+    private DhisOidcProviderRepository clientRegistrationRepository;
 
     private DefaultOAuth2AuthorizationRequestResolver defaultResolver;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -46,10 +46,10 @@ public class DhisOidcUser
 
     private final UserCredentials userCredentials;
 
-    public DhisOidcUser( UserCredentials userCredentials, Map<String, Object> attributes, String sub,
+    public DhisOidcUser( UserCredentials userCredentials, Map<String, Object> attributes, String nameAttributeKey,
         OidcIdToken idToken )
     {
-        super( userCredentials.getAuthorities(), attributes, sub );
+        super( userCredentials.getAuthorities(), attributes, nameAttributeKey );
         this.oidcIdToken = idToken;
         this.userCredentials = userCredentials;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUserService.java
@@ -56,7 +56,7 @@ public class DhisOidcUserService
     public UserService userService;
 
     @Autowired
-    private DhisClientRegistrationRepository clientRegistrationRepository;
+    private DhisOidcProviderRepository clientRegistrationRepository;
 
     @Override
     public OidcUser loadUser( OidcUserRequest userRequest )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/OIDCLoginEnabledCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/OIDCLoginEnabledCondition.java
@@ -35,7 +35,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class OidcEnabledCondition extends PropertiesAwareConfigurationCondition
+public class OIDCLoginEnabledCondition extends PropertiesAwareConfigurationCondition
 {
     @Override
     public boolean matches( ConditionContext context, AnnotatedTypeMetadata metadata )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AbstractOidcProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AbstractOidcProvider.java
@@ -32,43 +32,47 @@ package org.hisp.dhis.security.oidc.provider;
  */
 public abstract class AbstractOidcProvider
 {
-    protected static final String DEFAULT_REDIRECT_TEMPLATE_URL = "{baseUrl}/oauth2/code/{registrationId}";
+    public static final String DEFAULT_REDIRECT_TEMPLATE_URL = "{baseUrl}/oauth2/code/{registrationId}";
 
     public static final String DEFAULT_MAPPING_CLAIM = "email";
 
     public static final String DEFAULT_SCOPE = "openid";
 
-    public final static String PROVIDER_ID = "provider_id";
+    public static final String PROVIDER_ID = "provider_id";
 
-    public final static String CLIENT_ID = "client_id";
+    public static final String CLIENT_ID = "client_id";
 
-    public final static String CLIENT_SECRET = "client_secret";
+    public static final String CLIENT_SECRET = "client_secret";
 
-    public final static String MAPPING_CLAIM = "mapping_claim";
+    public static final String MAPPING_CLAIM = "mapping_claim";
 
-    public final static String REDIRECT_URL = "redirect_url";
+    public static final String REDIRECT_URL = "redirect_url";
 
-    public final static String AUTHORIZATION_URI = "authorization_uri";
+    public static final String AUTHORIZATION_URI = "authorization_uri";
 
-    public final static String TOKEN_URI = "token_uri";
+    public static final String TOKEN_URI = "token_uri";
 
-    public final static String USERINFO_URI = "user_info_uri";
+    public static final String USERINFO_URI = "user_info_uri";
 
-    public final static String JWK_URI = "jwk_uri";
+    public static final String JWK_URI = "jwk_uri";
 
-    public final static String END_SESSION_ENDPOINT = "end_session_endpoint";
+    public static final String ISSUER_URI = "issuer_uri";
 
-    public final static String DISPLAY_ALIAS = "display_alias";
+    public static final String END_SESSION_ENDPOINT = "end_session_endpoint";
 
-    public final static String ENABLE_LOGOUT = "enable_logout";
+    public static final String DISPLAY_ALIAS = "display_alias";
 
-    public final static String SCOPES = "scopes";
+    public static final String ENABLE_LOGOUT = "enable_logout";
 
-    public final static String LOGO_IMAGE = "logo_image";
+    public static final String SCOPES = "scopes";
 
-    public final static String LOGO_IMAGE_PADDING = "logo_image_padding";
+    public static final String LOGIN_IMAGE = "login_image";
 
-    public final static String ENABLE_PKCE = "enable_pkce";
+    public static final String LOGIN_IMAGE_PADDING = "login_image_padding";
 
-    public final static String EXTRA_REQUEST_PARAMETERS = "extra_request_parameters";
+    public static final String ENABLE_PKCE = "enable_pkce";
+
+    public static final String EXTRA_REQUEST_PARAMETERS = "extra_request_parameters";
+
+    public static final String EXTERNAL_CLIENT_PREFIX = "ext_client";
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
@@ -66,11 +65,9 @@ public class AzureAdProvider extends AbstractOidcProvider
         throw new IllegalStateException( "Utility class" );
     }
 
-    public static List<DhisOidcClientRegistration> buildList( DhisConfigurationProvider config )
+    public static List<DhisOidcClientRegistration> parse( Properties config )
     {
         Objects.requireNonNull( config, "DhisConfigurationProvider is missing!" );
-
-        final Properties properties = config.getProperties();
 
         final ImmutableList.Builder<DhisOidcClientRegistration> clients = ImmutableList.builder();
 
@@ -78,22 +75,20 @@ public class AzureAdProvider extends AbstractOidcProvider
         {
             String propertyPrefix = PROVIDER_PREFIX + i + '.';
 
-            String tenant = properties.getProperty( propertyPrefix + AZURE_TENANT, "" );
+            String tenant = config.getProperty( propertyPrefix + AZURE_TENANT, "" );
             if ( tenant.isEmpty() )
             {
                 continue;
             }
 
-            ClientRegistration.Builder builder = makeBuilder( config, tenant, propertyPrefix );
-
             DhisOidcClientRegistration dhisOidcClientRegistration = DhisOidcClientRegistration.builder()
-                .clientRegistration( builder.build() )
+                .clientRegistration( buildClientRegistration( config, tenant, propertyPrefix ) )
                 .mappingClaimKey( MoreObjects.firstNonNull(
-                    properties.getProperty( propertyPrefix + MAPPING_CLAIM ),
+                    config.getProperty( propertyPrefix + MAPPING_CLAIM ),
                     DEFAULT_MAPPING_CLAIM ) )
                 .loginIcon( "../security/btn_azure_login.svg" )
                 .loginIconPadding( "13px 13px" )
-                .loginText( properties.getProperty( propertyPrefix + DISPLAY_ALIAS, "login_with_azure" ) )
+                .loginText( config.getProperty( propertyPrefix + DISPLAY_ALIAS, "login_with_azure" ) )
                 .build();
 
             clients.add( dhisOidcClientRegistration );
@@ -102,11 +97,9 @@ public class AzureAdProvider extends AbstractOidcProvider
         return clients.build();
     }
 
-    private static ClientRegistration.Builder makeBuilder( DhisConfigurationProvider config, String tenant,
+    private static ClientRegistration buildClientRegistration( Properties properties, String tenant,
         String propertyPrefix )
     {
-        Properties properties = config.getProperties();
-
         String clientId = properties.getProperty( propertyPrefix + CLIENT_ID, "" );
         String clientSecret = properties.getProperty( propertyPrefix + CLIENT_SECRET );
 
@@ -140,14 +133,13 @@ public class AzureAdProvider extends AbstractOidcProvider
         builder.userNameAttributeName( IdTokenClaimNames.SUB );
 
         boolean supportLogout = Boolean.parseBoolean( MoreObjects.firstNonNull(
-            properties.getProperty( propertyPrefix + ENABLE_LOGOUT ),
-            "TRUE" ) );
+            properties.getProperty( propertyPrefix + ENABLE_LOGOUT ), "TRUE" ) );
         if ( supportLogout )
         {
             builder.providerConfigurationMetadata(
                 ImmutableMap.of( "end_session_endpoint", tenantUriStart + "/oauth2/v2.0/logout" ) );
         }
 
-        return builder;
+        return builder.build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/GenericOidcProviderBuilderConfigParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/GenericOidcProviderBuilderConfigParserTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -44,25 +43,24 @@ public class GenericOidcProviderBuilderConfigParserTest
     @Test
     public void parseConfigAllValidParameters()
     {
-        Properties properties = new Properties();
+        Properties p = new Properties();
+        p.put( "oidc.provider.idporten.client_id", "testClientId" );
+        p.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
+        p.put( "oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize" );
+        p.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
+        p.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
+        p.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
+        p.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
+        p.put( "oidc.provider.idporten.scopes", "pid" );
+        p.put( "oidc.provider.idporten.mapping_claim", "helseid://claims/identity/pid" );
+        p.put( "oidc.provider.idporten.display_alias", "IdPorten" );
+        p.put( "oidc.provider.idporten.enable_logout", "true" );
+        p.put( "oidc.provider.idporten.login_image", "../security/idporten-logo.svg" );
+        p.put( "oidc.provider.idporten.login_image_padding", "0px 0px" );
+        p.put( "oidc.provider.idporten.extra_request_parameters", "acr_value 4,test_param five" );
+        p.put( "oidc.provider.idporten.enable_pkce", "false" );
 
-        properties.put( "oidc.provider.idporten.client_id", "testClientId" );
-        properties.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
-        properties.put( "oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize" );
-        properties.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
-        properties.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
-        properties.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
-        properties.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
-        properties.put( "oidc.provider.idporten.scopes", "pid" );
-        properties.put( "oidc.provider.idporten.mapping_claim", "helseid://claims/identity/pid" );
-        properties.put( "oidc.provider.idporten.display_alias", "IdPorten" );
-        properties.put( "oidc.provider.idporten.enable_logout", "true" );
-        properties.put( "oidc.provider.idporten.logo_image", "../security/idporten-logo.svg" );
-        properties.put( "oidc.provider.idporten.logo_image_padding", "0px 0px" );
-        properties.put( "oidc.provider.idporten.extra_request_parameters", "acr_value 4,test_param five" );
-        properties.put( "oidc.provider.idporten.enable_pkce", "false" );
-
-        List<Map<String, String>> parse = GenericOidcProviderConfigParser.parse( properties );
+        List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse( p );
 
         assertThat( parse, hasSize( 1 ) );
     }
@@ -70,17 +68,16 @@ public class GenericOidcProviderBuilderConfigParserTest
     @Test
     public void parseValidMinimumConfig()
     {
-        Properties properties = new Properties();
+        Properties p = new Properties();
+        p.put( "oidc.provider.idporten.client_id", "testClientId" );
+        p.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
+        p.put( "oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize" );
+        p.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
+        p.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
+        p.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
+        p.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
 
-        properties.put( "oidc.provider.idporten.client_id", "testClientId" );
-        properties.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
-        properties.put( "oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize" );
-        properties.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
-        properties.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
-        properties.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
-        properties.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
-
-        List<Map<String, String>> parse = GenericOidcProviderConfigParser.parse( properties );
+        List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse( p );
 
         assertThat( parse, hasSize( 1 ) );
     }
@@ -88,16 +85,15 @@ public class GenericOidcProviderBuilderConfigParserTest
     @Test
     public void parseConfigMissingRequiredParameter()
     {
-        Properties properties = new Properties();
+        Properties p = new Properties();
+        p.put( "oidc.provider.idporten.client_id", "testClientId" );
+        p.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
+        p.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
+        p.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
+        p.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
+        p.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
 
-        properties.put( "oidc.provider.idporten.client_id", "testClientId" );
-        properties.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
-        properties.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
-        properties.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
-        properties.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
-        properties.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
-
-        List<Map<String, String>> parse = GenericOidcProviderConfigParser.parse( properties );
+        List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse( p );
 
         assertThat( parse, hasSize( 0 ) );
     }
@@ -105,17 +101,16 @@ public class GenericOidcProviderBuilderConfigParserTest
     @Test
     public void parseConfigMalformedKeyNameParameter()
     {
-        Properties properties = new Properties();
+        Properties p = new Properties();
+        p.put( "oidc.provider.idporten.client_id", "testClientId" );
+        p.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
+        p.put( "oidc.provider.idporten.INVALID_PROPERTY_NAME", "https://oidc-ver2.difi.no/authorize" );
+        p.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
+        p.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
+        p.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
+        p.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
 
-        properties.put( "oidc.provider.idporten.client_id", "testClientId" );
-        properties.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
-        properties.put( "oidc.provider.idporten.INVALID_PROPERTY_NAME", "https://oidc-ver2.difi.no/authorize" );
-        properties.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
-        properties.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
-        properties.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
-        properties.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
-
-        List<Map<String, String>> parse = GenericOidcProviderConfigParser.parse( properties );
+        List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse( p );
 
         assertThat( parse, hasSize( 0 ) );
     }
@@ -123,18 +118,16 @@ public class GenericOidcProviderBuilderConfigParserTest
     @Test
     public void parseConfigInvalidURIParameter()
     {
-        Properties properties = new Properties();
+        Properties p = new Properties();
+        p.put( "oidc.provider.idporten.client_id", "testClientId" );
+        p.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
+        p.put( "oidc.provider.idporten.authorization_uri", "INVALID_URI_SCHEME://oidc-ver2.difi.no/authorize" );
+        p.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
+        p.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
+        p.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
+        p.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
 
-        properties.put( "oidc.provider.idporten.client_id", "testClientId" );
-        properties.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
-        properties
-            .put( "oidc.provider.idporten.authorization_uri", "INVALID_URI_SCHEME://oidc-ver2.difi.no/authorize" );
-        properties.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
-        properties.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
-        properties.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
-        properties.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
-
-        List<Map<String, String>> parse = GenericOidcProviderConfigParser.parse( properties );
+        List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse( p );
 
         assertThat( parse, hasSize( 0 ) );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/provider/GenericOidcProviderBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/provider/GenericOidcProviderBuilderTest.java
@@ -27,9 +27,12 @@
  */
 package org.hisp.dhis.security.oidc.provider;
 
+import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.EXTRA_REQUEST_PARAMETERS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -46,35 +49,85 @@ public class GenericOidcProviderBuilderTest
     @Test
     public void testBuildSuccessfully()
     {
-        Properties properties = new Properties();
+        Properties p = new Properties();
+        p.put( "oidc.provider.idporten.client_id", "testClientId" );
+        p.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
+        p.put( "oidc.provider.idporten.ext_client.android.client_id", "externalClientId" );
+        p.put( "oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize" );
+        p.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
+        p.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
+        p.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
+        p.put( "oidc.provider.idporten.issuer_uri", "https://oidc-ver2.difi.no" );
+        p.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
+        p.put( "oidc.provider.idporten.scopes", "pid" );
+        p.put( "oidc.provider.idporten.mapping_claim", "helseid://claims/identity/pid" );
+        p.put( "oidc.provider.idporten.display_alias", "IdPorten" );
+        p.put( "oidc.provider.idporten.enable_logout", "true" );
+        p.put( "oidc.provider.idporten.login_image", "../security/idporten-logo.svg" );
+        p.put( "oidc.provider.idporten.login_image_padding", "0px 0px" );
+        p.put( "oidc.provider.idporten.extra_request_parameters", "acr_value 4 , test_param five" );
+        p.put( "oidc.provider.idporten.enable_pkce", "true" );
 
-        properties.put( "oidc.provider.idporten.client_id", "testClientId" );
-        properties.put( "oidc.provider.idporten.client_secret", "testClientSecret!#!?" );
-        properties.put( "oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize" );
-        properties.put( "oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token" );
-        properties.put( "oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo" );
-        properties.put( "oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk" );
-        properties.put( "oidc.provider.idporten.end_session_endpoint", "https://oidc-ver2.difi.no/endsession" );
-        properties.put( "oidc.provider.idporten.scopes", "pid" );
-        properties.put( "oidc.provider.idporten.mapping_claim", "helseid://claims/identity/pid" );
-        properties.put( "oidc.provider.idporten.display_alias", "IdPorten" );
-        properties.put( "oidc.provider.idporten.enable_logout", "true" );
-        properties.put( "oidc.provider.idporten.logo_image", "../security/idporten-logo.svg" );
-        properties.put( "oidc.provider.idporten.extra_request_parameters", " acr_value 4 , test_param five" );
-        properties.put( "oidc.provider.idporten.enable_pkce", "false" );
-
-        List<Map<String, String>> providerConfigList = GenericOidcProviderConfigParser.parse( properties );
-
+        List<DhisOidcClientRegistration> providerConfigList = GenericOidcProviderConfigParser.parse( p );
         assertEquals( providerConfigList.size(), 1 );
 
-        Map<String, String> providerConfig = providerConfigList.get( 0 );
+        DhisOidcClientRegistration r = providerConfigList.get( 0 );
+        assertNotNull( r );
 
-        final DhisOidcClientRegistration clientRegistration = GenericOidcProviderBuilder.build( providerConfig );
-
-        assertNotNull( clientRegistration );
-
-        final String registrationId = clientRegistration.getRegistrationId();
-
+        final String registrationId = r.getClientRegistration().getRegistrationId();
         assertEquals( registrationId, "idporten" );
+
+        assertEquals( "helseid://claims/identity/pid", r.getMappingClaimKey() );
+        assertEquals( "../security/idporten-logo.svg", r.getLoginIcon() );
+        assertEquals( "0px 0px", r.getLoginIconPadding() );
+        assertEquals( "IdPorten", r.getLoginText() );
+        assertEquals( "testClientId", r.getClientRegistration().getClientId() );
+        assertEquals( "testClientSecret!#!?", r.getClientRegistration().getClientSecret() );
+        assertTrue( r.getClientRegistration().getScopes().contains( "pid" ) );
+
+        assertEquals( "https://oidc-ver2.difi.no/token",
+            r.getClientRegistration().getProviderDetails().getTokenUri() );
+
+        assertEquals( "https://oidc-ver2.difi.no/authorize",
+            r.getClientRegistration().getProviderDetails().getAuthorizationUri() );
+
+        assertEquals( "https://oidc-ver2.difi.no/jwk",
+            r.getClientRegistration().getProviderDetails().getJwkSetUri() );
+
+        assertEquals( "https://oidc-ver2.difi.no/userinfo",
+            r.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUri() );
+
+        assertEquals( "https://oidc-ver2.difi.no",
+            r.getClientRegistration().getProviderDetails().getIssuerUri() );
+
+        assertEquals( "true",
+            r.getClientRegistration().getProviderDetails().getConfigurationMetadata().get( "enable_pkce" ) );
+
+        Object parameters = r.getClientRegistration().getProviderDetails().getConfigurationMetadata()
+            .get( "extra_request_parameters" );
+
+        Map<String, String> extraRequestParams = (Map<String, String>) parameters;
+        assertEquals( "4", extraRequestParams.get( "acr_value" ) );
+
+        Map<String, Map<String, String>> externalClients = r.getExternalClients();
+        assertNotNull( externalClients );
+
+        Map<String, String> android = externalClients.get( "android" );
+        assertNotNull( externalClients );
+
+        String client_id = android.get( "client_id" );
+        assertEquals( "externalClientId", client_id );
+    }
+
+    @Test
+    public void testParseExtraRequestParameters()
+    {
+        HashMap<String, String> hashMap = new HashMap<>();
+        hashMap.put( EXTRA_REQUEST_PARAMETERS, "   acr_value    4    ,    test_param five,    test_param2  six " );
+
+        Map<String, String> params = GenericOidcProviderBuilder.getExtraRequestParameters( hashMap );
+        assertEquals( "4", params.get( "acr_value" ) );
+        assertEquals( "five", params.get( "test_param" ) );
+        assertEquals( "six", params.get( "test_param2" ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-external/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-external/pom.xml
@@ -100,6 +100,11 @@
       <artifactId>spring-security-jwt</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-resource-server</artifactId>
+    </dependency>
+
     <!-- Jackson -->
 
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -129,7 +129,7 @@ public enum ConfigurationKey
     OIDC_LOGOUT_REDIRECT_URL( "oidc.logout.redirect_url", "", false ),
     OIDC_PROVIDER_GOOGLE_CLIENT_ID( "oidc.provider.google.client_id", "", true ),
     OIDC_PROVIDER_GOOGLE_CLIENT_SECRET( "oidc.provider.google.client_secret", "", true ),
-    OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM( "oidc.provider.google.mapping_claim", "email", true ),
+    OIDC_PROVIDER_GOOGLE_MAPPING_CLAIM( "oidc.provider.google.mapping_claim", "", true ),
     OIDC_PROVIDER_GOOGLE_REDIRECT_URI( "oidc.provider.google.redirect_url", "", true ),
     OIDC_PROVIDER_WSO2_CLIENT_ID( "oidc.provider.wso2.client_id", "", false ),
     OIDC_PROVIDER_WSO2_CLIENT_SECRET( "oidc.provider.wso2.client_secret", "", false ),
@@ -146,7 +146,9 @@ public enum ConfigurationKey
     DB_POOL_TYPE( "db.pool.type", "c3p0", false ),
     ACTIVE_READ_REPLICAS( "active.read.replicas", "0", false ),
     AUDIT_ENABLED( "system.audit.enabled", Constants.TRUE, false ),
-    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false );
+    TRACKER_IMPORT_PREHEAT_CACHE_ENABLED( "tracker.import.preheat.cache.enabled", Constants.ON, false ),
+    ENABLE_OAUTH2_AUTHORIZATION_SERVER( "oauth2.authorization.server.enabled", Constants.ON, false ),
+    ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION( "oidc.jwt.token.authentication.enabled", Constants.OFF, false );
 
     private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -184,6 +184,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.MimeTypeUtils;
 import org.xml.sax.InputSource;
 
+import com.google.api.client.util.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
@@ -2262,9 +2263,17 @@ public abstract class DhisConvenienceTest
 
     protected User createUser( String username, String... authorities )
     {
-        checkUserServiceWasInjected();
+        return _createUser( username, null, authorities );
+    }
 
-        String password = DEFAULT_ADMIN_PASSWORD;
+    protected User createOpenIDUser( String username, String openIDIdentifier )
+    {
+        return _createUser( username, openIDIdentifier );
+    }
+
+    private User _createUser( String username, String openIDIdentifier, String... authorities )
+    {
+        checkUserServiceWasInjected();
 
         UserAuthorityGroup group = createAuthorityGroup( username, authorities );
 
@@ -2274,9 +2283,9 @@ public abstract class DhisConvenienceTest
 
         userService.addUser( user );
 
-        UserCredentials credentials = createUserCredentials( username, user, group );
+        UserCredentials credentials = createUserCredentials( username, openIDIdentifier, user, group );
 
-        userService.encodeAndSetPassword( credentials, password );
+        userService.encodeAndSetPassword( credentials, DEFAULT_ADMIN_PASSWORD );
         userService.addUserCredentials( credentials );
 
         user.setUserCredentials( credentials );
@@ -2302,7 +2311,7 @@ public abstract class DhisConvenienceTest
 
         userService.addUser( user );
 
-        UserCredentials credentials = createUserCredentials( username, user, group );
+        UserCredentials credentials = createUserCredentials( username, null, user, group );
         credentials.setUid( "KvMx6c1eoYo" );
         credentials.setUuid( UUID.fromString( "6507f586-f154-4ec1-a25e-d7aa51de5216" ) );
 
@@ -2414,7 +2423,8 @@ public abstract class DhisConvenienceTest
         return user;
     }
 
-    private static UserCredentials createUserCredentials( String username, User user, UserAuthorityGroup group )
+    private static UserCredentials createUserCredentials( String username, String openIDIdentifier, User user,
+        UserAuthorityGroup group )
     {
         UserCredentials credentials = new UserCredentials();
         credentials.setCode( username );
@@ -2422,6 +2432,13 @@ public abstract class DhisConvenienceTest
         credentials.setUserInfo( user );
         credentials.setUsername( username );
         credentials.getUserAuthorityGroups().add( group );
+
+        if ( !Strings.isNullOrEmpty( openIDIdentifier ) )
+        {
+            credentials.setOpenId( openIDIdentifier );
+            credentials.setExternalAuth( true );
+        }
+
         return credentials;
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/h2TestConfigWithJWTAuth.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/h2TestConfigWithJWTAuth.conf
@@ -1,0 +1,13 @@
+filestore.provider = transient
+filestore.container = files
+connection.schema=update
+encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
+
+connection.dialect=org.hisp.dhis.hibernate.dialect.DhisH2Dialect
+connection.driver_class=org.h2.Driver
+connection.url=jdbc:h2:mem:dhis2;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;ALIAS_COLUMN_NAME=TRUE;DB_CLOSE_ON_EXIT=FALSE;INIT=create domain if not exists jsonb as other;
+connection.username=sa
+connection.password=sa
+
+oauth2.authorization.server.enabled=off
+oidc.jwt.token.authentication.enabled=on

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.utils.TestUtils;
+import org.hisp.dhis.webapi.json.JsonResponse;
+import org.hisp.dhis.webapi.security.config.WebMvcConfig;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+/**
+ * Base class for convenient testing of the web API on basis of
+ * {@link JsonResponse}.
+ *
+ * @author Morten Svanæs
+ */
+@RunWith( SpringRunner.class )
+@WebAppConfiguration
+@ContextConfiguration( classes = { WebMvcConfig.class, WebTestConfigurationWithJwtTokenAuth.class } )
+@ActiveProfiles( "test-h2" )
+@Transactional
+public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenienceTest implements AuthenticatedWebClient
+{
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
+
+    @Autowired
+    private UserService _userService;
+
+    protected MockMvc mvc;
+
+    @Before
+    public final void setup()
+        throws Exception
+    {
+        userService = _userService;
+        CharacterEncodingFilter characterEncodingFilter = new CharacterEncodingFilter();
+        characterEncodingFilter.setEncoding( "UTF-8" );
+        characterEncodingFilter.setForceEncoding( true );
+
+        mvc = MockMvcBuilders.webAppContextSetup( webApplicationContext )
+            .addFilter( springSecurityFilterChain ).build();
+
+        TestUtils.executeStartupRoutines( webApplicationContext );
+    }
+
+    public WebClient.HttpResponse authWebRequest( String token, MockHttpServletRequestBuilder request )
+    {
+        return failOnException(
+            () -> new WebClient.HttpResponse(
+                mvc.perform( request.header( "Authorization", "Bearer " + token ) )
+                    .andReturn()
+                    .getResponse() ) );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfigurationWithJwtTokenAuth.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfigurationWithJwtTokenAuth.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi;
+
+import javax.transaction.Transactional;
+
+import org.hisp.dhis.artemis.config.ArtemisConfig;
+import org.hisp.dhis.config.DataSourceConfig;
+import org.hisp.dhis.config.H2DhisConfigurationProvider;
+import org.hisp.dhis.config.HibernateConfig;
+import org.hisp.dhis.config.HibernateEncryptionConfig;
+import org.hisp.dhis.config.ServiceConfig;
+import org.hisp.dhis.config.StartupConfig;
+import org.hisp.dhis.config.StoreConfig;
+import org.hisp.dhis.configuration.NotifierConfiguration;
+import org.hisp.dhis.db.migration.config.FlywayConfig;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.jdbc.config.JdbcConfig;
+import org.hisp.dhis.leader.election.LeaderElectionConfiguration;
+import org.hisp.dhis.webapi.security.config.AuthenticationProviderConfig;
+import org.hisp.dhis.webapi.security.config.DhisWebApiWebSecurityConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Controller;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Morten Svanæs
+ */
+@Configuration
+@ComponentScan( basePackages = { "org.hisp.dhis" }, useDefaultFilters = false, includeFilters = {
+    @Filter( type = FilterType.ANNOTATION, value = Service.class ),
+    @Filter( type = FilterType.ANNOTATION, value = Component.class ),
+    @Filter( type = FilterType.ANNOTATION, value = Repository.class ),
+    @Filter( type = FilterType.ANNOTATION, value = Controller.class )
+
+}, excludeFilters = @Filter( Configuration.class ) )
+@Import( {
+    HibernateConfig.class,
+    DataSourceConfig.class,
+    JdbcConfig.class,
+    FlywayConfig.class,
+    HibernateEncryptionConfig.class,
+    ServiceConfig.class,
+    StoreConfig.class,
+    LeaderElectionConfiguration.class,
+    NotifierConfiguration.class,
+    DhisWebApiWebSecurityConfig.class,
+    org.hisp.dhis.setting.config.ServiceConfig.class,
+    org.hisp.dhis.external.config.ServiceConfig.class,
+    org.hisp.dhis.dxf2.config.ServiceConfig.class,
+    org.hisp.dhis.support.config.ServiceConfig.class,
+    org.hisp.dhis.validation.config.ServiceConfig.class,
+    org.hisp.dhis.validation.config.StoreConfig.class,
+    org.hisp.dhis.programrule.config.ProgramRuleConfig.class,
+    org.hisp.dhis.reporting.config.StoreConfig.class,
+    org.hisp.dhis.analytics.config.ServiceConfig.class,
+    org.hisp.dhis.commons.config.JacksonObjectMapperConfig.class,
+    StartupConfig.class,
+    ArtemisConfig.class,
+    AuthenticationProviderConfig.class,
+} )
+@Transactional
+public class WebTestConfigurationWithJwtTokenAuth
+{
+    @Bean( name = "dhisConfigurationProvider" )
+    public DhisConfigurationProvider dhisConfigurationProvider()
+    {
+        return new H2DhisConfigurationProvider( "h2TestConfigWithJWTAuth.conf" );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
@@ -196,7 +196,8 @@ public class JwtBearerTokenTest extends DhisControllerWithJwtTokenAuthTest
         JsonError error = GET( EXPIRED_GOOGLE_JWT_TOKEN, "/me" ).error( HttpStatus.UNAUTHORIZED );
 
         assertEquals( "invalid_token", error.getMessage() );
-        assertEquals( "An error occurred while attempting to decode the Jwt: Signed JWT rejected: Another algorithm expected, or no matching key(s) found",
+        assertEquals(
+            "An error occurred while attempting to decode the Jwt: Signed JWT rejected: Another algorithm expected, or no matching key(s) found",
             error.getDevMessage() );
     }
 

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
@@ -196,7 +196,7 @@ public class JwtBearerTokenTest extends DhisControllerWithJwtTokenAuthTest
         JsonError error = GET( EXPIRED_GOOGLE_JWT_TOKEN, "/me" ).error( HttpStatus.UNAUTHORIZED );
 
         assertEquals( "invalid_token", error.getMessage() );
-        assertEquals( "An error occurred while attempting to decode the Jwt: Jwt expired at 2021-03-05T16:19:50Z",
+        assertEquals( "An error occurred while attempting to decode the Jwt: Signed JWT rejected: Another algorithm expected, or no matching key(s) found",
             error.getDevMessage() );
     }
 

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.security.jwt.DhisJwtAuthenticationManagerResolver;
+import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
+import org.hisp.dhis.security.oidc.GenericOidcProviderConfigParser;
+import org.hisp.dhis.security.oidc.provider.GoogleProvider;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.DhisControllerWithJwtTokenAuthTest;
+import org.hisp.dhis.webapi.json.domain.JsonError;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
+import org.hisp.dhis.webapi.security.config.DhisWebApiWebSecurityConfig;
+import org.hisp.dhis.webapi.security.utils.JoseHeader;
+import org.hisp.dhis.webapi.security.utils.JoseHeaderNames;
+import org.hisp.dhis.webapi.security.utils.JwtClaimsSet;
+import org.hisp.dhis.webapi.security.utils.JwtUtils;
+import org.hisp.dhis.webapi.security.utils.TestJoseHeaders;
+import org.hisp.dhis.webapi.security.utils.TestJwks;
+import org.hisp.dhis.webapi.security.utils.TestJwtClaimsSets;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class JwtBearerTokenTest extends DhisControllerWithJwtTokenAuthTest
+{
+    // @formatter:off
+    public static final String EXPIRED_GOOGLE_JWT_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImU4NzMyZGIwNjI4NzUxNTU1NjIx"
+        + "M2I4MGFjYmNmZDA4Y2ZiMzAyYTkiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiO"
+        + "iIxMDE5NDE3MDAyNTQ0LW1xYTdmbGs0bWpvaHJnc2JnOWJ0YTlidmx1b2o4NW8wLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwiY"
+        + "XVkIjoiMTAxOTQxNzAwMjU0NC1tcWE3ZmxrNG1qb2hyZ3NiZzlidGE5YnZsdW9qODVvMC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvb"
+        + "SIsInN1YiI6IjExMDk3ODA1MDEyNzk2NzA2NTUwNiIsImVtYWlsIjoiZGhpczJvaWRjdXNlckBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZ"
+        + "mllZCI6dHJ1ZSwiYXRfaGFzaCI6IkhXbTNXcXphM2p5TEFUZjNlU1pBNVEiLCJuYW1lIjoiZGhpczJvaWRjdXNlciBUZXN0ZXIiLCJwa"
+        + "WN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tLy1oRmptUnhOQkJTWS9BQUFBQUFBQUFBSS9BQUFBQUFBQUFBQ"
+        + "S9BTVp1dWNuQkdYVTF5X05fV25qSXJndHBpSXFWMl9ndll3L3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJkaGlzMm9pZGN1c"
+        + "2VyIiwiZmFtaWx5X25hbWUiOiJUZXN0ZXIiLCJsb2NhbGUiOiJlbiIsImlhdCI6MTYxNDk1NzU5MCwiZXhwIjoxNjE0OTYxMTkwfQ.OC"
+        + "m7hj4H-UqRpM_Xrfq58U3ZGI3k7-S3c4AslVAaMxKsNitsPDZ7oxs-FJT-E7uDqnp1wW5LyBLj8jfJZ4JnvuiNGZrvCCpR3m70_4mSgP"
+        + "8VTjFFEijgfW1IIy_BWI8gDY6iCK7qgOATdYnCyJteWBMKRPr5wVSN05TT3xxLzsE7C5ViOzHAm2v6XrrsEhfcjNmwKmlljjpImTwtUS"
+        + "TBS3DWoWsHaNqXfE3rO0M7231FWl2X0vk5oO-KycNoS1vDZLAvdf6QRJVnPMkQ6Cx5XSMSYEmUmFqM3Sj2ip0Q48hAe4ydzIgRWdGbzG"
+        + "nMH3euqGWr4_G_EBvVqfVPnBF0YA";
+    // @formatter:on
+
+    public static final String GOOGLE_CLIENT_ID = "1019417002544-mqa7flk4mjohrgsbg9bta9bvluoj85o0.apps.googleusercontent.com";
+
+    public static final String TEST_PROVIDER_ONE_URI = "testproviderone.com";
+
+    public static final String TEST_PROVIDER_ONE_NAME = "testproviderone";
+
+    public static final String CLIENT_ID_1 = "client-1";
+
+    public static final String DEFAULT_EMAIL = "admin@dhis2.org";
+
+    public static final String DEFAULT_MAPPING_CLAIM = "email";
+
+    @Autowired
+    private DhisOidcProviderRepository dhisOidcProviderRepository;
+
+    @Autowired
+    private DhisJwtAuthenticationManagerResolver dhisJwtAuthenticationManagerResolver;
+
+    private static List<JWK> jwkList;
+
+    private static JwtUtils jwsEncoder;
+
+    private static final RSAKey defaultRSA = TestJwks.DEFAULT_RSA_JWK;
+
+    private static NimbusJwtDecoder jwtDecoder;
+
+    @BeforeClass
+    public static void setUpClass()
+        throws JOSEException
+    {
+        DhisWebApiWebSecurityConfig.setApiContextPath( "" );
+
+        jwkList = new ArrayList<>();
+        jwkList.add( defaultRSA );
+
+        JWKSource<SecurityContext> jwkSource = ( jwkSelector, securityContext ) -> jwkSelector
+            .select( new JWKSet( jwkList ) );
+        jwsEncoder = new JwtUtils( jwkSource );
+
+        jwtDecoder = NimbusJwtDecoder.withPublicKey( defaultRSA.toRSAPublicKey() ).build();
+    }
+
+    @Before
+    public void setUp()
+    {
+        dhisJwtAuthenticationManagerResolver.setJwtDecoder( jwtDecoder );
+
+        dhisOidcProviderRepository.clear();
+    }
+
+    private Jwt createJwt( String provider, String clientId, String mappingKey, String mappingValue )
+    {
+        JoseHeader joseHeader = TestJoseHeaders.joseHeader( provider ).build();
+        JwtClaimsSet jwtClaimsSet = TestJwtClaimsSets.jwtClaimsSet( provider, clientId, mappingKey,
+            mappingValue ).build();
+
+        return jwsEncoder.encode( joseHeader, jwtClaimsSet );
+    }
+
+    @Test
+    public void testJwkEncodeEndDecode()
+        throws JOSEException
+    {
+        Jwt encodedJws = createJwt( TEST_PROVIDER_ONE_URI, CLIENT_ID_1, DEFAULT_MAPPING_CLAIM, DEFAULT_EMAIL );
+
+        assertEquals( "JWT", encodedJws.getHeaders().get( JoseHeaderNames.TYP ) );
+        assertEquals( defaultRSA.getKeyID(), encodedJws.getHeaders().get( JoseHeaderNames.KID ) );
+        assertNotNull( encodedJws.getId() );
+
+        String tokenValue = encodedJws.getTokenValue();
+
+        jwtDecoder.decode( tokenValue );
+    }
+
+    @Test
+    public void testSuccessfulRequest()
+    {
+        setupTestingProvider( CLIENT_ID_1, TEST_PROVIDER_ONE_NAME, TEST_PROVIDER_ONE_URI );
+
+        User openIDUser = createOpenIDUser( "openiduser", "openiduser@oidc.org" );
+
+        String tokenValue = createJwt( TEST_PROVIDER_ONE_URI, CLIENT_ID_1, "email", "openiduser@oidc.org" )
+            .getTokenValue();
+
+        JsonUser as = GET( tokenValue, "/me?fields=settings,id" ).content().as( JsonUser.class );
+        assertEquals( openIDUser.getUid(), as.getId() );
+    }
+
+    @Test
+    public void testMalformedToken()
+    {
+        JsonError error = GET( "NOT_A_JWT_TOKEN", "/me" ).error( HttpStatus.UNAUTHORIZED );
+
+        assertEquals( "invalid_token", error.getMessage() );
+        assertEquals( "Invalid JWT serialization: Missing dot delimiter(s)",
+            error.getDevMessage() );
+    }
+
+    @Test
+    public void testExpiredToken()
+    {
+        dhisJwtAuthenticationManagerResolver.setJwtDecoder( null );
+
+        setupGoogleProvider( GOOGLE_CLIENT_ID );
+
+        JsonError error = GET( EXPIRED_GOOGLE_JWT_TOKEN, "/me" ).error( HttpStatus.UNAUTHORIZED );
+
+        assertEquals( "invalid_token", error.getMessage() );
+        assertEquals( "An error occurred while attempting to decode the Jwt: Jwt expired at 2021-03-05T16:19:50Z",
+            error.getDevMessage() );
+    }
+
+    @Test
+    public void testMissingUser()
+    {
+        setupTestingProvider( CLIENT_ID_1, TEST_PROVIDER_ONE_NAME, TEST_PROVIDER_ONE_URI );
+
+        String tokenValue = createJwt( TEST_PROVIDER_ONE_URI, CLIENT_ID_1, DEFAULT_MAPPING_CLAIM, DEFAULT_EMAIL )
+            .getTokenValue();
+
+        JsonError error = GET( tokenValue, "/me" ).error( HttpStatus.UNAUTHORIZED );
+
+        assertEquals( "invalid_token", error.getMessage() );
+        assertEquals( "Found no matching DHIS2 user for the mapping claim:'email' with the value:'admin@dhis2.org'",
+            error.getDevMessage() );
+    }
+
+    @Test
+    public void testNoClientMatch()
+    {
+        String providerURI = "testprovidertwo.com";
+
+        setupTestingProvider( "client-2", "testprovidertwo", providerURI );
+
+        String tokenValue = createJwt( providerURI, CLIENT_ID_1, DEFAULT_MAPPING_CLAIM, DEFAULT_EMAIL ).getTokenValue();
+
+        JsonError error = GET( tokenValue, "/me" ).error( HttpStatus.UNAUTHORIZED );
+
+        assertEquals( "invalid_token", error.getMessage() );
+        assertEquals( "Invalid audience", error.getDevMessage() );
+    }
+
+    private void setupGoogleProvider( String clientId )
+    {
+        Properties config = new Properties();
+        config.put( ConfigurationKey.OIDC_PROVIDER_GOOGLE_CLIENT_ID.getKey(), clientId );
+        config.put( ConfigurationKey.OIDC_PROVIDER_GOOGLE_CLIENT_SECRET.getKey(), "secret" );
+        DhisOidcClientRegistration parse = GoogleProvider.parse( config );
+        dhisOidcProviderRepository.addRegistration( parse );
+    }
+
+    private void setupTestingProvider( String clientId, String providerName, final String providerURI )
+    {
+        Properties config = new Properties();
+
+        config.put( "oidc.provider." + providerName + ".client_id", clientId );
+        config.put( "oidc.provider." + providerName + ".client_secret", "secret" );
+        config.put( "oidc.provider." + providerName + ".issuer_uri", "https://" + providerURI );
+        config.put( "oidc.provider." + providerName + ".authorization_uri", "https://" + providerURI + "/authorize" );
+        config.put( "oidc.provider." + providerName + ".token_uri", "https://" + providerURI + "/token" );
+        config.put( "oidc.provider." + providerName + ".user_info_uri", "https://" + providerURI + "/userinfo" );
+        config.put( "oidc.provider." + providerName + ".jwk_uri", "https://" + providerURI + "/jwk" );
+
+        GenericOidcProviderConfigParser.parse( config ).forEach( dhisOidcProviderRepository::addRegistration );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JoseHeader.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JoseHeader.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.springframework.security.oauth2.core.converter.ClaimConversionService;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
+import org.springframework.util.Assert;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public final class JoseHeader
+{
+    private final Map<String, Object> headers;
+
+    private JoseHeader( Map<String, Object> headers )
+    {
+        this.headers = Collections.unmodifiableMap( new HashMap<>( headers ) );
+    }
+
+    public JwsAlgorithm getJwsAlgorithm()
+    {
+        return getHeader( JoseHeaderNames.ALG );
+    }
+
+    public URL getJwkSetUri()
+    {
+        return getHeader( JoseHeaderNames.JKU );
+    }
+
+    public Map<String, Object> getJwk()
+    {
+        return getHeader( JoseHeaderNames.JWK );
+    }
+
+    public String getKeyId()
+    {
+        return getHeader( JoseHeaderNames.KID );
+    }
+
+    public URL getX509Uri()
+    {
+        return getHeader( JoseHeaderNames.X5U );
+    }
+
+    public List<String> getX509CertificateChain()
+    {
+        return getHeader( JoseHeaderNames.X5C );
+    }
+
+    public String getX509SHA1Thumbprint()
+    {
+        return getHeader( JoseHeaderNames.X5T );
+    }
+
+    public String getX509SHA256Thumbprint()
+    {
+        return getHeader( JoseHeaderNames.X5T_S256 );
+    }
+
+    public Set<String> getCritical()
+    {
+        return getHeader( JoseHeaderNames.CRIT );
+    }
+
+    public String getType()
+    {
+        return getHeader( JoseHeaderNames.TYP );
+    }
+
+    public String getContentType()
+    {
+        return getHeader( JoseHeaderNames.CTY );
+    }
+
+    public Map<String, Object> getHeaders()
+    {
+        return this.headers;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public <T> T getHeader( String name )
+    {
+        Assert.hasText( name, "name cannot be empty" );
+        return (T) getHeaders().get( name );
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder withAlgorithm( JwsAlgorithm jwsAlgorithm )
+    {
+        return new Builder( jwsAlgorithm );
+    }
+
+    public static Builder from( JoseHeader headers )
+    {
+        return new Builder( headers );
+    }
+
+    public static final class Builder
+    {
+        private final Map<String, Object> headers = new HashMap<>();
+
+        private Builder()
+        {
+        }
+
+        private Builder( JwsAlgorithm jwsAlgorithm )
+        {
+            Assert.notNull( jwsAlgorithm, "jwsAlgorithm cannot be null" );
+            header( JoseHeaderNames.ALG, jwsAlgorithm );
+        }
+
+        private Builder( JoseHeader headers )
+        {
+            Assert.notNull( headers, "headers cannot be null" );
+            this.headers.putAll( headers.getHeaders() );
+        }
+
+        public Builder jwsAlgorithm( JwsAlgorithm jwsAlgorithm )
+        {
+            return header( JoseHeaderNames.ALG, jwsAlgorithm );
+        }
+
+        public Builder jwkSetUri( String jwkSetUri )
+        {
+            return header( JoseHeaderNames.JKU, jwkSetUri );
+        }
+
+        public Builder jwk( Map<String, Object> jwk )
+        {
+            return header( JoseHeaderNames.JWK, jwk );
+        }
+
+        public Builder keyId( String keyId )
+        {
+            return header( JoseHeaderNames.KID, keyId );
+        }
+
+        public Builder x509Uri( String x509Uri )
+        {
+            return header( JoseHeaderNames.X5U, x509Uri );
+        }
+
+        public Builder x509CertificateChain( List<String> x509CertificateChain )
+        {
+            return header( JoseHeaderNames.X5C, x509CertificateChain );
+        }
+
+        public Builder x509SHA1Thumbprint( String x509SHA1Thumbprint )
+        {
+            return header( JoseHeaderNames.X5T, x509SHA1Thumbprint );
+        }
+
+        public Builder x509SHA256Thumbprint( String x509SHA256Thumbprint )
+        {
+            return header( JoseHeaderNames.X5T_S256, x509SHA256Thumbprint );
+        }
+
+        public Builder critical( Set<String> headerNames )
+        {
+            return header( JoseHeaderNames.CRIT, headerNames );
+        }
+
+        public Builder type( String type )
+        {
+            return header( JoseHeaderNames.TYP, type );
+        }
+
+        public Builder contentType( String contentType )
+        {
+            return header( JoseHeaderNames.CTY, contentType );
+        }
+
+        public Builder header( String name, Object value )
+        {
+            Assert.hasText( name, "name cannot be empty" );
+            Assert.notNull( value, "value cannot be null" );
+            this.headers.put( name, value );
+            return this;
+        }
+
+        public Builder headers( Consumer<Map<String, Object>> headersConsumer )
+        {
+            headersConsumer.accept( this.headers );
+            return this;
+        }
+
+        public JoseHeader build()
+        {
+            Assert.notEmpty( this.headers, "headers cannot be empty" );
+            convertAsURL( JoseHeaderNames.JKU );
+            convertAsURL( JoseHeaderNames.X5U );
+            return new JoseHeader( this.headers );
+        }
+
+        private void convertAsURL( String header )
+        {
+            Object value = this.headers.get( header );
+            if ( value != null )
+            {
+                URL convertedValue = ClaimConversionService.getSharedInstance().convert( value, URL.class );
+                Assert.isTrue( convertedValue != null,
+                    () -> "Unable to convert header '" + header + "' of type '" + value.getClass() + "' to URL." );
+                this.headers.put( header, convertedValue );
+            }
+        }
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JoseHeaderNames.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JoseHeaderNames.java
@@ -25,52 +25,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.security.oidc;
-
-import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.CLIENT_ID;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import lombok.Builder;
-import lombok.Data;
-
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
+package org.hisp.dhis.webapi.security.utils;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
-@Builder
-public class DhisOidcClientRegistration
+public final class JoseHeaderNames
 {
-    private final ClientRegistration clientRegistration;
+    public static final String ALG = "alg";
 
-    private final String mappingClaimKey;
+    public static final String JKU = "jku";
 
-    private final String loginIcon;
+    public static final String JWK = "jwk";
 
-    private final String loginIconPadding;
+    public static final String KID = "kid";
 
-    private final String loginText;
+    public static final String X5U = "x5u";
 
-    @Builder.Default
-    private final Map<String, Map<String, String>> externalClients = new HashMap<>();
+    public static final String X5C = "x5c";
 
-    public Collection<String> getClientIds()
+    public static final String X5T = "x5t";
+
+    public static final String X5T_S256 = "x5t#S256";
+
+    public static final String TYP = "typ";
+
+    public static final String CTY = "cty";
+
+    public static final String CRIT = "crit";
+
+    private JoseHeaderNames()
     {
-        Set<String> allExternalClientIds = externalClients.entrySet()
-            .stream()
-            .flatMap( e -> e.getValue().entrySet().stream() )
-            .filter( e -> e.getKey().contains( CLIENT_ID ) )
-            .map( Map.Entry::getValue )
-            .collect( Collectors.toSet() );
-
-        allExternalClientIds.add( clientRegistration.getClientId() );
-        return Collections.unmodifiableSet( allExternalClientIds );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/Jwks.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/Jwks.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.security.KeyPair;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.RSAKey;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public final class Jwks
+{
+    private Jwks()
+    {
+    }
+
+    public static RSAKey generateRsa()
+    {
+        KeyPair keyPair = KeyGeneratorUtils.generateRsaKey();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        // @formatter:off
+		return new RSAKey.Builder(publicKey)
+				.privateKey(privateKey)
+				.keyID(UUID.randomUUID().toString())
+				.build();
+		// @formatter:on
+    }
+
+    public static ECKey generateEc()
+    {
+        KeyPair keyPair = KeyGeneratorUtils.generateEcKey();
+        ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
+        ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
+        Curve curve = Curve.forECParameterSpec( publicKey.getParams() );
+        // @formatter:off
+		return new ECKey.Builder(curve, publicKey)
+				.privateKey(privateKey)
+				.keyID(UUID.randomUUID().toString())
+				.build();
+		// @formatter:on
+    }
+
+    public static OctetSequenceKey generateSecret()
+    {
+        SecretKey secretKey = KeyGeneratorUtils.generateSecretKey();
+        // @formatter:off
+		return new OctetSequenceKey.Builder(secretKey)
+				.keyID(UUID.randomUUID().toString())
+				.build();
+		// @formatter:on
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JwtClaimsSet.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JwtClaimsSet.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.springframework.security.oauth2.jwt.JwtClaimAccessor;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.util.Assert;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public final class JwtClaimsSet implements JwtClaimAccessor
+{
+    private final Map<String, Object> claims;
+
+    private JwtClaimsSet( Map<String, Object> claims )
+    {
+        this.claims = Collections.unmodifiableMap( new HashMap<>( claims ) );
+    }
+
+    @Override
+    public Map<String, Object> getClaims()
+    {
+        return this.claims;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder from( JwtClaimsSet claims )
+    {
+        return new Builder( claims );
+    }
+
+    public static final class Builder
+    {
+        private final Map<String, Object> claims = new HashMap<>();
+
+        private Builder()
+        {
+        }
+
+        private Builder( JwtClaimsSet claims )
+        {
+            Assert.notNull( claims, "claims cannot be null" );
+            this.claims.putAll( claims.getClaims() );
+        }
+
+        public Builder issuer( String issuer )
+        {
+            return claim( JwtClaimNames.ISS, issuer );
+        }
+
+        public Builder subject( String subject )
+        {
+            return claim( JwtClaimNames.SUB, subject );
+        }
+
+        public Builder audience( List<String> audience )
+        {
+            return claim( JwtClaimNames.AUD, audience );
+        }
+
+        public Builder expiresAt( Instant expiresAt )
+        {
+            return claim( JwtClaimNames.EXP, expiresAt );
+        }
+
+        public Builder notBefore( Instant notBefore )
+        {
+            return claim( JwtClaimNames.NBF, notBefore );
+        }
+
+        public Builder issuedAt( Instant issuedAt )
+        {
+            return claim( JwtClaimNames.IAT, issuedAt );
+        }
+
+        public Builder id( String jti )
+        {
+            return claim( JwtClaimNames.JTI, jti );
+        }
+
+        public Builder claim( String name, Object value )
+        {
+            Assert.hasText( name, "name cannot be empty" );
+            Assert.notNull( value, "value cannot be null" );
+            this.claims.put( name, value );
+            return this;
+        }
+
+        public Builder claims( Consumer<Map<String, Object>> claimsConsumer )
+        {
+            claimsConsumer.accept( this.claims );
+            return this;
+        }
+
+        public JwtClaimsSet build()
+        {
+            Assert.notEmpty( this.claims, "claims cannot be empty" );
+            return new JwtClaimsSet( this.claims );
+        }
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JwtEncodingException.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JwtEncodingException.java
@@ -25,52 +25,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.security.oidc;
+package org.hisp.dhis.webapi.security.utils;
 
-import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.CLIENT_ID;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import lombok.Builder;
-import lombok.Data;
-
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.jwt.JwtException;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
-@Builder
-public class DhisOidcClientRegistration
+public class JwtEncodingException extends JwtException
 {
-    private final ClientRegistration clientRegistration;
-
-    private final String mappingClaimKey;
-
-    private final String loginIcon;
-
-    private final String loginIconPadding;
-
-    private final String loginText;
-
-    @Builder.Default
-    private final Map<String, Map<String, String>> externalClients = new HashMap<>();
-
-    public Collection<String> getClientIds()
+    public JwtEncodingException( String message )
     {
-        Set<String> allExternalClientIds = externalClients.entrySet()
-            .stream()
-            .flatMap( e -> e.getValue().entrySet().stream() )
-            .filter( e -> e.getKey().contains( CLIENT_ID ) )
-            .map( Map.Entry::getValue )
-            .collect( Collectors.toSet() );
+        super( message );
+    }
 
-        allExternalClientIds.add( clientRegistration.getClientId() );
-        return Collections.unmodifiableSet( allExternalClientIds );
+    public JwtEncodingException( String message, Throwable cause )
+    {
+        super( message, cause );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JwtUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/JwtUtils.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.net.URL;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import net.minidev.json.JSONObject;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.produce.JWSSignerFactory;
+import com.nimbusds.jose.util.Base64;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class JwtUtils
+{
+    private static final String ENCODING_ERROR_MESSAGE_TEMPLATE = "An error occurred while attempting to encode the Jwt: %s";
+
+    private static final JWSSignerFactory JWS_SIGNER_FACTORY = new DefaultJWSSignerFactory();
+
+    private static final Converter<JoseHeader, JWSHeader> JWS_HEADER_CONVERTER = new JwsHeaderConverter();
+
+    private static final Converter<JwtClaimsSet, JWTClaimsSet> JWT_CLAIMS_SET_CONVERTER = new JwtClaimsSetConverter();
+
+    private final Map<JWK, JWSSigner> jwsSigners = new ConcurrentHashMap<>();
+
+    private final JWKSource<SecurityContext> jwkSource;
+
+    public JWKSource<SecurityContext> jwkSource()
+    {
+        RSAKey rsaKey = Jwks.generateRsa();
+        JWKSet jwkSet = new JWKSet( rsaKey );
+        return ( jwkSelector, securityContext ) -> jwkSelector.select( jwkSet );
+    }
+
+    public JwtUtils()
+    {
+        this.jwkSource = jwkSource();
+    }
+
+    public JwtUtils( JWKSource<SecurityContext> jwkSource )
+    {
+        this.jwkSource = jwkSource;
+    }
+
+    public Jwt encode( JoseHeader headers, JwtClaimsSet claims )
+        throws JwtEncodingException
+    {
+        Assert.notNull( headers, "headers cannot be null" );
+        Assert.notNull( claims, "claims cannot be null" );
+
+        JWK jwk = selectJwk( headers );
+        if ( jwk == null )
+        {
+            throw new JwtEncodingException(
+                String.format( ENCODING_ERROR_MESSAGE_TEMPLATE, "Failed to select a JWK signing key" ) );
+        }
+        else if ( !StringUtils.hasText( jwk.getKeyID() ) )
+        {
+            throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                "The \"kid\" (key ID) from the selected JWK cannot be empty" ) );
+        }
+
+        headers = JoseHeader.from( headers )
+            .type( JOSEObjectType.JWT.getType() )
+            .keyId( jwk.getKeyID() )
+            .build();
+        claims = JwtClaimsSet.from( claims )
+            .id( UUID.randomUUID().toString() )
+            .build();
+
+        JWSHeader jwsHeader = JWS_HEADER_CONVERTER.convert( headers );
+        JWTClaimsSet jwtClaimsSet = JWT_CLAIMS_SET_CONVERTER.convert( claims );
+
+        JWSSigner jwsSigner = this.jwsSigners.computeIfAbsent( jwk, ( key ) -> {
+            try
+            {
+                return JWS_SIGNER_FACTORY.createJWSSigner( key );
+            }
+            catch ( JOSEException ex )
+            {
+                throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                    "Failed to create a JWS Signer -> " + ex.getMessage() ), ex );
+            }
+        } );
+
+        SignedJWT signedJwt = new SignedJWT( jwsHeader, jwtClaimsSet );
+        try
+        {
+            signedJwt.sign( jwsSigner );
+        }
+        catch ( JOSEException ex )
+        {
+            throw new JwtEncodingException(
+                String.format( ENCODING_ERROR_MESSAGE_TEMPLATE, "Failed to sign the JWT -> " + ex.getMessage() ), ex );
+        }
+        String jws = signedJwt.serialize();
+
+        return new Jwt( jws, claims.getIssuedAt(), claims.getExpiresAt(), headers.getHeaders(), claims.getClaims() );
+    }
+
+    private static class JwsHeaderConverter implements Converter<JoseHeader, JWSHeader>
+    {
+
+        @Override
+        public JWSHeader convert( JoseHeader headers )
+        {
+            JWSHeader.Builder builder = new JWSHeader.Builder(
+                JWSAlgorithm.parse( headers.getJwsAlgorithm().getName() ) );
+
+            Set<String> critical = headers.getCritical();
+            if ( !CollectionUtils.isEmpty( critical ) )
+            {
+                builder.criticalParams( critical );
+            }
+
+            String contentType = headers.getContentType();
+            if ( StringUtils.hasText( contentType ) )
+            {
+                builder.contentType( contentType );
+            }
+
+            URL jwkSetUri = headers.getJwkSetUri();
+            if ( jwkSetUri != null )
+            {
+                try
+                {
+                    builder.jwkURL( jwkSetUri.toURI() );
+                }
+                catch ( Exception ex )
+                {
+                    throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                        "Failed to convert '" + JoseHeaderNames.JKU + "' JOSE header to a URI" ), ex );
+                }
+            }
+
+            Map<String, Object> jwk = headers.getJwk();
+            if ( !CollectionUtils.isEmpty( jwk ) )
+            {
+                try
+                {
+                    builder.jwk( JWK.parse( new JSONObject( jwk ) ) );
+                }
+                catch ( Exception ex )
+                {
+                    throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                        "Failed to convert '" + JoseHeaderNames.JWK + "' JOSE header" ), ex );
+                }
+            }
+
+            String keyId = headers.getKeyId();
+            if ( StringUtils.hasText( keyId ) )
+            {
+                builder.keyID( keyId );
+            }
+
+            String type = headers.getType();
+            if ( StringUtils.hasText( type ) )
+            {
+                builder.type( new JOSEObjectType( type ) );
+            }
+
+            List<String> x509CertificateChain = headers.getX509CertificateChain();
+            if ( !CollectionUtils.isEmpty( x509CertificateChain ) )
+            {
+                builder
+                    .x509CertChain( x509CertificateChain.stream().map( Base64::new ).collect( Collectors.toList() ) );
+            }
+
+            String x509SHA1Thumbprint = headers.getX509SHA1Thumbprint();
+            if ( StringUtils.hasText( x509SHA1Thumbprint ) )
+            {
+                builder.x509CertThumbprint( new Base64URL( x509SHA1Thumbprint ) );
+            }
+
+            String x509SHA256Thumbprint = headers.getX509SHA256Thumbprint();
+            if ( StringUtils.hasText( x509SHA256Thumbprint ) )
+            {
+                builder.x509CertSHA256Thumbprint( new Base64URL( x509SHA256Thumbprint ) );
+            }
+
+            URL x509Uri = headers.getX509Uri();
+            if ( x509Uri != null )
+            {
+                try
+                {
+                    builder.x509CertURL( x509Uri.toURI() );
+                }
+                catch ( Exception ex )
+                {
+                    throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                        "Failed to convert '" + JoseHeaderNames.X5U + "' JOSE header to a URI" ), ex );
+                }
+            }
+
+            Map<String, Object> customHeaders = headers.getHeaders().entrySet().stream()
+                .filter( ( header ) -> !JWSHeader.getRegisteredParameterNames().contains( header.getKey() ) )
+                .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+            if ( !CollectionUtils.isEmpty( customHeaders ) )
+            {
+                builder.customParams( customHeaders );
+            }
+
+            return builder.build();
+        }
+
+    }
+
+    private static class JwtClaimsSetConverter implements Converter<JwtClaimsSet, JWTClaimsSet>
+    {
+
+        @Override
+        public JWTClaimsSet convert( JwtClaimsSet claims )
+        {
+            JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder();
+
+            URL issuer = claims.getIssuer();
+            if ( issuer != null )
+            {
+                builder.issuer( issuer.toExternalForm() );
+            }
+
+            String subject = claims.getSubject();
+            if ( StringUtils.hasText( subject ) )
+            {
+                builder.subject( subject );
+            }
+
+            List<String> audience = claims.getAudience();
+            if ( !CollectionUtils.isEmpty( audience ) )
+            {
+                builder.audience( audience );
+            }
+
+            Instant issuedAt = claims.getIssuedAt();
+            if ( issuedAt != null )
+            {
+                builder.issueTime( Date.from( issuedAt ) );
+            }
+
+            Instant expiresAt = claims.getExpiresAt();
+            if ( expiresAt != null )
+            {
+                builder.expirationTime( Date.from( expiresAt ) );
+            }
+
+            Instant notBefore = claims.getNotBefore();
+            if ( notBefore != null )
+            {
+                builder.notBeforeTime( Date.from( notBefore ) );
+            }
+
+            String jwtId = claims.getId();
+            if ( StringUtils.hasText( jwtId ) )
+            {
+                builder.jwtID( jwtId );
+            }
+
+            Map<String, Object> customClaims = claims.getClaims().entrySet().stream()
+                .filter( ( claim ) -> !JWTClaimsSet.getRegisteredNames().contains( claim.getKey() ) )
+                .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+            if ( !CollectionUtils.isEmpty( customClaims ) )
+            {
+                customClaims.forEach( builder::claim );
+            }
+
+            return builder.build();
+        }
+
+    }
+
+    private JWK selectJwk( JoseHeader headers )
+    {
+        JWSAlgorithm jwsAlgorithm = JWSAlgorithm.parse( headers.getJwsAlgorithm().getName() );
+        JWSHeader jwsHeader = new JWSHeader( jwsAlgorithm );
+        JWKSelector jwkSelector = new JWKSelector( JWKMatcher.forJWSHeader( jwsHeader ) );
+
+        List<JWK> jwks;
+        try
+        {
+            jwks = this.jwkSource.get( jwkSelector, null );
+        }
+        catch ( KeySourceException ex )
+        {
+            throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                "Failed to select a JWK signing key -> " + ex.getMessage() ), ex );
+        }
+
+        if ( jwks.size() > 1 )
+        {
+            throw new JwtEncodingException( String.format( ENCODING_ERROR_MESSAGE_TEMPLATE,
+                "Found multiple JWK signing keys for algorithm '" + jwsAlgorithm.getName() + "'" ) );
+        }
+
+        return !jwks.isEmpty() ? jwks.get( 0 ) : null;
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/KeyGeneratorUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/KeyGeneratorUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.EllipticCurve;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+final class KeyGeneratorUtils
+{
+    private KeyGeneratorUtils()
+    {
+    }
+
+    static SecretKey generateSecretKey()
+    {
+        SecretKey hmacKey;
+        try
+        {
+            hmacKey = KeyGenerator.getInstance( "HmacSha256" ).generateKey();
+        }
+        catch ( Exception ex )
+        {
+            throw new IllegalStateException( ex );
+        }
+
+        return hmacKey;
+    }
+
+    static KeyPair generateRsaKey()
+    {
+        KeyPair keyPair;
+        try
+        {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA" );
+            keyPairGenerator.initialize( 2048 );
+            keyPair = keyPairGenerator.generateKeyPair();
+        }
+        catch ( Exception ex )
+        {
+            throw new IllegalStateException( ex );
+        }
+
+        return keyPair;
+    }
+
+    static KeyPair generateEcKey()
+    {
+        EllipticCurve ellipticCurve = new EllipticCurve( new ECFieldFp(
+            new BigInteger( "115792089210356248762697446949407573530086143415290314195533631308867097853951" ) ),
+            new BigInteger( "115792089210356248762697446949407573530086143415290314195533631308867097853948" ),
+            new BigInteger( "41058363725152142129326129780047268409114441015993725554835256314039467401291" ) );
+
+        ECPoint ecPoint = new ECPoint(
+            new BigInteger( "48439561293906451759052585252797914202762949526041747995844080717082404635286" ),
+            new BigInteger( "36134250956749795798585127919587881956611106672985015071877198253568414405109" ) );
+
+        ECParameterSpec ecParameterSpec = new ECParameterSpec(
+            ellipticCurve,
+            ecPoint,
+            new BigInteger( "115792089210356248762697446949407573529996955224135760342422259061068512044369" ),
+            1 );
+
+        KeyPair keyPair;
+        try
+        {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "EC" );
+            keyPairGenerator.initialize( ecParameterSpec );
+            keyPair = keyPairGenerator.generateKeyPair();
+        }
+        catch ( Exception ex )
+        {
+            throw new IllegalStateException( ex );
+        }
+
+        return keyPair;
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestJoseHeaders.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestJoseHeaders.java
@@ -25,52 +25,49 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.security.oidc;
+package org.hisp.dhis.webapi.security.utils;
 
-import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.CLIENT_ID;
-
-import java.util.Collection;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import lombok.Builder;
-import lombok.Data;
-
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
-@Builder
-public class DhisOidcClientRegistration
+public final class TestJoseHeaders
 {
-    private final ClientRegistration clientRegistration;
-
-    private final String mappingClaimKey;
-
-    private final String loginIcon;
-
-    private final String loginIconPadding;
-
-    private final String loginText;
-
-    @Builder.Default
-    private final Map<String, Map<String, String>> externalClients = new HashMap<>();
-
-    public Collection<String> getClientIds()
+    private TestJoseHeaders()
     {
-        Set<String> allExternalClientIds = externalClients.entrySet()
-            .stream()
-            .flatMap( e -> e.getValue().entrySet().stream() )
-            .filter( e -> e.getKey().contains( CLIENT_ID ) )
-            .map( Map.Entry::getValue )
-            .collect( Collectors.toSet() );
+    }
 
-        allExternalClientIds.add( clientRegistration.getClientId() );
-        return Collections.unmodifiableSet( allExternalClientIds );
+    public static JoseHeader.Builder joseHeader( String provider )
+    {
+        return joseHeader( SignatureAlgorithm.RS256, provider );
+    }
+
+    public static JoseHeader.Builder joseHeader( SignatureAlgorithm signatureAlgorithm, String provider )
+    {
+        return JoseHeader.withAlgorithm( signatureAlgorithm )
+            .jwkSetUri( "https://" + provider + "/oauth2/jwks" )
+            .jwk( rsaJwk() )
+            .keyId( "keyId" )
+            .x509Uri( "https://" + provider + "/oauth2/x509" )
+            .x509CertificateChain( Arrays.asList( "x509Cert1", "x509Cert2" ) )
+            .x509SHA1Thumbprint( "x509SHA1Thumbprint" )
+            .x509SHA256Thumbprint( "x509SHA256Thumbprint" )
+            .type( "JWT" )
+            .contentType( "jwt-content-type" )
+            .header( "custom-header-name", "custom-header-value" );
+    }
+
+    private static Map<String, Object> rsaJwk()
+    {
+        Map<String, Object> rsaJwk = new HashMap<>();
+        rsaJwk.put( "kty", "RSA" );
+        rsaJwk.put( "n", "modulus" );
+        rsaJwk.put( "e", "exponent" );
+        return rsaJwk;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestJwks.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestJwks.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import javax.crypto.SecretKey;
+
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.RSAKey;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public final class TestJwks
+{
+    public static final RSAKey DEFAULT_RSA_JWK = jwk(
+        TestKeys.DEFAULT_PUBLIC_KEY,
+        TestKeys.DEFAULT_PRIVATE_KEY ).build();
+
+    public static final ECKey DEFAULT_EC_JWK = jwk(
+        (ECPublicKey) TestKeys.DEFAULT_EC_KEY_PAIR.getPublic(),
+        (ECPrivateKey) TestKeys.DEFAULT_EC_KEY_PAIR.getPrivate() ).build();
+
+    public static final OctetSequenceKey DEFAULT_SECRET_JWK = jwk(
+        TestKeys.DEFAULT_SECRET_KEY ).build();
+
+    private TestJwks()
+    {
+    }
+
+    public static RSAKey.Builder jwk( RSAPublicKey publicKey, RSAPrivateKey privateKey )
+    {
+        return new RSAKey.Builder( publicKey )
+            .privateKey( privateKey )
+            .keyUse( KeyUse.SIGNATURE )
+            .keyID( "rsa-jwk-kid" );
+    }
+
+    public static ECKey.Builder jwk( ECPublicKey publicKey, ECPrivateKey privateKey )
+    {
+        Curve curve = Curve.forECParameterSpec( publicKey.getParams() );
+        return new ECKey.Builder( curve, publicKey )
+            .privateKey( privateKey )
+            .keyUse( KeyUse.SIGNATURE )
+            .keyID( "ec-jwk-kid" );
+    }
+
+    public static OctetSequenceKey.Builder jwk( SecretKey secretKey )
+    {
+        return new OctetSequenceKey.Builder( secretKey )
+            .keyUse( KeyUse.SIGNATURE )
+            .keyID( "secret-jwk-kid" );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestJwtClaimsSets.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestJwtClaimsSets.java
@@ -25,52 +25,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.security.oidc;
+package org.hisp.dhis.webapi.security.utils;
 
-import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.CLIENT_ID;
-
-import java.util.Collection;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import lombok.Builder;
-import lombok.Data;
-
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
-@Builder
-public class DhisOidcClientRegistration
+public final class TestJwtClaimsSets
 {
-    private final ClientRegistration clientRegistration;
-
-    private final String mappingClaimKey;
-
-    private final String loginIcon;
-
-    private final String loginIconPadding;
-
-    private final String loginText;
-
-    @Builder.Default
-    private final Map<String, Map<String, String>> externalClients = new HashMap<>();
-
-    public Collection<String> getClientIds()
+    private TestJwtClaimsSets()
     {
-        Set<String> allExternalClientIds = externalClients.entrySet()
-            .stream()
-            .flatMap( e -> e.getValue().entrySet().stream() )
-            .filter( e -> e.getKey().contains( CLIENT_ID ) )
-            .map( Map.Entry::getValue )
-            .collect( Collectors.toSet() );
+    }
 
-        allExternalClientIds.add( clientRegistration.getClientId() );
-        return Collections.unmodifiableSet( allExternalClientIds );
+    public static JwtClaimsSet.Builder jwtClaimsSet( final String providerURI, String clientId,
+        String customClaimKey1, String customClaimValue1 )
+    {
+        String issuer = "https://" + providerURI;
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plus( 1, ChronoUnit.HOURS );
+
+        return JwtClaimsSet.builder()
+            .issuer( issuer )
+            .subject( "subject" )
+            .audience( Collections.singletonList( clientId ) )
+            .issuedAt( issuedAt )
+            .notBefore( issuedAt )
+            .expiresAt( expiresAt )
+            .id( "jti" )
+            .claim( customClaimKey1, customClaimValue1 );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestKeys.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/utils/TestKeys.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.utils;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.EllipticCurve;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public final class TestKeys
+{
+    public static final KeyFactory kf;
+    static
+    {
+        try
+        {
+            kf = KeyFactory.getInstance( "RSA" );
+        }
+        catch ( NoSuchAlgorithmException ex )
+        {
+            throw new IllegalStateException( ex );
+        }
+    }
+
+    public static final String DEFAULT_ENCODED_SECRET_KEY = "bCzY/M48bbkwBEWjmNSIEPfwApcvXOnkCxORBEbPr+4=";
+
+    public static final SecretKey DEFAULT_SECRET_KEY = new SecretKeySpec(
+        Base64.getDecoder().decode( DEFAULT_ENCODED_SECRET_KEY ), "AES" );
+
+    public static final String DEFAULT_RSA_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3FlqJr5TRskIQIgdE3Dd"
+        + "7D9lboWdcTUT8a+fJR7MAvQm7XXNoYkm3v7MQL1NYtDvL2l8CAnc0WdSTINU6IRv"
+        + "c5Kqo2Q4csNX9SHOmEfzoROjQqahEcve1jBXluoCXdYuYpx4/1tfRgG6ii4Uhxh6"
+        + "iI8qNMJQX+fLfqhbfYfxBQVRPywBkAbIP4x1EAsbC6FSNmkhCxiMNqEgxaIpY8C2"
+        + "kJdJ/ZIV+WW4noDdzpKqHcwmB8FsrumlVY/DNVvUSDIipiq9PbP4H99TXN1o746o"
+        + "RaNa07rq1hoCgMSSy+85SagCoxlmyE+D+of9SsMY8Ol9t0rdzpobBuhyJ/o5dfvj"
+        + "KwIDAQAB";
+
+    public static final RSAPublicKey DEFAULT_PUBLIC_KEY;
+    static
+    {
+        X509EncodedKeySpec spec = new X509EncodedKeySpec( Base64.getDecoder().decode( DEFAULT_RSA_PUBLIC_KEY ) );
+        try
+        {
+            DEFAULT_PUBLIC_KEY = (RSAPublicKey) kf.generatePublic( spec );
+        }
+        catch ( InvalidKeySpecException ex )
+        {
+            throw new IllegalArgumentException( ex );
+        }
+    }
+
+    public static final String DEFAULT_RSA_PRIVATE_KEY = "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDcWWomvlNGyQhA"
+        + "iB0TcN3sP2VuhZ1xNRPxr58lHswC9Cbtdc2hiSbe/sxAvU1i0O8vaXwICdzRZ1JM"
+        + "g1TohG9zkqqjZDhyw1f1Ic6YR/OhE6NCpqERy97WMFeW6gJd1i5inHj/W19GAbqK"
+        + "LhSHGHqIjyo0wlBf58t+qFt9h/EFBVE/LAGQBsg/jHUQCxsLoVI2aSELGIw2oSDF"
+        + "oiljwLaQl0n9khX5ZbiegN3OkqodzCYHwWyu6aVVj8M1W9RIMiKmKr09s/gf31Nc"
+        + "3WjvjqhFo1rTuurWGgKAxJLL7zlJqAKjGWbIT4P6h/1Kwxjw6X23St3OmhsG6HIn"
+        + "+jl1++MrAgMBAAECggEBAMf820wop3pyUOwI3aLcaH7YFx5VZMzvqJdNlvpg1jbE"
+        + "E2Sn66b1zPLNfOIxLcBG8x8r9Ody1Bi2Vsqc0/5o3KKfdgHvnxAB3Z3dPh2WCDek"
+        + "lCOVClEVoLzziTuuTdGO5/CWJXdWHcVzIjPxmK34eJXioiLaTYqN3XKqKMdpD0ZG"
+        + "mtNTGvGf+9fQ4i94t0WqIxpMpGt7NM4RHy3+Onggev0zLiDANC23mWrTsUgect/7"
+        + "62TYg8g1bKwLAb9wCBT+BiOuCc2wrArRLOJgUkj/F4/gtrR9ima34SvWUyoUaKA0"
+        + "bi4YBX9l8oJwFGHbU9uFGEMnH0T/V0KtIB7qetReywkCgYEA9cFyfBIQrYISV/OA"
+        + "+Z0bo3vh2aL0QgKrSXZ924cLt7itQAHNZ2ya+e3JRlTczi5mnWfjPWZ6eJB/8MlH"
+        + "Gpn12o/POEkU+XjZZSPe1RWGt5g0S3lWqyx9toCS9ACXcN9tGbaqcFSVI73zVTRA"
+        + "8J9grR0fbGn7jaTlTX2tnlOTQ60CgYEA5YjYpEq4L8UUMFkuj+BsS3u0oEBnzuHd"
+        + "I9LEHmN+CMPosvabQu5wkJXLuqo2TxRnAznsA8R3pCLkdPGoWMCiWRAsCn979TdY"
+        + "QbqO2qvBAD2Q19GtY7lIu6C35/enQWzJUMQE3WW0OvjLzZ0l/9mA2FBRR+3F9A1d"
+        + "rBdnmv0c3TcCgYEAi2i+ggVZcqPbtgrLOk5WVGo9F1GqUBvlgNn30WWNTx4zIaEk"
+        + "HSxtyaOLTxtq2odV7Kr3LGiKxwPpn/T+Ief+oIp92YcTn+VfJVGw4Z3BezqbR8lA"
+        + "Uf/+HF5ZfpMrVXtZD4Igs3I33Duv4sCuqhEvLWTc44pHifVloozNxYfRfU0CgYBN"
+        + "HXa7a6cJ1Yp829l62QlJKtx6Ymj95oAnQu5Ez2ROiZMqXRO4nucOjGUP55Orac1a"
+        + "FiGm+mC/skFS0MWgW8evaHGDbWU180wheQ35hW6oKAb7myRHtr4q20ouEtQMdQIF"
+        + "snV39G1iyqeeAsf7dxWElydXpRi2b68i3BIgzhzebQKBgQCdUQuTsqV9y/JFpu6H"
+        + "c5TVvhG/ubfBspI5DhQqIGijnVBzFT//UfIYMSKJo75qqBEyP2EJSmCsunWsAFsM"
+        + "TszuiGTkrKcZy9G0wJqPztZZl2F2+bJgnA6nBEV7g5PA4Af+QSmaIhRwqGDAuROR"
+        + "47jndeyIaMTNETEmOnms+as17g==";
+
+    public static final RSAPrivateKey DEFAULT_PRIVATE_KEY;
+    static
+    {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec( Base64.getDecoder().decode( DEFAULT_RSA_PRIVATE_KEY ) );
+        try
+        {
+            DEFAULT_PRIVATE_KEY = (RSAPrivateKey) kf.generatePrivate( spec );
+        }
+        catch ( InvalidKeySpecException ex )
+        {
+            throw new IllegalArgumentException( ex );
+        }
+    }
+
+    public static final KeyPair DEFAULT_RSA_KEY_PAIR = new KeyPair( DEFAULT_PUBLIC_KEY, DEFAULT_PRIVATE_KEY );
+
+    public static final KeyPair DEFAULT_EC_KEY_PAIR = generateEcKeyPair();
+
+    static KeyPair generateEcKeyPair()
+    {
+        EllipticCurve ellipticCurve = new EllipticCurve( new ECFieldFp(
+            new BigInteger( "115792089210356248762697446949407573530086143415290314195533631308867097853951" ) ),
+            new BigInteger( "115792089210356248762697446949407573530086143415290314195533631308867097853948" ),
+            new BigInteger( "41058363725152142129326129780047268409114441015993725554835256314039467401291" ) );
+        ECPoint ecPoint = new ECPoint(
+            new BigInteger( "48439561293906451759052585252797914202762949526041747995844080717082404635286" ),
+            new BigInteger( "36134250956749795798585127919587881956611106672985015071877198253568414405109" ) );
+        ECParameterSpec ecParameterSpec = new ECParameterSpec( ellipticCurve, ecPoint,
+            new BigInteger( "115792089210356248762697446949407573529996955224135760342422259061068512044369" ), 1 );
+
+        KeyPair keyPair;
+        try
+        {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "EC" );
+            keyPairGenerator.initialize( ecParameterSpec );
+            keyPair = keyPairGenerator.generateKeyPair();
+        }
+        catch ( Exception ex )
+        {
+            throw new IllegalStateException( ex );
+        }
+
+        return keyPair;
+    }
+
+    private TestKeys()
+    {
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationListener.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationListener.java
@@ -70,9 +70,11 @@ public class AuthenticationListener
         Authentication auth = event.getAuthentication();
         String username = event.getAuthentication().getName();
 
-        if ( TwoFactorWebAuthenticationDetails.class.isAssignableFrom( auth.getDetails().getClass() ) )
+        Object details = auth.getDetails();
+
+        if ( details != null && TwoFactorWebAuthenticationDetails.class.isAssignableFrom( details.getClass() ) )
         {
-            TwoFactorWebAuthenticationDetails authDetails = (TwoFactorWebAuthenticationDetails) auth.getDetails();
+            TwoFactorWebAuthenticationDetails authDetails = (TwoFactorWebAuthenticationDetails) details;
 
             log.info( String.format( "Login attempt failed for remote IP: %s", authDetails.getIp() ) );
         }
@@ -88,8 +90,8 @@ public class AuthenticationListener
                 username = userCredentials.getUsername();
             }
 
-            WebAuthenticationDetails details = (WebAuthenticationDetails) authenticationToken.getDetails();
-            String remoteAddress = details.getRemoteAddress();
+            WebAuthenticationDetails tokenDetails = (WebAuthenticationDetails) authenticationToken.getDetails();
+            String remoteAddress = tokenDetails.getRemoteAddress();
 
             log.info( String.format( "OIDC login attempt failed for remote IP: %s", remoteAddress ) );
         }
@@ -103,9 +105,11 @@ public class AuthenticationListener
         Authentication auth = event.getAuthentication();
         String username = event.getAuthentication().getName();
 
-        if ( TwoFactorWebAuthenticationDetails.class.isAssignableFrom( auth.getDetails().getClass() ) )
+        Object details = auth.getDetails();
+
+        if ( TwoFactorWebAuthenticationDetails.class.isAssignableFrom( details.getClass() ) )
         {
-            TwoFactorWebAuthenticationDetails authDetails = (TwoFactorWebAuthenticationDetails) auth.getDetails();
+            TwoFactorWebAuthenticationDetails authDetails = (TwoFactorWebAuthenticationDetails) details;
 
             log.debug( String.format( "Login attempt succeeded for remote IP: %s", authDetails.getIp() ) );
         }
@@ -117,8 +121,8 @@ public class AuthenticationListener
             UserCredentials userCredentials = principal.getUserCredentials();
             username = userCredentials.getUsername();
 
-            WebAuthenticationDetails details = (WebAuthenticationDetails) authenticationToken.getDetails();
-            String remoteAddress = details.getRemoteAddress();
+            WebAuthenticationDetails tokenDetails = (WebAuthenticationDetails) authenticationToken.getDetails();
+            String remoteAddress = tokenDetails.getRemoteAddress();
 
             log.debug( String.format( "OIDC login attempt succeeded for remote IP: %s", remoteAddress ) );
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -31,11 +31,16 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.security.jwt.DhisBearerJwtTokenAuthenticationEntryPoint;
+import org.hisp.dhis.security.jwt.DhisJwtAuthenticationManagerResolver;
 import org.hisp.dhis.security.ldap.authentication.CustomLdapAuthenticationProvider;
 import org.hisp.dhis.security.oauth2.DefaultClientDetailsService;
-import org.hisp.dhis.security.oidc.DhisClientRegistrationRepository;
+import org.hisp.dhis.security.oauth2.OAuth2AuthorizationServerEnabledCondition;
 import org.hisp.dhis.security.oidc.DhisCustomAuthorizationRequestResolver;
-import org.hisp.dhis.security.oidc.OidcEnabledCondition;
+import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
+import org.hisp.dhis.security.oidc.OIDCLoginEnabledCondition;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.webapi.filter.CorsFilter;
 import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
@@ -49,7 +54,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
-import org.springframework.security.access.expression.SecurityExpressionHandler;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.ProviderManager;
@@ -58,6 +63,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.authentication.configurers.userdetails.DaoAuthenticationConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurer;
@@ -76,10 +82,10 @@ import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.DefaultSecurityFilterChain;
-import org.springframework.security.web.FilterInvocation;
-import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
@@ -92,6 +98,13 @@ import com.google.common.collect.ImmutableList;
 @Order( 1999 )
 public class DhisWebApiWebSecurityConfig
 {
+    private static String apiContextPath = "/api";
+
+    public static void setApiContextPath( String apiContextPath )
+    {
+        DhisWebApiWebSecurityConfig.apiContextPath = apiContextPath;
+    }
+
     @Autowired
     public DataSource dataSource;
 
@@ -106,6 +119,7 @@ public class DhisWebApiWebSecurityConfig
     @Configuration
     @Order( 1001 )
     @Import( { AuthorizationServerEndpointsConfiguration.class } )
+    @Conditional( value = OAuth2AuthorizationServerEnabledCondition.class )
     public class OAuth2SecurityConfig extends WebSecurityConfigurerAdapter implements AuthorizationServerConfigurer
     {
         @Autowired
@@ -138,9 +152,6 @@ public class DhisWebApiWebSecurityConfig
             configure( configurer );
             http.apply( configurer );
 
-            // This is the only endpoint we need to configure.
-            // The other /authorize endpoint is only accessible AFTER you have
-            // been authorized.
             String tokenEndpointPath = handlerMapping.getServletPath( "/oauth/token" );
 
             http
@@ -218,60 +229,6 @@ public class DhisWebApiWebSecurityConfig
         }
     }
 
-    /**
-     * This class is configuring the OIDC endpoints
-     */
-    @Configuration
-    @Order( 1010 )
-    @Conditional( value = OidcEnabledCondition.class )
-    public static class OidcSecurityConfig extends WebSecurityConfigurerAdapter
-    {
-        @Autowired
-        private DhisClientRegistrationRepository dhisClientRegistrationRepository;
-
-        @Autowired
-        private DhisCustomAuthorizationRequestResolver dhisCustomAuthorizationRequestResolver;
-
-        @Autowired
-        private DefaultAuthenticationEventPublisher authenticationEventPublisher;
-
-        public void configure( AuthenticationManagerBuilder auth )
-            throws Exception
-        {
-            auth.authenticationEventPublisher( authenticationEventPublisher );
-        }
-
-        @Override
-        protected void configure( HttpSecurity http )
-            throws Exception
-        {
-            Set<String> providerIds = dhisClientRegistrationRepository.getAllRegistrationId();
-
-            http
-                .antMatcher( "/oauth2/**" )
-                .authorizeRequests( authorize -> {
-                    for ( String providerId : providerIds )
-                    {
-                        authorize
-                            .antMatchers( "/oauth2/authorization/" + providerId ).permitAll()
-                            .antMatchers( "/oauth2/code/" + providerId ).permitAll();
-                    }
-                    authorize.anyRequest().authenticated();
-                } )
-
-                .oauth2Login( oauth2 -> oauth2
-                    .failureUrl( "/dhis-web-dashboard" )
-                    .clientRegistrationRepository( dhisClientRegistrationRepository )
-                    .loginProcessingUrl( "/oauth2/code/*" )
-                    .authorizationEndpoint()
-                    .authorizationRequestResolver( dhisCustomAuthorizationRequestResolver ) )
-
-                .csrf().disable();
-
-            setHttpHeaders( http );
-        }
-    }
-
     @Bean
     public TokenStore tokenStore()
     {
@@ -289,12 +246,66 @@ public class DhisWebApiWebSecurityConfig
     }
 
     /**
+     * This class is configuring the OIDC login endpoints
+     */
+    @Configuration
+    @Order( 1010 )
+    @Conditional( value = OIDCLoginEnabledCondition.class )
+    public static class OidcSecurityConfig extends WebSecurityConfigurerAdapter
+    {
+        @Autowired
+        private DhisOidcProviderRepository dhisOidcProviderRepository;
+
+        @Autowired
+        private DhisCustomAuthorizationRequestResolver dhisCustomAuthorizationRequestResolver;
+
+        @Autowired
+        private DefaultAuthenticationEventPublisher authenticationEventPublisher;
+
+        public void configure( AuthenticationManagerBuilder auth )
+            throws Exception
+        {
+            auth.authenticationEventPublisher( authenticationEventPublisher );
+        }
+
+        @Override
+        protected void configure( HttpSecurity http )
+            throws Exception
+        {
+            Set<String> providerIds = dhisOidcProviderRepository.getAllRegistrationId();
+
+            http
+                .antMatcher( "/oauth2/**" )
+                .authorizeRequests( authorize -> {
+                    providerIds.forEach( providerId -> authorize
+                        .antMatchers( "/oauth2/authorization/" + providerId ).permitAll()
+                        .antMatchers( "/oauth2/code/" + providerId ).permitAll() );
+                    authorize.anyRequest().authenticated();
+                } )
+
+                .oauth2Login( oauth2 -> oauth2
+                    .failureUrl( "/dhis-web-dashboard" )
+                    .clientRegistrationRepository( dhisOidcProviderRepository )
+                    .loginProcessingUrl( "/oauth2/code/*" )
+                    .authorizationEndpoint()
+                    .authorizationRequestResolver( dhisCustomAuthorizationRequestResolver ) )
+
+                .csrf().disable();
+
+            setHttpHeaders( http );
+        }
+    }
+
+    /**
      * This configuration class is responsible for setting up the /api endpoints
      */
     @Configuration
     @Order( 1100 )
     public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter
     {
+        @Autowired
+        private DhisConfigurationProvider dhisConfig;
+
         @Autowired
         @Qualifier( "defaultTokenService" )
         private ResourceServerTokenServices tokenServices;
@@ -313,17 +324,18 @@ public class DhisWebApiWebSecurityConfig
         @Autowired
         private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
-        final private SecurityExpressionHandler<FilterInvocation> expressionHandler = new OAuth2WebSecurityExpressionHandler();
+        @Autowired
+        private DhisJwtAuthenticationManagerResolver dhisJwtAuthenticationManagerResolver;
 
-        final private AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
-
-        final private AccessDeniedHandler accessDeniedHandler = new OAuth2AccessDeniedHandler();
+        @Autowired
+        private DhisBearerJwtTokenAuthenticationEntryPoint bearerTokenEntryPoint;
 
         public void configure( AuthenticationManagerBuilder auth )
             throws Exception
         {
             auth.authenticationProvider( twoFactorAuthenticationProvider );
             auth.authenticationProvider( customLdapAuthenticationProvider );
+
             auth.authenticationEventPublisher( authenticationEventPublisher );
         }
 
@@ -343,50 +355,103 @@ public class DhisWebApiWebSecurityConfig
             return oauthAuthenticationManager;
         }
 
+        private void configureAccessRestrictions(
+            ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry authorize )
+        {
+            if ( dhisConfig.getBoolean( ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER ) )
+            {
+                authorize.expressionHandler( new OAuth2WebSecurityExpressionHandler() );
+            }
+
+            authorize
+                .antMatchers( apiContextPath + "/account/username" ).permitAll()
+                .antMatchers( apiContextPath + "/account/recovery" ).permitAll()
+                .antMatchers( apiContextPath + "/account/restore" ).permitAll()
+                .antMatchers( apiContextPath + "/account/password" ).permitAll()
+                .antMatchers( apiContextPath + "/account/validatePassword" ).permitAll()
+                .antMatchers( apiContextPath + "/account/validateUsername" ).permitAll()
+                .antMatchers( apiContextPath + "/account" ).permitAll()
+                .antMatchers( apiContextPath + "/staticContent/*" ).permitAll()
+                .antMatchers( apiContextPath + "/externalFileResources/*" ).permitAll()
+                .antMatchers( apiContextPath + "/icons/*/icon.svg" ).permitAll()
+                .anyRequest().authenticated();
+        }
+
         protected void configure( HttpSecurity http )
             throws Exception
         {
             http
-                .antMatcher( "/api/**" )
-                .authorizeRequests( authorize -> authorize
-
-                    .expressionHandler( expressionHandler )
-
-                    .antMatchers( "/api/account/username" ).permitAll()
-                    .antMatchers( "/api/account/recovery" ).permitAll()
-                    .antMatchers( "/api/account/restore" ).permitAll()
-                    .antMatchers( "/api/account/password" ).permitAll()
-                    .antMatchers( "/api/account/validatePassword" ).permitAll()
-                    .antMatchers( "/api/account/validateUsername" ).permitAll()
-                    .antMatchers( "/api/account" ).permitAll()
-                    .antMatchers( "/api/staticContent/*" ).permitAll()
-                    .antMatchers( "/api/externalFileResources/*" ).permitAll()
-                    .antMatchers( "/api/icons/*/icon.svg" ).permitAll()
-                    .anyRequest().authenticated() )
+                .antMatcher( apiContextPath + "/**" )
+                .authorizeRequests( this::configureAccessRestrictions )
                 .httpBasic()
                 .authenticationEntryPoint( basicAuthenticationEntryPoint() )
-                .and().csrf().disable()
+                .and().csrf().disable();
 
-                .exceptionHandling()
-                .accessDeniedHandler( accessDeniedHandler );
+            if ( dhisConfig.getBoolean( ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER ) )
+            {
+                http.exceptionHandling().accessDeniedHandler( new OAuth2AccessDeniedHandler() );
+            }
 
             http
                 .addFilterBefore( CorsFilter.get(), BasicAuthenticationFilter.class )
                 .addFilterBefore( CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class );
 
-            // This is the OAuth2 resource filter it will be checking for the
-            // "Authorization: Bearer <token>" header if
-            // the "Authorization: Basic <username:password>" header is not
-            // present or valid.
-            OAuth2AuthenticationProcessingFilter resourcesServerFilter = new OAuth2AuthenticationProcessingFilter();
-            resourcesServerFilter.setAuthenticationEntryPoint( authenticationEntryPoint );
-            resourcesServerFilter.setAuthenticationManager( oauthAuthenticationManager( http ) );
-            resourcesServerFilter.setStateless( false );
-
-            // Adds the resource (oath2 token) filter after http basic filer.
-            http.addFilterAfter( resourcesServerFilter, BasicAuthenticationFilter.class );
+            configureOAuth2TokenFilter( http );
 
             setHttpHeaders( http );
+        }
+
+        private void configureOAuth2TokenFilter( HttpSecurity http )
+        {
+            if ( dhisConfig.isEnabled( ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER ) )
+            {
+                AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
+
+                OAuth2AuthenticationProcessingFilter filter = new OAuth2AuthenticationProcessingFilter();
+                filter.setAuthenticationEntryPoint( authenticationEntryPoint );
+                filter.setAuthenticationManager( oauthAuthenticationManager( http ) );
+                filter.setStateless( false );
+
+                http.addFilterAfter( filter, BasicAuthenticationFilter.class );
+            }
+            else if ( dhisConfig.isEnabled( ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION ) )
+            {
+                http.addFilterAfter( getBearerTokenAuthenticationFilter(), BasicAuthenticationFilter.class );
+            }
+        }
+
+        private BearerTokenAuthenticationFilter getBearerTokenAuthenticationFilter()
+        {
+            BearerTokenAuthenticationFilter jwtFilter = new BearerTokenAuthenticationFilter(
+                dhisJwtAuthenticationManagerResolver );
+
+            jwtFilter.setAuthenticationEntryPoint( bearerTokenEntryPoint );
+            jwtFilter.setBearerTokenResolver( new DefaultBearerTokenResolver() );
+
+            // "Dummy" failure handler to activate auth failed messages being
+            // sent to the
+            // central AuthenticationLoggerListener
+            jwtFilter.setAuthenticationFailureHandler( ( request, response, exception ) -> {
+                authenticationEventPublisher.publishAuthenticationFailure( exception,
+                    new AbstractAuthenticationToken( null )
+                    {
+                        @Override
+                        public Object getCredentials()
+                        {
+                            return null;
+                        }
+
+                        @Override
+                        public Object getPrincipal()
+                        {
+                            return null;
+                        }
+                    } );
+
+                bearerTokenEntryPoint.commence( request, response, exception );
+            } );
+
+            return jwtFilter;
         }
 
         @Bean

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -77,9 +77,9 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer
 
         context.addListener( new ContextLoaderListener( annotationConfigWebApplicationContext ) );
 
-        ServletRegistration.Dynamic dispatcher = context
-            .addServlet( "dispatcher", new DispatcherServlet( annotationConfigWebApplicationContext ) );
+        DispatcherServlet servlet = new DispatcherServlet( annotationConfigWebApplicationContext );
 
+        ServletRegistration.Dynamic dispatcher = context.addServlet( "dispatcher", servlet );
         dispatcher.setAsyncSupported( true );
         dispatcher.setLoadOnStartup( 1 );
         dispatcher.addMapping( "/api/*" );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/action/LoginAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/action/LoginAction.java
@@ -37,8 +37,8 @@ import java.util.Set;
 import org.apache.struts2.ServletActionContext;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager;
-import org.hisp.dhis.security.oidc.DhisClientRegistrationRepository;
 import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mobile.device.Device;
 import org.springframework.mobile.device.DeviceResolver;
@@ -70,7 +70,7 @@ public class LoginAction
     private DhisConfigurationProvider configurationProvider;
 
     @Autowired
-    private DhisClientRegistrationRepository repository;
+    private DhisOidcProviderRepository repository;
 
     // -------------------------------------------------------------------------
     // Input & Output

--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -35,15 +35,6 @@
             <artifactId>dhis-web-api</artifactId>
         </dependency>
 
-        <!--    <dependency>-->
-        <!--      <groupId>org.hisp.dhis</groupId>-->
-        <!--      <artifactId>dhis-web-uaa</artifactId>-->
-        <!--      <version>${project.version}</version>-->
-        <!--      <type>war</type>-->
-        <!--    </dependency>-->
-
-        <!-- Web maintenance modules -->
-
         <dependency>
             <groupId>org.hisp.dhis</groupId>
             <artifactId>dhis-web-dataentry</artifactId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1008,6 +1008,11 @@
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-oauth2-resource-server</artifactId>
+        <version>${spring-security.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-jwt</artifactId>
         <version>${spring-security-jwt.version}</version>
       </dependency>


### PR DESCRIPTION
### Summary

This PR adds support for using JWT OpenID Connect bearer tokens for authenticating against the DHIS2 API endpoints.
In order to use the DHIS2 mobile clients with an OpenID Connect logged-in user, the mobile/external clients needs login and fetch access/refresh and ID tokens directly against the provider and then use the tokens as bearer tokens in subsequent requests against the DHIS2 API. In the OAuth2 terminology having this kind of feature set on the server is called being a [resource server](https://www.oauth.com/oauth2-servers/the-resource-server/).

We are using the [BearerTokenAuthenticationFilter](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationFilter.html) from Spring security as the authentication filter. If the request has an `Authorization` header with a `Bearer [JWT_TOKEN]`, it will be parsed and validated  against the configured OIDC provider(s), if config parameter `oidc.jwt.token.authentication.enabled` is enabled and `oauth2.authorization.server.enabled` is disabled.

Since the ["deprecated"](https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide) existing OAuth2 authorization server features can't co-exist with this new JWT authentication features, only one can be enabled at the same time. So in other words as of right now you have to chose from either having existing OAuth2 authorization support or new JWT token support. Since in most cases if you are using JWT tokens, it means you are using an external provider, having "local" authorization server support at the same time usually doesn't make sense.

The JWT token support build upon the existing [OIDC login/SSO support](https://github.com/dhis2/dhis2-docs/blob/master/src/commonmark/en/content/sysadmin/installation.md#openid-connect-oidc-configuration). In order to use the JWT tokens you need to configure an OIDC provider that will issue your JWT tokens according to this guide: [https://github.com/dhis2/dhis2-docs/blob/master/src/commonmark/en/content/sysadmin/installation.md#openid-connect-oidc-configuration](https://github.com/dhis2/dhis2-docs/blob/master/src/commonmark/en/content/sysadmin/installation.md#openid-connect-oidc-configuration)

### Automatic testing
JWT token support has unit tests in this test class: [JwtBearerTokenTest.java](https://github.com/dhis2/dhis2-core/blob/c781f610c881039194bf6e94238057261fd130a0/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java)
In order to test a full "happy path" with JWT tokens we need to do considerable prework to generate a valid token that can be used without a lot of mocking. Most of the test code used to generate the tokens are taken from the new experimental [Spring-Authorization-Server](https://github.com/spring-projects-experimental/spring-authorization-server) project. This project is considered to be the heir to the existing deprecated authorization server, hence some included classes in this PR can possibly be refactored to use their future jars, when the project is ready for production. The main dependency that does the actuall JWT encode/decode work was already included as a dependency: ["Nimbus Jose JWT"](https://connect2id.com/products/nimbus-jose-jwt), (and is the same in Spring-Authorization-Server) 

### Manual testing
To do a full test on a live server you need to do the following:
* Configure an OIDC provider see: [openid-connect-oidc-configuration](https://github.com/dhis2/dhis2-docs/blob/master/src/commonmark/en/content/sysadmin/installation.md#openid-connect-oidc-configuration)
* Enable `oidc.jwt.token.authentication.enabled` and disable `oauth2.authorization.server.enabled` in the dhis.conf
* Run the "JWT/OIDC auth test" Android client in an emulator. Note: **As soon as the DHIS2 mobile client is updated with JWT support, this will be used instead.**
* Start the DHIS2 server
* Run the Android client and do the Authorization code flow against your configured provider and obtain a JWT ID token.
* Press the "Call DHIS2 API" button in the Android client and observe the returned request.

[[https://jira.dhis2.org/browse/DHIS2-10337](https://jira.dhis2.org/browse/DHIS2-10337)]

(cherry picked from commit 9b34203d512ca819251b5a9985a621ca4c4dc9c9)
Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>