### PR TITLE
test: adds spring controller tests for user account expiry [DHIS2-10717]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonNode.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/JsonNode.java
@@ -173,4 +173,16 @@ public interface JsonNode extends Serializable
      *         provided JSON
      */
     JsonNode replaceWith( String json );
+
+    /**
+     * Adds an additional property to this node assuming this node represents a
+     * {@link JsonNodeType#OBJECT}.
+     *
+     * @param name a JSON object property name
+     * @param value a JSON value
+     * @return a new document root where this node got another property with the
+     *         provided name and value
+     */
+    JsonNode addMember( String name, String value );
+
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserCredentials.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserCredentials.java
@@ -44,4 +44,9 @@ public interface JsonUserCredentials extends JsonIdentifiableObject
         return get( "lastLogin", JsonDate.class ).date();
     }
 
+    default LocalDateTime getAccountExpiry()
+    {
+        return get( "accountExpiry", JsonDate.class ).date();
+    }
+
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonDocumentTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/JsonDocumentTest.java
@@ -352,4 +352,12 @@ public class JsonDocumentTest
         assertEquals( "{ \"b\" : [42, false] }",
             onlyA.members().get( "b" ).elements().get( 0 ).replaceWith( "42" ).toString() );
     }
+
+    @Test
+    public void testAdd()
+    {
+        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        assertEquals( "{\"a\": { \"b\" : [12, false] , \"c\":{}} }",
+            doc.get( ".a" ).addMember( "c", "{}" ).toString() );
+    }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -29,11 +29,13 @@ package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.hisp.dhis.webapi.WebClient.Body;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertError;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertSeries;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
 
@@ -260,6 +262,38 @@ public class AbstractCrudControllerTest extends DhisControllerConvenienceTest
         assertStatus( HttpStatus.OK, PUT( "/userGroups/" + groupId + "?skipSharing=true", groupWithoutSharing ) );
         assertEquals( "rw------", GET( "/userGroups/{id}", groupId )
             .content().as( JsonGeoMap.class ).getSharing().getPublic().string() );
+    }
+
+    @Test
+    public void testPutJsonObject_accountExpiry()
+    {
+        String userId = switchToNewUser( "someUser" ).getUid();
+        switchToSuperuser();
+
+        JsonUser user = GET( "/users/{id}", userId ).content().as( JsonUser.class );
+
+        assertStatus( HttpStatus.OK,
+            PUT( "/users/{id}", userId,
+                Body( user.getUserCredentials().node()
+                    .addMember( "accountExpiry", "null" ).toString() ) ) );
+
+        assertNull( GET( "/users/{id}", userId )
+            .content().as( JsonUser.class ).getUserCredentials().getAccountExpiry() );
+    }
+
+    @Test
+    public void testPutJsonObject_accountExpiry_PutNoChange()
+    {
+        String userId = switchToNewUser( "someUser" ).getUid();
+        switchToSuperuser();
+
+        JsonUser user = GET( "/users/{id}", userId ).content().as( JsonUser.class );
+
+        assertStatus( HttpStatus.OK,
+            PUT( "/users/{id}", userId, Body( user.toString() ) ) );
+
+        assertNull( GET( "/users/{id}", userId )
+            .content().as( JsonUser.class ).getUserCredentials().getAccountExpiry() );
     }
 
     @Test


### PR DESCRIPTION
This was done as part or outcome of an investigation into DHIS2-10717.

The PR adds two tests that show that `PUT`ing a user without `accountExpiry` in user credentials or with `"accountExpiry": null` this does not set the `accountExpiry` to any value but it stays null.

This needed a small addition to the `JsonNode` allowing to add members.

All changes only affect tests or test support code.