### PR TITLE
fix: set default UTF_8 charset for StringHttpMessageConverter

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
@@ -27,34 +27,24 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.*;
 
-import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.cache.CacheStrategy;
-import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.dataset.DataSetService;
-import org.hisp.dhis.datasetreport.DataSetReportService;
-import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodService;
-import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.system.grid.GridUtils;
-import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.service.WebMessageService;
-import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.cache.*;
+import org.hisp.dhis.dataset.*;
+import org.hisp.dhis.datasetreport.*;
+import org.hisp.dhis.dxf2.webmessage.*;
+import org.hisp.dhis.organisationunit.*;
+import org.hisp.dhis.period.*;
+import org.hisp.dhis.system.grid.*;
+import org.hisp.dhis.webapi.mvc.annotation.*;
+import org.hisp.dhis.webapi.service.*;
+import org.hisp.dhis.webapi.utils.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * @author Stian Sandvold
@@ -87,7 +77,8 @@ public class DataSetReportController
     @Autowired
     IdentifiableObjectManager idObjectManager;
 
-    @RequestMapping( value = RESOURCE_PATH + "/custom", method = RequestMethod.GET, produces = "text/html" )
+    @RequestMapping( value = RESOURCE_PATH
+        + "/custom", method = RequestMethod.GET, produces = "text/html;charset=UTF-8" )
     public @ResponseBody String getCustomDataSetReport( HttpServletResponse response,
         @RequestParam String ds,
         @RequestParam String pe,

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -27,60 +27,37 @@
  */
 package org.hisp.dhis.webapi.security.config;
 
-import static org.springframework.http.MediaType.parseMediaType;
+import static org.springframework.http.MediaType.*;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.nio.charset.*;
+import java.util.*;
+import java.util.stream.*;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.hisp.dhis.common.Compression;
-import org.hisp.dhis.node.DefaultNodeService;
-import org.hisp.dhis.node.NodeService;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.UserSettingService;
-import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
-import org.hisp.dhis.webapi.mvc.CurrentUserInfoHandlerMethodArgumentResolver;
-import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
-import org.hisp.dhis.webapi.mvc.DhisApiVersionHandlerMethodArgumentResolver;
-import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
-import org.hisp.dhis.webapi.mvc.messageconverter.CsvMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.ExcelMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.JsonPMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.PdfMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.RenderServiceMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
-import org.hisp.dhis.webapi.service.ContextService;
-import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.core.annotation.Order;
-import org.springframework.format.FormatterRegistry;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.ByteArrayHttpMessageConverter;
-import org.springframework.http.converter.FormHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.StringHttpMessageConverter;
-import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
-import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
-import org.springframework.web.accept.ContentNegotiationManager;
-import org.springframework.web.accept.FixedContentNegotiationStrategy;
-import org.springframework.web.accept.HeaderContentNegotiationStrategy;
-import org.springframework.web.accept.ParameterContentNegotiationStrategy;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.multipart.MultipartResolver;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
-import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.apache.commons.lang3.*;
+import org.hisp.dhis.common.*;
+import org.hisp.dhis.node.*;
+import org.hisp.dhis.user.*;
+import org.hisp.dhis.webapi.mvc.*;
+import org.hisp.dhis.webapi.mvc.interceptor.*;
+import org.hisp.dhis.webapi.mvc.messageconverter.*;
+import org.hisp.dhis.webapi.service.*;
+import org.hisp.dhis.webapi.view.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.annotation.*;
+import org.springframework.core.annotation.*;
+import org.springframework.format.*;
+import org.springframework.http.*;
+import org.springframework.http.converter.*;
+import org.springframework.security.access.expression.method.*;
+import org.springframework.security.config.annotation.method.configuration.*;
+import org.springframework.web.accept.*;
+import org.springframework.web.method.support.*;
+import org.springframework.web.multipart.*;
+import org.springframework.web.multipart.commons.*;
+import org.springframework.web.servlet.config.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.*;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.*;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -161,7 +138,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration
         converters.add( new PdfMessageConverter( nodeService() ) );
         converters.add( new ExcelMessageConverter( nodeService() ) );
 
-        converters.add( new StringHttpMessageConverter() );
+        converters.add( new StringHttpMessageConverter( StandardCharsets.UTF_8 ) );
         converters.add( new ByteArrayHttpMessageConverter() );
         converters.add( new FormHttpMessageConverter() );
 


### PR DESCRIPTION
Issue : https://jira.dhis2.org/browse/DHIS2-8869
- DataSetReportController return `@ResponseBody String`  for `api/dataSetReport/custom` endpoint
- We already set charset encoding in method `contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING );`
- However, this code doesn't have effect, charset return is `Content-Type: text/html;charset=iso-8859-1`
- This can be reproduced on play instances, but I can't reproduce the issue on my local which runs mac os. So I guess the operating system default charset is applied, or something else changes the charset before return to client.

Fix:

- I found that we define messageConverters in `WebMvcConfig`, so all controller response will need to go through those messageConverters before returning to client.
- So I try to set default charset for `StringHttpMessageConverter`  to UTF-8.
- I also added `produces = "text/html;charset=UTF-8"` to the controller
- I build a war file with the fix and ask HISP Vietnam  ( issue reporter ) to test it, and the fix works on their server.

Todos
- This needs more investigation on why current code for setting the charset doesn't work, then we need to fix this for other places.

Below is screenshot from HISP Vietnam after fix
<img width="1364" alt="Screen Shot 2021-03-20 at 13 40 19" src="https://user-images.githubusercontent.com/766102/111906545-8e703800-8a83-11eb-81a1-38c1310534f8.png">
