### PR TITLE
fix: Adding paging flag [DHIS2-10742]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -118,6 +118,8 @@ public class EventDataQueryRequest
 
     private Integer pageSize;
 
+    private boolean paging;
+
     /**
      * Copies all properties of this request onto the given request.
      *
@@ -161,6 +163,7 @@ public class EventDataQueryRequest
         queryRequest.coordinateField = this.coordinateField;
         queryRequest.page = this.page;
         queryRequest.pageSize = this.pageSize;
+        queryRequest.paging = this.paging;
         return request;
     }
 
@@ -192,6 +195,7 @@ public class EventDataQueryRequest
                 .outputType( criteria.getOutputType() )
                 .page( criteria.getPage() )
                 .pageSize( criteria.getPageSize() )
+                .paging( criteria.isPaging() )
                 .programStatus( criteria.getProgramStatus() )
                 .relativePeriodDate( criteria.getRelativePeriodDate() )
                 .showHierarchy( criteria.isShowHierarchy() )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -262,4 +262,10 @@ public class EventsAnalyticsQueryCriteria
      * The page size.
      */
     private Integer pageSize = 50;
+
+    /**
+     * The paging parameter. When set to false we should not paginate. The
+     * default is true (always paginate).
+     */
+    private boolean paging = true;
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -151,6 +151,11 @@ public class EventQueryParams
     private Integer pageSize;
 
     /**
+     * The paging flag.
+     */
+    private boolean paging;
+
+    /**
      * The value sort order.
      */
     private SortOrder sortOrder;
@@ -273,6 +278,7 @@ public class EventQueryParams
         params.organisationUnitMode = this.organisationUnitMode;
         params.page = this.page;
         params.pageSize = this.pageSize;
+        params.paging = this.paging;
         params.sortOrder = this.sortOrder;
         params.limit = this.limit;
         params.outputType = this.outputType;
@@ -378,6 +384,7 @@ public class EventQueryParams
             .addIgnoreNull( "organisationUnitMode", organisationUnitMode )
             .addIgnoreNull( "page", page )
             .addIgnoreNull( "pageSize", pageSize )
+            .addIgnoreNull( "paging", paging )
             .addIgnoreNull( "sortOrder", sortOrder )
             .addIgnoreNull( "limit", limit )
             .addIgnoreNull( "outputType", outputType )
@@ -702,7 +709,7 @@ public class EventQueryParams
 
     public boolean isPaging()
     {
-        return page != null || pageSize != null;
+        return paging && (page != null || pageSize != null);
     }
 
     public int getPageWithDefault()
@@ -893,6 +900,11 @@ public class EventQueryParams
     public Integer getPageSize()
     {
         return pageSize;
+    }
+
+    public boolean getPaging()
+    {
+        return paging;
     }
 
     public SortOrder getSortOrder()
@@ -1158,6 +1170,12 @@ public class EventQueryParams
         public Builder withPageSize( Integer pageSize )
         {
             this.params.pageSize = pageSize;
+            return this;
+        }
+
+        public Builder withPaging( boolean paging )
+        {
+            this.params.paging = paging;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -250,6 +250,7 @@ public class DefaultEventDataQueryService
             .withCoordinateField( getCoordinateField( request.getCoordinateField() ) )
             .withPage( request.getPage() )
             .withPageSize( request.getPageSize() )
+            .withPaging( request.isPaging() )
             .withProgramStatus( request.getProgramStatus() )
             .withApiVersion( request.getApiVersion() )
             .build();


### PR DESCRIPTION
This PR will enable the usage of the `paging` parameter.

Currently, this endpoint is always paging which is not useful for displaying events in Maps.

You will notice that the `paging` parameter is set to `true` (as default) to avoid performance issues.
But once the flag `paging` is set to `false` (URL param _paging=false_), the endpoint should not paginate. Instead, it should bring all elements.

**Was already approved by the Release Control Committee, can go into patch/2.36.0.**
