### PR TITLE
perf: [DHIS2-10714] optimize get teis api to avoid count until its necessary (2.37)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceService.java
@@ -117,12 +117,27 @@ public interface TrackedEntityInstanceService
      * @param skipAccessValidation If true, access validation is skipped. Should
      *        be set to true only for internal tasks (e.g. currently used by
      *        synchronization job)
+     * @param skipSearchScopeValidation if true, search scope validation is
+     *        skipped.
      * @return List of TEIs matching the params
      */
     List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params,
-        boolean skipAccessValidation );
+        boolean skipAccessValidation, boolean skipSearchScopeValidation );
 
-    List<Long> getTrackedEntityInstanceIds( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation );
+    /**
+     * Returns a list tracked entity instance primary key ids based on the given
+     * TrackedEntityInstanceQueryParams.
+     *
+     * @param params the TrackedEntityInstanceQueryParams.
+     * @param skipAccessValidation If true, access validation is skipped. Should
+     *        be set to true only for internal tasks (e.g. currently used by
+     *        synchronization job)
+     * @param skipSearchScopeValidation if true, search scope validation is
+     *        skipped.
+     * @return List of TEI IDs matching the params
+     */
+    List<Long> getTrackedEntityInstanceIds( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation,
+        boolean skipSearchScopeValidation );
 
     /**
      * Return the count of the Tracked entity instances that meet the criteria

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -157,7 +157,8 @@ public class ProgramStageDataEntrySMSListener
         List<TrackedEntityInstance> teis = new ArrayList<>();
 
         attributes.parallelStream().map( attr -> getParams( attr, sms, command.getProgram(), ous ) )
-            .forEach( param -> teis.addAll( trackedEntityInstanceService.getTrackedEntityInstances( param, false ) ) );
+            .forEach(
+                param -> teis.addAll( trackedEntityInstanceService.getTrackedEntityInstances( param, false, true ) ) );
 
         return teis;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -156,7 +156,7 @@ public class DefaultTrackedEntityInstanceService
     @Override
     @Transactional( readOnly = true )
     public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams params,
-        boolean skipAccessValidation )
+        boolean skipAccessValidation, boolean skipSearchScopeValidation )
     {
         if ( params.isOrQuery() && !params.hasAttributes() && !params.hasProgram() )
         {
@@ -172,6 +172,11 @@ public class DefaultTrackedEntityInstanceService
         if ( !skipAccessValidation )
         {
             validate( params );
+        }
+
+        if ( !skipSearchScopeValidation )
+        {
+            validateSearchScope( params, false );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -206,7 +211,7 @@ public class DefaultTrackedEntityInstanceService
     @Override
     @Transactional( readOnly = true )
     public List<Long> getTrackedEntityInstanceIds( TrackedEntityInstanceQueryParams params,
-        boolean skipAccessValidation )
+        boolean skipAccessValidation, boolean skipSearchScopeValidation )
     {
         if ( params.isOrQuery() && !params.hasAttributes() && !params.hasProgram() )
         {
@@ -225,6 +230,11 @@ public class DefaultTrackedEntityInstanceService
         if ( !skipAccessValidation )
         {
             validate( params );
+        }
+
+        if ( !skipSearchScopeValidation )
+        {
+            validateSearchScope( params, false );
         }
 
         User user = currentUserService.getCurrentUser();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -199,10 +199,10 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     }
 
     private List<TrackedEntityInstance> getTrackedEntityInstancesLegacy( TrackedEntityInstanceQueryParams queryParams,
-        TrackedEntityInstanceParams params, boolean skipAccessValidation )
+        TrackedEntityInstanceParams params, boolean skipAccessValidation, boolean skipSearchScopeValidation )
     {
         List<org.hisp.dhis.trackedentity.TrackedEntityInstance> daoTEIs = teiService
-            .getTrackedEntityInstances( queryParams, skipAccessValidation );
+            .getTrackedEntityInstances( queryParams, skipAccessValidation, skipSearchScopeValidation );
 
         List<TrackedEntityInstance> dtoTeis = new ArrayList<>();
         User user = queryParams.getUser();
@@ -252,7 +252,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     @Override
     @Transactional( readOnly = true )
     public List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams,
-        TrackedEntityInstanceParams params, boolean skipAccessValidation )
+        TrackedEntityInstanceParams params, boolean skipAccessValidation, boolean skipSearchScopeValidation )
     {
         if ( queryParams == null )
         {
@@ -262,11 +262,13 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
         if ( queryParams.isUseLegacy() )
         {
-            trackedEntityInstances = getTrackedEntityInstancesLegacy( queryParams, params, skipAccessValidation );
+            trackedEntityInstances = getTrackedEntityInstancesLegacy( queryParams, params, skipAccessValidation,
+                skipSearchScopeValidation );
         }
         else
         {
-            final List<Long> ids = teiService.getTrackedEntityInstanceIds( queryParams, skipAccessValidation );
+            final List<Long> ids = teiService.getTrackedEntityInstanceIds( queryParams, skipAccessValidation,
+                skipSearchScopeValidation );
 
             if ( ids.isEmpty() )
             {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/TrackedEntityInstanceService.java
@@ -67,11 +67,12 @@ public interface TrackedEntityInstanceService
      *        the directives for how much data should be fetched (e.g.
      *        Enrollments, Events, Relationships)
      * @param skipAccessValidation whether access validation should be ignored
-     *
+     * @param skipSearchScopeValidation whether search scope validation should
+     *        be ignored
      * @return a List of {@see TrackedEntityInstance}
      */
     List<TrackedEntityInstance> getTrackedEntityInstances( TrackedEntityInstanceQueryParams queryParams,
-        TrackedEntityInstanceParams params, boolean skipAccessValidation );
+        TrackedEntityInstanceParams params, boolean skipAccessValidation, boolean skipSearchScopeValidation );
 
     int getTrackedEntityInstanceCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation,
         boolean skipSearchScopeValidation );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -175,7 +175,7 @@ public class TrackerSynchronization extends DataSynchronizationWithPaging
         queryParams.setPage( page );
 
         List<TrackedEntityInstance> dtoTeis = teiService.getTrackedEntityInstances( queryParams,
-            TrackedEntityInstanceParams.DATA_SYNCHRONIZATION, true );
+            TrackedEntityInstanceParams.DATA_SYNCHRONIZATION, true, true );
         log.info( String.format( "Synchronizing page %d with page size %d", page, pageSize ) );
 
         if ( log.isDebugEnabled() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -125,7 +125,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
         assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 0 ) );
@@ -136,7 +136,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
                 .collect( Collectors.toSet() ) );
 
         final List<TrackedEntityInstance> limitedTTrackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( limitedTTrackedEntityInstances, hasSize( 2 ) );
     }
@@ -160,7 +160,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEnrollments( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -190,7 +190,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEnrollments( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -221,7 +221,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -256,7 +256,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -288,7 +288,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
 
@@ -327,7 +327,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
         TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
         Enrollment enrollment = tei.getEnrollments().get( 0 );
         Event event = enrollment.getEvents().get( 0 );
@@ -380,7 +380,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         Enrollment enrollment = trackedEntityInstances.get( 0 ).getEnrollments().get( 0 );
 
@@ -429,7 +429,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
         TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
         Enrollment enrollment = tei.getEnrollments().get( 0 );
         Event event = enrollment.getEvents().get( 0 );
@@ -455,7 +455,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
         TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
         Enrollment enrollment = tei.getEnrollments().get( 0 );
         Event event = enrollment.getEvents().get( 0 );
@@ -487,7 +487,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeRelationships( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances.get( 0 ).getRelationships(), hasSize( 1 ) );
         final Relationship relationship = trackedEntityInstances.get( 0 ).getRelationships().get( 0 );
@@ -519,7 +519,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeRelationships( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         // Fetch the TEI which is the vertex of the relationship TEI <-->
         // ENROLLMENT
@@ -573,7 +573,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         // Fetch the TEI which is the vertex of the relationship TEI <-->
         // ENROLLMENT
@@ -613,7 +613,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeProgramOwners( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances.get( 0 ).getProgramOwners(), hasSize( 1 ) );
         ProgramOwner programOwner = trackedEntityInstances.get( 0 ).getProgramOwners().get( 0 );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -125,7 +125,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
         assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 0 ) );
@@ -136,7 +136,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
                 .collect( Collectors.toSet() ) );
 
         final List<TrackedEntityInstance> limitedTTrackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( limitedTTrackedEntityInstances, hasSize( 2 ) );
     }
@@ -160,7 +160,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEnrollments( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -190,7 +190,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEnrollments( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -221,7 +221,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -256,7 +256,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 4 ) );
 
@@ -288,7 +288,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
 
@@ -327,7 +327,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
         TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
         Enrollment enrollment = tei.getEnrollments().get( 0 );
         Event event = enrollment.getEvents().get( 0 );
@@ -380,7 +380,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( false );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         Enrollment enrollment = trackedEntityInstances.get( 0 ).getEnrollments().get( 0 );
 
@@ -429,7 +429,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
         TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
         Enrollment enrollment = tei.getEnrollments().get( 0 );
         Event event = enrollment.getEvents().get( 0 );
@@ -455,7 +455,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
         TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
         Enrollment enrollment = tei.getEnrollments().get( 0 );
         Event event = enrollment.getEvents().get( 0 );
@@ -487,7 +487,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeRelationships( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances.get( 0 ).getRelationships(), hasSize( 1 ) );
         final Relationship relationship = trackedEntityInstances.get( 0 ).getRelationships().get( 0 );
@@ -519,7 +519,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeRelationships( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         // Fetch the TEI which is the vertex of the relationship TEI <-->
         // ENROLLMENT
@@ -573,7 +573,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeEvents( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         // Fetch the TEI which is the vertex of the relationship TEI <-->
         // ENROLLMENT
@@ -613,7 +613,7 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
         params.setIncludeProgramOwners( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances.get( 0 ).getProgramOwners(), hasSize( 1 ) );
         ProgramOwner programOwner = trackedEntityInstances.get( 0 ).getProgramOwners().get( 0 );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateAclTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateAclTest.java
@@ -99,7 +99,7 @@ public class TrackedEntityInstanceAttributesAggregateAclTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 0 ) );
     }
@@ -139,7 +139,7 @@ public class TrackedEntityInstanceAttributesAggregateAclTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( trackedEntityInstances, hasSize( 2 ) );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateAclTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateAclTest.java
@@ -99,7 +99,7 @@ public class TrackedEntityInstanceAttributesAggregateAclTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 0 ) );
     }
@@ -139,7 +139,7 @@ public class TrackedEntityInstanceAttributesAggregateAclTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertThat( trackedEntityInstances, hasSize( 2 ) );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateTest.java
@@ -145,7 +145,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "C", "E" );
     }
@@ -161,7 +161,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         queryParams.setIncludeAllAttributes( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, TrackedEntityInstanceParams.TRUE, false );
+            .getTrackedEntityInstances( queryParams, TrackedEntityInstanceParams.TRUE, false, false );
 
         assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 1 ) );
         assertThat( trackedEntityInstances.get( 0 ).getProgramOwners(), hasSize( 2 ) );
@@ -180,7 +180,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "C" );
 
@@ -198,7 +198,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "E" );
     }
@@ -215,7 +215,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false );
+            .getTrackedEntityInstances( queryParams, params, false, false );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "C" );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateTest.java
@@ -145,7 +145,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "C", "E" );
     }
@@ -161,7 +161,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         queryParams.setIncludeAllAttributes( true );
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, TrackedEntityInstanceParams.TRUE, false, false );
+            .getTrackedEntityInstances( queryParams, TrackedEntityInstanceParams.TRUE, false, true );
 
         assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 1 ) );
         assertThat( trackedEntityInstances.get( 0 ).getProgramOwners(), hasSize( 2 ) );
@@ -180,7 +180,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "C" );
 
@@ -198,7 +198,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "E" );
     }
@@ -215,7 +215,7 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
         TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
 
         final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, false );
+            .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertAttributes( trackedEntityInstances.get( 0 ).getAttributes(), "A", "B", "C" );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/sync/TrackerSynchronizationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/sync/TrackerSynchronizationTest.java
@@ -244,7 +244,7 @@ public class TrackerSynchronizationTest extends DhisSpringTest
     public void testSkipSyncFunctionality()
     {
         List<org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance> fetchedTeis = subject
-            .getTrackedEntityInstances( queryParams, params, true );
+            .getTrackedEntityInstances( queryParams, params, true, true );
 
         assertEquals( 1, fetchedTeis.get( 0 ).getAttributes().size() );
     }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -47,7 +47,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.cache.CacheStrategy;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -120,8 +120,6 @@ import com.google.common.collect.Lists;
 @RequiredArgsConstructor
 public class TrackedEntityInstanceController
 {
-    public static final int TEI_COUNT_THRESHOLD_FOR_USE_LEGACY = 500;
-
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     private final org.hisp.dhis.trackedentity.TrackedEntityInstanceService instanceService;
@@ -159,27 +157,26 @@ public class TrackedEntityInstanceController
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
-
-        if ( queryParams.getMaxTeiLimit() > 0 && count > 0
-            && count > queryParams.getMaxTeiLimit() )
+        if ( queryParams.isSkipPaging() )
         {
-            throw new IllegalQueryException( "maxteicountreached" );
-        }
-
-        if ( count > TEI_COUNT_THRESHOLD_FOR_USE_LEGACY && queryParams.isSkipPaging() )
-        {
+            /*
+             * TODO: Find a way to not use legacy at all. If result set is huge,
+             * our refactored mechanism fails due to appending the huge list of
+             * ids in sql. To be safe, we switch to legacy mechanism if paging
+             * is explicitly skipped.
+             */
             queryParams.setUseLegacy( true );
         }
 
         List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService.getTrackedEntityInstances(
             queryParams,
-            getTrackedEntityInstanceParams( fields ), true );
+            getTrackedEntityInstanceParams( fields ), false, false );
 
         RootNode rootNode = NodeUtils.createMetadata();
 
         if ( queryParams.isPaging() && queryParams.isTotalPages() )
         {
+            int count = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, true );
             Pager pager = new Pager( queryParams.getPageWithDefault(), count, queryParams.getPageSizeWithDefault() );
             rootNode.addChild( NodeUtils.createPager( pager ) );
         }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -75,7 +75,6 @@ public class TrackerTrackedEntitiesExportController
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-
         if ( queryParams.isSkipPaging() )
         {
             /*

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.domain.mapper.TrackedEntityMapper;
-import org.hisp.dhis.webapi.controller.event.TrackedEntityInstanceController;
 import org.hisp.dhis.webapi.controller.event.mapper.TrackedEntityCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerTrackedEntityCriteria;
@@ -76,17 +75,21 @@ public class TrackerTrackedEntitiesExportController
 
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        int teiCount = trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, false, false );
 
-        if ( teiCount > TrackedEntityInstanceController.TEI_COUNT_THRESHOLD_FOR_USE_LEGACY
-            && queryParams.isSkipPaging() )
+        if ( queryParams.isSkipPaging() )
         {
+            /*
+             * TODO: Find a way to not use legacy at all. If result set is huge,
+             * our refactored mechanism fails due to appending the huge list of
+             * ids in sql. To be safe, we switch to legacy mechanism if paging
+             * is explicitly skipped.
+             */
             queryParams.setUseLegacy( true );
         }
 
         Collection<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
             .fromCollection( trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
-                trackedEntityInstanceSupportService.getTrackedEntityInstanceParams( fields ), true ) );
+                trackedEntityInstanceSupportService.getTrackedEntityInstanceParams( fields ), false, false ) );
 
         PagingWrapper<TrackedEntity> trackedEntityInstancePagingWrapper = new PagingWrapper<>();
 
@@ -94,7 +97,7 @@ public class TrackerTrackedEntitiesExportController
         {
 
             Long count = criteria.isTotalPages()
-                ? (long) teiCount
+                ? (long) trackedEntityInstanceService.getTrackedEntityInstanceCount( queryParams, true, true )
                 : null;
 
             trackedEntityInstancePagingWrapper = trackedEntityInstancePagingWrapper.withPager(


### PR DESCRIPTION
api/trackedEntityInstances and api/tracker/trackedEntities are modified to avoid counting teis unless its necessary.