### PR TITLE
fix: Tracker preheat cache disabled

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
@@ -39,8 +39,10 @@ import lombok.RequiredArgsConstructor;
 import org.cache2k.Cache;
 import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
@@ -136,9 +138,17 @@ public class DefaultPreheatCacheService implements PreheatCacheService
         }
     }
 
+    @EventListener
+    @Override
+    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
+    {
+        invalidateCache();
+    }
+
+    @Override
     public void invalidateCache()
     {
-        cache.keySet().forEach( k -> cache.get( k ).removeAll() );
+        cache.values().forEach( Cache::removeAll );
     }
 
     private boolean isCacheEnabled()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.preheat.cache;
 
-import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,11 +39,8 @@ import lombok.RequiredArgsConstructor;
 import org.cache2k.Cache;
 import org.cache2k.Cache2kBuilder;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
-import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.tracker.TrackerIdScheme;
-import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
@@ -141,22 +136,20 @@ public class DefaultPreheatCacheService implements PreheatCacheService
         }
     }
 
-    @EventListener
-    @Override
-    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
-    {
-        invalidateCache();
-    }
-
-    @Override
     public void invalidateCache()
     {
-        cache.values().forEach( Cache::removeAll );
+        cache.keySet().forEach( k -> cache.get( k ).removeAll() );
     }
 
     private boolean isCacheEnabled()
     {
-        return !isTestRun( this.environment.getActiveProfiles() )
-            && config.isEnabled( ConfigurationKey.TRACKER_IMPORT_PREHEAT_CACHE_ENABLED );
+        return false;
+
+        // Due to concerns and issues with the current cache implementation, we
+        // decided to
+        // deactivate the cache in the preheat completely for now.
+        // return !isTestRun( this.environment.getActiveProfiles() )
+        // && config.isEnabled(
+        // ConfigurationKey.TRACKER_IMPORT_PREHEAT_CACHE_ENABLED );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheServiceTest.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -67,6 +68,7 @@ public class DefaultPreheatCacheServiceTest
     }
 
     @Test
+    @Ignore
     public void testEnabledCacheIsCachingTEI()
     {
         Mockito.when( config.isEnabled( ConfigurationKey.TRACKER_IMPORT_PREHEAT_CACHE_ENABLED ) ).thenReturn( true );
@@ -85,6 +87,7 @@ public class DefaultPreheatCacheServiceTest
     }
 
     @Test
+    @Ignore
     public void testDisabledCacheIsNotCachingTEI()
     {
         Mockito.when( config.isEnabled( ConfigurationKey.TRACKER_IMPORT_PREHEAT_CACHE_ENABLED ) ).thenReturn( false );


### PR DESCRIPTION
Disable the preheat cache in the new tracker importer.

It was not working as intended and potentially allowing breaking the ACL