### PR TITLE
[DRAFT] fix: Dropping support for refactored attributes

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/VisualizationFontStyle.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/VisualizationFontStyle.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 
 import org.hisp.dhis.common.FontStyle;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -43,6 +44,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  *
  * @author Lars Helge Overland
  */
+@JsonIgnoreProperties( ignoreUnknown = true )
 @JacksonXmlRootElement( localName = "visualizationFontStyle", namespace = DXF_2_0 )
 public class VisualizationFontStyle
     implements Serializable
@@ -50,20 +52,6 @@ public class VisualizationFontStyle
     private FontStyle visualizationTitle;
 
     private FontStyle visualizationSubtitle;
-
-    private FontStyle horizontalAxisTitle;
-
-    private FontStyle verticalAxisTitle;
-
-    private FontStyle targetLineLabel;
-
-    private FontStyle baseLineLabel;
-
-    private FontStyle seriesAxisLabel;
-
-    private FontStyle categoryAxisLabel;
-
-    private FontStyle legend;
 
     public VisualizationFontStyle()
     {
@@ -91,89 +79,5 @@ public class VisualizationFontStyle
     public void setVisualizationSubtitle( FontStyle visualizationSubtitle )
     {
         this.visualizationSubtitle = visualizationSubtitle;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getHorizontalAxisTitle()
-    {
-        return horizontalAxisTitle;
-    }
-
-    public void setHorizontalAxisTitle( FontStyle horizontalAxisTitle )
-    {
-        this.horizontalAxisTitle = horizontalAxisTitle;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getVerticalAxisTitle()
-    {
-        return verticalAxisTitle;
-    }
-
-    public void setVerticalAxisTitle( FontStyle verticalAxisTitle )
-    {
-        this.verticalAxisTitle = verticalAxisTitle;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getTargetLineLabel()
-    {
-        return targetLineLabel;
-    }
-
-    public void setTargetLineLabel( FontStyle targetLineLabel )
-    {
-        this.targetLineLabel = targetLineLabel;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getBaseLineLabel()
-    {
-        return baseLineLabel;
-    }
-
-    public void setBaseLineLabel( FontStyle baseLineLabel )
-    {
-        this.baseLineLabel = baseLineLabel;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getSeriesAxisLabel()
-    {
-        return seriesAxisLabel;
-    }
-
-    public void setSeriesAxisLabel( FontStyle seriesAxisLabel )
-    {
-        this.seriesAxisLabel = seriesAxisLabel;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getCategoryAxisLabel()
-    {
-        return categoryAxisLabel;
-    }
-
-    public void setCategoryAxisLabel( FontStyle categoryAxisLabel )
-    {
-        this.categoryAxisLabel = categoryAxisLabel;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public FontStyle getLegend()
-    {
-        return legend;
-    }
-
-    public void setLegend( FontStyle legend )
-    {
-        this.legend = legend;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/visualization/VisualizationStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/visualization/VisualizationStoreTest.java
@@ -90,9 +90,6 @@ public class VisualizationStoreTest
 
         VisualizationFontStyle fontStyle = new VisualizationFontStyle();
         fontStyle.setVisualizationTitle( visualizationTitle );
-        fontStyle.setHorizontalAxisTitle( horizontalAxisTitle );
-        fontStyle.setSeriesAxisLabel( seriesAxisLabel );
-        fontStyle.setTargetLineLabel( targetLineLabel );
 
         RelativePeriods relativePeriods = new RelativePeriods()
             .setLast30Days( true );
@@ -114,15 +111,6 @@ public class VisualizationStoreTest
         assertNotNull( vA.getFontStyle().getVisualizationTitle() );
         assertEquals( Font.VERDANA, vA.getFontStyle().getVisualizationTitle().getFont() );
         assertEquals( Integer.valueOf( 16 ), vA.getFontStyle().getVisualizationTitle().getFontSize() );
-        assertNotNull( vA.getFontStyle().getHorizontalAxisTitle() );
-        assertEquals( Font.ARIAL, vA.getFontStyle().getHorizontalAxisTitle().getFont() );
-        assertTrue( vA.getFontStyle().getHorizontalAxisTitle().getItalic() );
-        assertNotNull( vA.getFontStyle().getSeriesAxisLabel() );
-        assertEquals( Font.ARIAL, vA.getFontStyle().getSeriesAxisLabel().getFont() );
-        assertTrue( vA.getFontStyle().getSeriesAxisLabel().getUnderline() );
-        assertNotNull( vA.getFontStyle().getTargetLineLabel() );
-        assertEquals( Font.VERDANA, vA.getFontStyle().getTargetLineLabel().getFont() );
-        assertTrue( vA.getFontStyle().getTargetLineLabel().getBold() );
 
         assertNotNull( vA.getRelatives() );
         assertTrue( vA.getRelatives().isLast30Days() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization.json
@@ -317,33 +317,6 @@
           "underline": false,
           "textColor": "#3a3a3a",
           "textAlign": "LEFT"
-        },
-        "horizontalAxisTitle": {
-          "font": "ROBOTO",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#2a2a2a",
-          "textAlign": "CENTER"
-        },
-        "categoryAxisLabel": {
-          "font": "ROBOTO",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#dedede",
-          "textAlign": "CENTER"
-        },
-        "targetLineLabel": {
-          "font": "ARIAL",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#dedede",
-          "textAlign": "CENTER"
         }
       },
       "colorSet": "color_set_01",
@@ -467,33 +440,6 @@
           "underline": false,
           "textColor": "#3a3a3a",
           "textAlign": "LEFT"
-        },
-        "horizontalAxisTitle": {
-          "font": "ROBOTO",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#2a2a2a",
-          "textAlign": "CENTER"
-        },
-        "categoryAxisLabel": {
-          "font": "ROBOTO",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#dedede",
-          "textAlign": "CENTER"
-        },
-        "targetLineLabel": {
-          "font": "ARIAL",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#dedede",
-          "textAlign": "CENTER"
         }
       },
       "colorSet": "color_set_01",
@@ -617,33 +563,6 @@
           "underline": false,
           "textColor": "#3a3a3a",
           "textAlign": "LEFT"
-        },
-        "horizontalAxisTitle": {
-          "font": "ROBOTO",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#2a2a2a",
-          "textAlign": "CENTER"
-        },
-        "categoryAxisLabel": {
-          "font": "ROBOTO",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#dedede",
-          "textAlign": "CENTER"
-        },
-        "targetLineLabel": {
-          "font": "ARIAL",
-          "fontSize": 12,
-          "bold": false,
-          "italic": true,
-          "underline": false,
-          "textColor": "#dedede",
-          "textAlign": "CENTER"
         }
       },
       "colorSet": "color_set_01",


### PR DESCRIPTION
We are dropping the support to those fields are they are not going to be supported anymore.
At this point, we expect all of them to be migrated.

I added the annotation `@JsonIgnoreProperties( ignoreUnknown = true )` just to prevent errors in case of any inconsistency, so the request will not fail. Any invalid property at the DB level will be ignored.

**This probably should be backported to 2.36 before the release to avoid clients using the old attributes.
Otherwise, it will create issues as it will allow clients to use the same feature/attributes located in different places/objects.**