### PR TITLE
fix: Properly invalidate LocalCache and add listener to invalidate Tracker Preheat cache [DHIS2-10726]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -156,7 +156,7 @@ public class LocalCache<V> implements Cache<V>
     @Override
     public void invalidateAll()
     {
-        cache2kInstance.clear();
+        cache2kInstance.removeAll();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
@@ -41,9 +41,11 @@ import lombok.RequiredArgsConstructor;
 import org.cache2k.Cache;
 import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
@@ -139,9 +141,17 @@ public class DefaultPreheatCacheService implements PreheatCacheService
         }
     }
 
+    @EventListener
+    @Override
+    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
+    {
+        invalidateCache();
+    }
+
+    @Override
     public void invalidateCache()
     {
-        cache.keySet().forEach( k -> cache.get( k ).removeAll() );
+        cache.values().forEach( Cache::removeAll );
     }
 
     private boolean isCacheEnabled()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/PreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/PreheatCacheService.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 
 /**
  * A DHIS2 metadata cache implementation to reduce db lookups during pre-heat
@@ -79,4 +80,11 @@ public interface PreheatCacheService
      * Invalidates all caches.
      */
     void invalidateCache();
+
+    /**
+     * Event handler for {@link ApplicationCacheClearedEvent}.
+     *
+     * @param event the {@link ApplicationCacheClearedEvent}.
+     */
+    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.cache;
 
 import java.time.Duration;
 
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+
 /**
  * The {@link CacheProvider} has a factory method for each {@link Cache} use
  * case in DHIS2.
@@ -100,4 +102,6 @@ public interface CacheProvider
     <V> Cache<V> createUserGroupNameCache();
 
     <V> Cache<V> createUserDisplayNameCache();
+
+    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -420,6 +420,7 @@ public class DefaultCacheProvider
     }
 
     @EventListener
+    @Override
     public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
     {
         allCaches.values().forEach( Cache::invalidateAll );


### PR DESCRIPTION
I hope this will make some difference.
In the documentation of Cache2K the difference between clear and removeAll is that the latter is also calling the listeners, so I think that now the empty caches will be actually cleaned.