### PR TITLE
fix: drop legacy sharing tables with cascade [2.36.0]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_20__Drop_legacy_sharing_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_20__Drop_legacy_sharing_tables.sql
@@ -94,5 +94,7 @@ DROP TABLE IF EXISTS chartuseraccesses;
 DROP TABLE IF EXISTS chartusergroupaccesses;
 DROP TABLE IF EXISTS reporttableuseraccesses;
 DROP TABLE IF EXISTS reporttableusergroupaccesses;
-DROP TABLE IF EXISTS useraccess;
-DROP TABLE IF EXISTS usergroupaccess;
+DROP TABLE IF EXISTS patienttabularreportusergroupaccesses;
+DROP TABLE IF EXISTS patientaggregatereportusergroupacceses;
+DROP TABLE IF EXISTS useraccess CASCADE;
+DROP TABLE IF EXISTS usergroupaccess CASCADE; 


### PR DESCRIPTION
backport same fix from 2.36