### PR TITLE
fix: Validation details with all items DHIS2-8876

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/ValidationRuleExpressionDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/ValidationRuleExpressionDetails.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.dataanalysis;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,17 +49,7 @@ public class ValidationRuleExpressionDetails
 
     private List<Map<String, String>> rightSide = new ArrayList<>();
 
-    public ValidationRuleExpressionDetails()
-    {
-    }
-
-    public ValidationRuleExpressionDetails( List<Map<String, String>> leftSide, List<Map<String, String>> rightSide )
-    {
-        this.leftSide = leftSide;
-        this.rightSide = rightSide;
-    }
-
-    private void addDetailTo( String name, String value, List<Map<String, String>> side )
+    public static void addDetailTo( String name, String value, List<Map<String, String>> side )
     {
         if ( !Strings.isNullOrEmpty( name ) )
         {
@@ -69,14 +61,14 @@ public class ValidationRuleExpressionDetails
         }
     }
 
-    public void addLeftSideDetail( String name, String value )
-    {
-        addDetailTo( name, value, leftSide );
-    }
+    private Comparator<Map<String, String>> mapComparator = ( m1, m2 ) -> m1.get( "name" )
+        .compareTo( m2.get( "name" ) );
 
-    public void addRightSideDetail( String name, String value )
+    public void sortByName()
     {
-        addDetailTo( name, value, rightSide );
+        Collections.sort( leftSide, mapComparator );
+
+        Collections.sort( rightSide, mapComparator );
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -200,17 +199,6 @@ public interface ExpressionService
      * @return a Set of data elements included in the expression string.
      */
     Set<DataElement> getExpressionDataElements( String expression, ParseType parseType );
-
-    /**
-     * Returns, in data element operand format, all data elements and all data
-     * element operands found in an expression. Returns an empty set if the
-     * expression is null.
-     *
-     * @param expression The expression string.
-     * @param parseType the type of expression to parse.
-     * @return A Set of Operands.
-     */
-    Set<DataElementOperand> getExpressionOperands( String expression, ParseType parseType );
 
     /**
      * Returns all CategoryOptionCombo uids in the given expression string that

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationService.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -54,6 +55,14 @@ public interface ValidationService
      * @return a collection of ValidationResults found.
      */
     List<ValidationResult> validationAnalysis( ValidationAnalysisParams parameters );
+
+    /**
+     * Get validation rule expression details for a validation run.
+     *
+     * @param parameters the parameters to base the analysis on.
+     * @return the validation rule expression details
+     */
+    ValidationRuleExpressionDetails getValidationRuleExpressionDetails( ValidationAnalysisParams parameters );
 
     /**
      * Validate that missing data values have a corresponding comment, assuming

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -87,7 +87,6 @@ import org.hisp.dhis.antlr.Parser;
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -98,7 +98,6 @@ import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.expression.dataitem.DimItemDataElementAndOperand;
 import org.hisp.dhis.expression.dataitem.DimItemIndicator;
@@ -483,17 +482,6 @@ public class DefaultExpressionService
         return getExpressionDimensionalItemIds( expression, parseType ).stream()
             .filter( DimensionalItemId::isDataElementOrOperand )
             .map( i -> dataElementService.getDataElement( i.getId0() ) )
-            .collect( Collectors.toSet() );
-    }
-
-    @Override
-    @Transactional
-    public Set<DataElementOperand> getExpressionOperands( String expression, ParseType parseType )
-    {
-        return getExpressionDimensionalItemIds( expression, parseType ).stream()
-            .filter( DimensionalItemId::isDataElementOrOperand )
-            .map( i -> new DataElementOperand( dataElementService.getDataElement( i.getId0() ),
-                i.getId1() == null ? null : categoryService.getCategoryOptionCombo( i.getId1() ) ) )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -156,8 +156,6 @@ public class DefaultExpressionService
 
     private final ConstantService constantService;
 
-    private final CategoryService categoryService;
-
     private final OrganisationUnitGroupService organisationUnitGroupService;
 
     private final DimensionService dimensionService;
@@ -243,14 +241,13 @@ public class DefaultExpressionService
 
     public DefaultExpressionService(
         @Qualifier( "org.hisp.dhis.expression.ExpressionStore" ) HibernateGenericStore<Expression> expressionStore,
-        DataElementService dataElementService, ConstantService constantService, CategoryService categoryService,
+        DataElementService dataElementService, ConstantService constantService,
         OrganisationUnitGroupService organisationUnitGroupService, DimensionService dimensionService,
         IdentifiableObjectManager idObjectManager, CacheProvider cacheProvider )
     {
         checkNotNull( expressionStore );
         checkNotNull( dataElementService );
         checkNotNull( constantService );
-        checkNotNull( categoryService );
         checkNotNull( organisationUnitGroupService );
         checkNotNull( dimensionService );
         checkNotNull( cacheProvider );
@@ -258,7 +255,6 @@ public class DefaultExpressionService
         this.expressionStore = expressionStore;
         this.dataElementService = dataElementService;
         this.constantService = constantService;
-        this.categoryService = categoryService;
         this.organisationUnitGroupService = organisationUnitGroupService;
         this.dimensionService = dimensionService;
         this.idObjectManager = idObjectManager;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -244,7 +244,7 @@ public class ExpressionService2Test extends DhisSpringTest
     public void setUp()
     {
         target = new DefaultExpressionService( hibernateGenericStore, dataElementService, constantService,
-            categoryService, organisationUnitGroupService, dimensionService, idObjectManager, cacheProvider );
+            organisationUnitGroupService, dimensionService, idObjectManager, cacheProvider );
 
         rnd = new BeanRandomizer();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -27,14 +27,11 @@
  */
 package org.hisp.dhis.expression;
 
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 import static org.hisp.dhis.expression.Expression.SEPARATOR;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
@@ -59,7 +56,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.math3.util.Precision;
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.Category;
@@ -528,34 +524,6 @@ public class ExpressionService2Test extends DhisSpringTest
 
         assertThat( dataElements, hasSize( 2 ) );
         assertThat( dataElements, hasItems( deA, deB ) );
-    }
-
-    @Test
-    @SuppressWarnings( "unchecked" )
-    public void testGetExpressionOperands()
-    {
-        when( dataElementService.getDataElement( deA.getUid() ) ).thenReturn( deA );
-        when( dataElementService.getDataElement( deB.getUid() ) ).thenReturn( deB );
-        when( categoryService.getCategoryOptionCombo( coc.getUid() ) ).thenReturn( coc );
-
-        Set<DataElementOperand> operands = target.getExpressionOperands( expressionO, PREDICTOR_EXPRESSION );
-
-        assertEquals( 2, operands.size() );
-
-        assertThat( operands,
-            IsIterableContainingInAnyOrder.containsInAnyOrder(
-                allOf( hasProperty( "dataElement", is( deA ) ),
-                    hasProperty( "categoryOptionCombo", is( coc ) ),
-                    hasProperty( "attributeOptionCombo", is( nullValue() ) ) ),
-                allOf( hasProperty( "dataElement", is( deB ) ),
-                    hasProperty( "categoryOptionCombo", is( coc ) ),
-                    hasProperty( "attributeOptionCombo", is( nullValue() ) ) ) ) );
-    }
-
-    @Test
-    public void testGetExpressionOperandsWhenNull()
-    {
-        assertThat( target.getExpressionOperands( null, INDICATOR_EXPRESSION ), hasSize( 0 ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -478,26 +478,14 @@ public class DataValidationTask
     {
         Map<String, Double> expressionValueMap = new HashMap<>();
 
-        Map<DimensionalItemObject, Double> nonAocValues = valueMap == null
-            ? null
-            : valueMap.get( NON_AOC );
-
-        MapMap<String, DimensionalItemObject, Double> aocValues = valueMap;
-
-        if ( aocValues == null )
+        if ( valueMap == null )
         {
-            if ( nonAocValues == null )
-            {
-                return expressionValueMap;
-            }
-            else
-            {
-                aocValues = new MapMap<>();
-                aocValues.putEntries( context.getDefaultAttributeCombo().getUid(), nonAocValues );
-            }
+            return expressionValueMap;
         }
 
-        for ( Map.Entry<String, Map<DimensionalItemObject, Double>> entry : aocValues.entrySet() )
+        Map<DimensionalItemObject, Double> nonAocValues = valueMap.get( NON_AOC );
+
+        for ( Map.Entry<String, Map<DimensionalItemObject, Double>> entry : valueMap.entrySet() )
         {
             Map<DimensionalItemObject, Double> values = entry.getValue();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -404,8 +404,8 @@ public class DefaultValidationService
         // 2. Get the dimensional objects from the IDs. (Get them all at once
         // for best performance.)
 
-        Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap =
-            dimensionService.getNoAclDataDimensionalItemObjectMap( allItemIds );
+        Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap = dimensionService
+            .getNoAclDataDimensionalItemObjectMap( allItemIds );
 
         // 3. Save the dimensional objects in the extended period types.
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -202,15 +202,15 @@ public class DefaultValidationService
     {
         ValidationRunContext context = getValidationContext( parameters );
 
-        ValidationRuleExpressionDetails validationRuleExpressionDetails = new ValidationRuleExpressionDetails();
+        ValidationRuleExpressionDetails details = new ValidationRuleExpressionDetails();
 
-        context.setValidationRuleExpressionDetails( validationRuleExpressionDetails );
+        context.setValidationRuleExpressionDetails( details );
 
         Validator.validate( context, applicationContext, analyticsService );
 
-        validationRuleExpressionDetails.sortByName();
+        details.sortByName();
 
-        return validationRuleExpressionDetails;
+        return details;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -399,6 +399,34 @@ public class DefaultValidationService
 
         SetMap<PeriodTypeExtended, DimensionalItemId> periodItemIds = new SetMap<>();
 
+        getItemIdsForRules( allItemIds, periodItemIds, periodTypeXMap, rules );
+
+        // 2. Get the dimensional objects from the IDs. (Get them all at once
+        // for best performance.)
+
+        Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap =
+            dimensionService.getNoAclDataDimensionalItemObjectMap( allItemIds );
+
+        // 3. Save the dimensional objects in the extended period types.
+
+        saveObjectsInPeriodTypeX( periodItemIds, dimensionItemMap );
+
+        return dimensionItemMap;
+    }
+
+    /**
+     * Finds all the dimensional object IDs in the validation rules expressions.
+     *
+     * @param allItemIds inserts all IDs here.
+     * @param periodItemIds inserts IDs by period type here.
+     * @param periodTypeXMap map of extended period types by period type.
+     * @param rules validation rules to process.
+     */
+    private void getItemIdsForRules( Set<DimensionalItemId> allItemIds,
+        SetMap<PeriodTypeExtended, DimensionalItemId> periodItemIds,
+        Map<PeriodType, PeriodTypeExtended> periodTypeXMap,
+        Collection<ValidationRule> rules )
+    {
         for ( ValidationRule rule : rules )
         {
             PeriodTypeExtended periodX = periodTypeXMap.get( rule.getPeriodType() );
@@ -430,15 +458,19 @@ public class DefaultValidationService
 
             allItemIds.addAll( bothSidesItemIds );
         }
+    }
 
-        // 2. Get the dimensional objects from the IDs. (Get them all at once
-        // for best performance.)
-
-        Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap = dimensionService
-            .getNoAclDataDimensionalItemObjectMap( allItemIds );
-
-        // 3. Save the dimensional objects in the extended period types.
-
+    /**
+     * Saves the dimension item objects in the period type extended, organizing
+     * them according to how they will be used in fetching their values.
+     *
+     * @param periodItemIds map from periodX to set of object IDs.
+     * @param dimensionItemMap map from object ID to Object.
+     */
+    private void saveObjectsInPeriodTypeX(
+        SetMap<PeriodTypeExtended, DimensionalItemId> periodItemIds,
+        Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap )
+    {
         for ( Map.Entry<PeriodTypeExtended, Set<DimensionalItemId>> entry : periodItemIds.entrySet() )
         {
             PeriodTypeExtended periodTypeX = entry.getKey();
@@ -472,8 +504,6 @@ public class DefaultValidationService
                 }
             }
         }
-
-        return dimensionItemMap;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/PeriodTypeExtended.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/PeriodTypeExtended.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -80,6 +81,12 @@ public class PeriodTypeExtended
     private boolean slidingWindowsNeeded = false;
 
     private boolean nonSlidingWindowsNeeded = false;
+
+    private Set<DimensionalItemId> leftSideItemIds = new HashSet<>();
+
+    private Set<DimensionalItemId> rightSideItemIds = new HashSet<>();
+
+    private Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap;
 
     public PeriodTypeExtended( PeriodType periodType )
     {
@@ -148,6 +155,25 @@ public class PeriodTypeExtended
         }
     }
 
+    public boolean areSlidingWindowsNeeded()
+    {
+        return slidingWindowsNeeded;
+    }
+
+    public boolean areNonSlidingWindowsNeeded()
+    {
+        return nonSlidingWindowsNeeded;
+    }
+
+    // -------------------------------------------------------------------------
+    // Set methods
+    // -------------------------------------------------------------------------
+
+    public void setDimensionItemMap( Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap )
+    {
+        this.dimensionItemMap = dimensionItemMap;
+    }
+
     // -------------------------------------------------------------------------
     // Get methods
     // -------------------------------------------------------------------------
@@ -207,13 +233,18 @@ public class PeriodTypeExtended
         return allowedPeriodTypes;
     }
 
-    public boolean areSlidingWindowsNeeded()
+    public Set<DimensionalItemId> getLeftSideItemIds()
     {
-        return slidingWindowsNeeded;
+        return leftSideItemIds;
     }
 
-    public boolean areNonSlidingWindowsNeeded()
+    public Set<DimensionalItemId> getRightSideItemIds()
     {
-        return nonSlidingWindowsNeeded;
+        return rightSideItemIds;
+    }
+
+    public Map<DimensionalItemId, DimensionalItemObject> getDimensionItemMap()
+    {
+        return dimensionItemMap;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/PeriodTypeExtended.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/PeriodTypeExtended.java
@@ -56,37 +56,39 @@ import org.hisp.dhis.period.PeriodType;
  */
 public class PeriodTypeExtended
 {
-    private PeriodType periodType;
+    private final PeriodType periodType;
 
-    private Set<Period> periods = new HashSet<>();
+    private final Set<Period> periods = new HashSet<>();
 
-    private Set<ValidationRuleExtended> ruleXs = new HashSet<>();
+    private final Set<ValidationRuleExtended> ruleXs = new HashSet<>();
 
-    private Set<PeriodType> allowedPeriodTypes = new HashSet<>();
+    private final Set<PeriodType> allowedPeriodTypes = new HashSet<>();
 
-    private Set<DimensionalItemObject> eventItems = new HashSet<>();
+    private final Set<DimensionalItemObject> eventItems = new HashSet<>();
 
-    private Set<DimensionalItemObject> eventItemsWithoutAttributeOptions = new HashSet<>();
+    private final Set<DimensionalItemObject> eventItemsWithoutAttributeOptions = new HashSet<>();
 
-    private Set<DimensionalItemObject> indicators = new HashSet<>();
+    private final Set<DimensionalItemObject> indicators = new HashSet<>();
 
-    private Set<DataElement> dataElements = new HashSet<>();
+    private final Set<DataElement> dataElements = new HashSet<>();
 
-    private Set<DataElementOperand> dataElementOperands = new HashSet<>();
+    private final Set<DataElementOperand> dataElementOperands = new HashSet<>();
 
-    private Map<Long, DataElement> dataElementIdMap = new HashMap<>();
+    private final Map<Long, DataElement> dataElementIdMap = new HashMap<>();
 
-    private Map<String, DataElementOperand> dataElementOperandIdMap = new HashMap<>();
+    private final Map<String, DataElementOperand> dataElementOperandIdMap = new HashMap<>();
+
+    private final Set<DimensionalItemId> leftSideItemIds = new HashSet<>();
+
+    private final Set<DimensionalItemId> rightSideItemIds = new HashSet<>();
 
     private boolean slidingWindowsNeeded = false;
 
     private boolean nonSlidingWindowsNeeded = false;
 
-    private Set<DimensionalItemId> leftSideItemIds = new HashSet<>();
-
-    private Set<DimensionalItemId> rightSideItemIds = new HashSet<>();
-
-    private Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap;
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
 
     public PeriodTypeExtended( PeriodType periodType )
     {
@@ -166,15 +168,6 @@ public class PeriodTypeExtended
     }
 
     // -------------------------------------------------------------------------
-    // Set methods
-    // -------------------------------------------------------------------------
-
-    public void setDimensionItemMap( Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap )
-    {
-        this.dimensionItemMap = dimensionItemMap;
-    }
-
-    // -------------------------------------------------------------------------
     // Get methods
     // -------------------------------------------------------------------------
 
@@ -241,10 +234,5 @@ public class PeriodTypeExtended
     public Set<DimensionalItemId> getRightSideItemIds()
     {
         return rightSideItemIds;
-    }
-
-    public Map<DimensionalItemId, DimensionalItemObject> getDimensionItemMap()
-    {
-        return dimensionItemMap;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
@@ -40,8 +40,11 @@ import org.apache.commons.lang3.Validate;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryOptionGroup;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.MapMapMap;
 import org.hisp.dhis.constant.Constant;
+import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.springframework.context.annotation.Scope;
@@ -72,6 +75,8 @@ public class ValidationRunContext
 
     private Set<CategoryOption> coDimensionConstraints;
 
+    private Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap;
+
     // -------------------------------------------------------------------------
     // Properties to configure analysis
     // -------------------------------------------------------------------------
@@ -94,6 +99,12 @@ public class ValidationRunContext
     }
 
     // -------------------------------------------------------------------------
+    // Return expression details if requested
+    // -------------------------------------------------------------------------
+
+    private ValidationRuleExpressionDetails validationRuleExpressionDetails;
+
+    // -------------------------------------------------------------------------
     // Id-to-Object Caches
     // -------------------------------------------------------------------------
 
@@ -102,6 +113,15 @@ public class ValidationRunContext
     private Map<Long, CategoryOptionCombo> aocIdMap = new ConcurrentHashMap<>();
 
     private Map<String, CategoryOptionCombo> aocUidMap = new ConcurrentHashMap<>();
+
+    // -------------------------------------------------------------------------
+    // Setter method
+    // -------------------------------------------------------------------------
+
+    public void setValidationRuleExpressionDetails( ValidationRuleExpressionDetails validationRuleExpressionDetails )
+    {
+        this.validationRuleExpressionDetails = validationRuleExpressionDetails;
+    }
 
     // -------------------------------------------------------------------------
     // Getter methods
@@ -147,6 +167,11 @@ public class ValidationRunContext
         return coDimensionConstraints;
     }
 
+    public Map<DimensionalItemId, DimensionalItemObject> getDimensionItemMap()
+    {
+        return dimensionItemMap;
+    }
+
     public boolean isSendNotifications()
     {
         return sendNotifications;
@@ -175,6 +200,11 @@ public class ValidationRunContext
     public Map<String, CategoryOptionCombo> getAocUidMap()
     {
         return aocUidMap;
+    }
+
+    public ValidationRuleExpressionDetails getValidationRuleExpressionDetails()
+    {
+        return validationRuleExpressionDetails;
     }
 
     // -------------------------------------------------------------------------
@@ -211,6 +241,11 @@ public class ValidationRunContext
     public boolean isAnalysisComplete()
     {
         return validationResults.size() >= maxResults;
+    }
+
+    public boolean processExpressionDetails()
+    {
+        return validationRuleExpressionDetails != null;
     }
 
     // -------------------------------------------------------------------------
@@ -342,6 +377,12 @@ public class ValidationRunContext
         public Builder withPersistResults( boolean persistResults )
         {
             this.context.persistResults = persistResults;
+            return this;
+        }
+
+        public Builder withDimensionItemMap( Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap )
+        {
+            this.context.dimensionItemMap = dimensionItemMap;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -50,6 +50,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.DhisTest;
@@ -60,6 +61,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UserContext;
+import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
@@ -87,6 +89,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -188,41 +191,41 @@ public class ValidationServiceTest
 
     private Set<OrganisationUnit> allSources = new HashSet<>();
 
-    private ValidationRule validationRuleA;
+    private ValidationRule ruleA;
 
-    private ValidationRule validationRuleB;
+    private ValidationRule ruleB;
 
-    private ValidationRule validationRuleC;
+    private ValidationRule ruleC;
 
-    private ValidationRule validationRuleD;
+    private ValidationRule ruleD;
 
-    private ValidationRule validationRuleE;
+    private ValidationRule ruleE;
 
-    private ValidationRule validationRuleF;
+    private ValidationRule ruleF;
 
-    private ValidationRule validationRuleG;
+    private ValidationRule ruleG;
 
-    private ValidationRule validationRuleP;
+    private ValidationRule ruleP;
 
-    private ValidationRule validationRuleQ;
+    private ValidationRule ruleQ;
 
-    private ValidationRule validationRuleR;
+    private ValidationRule ruleR;
 
-    private ValidationRule validationRuleS;
+    private ValidationRule ruleS;
 
-    private ValidationRule validationRuleT;
+    private ValidationRule ruleT;
 
-    private ValidationRule validationRuleU;
+    private ValidationRule ruleU;
 
-    private ValidationRule validationRuleX;
+    private ValidationRule ruleX;
 
     private ValidationRuleGroup group;
 
-    private PeriodType periodTypeWeekly;
+    private PeriodType ptWeekly;
 
-    private PeriodType periodTypeMonthly;
+    private PeriodType ptMonthly;
 
-    private PeriodType periodTypeYearly;
+    private PeriodType ptYearly;
 
     private CategoryOptionCombo defaultCombo;
 
@@ -239,9 +242,9 @@ public class ValidationServiceTest
         CurrentUserService currentUserService = new MockCurrentUserService( allSources, null );
         setDependency( validationService, "currentUserService", currentUserService, CurrentUserService.class );
 
-        periodTypeWeekly = new WeeklyPeriodType();
-        periodTypeMonthly = new MonthlyPeriodType();
-        periodTypeYearly = new YearlyPeriodType();
+        ptWeekly = new WeeklyPeriodType();
+        ptMonthly = new MonthlyPeriodType();
+        ptYearly = new YearlyPeriodType();
 
         dataElementA = createDataElement( 'A' );
         dataElementB = createDataElement( 'B' );
@@ -315,19 +318,19 @@ public class ValidationServiceTest
         Expression expressionU3 = new Expression( "1000", "expressionU3" );
         Expression expressionU4 = new Expression( "1000", "expressionU4" );
 
-        periodA = createPeriod( periodTypeMonthly, getDate( 2000, 3, 1 ), getDate( 2000, 3, 31 ) );
-        periodB = createPeriod( periodTypeMonthly, getDate( 2000, 4, 1 ), getDate( 2000, 4, 30 ) );
-        periodC = createPeriod( periodTypeMonthly, getDate( 2000, 5, 1 ), getDate( 2000, 5, 31 ) );
-        periodY = createPeriod( periodTypeYearly, getDate( 2000, 1, 1 ), getDate( 2000, 12, 31 ) );
+        periodA = createPeriod( ptMonthly, getDate( 2000, 3, 1 ), getDate( 2000, 3, 31 ) );
+        periodB = createPeriod( ptMonthly, getDate( 2000, 4, 1 ), getDate( 2000, 4, 30 ) );
+        periodC = createPeriod( ptMonthly, getDate( 2000, 5, 1 ), getDate( 2000, 5, 31 ) );
+        periodY = createPeriod( ptYearly, getDate( 2000, 1, 1 ), getDate( 2000, 12, 31 ) );
 
         dayInPeriodA = periodService.getDayInPeriod( periodA, new Date() );
         dayInPeriodB = periodService.getDayInPeriod( periodB, new Date() );
         dayInPeriodC = periodService.getDayInPeriod( periodC, new Date() );
         dayInPeriodY = periodService.getDayInPeriod( periodY, new Date() );
 
-        dataSetWeekly = createDataSet( 'W', periodTypeWeekly );
-        dataSetMonthly = createDataSet( 'M', periodTypeMonthly );
-        dataSetYearly = createDataSet( 'Y', periodTypeYearly );
+        dataSetWeekly = createDataSet( 'W', ptWeekly );
+        dataSetMonthly = createDataSet( 'M', ptMonthly );
+        dataSetYearly = createDataSet( 'Y', ptYearly );
 
         sourceA = createOrganisationUnit( 'A' );
         sourceB = createOrganisationUnit( 'B' );
@@ -392,45 +395,48 @@ public class ValidationServiceTest
         dataElementService.updateDataElement( dataElementD );
         dataElementService.updateDataElement( dataElementE );
 
-        validationRuleA = createValidationRule( "A", equal_to, expressionA, expressionB, periodTypeMonthly ); // deA
-                                                                                                              // +
-                                                                                                              // deB
-                                                                                                              // =
-                                                                                                              // deC
-                                                                                                              // -
-                                                                                                              // deD
-        validationRuleB = createValidationRule( "B", greater_than, expressionB2, expressionC,
-            periodTypeMonthly ); // deC - deD > deB * 2
-        validationRuleC = createValidationRule( "C", less_than_or_equal_to, expressionB3, expressionA2,
-            periodTypeMonthly ); // deC - deD <= deA + deB
-        validationRuleD = createValidationRule( "D", less_than, expressionA3, expressionC2,
-            periodTypeMonthly ); // deA + deB < deB * 2
-        validationRuleE = createValidationRule( "E", compulsory_pair, expressionI, expressionJ, periodTypeMonthly ); // deA
-                                                                                                                     // [Compulsory
-                                                                                                                     // pair]
-                                                                                                                     // deB
-        validationRuleF = createValidationRule( "F", exclusive_pair, expressionI2, expressionJ2,
-            periodTypeMonthly ); // deA [Exclusive pair] deB
-        validationRuleG = createValidationRule( "G", equal_to, expressionK, expressionL, periodTypeMonthly ); // deC
-                                                                                                              // =
-                                                                                                              // deD
-        validationRuleP = createValidationRule( "P", equal_to, expressionI3, expressionP,
-            periodTypeMonthly ); // deA = [days]
-        validationRuleQ = createValidationRule( "Q", equal_to, expressionQ, expressionP2,
-            periodTypeYearly ); // deE = [days]
-        validationRuleR = createValidationRule( "R", equal_to, expressionR, expressionU, periodTypeMonthly ); // deA(sum)
-                                                                                                              // +
-                                                                                                              // deB(sum)
-                                                                                                              // =
-                                                                                                              // 1000
-        validationRuleS = createValidationRule( "S", equal_to, expressionS, expressionU2,
-            periodTypeMonthly ); // deA.optionComboX + deB.optionComboX = 1000
-        validationRuleT = createValidationRule( "T", equal_to, expressionT, expressionU3,
-            periodTypeMonthly ); // deA.default + deB.optionComboX = 1000
-        validationRuleU = createValidationRule( "U", equal_to, expressionA4, expressionU4,
-            periodTypeMonthly ); // deA.default + deB.default = 1000
-        validationRuleX = createValidationRule( "X", equal_to, expressionA5, expressionC3,
-            periodTypeMonthly ); // deA + deB = deB * 2
+        // deA + deB = deC - deD
+        ruleA = createValidationRule( "A", equal_to, expressionA, expressionB, ptMonthly );
+
+        // deC - deD > deB * 2
+        ruleB = createValidationRule( "B", greater_than, expressionB2, expressionC, ptMonthly );
+
+        // deC - deD <= deA + deB
+        ruleC = createValidationRule( "C", less_than_or_equal_to, expressionB3, expressionA2, ptMonthly );
+
+        // deA + deB < deB * 2
+        ruleD = createValidationRule( "D", less_than, expressionA3, expressionC2, ptMonthly );
+
+        // deA [Compulsory pair] deB
+        ruleE = createValidationRule( "E", compulsory_pair, expressionI, expressionJ, ptMonthly );
+
+        // deA [Exclusive pair] deB
+        ruleF = createValidationRule( "F", exclusive_pair, expressionI2, expressionJ2, ptMonthly );
+
+        // deC = DeD
+        ruleG = createValidationRule( "G", equal_to, expressionK, expressionL, ptMonthly );
+
+        // deA = [days]
+        ruleP = createValidationRule( "P", equal_to, expressionI3, expressionP, ptMonthly );
+
+        // deE = [days]
+        ruleQ = createValidationRule( "Q", equal_to, expressionQ, expressionP2, ptYearly );
+
+        // deA(sum) + deB(sum) = 1000
+        ruleR = createValidationRule( "R", equal_to, expressionR, expressionU, ptMonthly );
+
+        // deA.optionComboX + deB.optionComboX = 1000
+        ruleS = createValidationRule( "S", equal_to, expressionS, expressionU2, ptMonthly );
+
+        // deA.default + deB.optionComboX = 1000
+        ruleT = createValidationRule( "T", equal_to, expressionT, expressionU3, ptMonthly );
+
+        // deA.default + deB.default = 1000
+        ruleU = createValidationRule( "U", equal_to, expressionA4, expressionU4, ptMonthly );
+
+        // deA + deB = deB * 2
+        ruleX = createValidationRule( "X", equal_to, expressionA5, expressionC3, ptMonthly );
+
         group = createValidationRuleGroup( 'A' );
 
         defaultCombo = categoryService.getDefaultCategoryOptionCombo();
@@ -616,15 +622,14 @@ public class ValidationServiceTest
         useDataValue( dataElementC, periodB, sourceC, "3" );
         useDataValue( dataElementD, periodB, sourceC, "4" );
 
-        validationRuleService.saveValidationRule( validationRuleA ); // Invalid
-        validationRuleService.saveValidationRule( validationRuleB ); // Invalid
-        validationRuleService.saveValidationRule( validationRuleC ); // Valid
-        validationRuleService.saveValidationRule( validationRuleD ); // Valid
+        validationRuleService.saveValidationRule( ruleA ); // Invalid
+        validationRuleService.saveValidationRule( ruleB ); // Invalid
+        validationRuleService.saveValidationRule( ruleC ); // Valid
+        validationRuleService.saveValidationRule( ruleD ); // Valid
 
         // Note: in this and subsequent tests we insert the validation results
-        // collection into a new HashSet. This
-        // insures that if they are the same as the reference results, they will
-        // appear in the same order.
+        // collection into a new HashSet. This insures that if they are the same
+        // as the reference results, they will appear in the same order.
 
         ValidationAnalysisParams parameters = validationService
             .newParamsBuilder( null, sourceB, getDate( 2000, 2, 1 ), getDate( 2000, 6, 1 ) )
@@ -634,23 +639,14 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( createValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( createValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
-        reference
-            .add( createValidationResult( validationRuleA, periodA, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( createValidationResult( validationRuleA, periodB, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
-
-        reference
-            .add( createValidationResult( validationRuleB, periodA, sourceB, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
-        reference
-            .add( createValidationResult( validationRuleB, periodB, sourceB, defaultCombo, -1.0, 4.0, dayInPeriodB ) );
-        reference
-            .add( createValidationResult( validationRuleB, periodA, sourceC, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
-        reference
-            .add( createValidationResult( validationRuleB, periodB, sourceC, defaultCombo, -1.0, 4.0, dayInPeriodB ) );
+        reference.add( createValidationResult( ruleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( createValidationResult( ruleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( createValidationResult( ruleA, periodA, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( createValidationResult( ruleA, periodB, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( createValidationResult( ruleB, periodA, sourceB, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
+        reference.add( createValidationResult( ruleB, periodB, sourceB, defaultCombo, -1.0, 4.0, dayInPeriodB ) );
+        reference.add( createValidationResult( ruleB, periodA, sourceC, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
+        reference.add( createValidationResult( ruleB, periodB, sourceC, defaultCombo, -1.0, 4.0, dayInPeriodB ) );
 
         assertResultsEquals( reference, results );
     }
@@ -678,13 +674,13 @@ public class ValidationServiceTest
         useDataValue( dataElementC, periodB, sourceC, "3" );
         useDataValue( dataElementD, periodB, sourceC, "4" );
 
-        validationRuleService.saveValidationRule( validationRuleA ); // Invalid
-        validationRuleService.saveValidationRule( validationRuleB ); // Invalid
-        validationRuleService.saveValidationRule( validationRuleC ); // Valid
-        validationRuleService.saveValidationRule( validationRuleD ); // Valid
+        validationRuleService.saveValidationRule( ruleA ); // Invalid
+        validationRuleService.saveValidationRule( ruleB ); // Invalid
+        validationRuleService.saveValidationRule( ruleC ); // Valid
+        validationRuleService.saveValidationRule( ruleD ); // Valid
 
-        group.getMembers().add( validationRuleA );
-        group.getMembers().add( validationRuleC );
+        group.getMembers().add( ruleA );
+        group.getMembers().add( ruleC );
 
         validationRuleService.addValidationRuleGroup( group );
 
@@ -695,14 +691,10 @@ public class ValidationServiceTest
         Collection<ValidationResult> results = validationService.validationAnalysis( params );
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodA, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodB, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( ruleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( ruleA, periodA, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleA, periodB, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
 
         assertResultsEquals( reference, results );
     }
@@ -740,12 +732,12 @@ public class ValidationServiceTest
         useDataValue( dataElementC, periodB, sourceC, "3" );
         useDataValue( dataElementD, periodB, sourceC, "4" );
 
-        validationRuleService.saveValidationRule( validationRuleA ); // Invalid
-        validationRuleService.saveValidationRule( validationRuleB ); // Invalid
-        validationRuleService.saveValidationRule( validationRuleC ); // Valid
-        validationRuleService.saveValidationRule( validationRuleD ); // Valid
+        validationRuleService.saveValidationRule( ruleA ); // Invalid
+        validationRuleService.saveValidationRule( ruleB ); // Invalid
+        validationRuleService.saveValidationRule( ruleC ); // Valid
+        validationRuleService.saveValidationRule( ruleD ); // Valid
 
-        List<ValidationRule> validationRules = Lists.newArrayList( validationRuleA, validationRuleC );
+        List<ValidationRule> validationRules = Lists.newArrayList( ruleA, ruleC );
         List<Period> periods = periodService.getPeriodsBetweenDates( getDate( 2000, 2, 1 ), getDate( 2000, 6, 1 ) );
 
         ValidationAnalysisParams params = validationService.newParamsBuilder( validationRules, null, periods )
@@ -754,18 +746,12 @@ public class ValidationServiceTest
         Collection<ValidationResult> results = validationService.validationAnalysis( params );
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodB, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodA, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleA, periodB, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( ruleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleA, periodB, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( ruleA, periodA, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleA, periodB, sourceB, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( ruleA, periodA, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleA, periodB, sourceC, defaultCombo, 3.0, -1.0, dayInPeriodB ) );
 
         assertResultsEquals( reference, results );
     }
@@ -778,20 +764,18 @@ public class ValidationServiceTest
         useDataValue( dataElementC, periodA, sourceA, "3" );
         useDataValue( dataElementD, periodA, sourceA, "4" );
 
-        validationRuleService.saveValidationRule( validationRuleA );
-        validationRuleService.saveValidationRule( validationRuleB );
-        validationRuleService.saveValidationRule( validationRuleC );
-        validationRuleService.saveValidationRule( validationRuleD );
+        validationRuleService.saveValidationRule( ruleA );
+        validationRuleService.saveValidationRule( ruleB );
+        validationRuleService.saveValidationRule( ruleC );
+        validationRuleService.saveValidationRule( ruleD );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
                 .build() );
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleA, periodA, sourceA, defaultCombo, 3.0, -1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleB, periodA, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -799,15 +783,15 @@ public class ValidationServiceTest
     @Test
     public void testValidateForm()
     {
-        validationRuleA.setSkipFormValidation( true );
+        ruleA.setSkipFormValidation( true );
 
         useDataValue( dataElementA, periodA, sourceA, "1" );
         useDataValue( dataElementB, periodA, sourceA, "2" );
         useDataValue( dataElementC, periodA, sourceA, "3" );
         useDataValue( dataElementD, periodA, sourceA, "4" );
 
-        validationRuleService.saveValidationRule( validationRuleA );
-        validationRuleService.saveValidationRule( validationRuleB );
+        validationRuleService.saveValidationRule( ruleA );
+        validationRuleService.saveValidationRule( ruleB );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -815,8 +799,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleB, periodA, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleB, periodA, sourceA, defaultCombo, -1.0, 4.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -827,8 +810,8 @@ public class ValidationServiceTest
         useDataValue( dataElementA, periodA, sourceA, "1111" );
         useDataValue( dataElementE, periodY, sourceB, "2222" );
 
-        validationRuleService.saveValidationRule( validationRuleP );
-        validationRuleService.saveValidationRule( validationRuleQ );
+        validationRuleService.saveValidationRule( ruleP );
+        validationRuleService.saveValidationRule( ruleQ );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -836,8 +819,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleP, periodA, sourceA, defaultCombo, 1111.0, 31.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleP, periodA, sourceA, defaultCombo, 1111.0, 31.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
 
@@ -847,8 +829,7 @@ public class ValidationServiceTest
 
         reference = new HashSet<>();
 
-        reference.add(
-            new ValidationResult( validationRuleQ, periodY, sourceB, defaultCombo, 2222.0, 366.0, dayInPeriodY ) );
+        reference.add( new ValidationResult( ruleQ, periodY, sourceB, defaultCombo, 2222.0, 366.0, dayInPeriodY ) );
 
         assertResultsEquals( reference, results );
     }
@@ -856,7 +837,7 @@ public class ValidationServiceTest
     @Test
     public void testValidateMissingValues00()
     {
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -870,7 +851,7 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementD, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
         Collection<ValidationResult> reference = new HashSet<>();
 
@@ -878,8 +859,7 @@ public class ValidationServiceTest
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
                 .build() );
 
-        reference
-            .add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 0.0, 1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleG, periodA, sourceA, defaultCombo, 0.0, 1.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -889,7 +869,7 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementC, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
         Collection<ValidationResult> reference = new HashSet<>();
 
@@ -897,8 +877,7 @@ public class ValidationServiceTest
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
                 .build() );
 
-        reference
-            .add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 1.0, 0.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleG, periodA, sourceA, defaultCombo, 1.0, 0.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -919,7 +898,7 @@ public class ValidationServiceTest
     @Test
     public void testValidateCompulsoryPair00()
     {
-        validationRuleService.saveValidationRule( validationRuleE );
+        validationRuleService.saveValidationRule( ruleE );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -933,7 +912,7 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementB, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleE );
+        validationRuleService.saveValidationRule( ruleE );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -941,8 +920,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 0.0, 1.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleE, periodA, sourceA, defaultCombo, 0.0, 1.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -952,7 +930,7 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementA, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleE );
+        validationRuleService.saveValidationRule( ruleE );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -960,8 +938,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleE, periodA, sourceA, defaultCombo, 1.0, 0.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleE, periodA, sourceA, defaultCombo, 1.0, 0.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -972,7 +949,7 @@ public class ValidationServiceTest
         useDataValue( dataElementA, periodA, sourceA, "1" );
         useDataValue( dataElementB, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleE );
+        validationRuleService.saveValidationRule( ruleE );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -985,9 +962,9 @@ public class ValidationServiceTest
     public void testValidateExclusivePairWithOtherData00()
     {
         useDataValue( dataElementC, periodA, sourceA, "96" );
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -995,8 +972,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 96.0, 0.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleG, periodA, sourceA, defaultCombo, 96.0, 0.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1005,11 +981,11 @@ public class ValidationServiceTest
     public void testValidateExclusivePairWithOtherData01()
     {
         useDataValue( dataElementC, periodA, sourceA, "97" );
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
         useDataValue( dataElementB, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1017,8 +993,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 97.0, 0.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleG, periodA, sourceA, defaultCombo, 97.0, 0.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1027,11 +1002,11 @@ public class ValidationServiceTest
     public void testValidateExclusivePairWithOtherData10()
     {
         useDataValue( dataElementC, periodA, sourceA, "98" );
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
         useDataValue( dataElementA, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1039,8 +1014,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 98.0, 0.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleG, periodA, sourceA, defaultCombo, 98.0, 0.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1049,12 +1023,12 @@ public class ValidationServiceTest
     public void testValidateExclusivePairWithOtherData11()
     {
         useDataValue( dataElementC, periodA, sourceA, "99" );
-        validationRuleService.saveValidationRule( validationRuleG );
+        validationRuleService.saveValidationRule( ruleG );
 
         useDataValue( dataElementA, periodA, sourceA, "1" );
         useDataValue( dataElementB, periodA, sourceA, "2" );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1062,10 +1036,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleG, periodA, sourceA, defaultCombo, 99.0, 0.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleF, periodA, sourceA, defaultCombo, 1.0, 2.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleG, periodA, sourceA, defaultCombo, 99.0, 0.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1073,7 +1045,7 @@ public class ValidationServiceTest
     @Test
     public void testValidateExclusivePair00()
     {
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1087,7 +1059,7 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementB, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1101,7 +1073,7 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementA, periodA, sourceA, "1" );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1116,7 +1088,7 @@ public class ValidationServiceTest
         useDataValue( dataElementA, periodA, sourceA, "1" );
         useDataValue( dataElementB, periodA, sourceA, "2" );
 
-        validationRuleService.saveValidationRule( validationRuleF );
+        validationRuleService.saveValidationRule( ruleF );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1124,8 +1096,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleF, periodA, sourceA, defaultCombo, 1.0, 2.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleF, periodA, sourceA, defaultCombo, 1.0, 2.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1162,13 +1133,10 @@ public class ValidationServiceTest
         Expression expressionV = new Expression( "#{" + dataElementD.getUid() + "}", "expressionV", NEVER_SKIP );
 
         ValidationRule validationRuleZ = createValidationRule( "Z", equal_to, expressionV, expressionZ,
-            periodTypeMonthly );
+            ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRuleZ ); // deD[all]
-                                                                     // =
-                                                                     // deD.optionComboA
-                                                                     // * 2 +
-                                                                     // deD.optionComboB
+        // deD[all] = deD.optionComboA * 2 + deD.optionComboB
+        validationRuleService.saveValidationRule( validationRuleZ );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1185,10 +1153,10 @@ public class ValidationServiceTest
     @Test
     public void testValidateWithDataSetElements()
     {
-        DataSet dataSetA = createDataSet( 'A', periodTypeMonthly );
-        DataSet dataSetB = createDataSet( 'B', periodTypeMonthly );
-        DataSet dataSetC = createDataSet( 'C', periodTypeMonthly );
-        DataSet dataSetD = createDataSet( 'D', periodTypeMonthly );
+        DataSet dataSetA = createDataSet( 'A', ptMonthly );
+        DataSet dataSetB = createDataSet( 'B', ptMonthly );
+        DataSet dataSetC = createDataSet( 'C', ptMonthly );
+        DataSet dataSetD = createDataSet( 'D', ptMonthly );
 
         dataSetA.addDataSetElement( dataElementA );
         dataSetA.addDataSetElement( dataElementB );
@@ -1207,24 +1175,20 @@ public class ValidationServiceTest
         dataSetService.addDataSet( dataSetC );
         dataSetService.addDataSet( dataSetD );
 
-        validationRuleService.saveValidationRule( validationRuleR );
-        validationRuleService.saveValidationRule( validationRuleS );
-        validationRuleService.saveValidationRule( validationRuleT );
-        validationRuleService.saveValidationRule( validationRuleU );
+        validationRuleService.saveValidationRule( ruleR );
+        validationRuleService.saveValidationRule( ruleS );
+        validationRuleService.saveValidationRule( ruleT );
+        validationRuleService.saveValidationRule( ruleU );
 
         useDataValue( dataElementA, periodA, sourceA, "1", optionCombo, optionCombo );
         useDataValue( dataElementB, periodA, sourceA, "2", optionCombo, optionCombo );
         useDataValue( dataElementA, periodA, sourceA, "4", optionComboX, optionCombo );
         useDataValue( dataElementB, periodA, sourceA, "8", optionComboX, optionCombo );
 
-        ValidationResult r = new ValidationResult( validationRuleR, periodA, sourceA, defaultCombo, 15.0, 1000.0,
-            dayInPeriodA );
-        ValidationResult s = new ValidationResult( validationRuleS, periodA, sourceA, defaultCombo, 12.0, 1000.0,
-            dayInPeriodA );
-        ValidationResult t = new ValidationResult( validationRuleT, periodA, sourceA, defaultCombo, 9.0, 1000.0,
-            dayInPeriodA );
-        ValidationResult u = new ValidationResult( validationRuleU, periodA, sourceA, defaultCombo, 3.0, 1000.0,
-            dayInPeriodA );
+        ValidationResult r = new ValidationResult( ruleR, periodA, sourceA, defaultCombo, 15.0, 1000.0, dayInPeriodA );
+        ValidationResult s = new ValidationResult( ruleS, periodA, sourceA, defaultCombo, 12.0, 1000.0, dayInPeriodA );
+        ValidationResult t = new ValidationResult( ruleT, periodA, sourceA, defaultCombo, 9.0, 1000.0, dayInPeriodA );
+        ValidationResult u = new ValidationResult( ruleU, periodA, sourceA, defaultCombo, 3.0, 1000.0, dayInPeriodA );
 
         assertResultsEquals( Lists.newArrayList( r, t, u ), validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetA, sourceA, periodA ).build() ) );
@@ -1273,12 +1237,11 @@ public class ValidationServiceTest
         useDataValue( dataElementA, periodA, sourceA, "2", optionCombo, optionComboBC );
         useDataValue( dataElementB, periodA, sourceA, "1", optionCombo, optionComboBC );
 
-        validationRuleService.saveValidationRule( validationRuleD ); // deA +
-                                                                     // deB <
-                                                                     // deB * 2
-        validationRuleService.saveValidationRule( validationRuleX ); // deA +
-                                                                     // deB =
-                                                                     // deB * 2
+        // deA + deB < deB * 2
+        validationRuleService.saveValidationRule( ruleD );
+
+        // deA + deB = deB * 2
+        validationRuleService.saveValidationRule( ruleX );
 
         //
         // optionComboAC
@@ -1290,10 +1253,8 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleD, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleX, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
 
@@ -1306,14 +1267,10 @@ public class ValidationServiceTest
 
         reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleD, periodA, sourceA, optionComboBC, 3.0, 2.0, dayInPeriodA ) );
-        reference
-            .add( new ValidationResult( validationRuleX, periodA, sourceA, optionComboBC, 3.0, 2.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleD, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleX, periodA, sourceA, optionComboAC, 7.0, 6.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleD, periodA, sourceA, optionComboBC, 3.0, 2.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( ruleX, periodA, sourceA, optionComboBC, 3.0, 2.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
 
@@ -1337,23 +1294,22 @@ public class ValidationServiceTest
         useDataValue( dataElementB, periodC, sourceA, "3" );
 
         Expression expressionLeft = new Expression(
-            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "expressionLeft", NEVER_SKIP );
+            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "exprLeft", NEVER_SKIP );
         Expression expressionRight = new Expression(
-            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "expressionRight", NEVER_SKIP );
+            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "exprRight", NEVER_SKIP );
 
-        ValidationRule validationRule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService.validationAnalysis( validationService.newParamsBuilder(
-            Sets.newHashSet( validationRule ), sourceA, Sets.newHashSet( periodA, periodB, periodC ) )
+            Sets.newHashSet( rule ), sourceA, Sets.newHashSet( periodA, periodB, periodC ) )
             .build() );
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodB, sourceA, defaultCombo, 1.0, 1.0, dayInPeriodB ) );
-        reference.add( new ValidationResult( validationRule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
+        reference.add( new ValidationResult( rule, periodB, sourceA, defaultCombo, 1.0, 1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( rule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1367,25 +1323,24 @@ public class ValidationServiceTest
         useDataValue( dataElementB, periodC, sourceA, "3" );
 
         Expression expressionLeft = new Expression(
-            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "expressionLeft",
+            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "exprLeft",
             SKIP_IF_ALL_VALUES_MISSING );
         Expression expressionRight = new Expression(
-            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "expressionRight",
+            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "exprRight",
             SKIP_IF_ALL_VALUES_MISSING );
 
-        ValidationRule validationRule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService.validationAnalysis( validationService.newParamsBuilder(
-            Sets.newHashSet( validationRule ), sourceA, Sets.newHashSet( periodA, periodB, periodC ) )
+            Sets.newHashSet( rule ), sourceA, Sets.newHashSet( periodA, periodB, periodC ) )
             .build() );
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodB, sourceA, defaultCombo, 1.0, 1.0, dayInPeriodB ) );
-        reference.add( new ValidationResult( validationRule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
+        reference.add( new ValidationResult( rule, periodB, sourceA, defaultCombo, 1.0, 1.0, dayInPeriodB ) );
+        reference.add( new ValidationResult( rule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1399,24 +1354,23 @@ public class ValidationServiceTest
         useDataValue( dataElementB, periodC, sourceA, "3" );
 
         Expression expressionLeft = new Expression(
-            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "expressionLeft",
-            SKIP_IF_ANY_VALUE_MISSING );
+            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}",
+            "exprLeft", SKIP_IF_ANY_VALUE_MISSING );
         Expression expressionRight = new Expression(
-            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}", "expressionRight",
-            SKIP_IF_ANY_VALUE_MISSING );
+            "#{" + dataElementA.getUid() + "} + #{" + dataElementB.getUid() + "}",
+            "expressionRight", SKIP_IF_ANY_VALUE_MISSING );
 
-        ValidationRule validationRule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService.validationAnalysis( validationService.newParamsBuilder(
-            Sets.newHashSet( validationRule ), sourceA, Sets.newHashSet( periodA, periodB, periodC ) )
+            Sets.newHashSet( rule ), sourceA, Sets.newHashSet( periodA, periodB, periodC ) )
             .build() );
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
+        reference.add( new ValidationResult( rule, periodC, sourceA, defaultCombo, 5.0, 5.0, dayInPeriodC ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1426,13 +1380,12 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementA, periodA, sourceA, "1" );
 
-        Expression expressionLeft = new Expression( "if(#{" + dataElementA.getUid() + "}==1,5,6)", "expressionLeft" );
-        Expression expressionRight = new Expression( "if(#{" + dataElementA.getUid() + "}==2,7,8)", "expressionRight" );
+        Expression expressionLeft = new Expression( "if(#{" + dataElementA.getUid() + "}==1,5,6)", "exprLeft" );
+        Expression expressionRight = new Expression( "if(#{" + dataElementA.getUid() + "}==2,7,8)", "exprRight" );
 
-        ValidationRule validationRule = createValidationRule( "R", equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1440,7 +1393,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodA, sourceA, defaultCombo, 5.0, 8.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( rule, periodA, sourceA, defaultCombo, 5.0, 8.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1450,15 +1403,12 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementA, periodA, sourceA, "1" );
 
-        Expression expressionLeft = new Expression( "if(isNull(#{" + dataElementA.getUid() + "}),5,6)",
-            "expressionLeft" );
-        Expression expressionRight = new Expression( "if(isNull(#{" + dataElementB.getUid() + "}),7,8)",
-            "expressionRight" );
+        Expression expressionLeft = new Expression( "if(isNull(#{" + dataElementA.getUid() + "}),5,6)", "exprLeft" );
+        Expression expressionRight = new Expression( "if(isNull(#{" + dataElementB.getUid() + "}),7,8)", "exprRight" );
 
-        ValidationRule validationRule = createValidationRule( "R", equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1466,7 +1416,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodA, sourceA, defaultCombo, 6.0, 7.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( rule, periodA, sourceA, defaultCombo, 6.0, 7.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1476,15 +1426,13 @@ public class ValidationServiceTest
     {
         useDataValue( dataElementA, periodA, sourceA, "1" );
 
-        Expression expressionLeft = new Expression( "if(isNotNull(#{" + dataElementA.getUid() + "}),5,6)",
-            "expressionLeft" );
+        Expression expressionLeft = new Expression( "if(isNotNull(#{" + dataElementA.getUid() + "}),5,6)", "exprLeft" );
         Expression expressionRight = new Expression( "if(isNotNull(#{" + dataElementB.getUid() + "}),7,8)",
-            "expressionRight" );
+            "exprRight" );
 
-        ValidationRule validationRule = createValidationRule( "R", equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1492,7 +1440,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodA, sourceA, defaultCombo, 5.0, 8.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( rule, periodA, sourceA, defaultCombo, 5.0, 8.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1503,14 +1451,13 @@ public class ValidationServiceTest
         useDataValue( dataElementA, periodA, sourceA, "3" );
 
         Expression expressionLeft = new Expression(
-            "firstNonNull( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "expressionLeft" );
+            "firstNonNull( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "exprLeft" );
         Expression expressionRight = new Expression(
-            "firstNonNull( #{" + dataElementB.getUid() + "}, #{" + dataElementA.getUid() + "} )", "expressionRight" );
+            "firstNonNull( #{" + dataElementB.getUid() + "}, #{" + dataElementA.getUid() + "} )", "exprRight" );
 
-        ValidationRule validationRule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", not_equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1518,7 +1465,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference.add( new ValidationResult( validationRule, periodA, sourceA, defaultCombo, 3.0, 3.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( rule, periodA, sourceA, defaultCombo, 3.0, 3.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1530,14 +1477,13 @@ public class ValidationServiceTest
         useDataValue( dataElementB, periodA, sourceA, "20" );
 
         Expression expressionLeft = new Expression(
-            "greatest( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "expressionLeft" );
+            "greatest( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "exprLeft" );
         Expression expressionRight = new Expression(
-            "least( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "expressionRight" );
+            "least( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "exprRight" );
 
-        ValidationRule validationRule = createValidationRule( "R", equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
+        ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         Collection<ValidationResult> results = validationService
             .validationAnalysis( validationService.newParamsBuilder( dataSetMonthly, sourceA, periodA )
@@ -1545,8 +1491,7 @@ public class ValidationServiceTest
 
         Collection<ValidationResult> reference = new HashSet<>();
 
-        reference
-            .add( new ValidationResult( validationRule, periodA, sourceA, defaultCombo, 20.0, 10.0, dayInPeriodA ) );
+        reference.add( new ValidationResult( rule, periodA, sourceA, defaultCombo, 20.0, 10.0, dayInPeriodA ) );
 
         assertResultsEquals( reference, results );
     }
@@ -1564,24 +1509,54 @@ public class ValidationServiceTest
         useDataValue( dataElementB, periodA, sourceA, "20" );
 
         Expression expressionLeft = new Expression(
-            "greatest( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "expressionLeft" );
+            "greatest( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "exprLeft" );
         Expression expressionRight = new Expression(
-            "least( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "expressionRight" );
+            "least( #{" + dataElementA.getUid() + "}, #{" + dataElementB.getUid() + "} )", "exprRight" );
 
-        ValidationRule validationRule = createValidationRule( "R", equal_to, expressionLeft, expressionRight,
-            periodTypeMonthly );
-        validationRule.setInstruction( "Validation rule instruction" );
+        ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
+        rule.setInstruction( "Validation rule instruction" );
 
-        validationRuleService.saveValidationRule( validationRule );
+        validationRuleService.saveValidationRule( rule );
 
         String instructionTranslated = "Validation rule instruction translated";
 
-        Set<Translation> listObjectTranslation = new HashSet<>( validationRule.getTranslations() );
-        listObjectTranslation
-            .add( new Translation( locale.getLanguage(), "INSTRUCTION", instructionTranslated ) );
+        Set<Translation> listObjectTranslation = new HashSet<>( rule.getTranslations() );
+        listObjectTranslation.add( new Translation( locale.getLanguage(), "INSTRUCTION", instructionTranslated ) );
 
-        identifiableObjectManager.updateTranslations( validationRule, listObjectTranslation );
+        identifiableObjectManager.updateTranslations( rule, listObjectTranslation );
 
-        Assert.assertEquals( instructionTranslated, validationRule.getDisplayInstruction() );
+        Assert.assertEquals( instructionTranslated, rule.getDisplayInstruction() );
+    }
+
+    @Test
+    public void testGetValidationRuleExpressionDetails()
+    {
+        useDataValue( dataElementA, periodA, sourceA, "10" );
+        useDataValue( dataElementB, periodA, sourceA, "20", optionComboX, optionCombo );
+
+        Expression expressionX = new Expression( "#{" + dataElementA.getUid()
+            + "} + #{" + dataElementB.getUid() + "}", "exprX" );
+        Expression expressionY = new Expression( "#{" + dataElementB.getUid()
+            + SEPARATOR + optionComboX.getUid() + "}", "exprY" );
+
+        ValidationRule rule = createValidationRule( "A", equal_to, expressionX, expressionY, ptMonthly );
+
+        validationRuleService.saveValidationRule( rule );
+
+        List<Map<String, String>> leftSideExpected = Lists.newArrayList(
+            ImmutableMap.of( "name", "DataElementA", "value", "10.0" ),
+            ImmutableMap.of( "name", "DataElementB", "value", "20.0" ) );
+
+        List<Map<String, String>> rightSideExpected = Lists.newArrayList(
+            ImmutableMap.of( "name", "DataElementB CategoryOptionX", "value", "20.0" ) );
+
+        ValidationRuleExpressionDetails details = validationService.getValidationRuleExpressionDetails(
+            validationService.newParamsBuilder(
+                Lists.newArrayList( rule ), sourceA, Lists.newArrayList( periodA ) )
+                .withAttributeOptionCombo( optionCombo )
+                .build() );
+
+        Assert.assertEquals( leftSideExpected, details.getLeftSide() );
+        Assert.assertEquals( rightSideExpected, details.getRightSide() );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -101,6 +100,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 /**
@@ -384,7 +384,7 @@ public class DataAnalysisController
         List<DeflatedDataValue> dataValues = new ArrayList<>( followupAnalysisService
             .getFollowupDataValues( Sets.newHashSet( organisationUnit ), dataElements,
                 periods, DataAnalysisService.MAX_OUTLIERS + 1 ) );
-                // +1 to detect overflow
+        // +1 to detect overflow
 
         session.setAttribute( KEY_ANALYSIS_DATA_VALUES, dataValues );
         session.setAttribute( KEY_ORG_UNIT, organisationUnit );


### PR DESCRIPTION
### The feature

When viewing Validation Rule results (Data Quality app -> Validation Rule Analysis -> Validate -> and Results are found), there is a Details column with an info "i" icon for each result. Clicking on the icon pops up a "Validation Details" window with the name and description of the rule, and sections for "LEFT SIDE" and "RIGHT SIDE". In each section there is a column DATA ELEMENT under which is listed the data elements in the expression, and a column VALUE, which should show the value for each individual data element in the expression.

This allows the user to "drill down" to see what data values went into the validation result computation, not just the value for the entire left and right sides as shown in the original "Validation Rule Analysis" results window. This is useful when the left or right side expression contains more than a single data element.

### The user's problem

This code only shows data values for data elements in the expression with an explicit category option combo, of the form #{deuid.cocuid}. It does not show values when only the data element is specified, of the form #{deuid}.

Further, this code was not modified when validation rules were expanded from just showing values from the datavalue table to also allowing Program Indicators, Program Attributes, and Program Data Elements (all from analytics). It only shows the values from the datavalue table.

### How the code worked

This feature uses the DataAnalysisController endpoint dataAnalysis/validationRulesExpression, which returns a ValidationRuleExpressionDetails object containing the left side and right side lists of "name/value" pairs corresponding to the data element (and category option combo) name, and the associated value. (There is no mention of data element in the WebAPI interface, only "name", and "value").

The controller called ExpressionService.getExpressionOperands to find the DataElementOperands (only) in the expression. This method was used only for these validation details. Then for each DataElementOperand, it called DataValueService.getDataValue to find the value from the datavalue table. This method returns only a single DataValue for the specified DataElement and CategoryOptionCombo (#{deuid.cocuid} in a validation expression). So when a DataElement alone was in a validation expression #{deuid}, it would never return a value.

### The fix not chosen

My first thought was to fix the problem as simply as possible, by extending the functionality of the DataValueService (and store) so that the value of a DataElement could be found by summing the values of all the DataValues for that DataElement with various CategoryOptionCombos.

A new DataValueService (and store) method would be needed for this, to query the datavalue table and return the sum of all matching values (with different catOptionCombos) for a data element. The existing getDataValue method returns a single DataValue, whose value could be either numeric or otherwise. What would be needed is either (a) a new query that assumes the values are numeric, casts them as such and sums them within the query, or (b) logic that retrieves the individual DataValues, and then in Java converts them to numeric and sums them. In either case, the existing getDataValue method could not be straightforwardly reused for this purpose.

What I didn't like about this approach is that (a) it would add more special-case methods to the general-purpose DataValueService and store, just for this validation rule details functionality, and (b) it doesn't solve the problem that only data value details are returned, and not program indicator, program attribute, or program data element values.

### The fix chosen

Instead, I created a new method in ValidationRuleService, to return a ValidationRuleExpressionDetails object with the expression item values for the given detailed selection (the given validation rule, orgUnit, period, and attributeOptionCombo). This service returns all the database values, whether from Data Elements, Program Indicators, Program Attributes, or Program Data Elements.

It does this by initiating a validation run, but instead of expecting validation results to be returned, it supplies a new ValidationRuleExpressionDetails object to be filled in. This invokes the code in DataValidationTask to go through the same, common logic for fetching all the database values, but then in this case DataValidationTask puts the values into  the supplied ValidationRuleExpressionDetails instead of evaluating the expression and returning validation results. DataValidationTask was refactored slightly to make this logic work.

This ensures that the detailed values returned will be supported for all the DimensionalItemObjects supported by validation rules, and will be the same values that would be fetched to evaluate the validation rule. For example, if sliding windows are used in the validation rule, the same logic will be applied to find the item values.

The name of the DimensionalItemObject returned in the ValidationRuleExpressionDetails is just getName() on the object. In the case of #{deuid.cocuid}, this returns the data element and category option combo names separated by a space. This is exactly what the old code returned. In the case of #{deuid} it returns just the data element name, which is as it should be. For the other types of DimensionalItemObject it also returns the sensible name of the object.

This PR also removes ExpressionService.getExpressionOperands and its test method. Now we don't need an ExpressionService method that is only used to support validation details.

ValidationRuleExpressionDetails was refactored to remove addLeftSideDetail and addRightSideDetail which called the private method addDetailTo, and just make addDetailTo public. This actually simplifies the calling code, which can now process each side with a reference to that side. A sortByName method was also added, so the left and right sides are returned through the WebAPI in order of the DimensionalItemObject name, rather than in a seemingly arbitrary order (the DimensionalItemObjects from the expression having been stored in a Set).

Test methods for the new ValidationRuleService.getValidationRuleExpressionDetails were added to ValidationServiceTest for data elements with and without a category option combo, and to AnalyticsValidationServiceTest for program indicators, program attributes, and program data elements.

### Future frontend adjustment

If this PR is approved and merged, I intend to create a frontend ticket to change the column name showing the left and right side details from "DATA ELEMENT" to something more general, since other types of object will also be shown here. My suggestion would be "ITEM NAME", but I am open to other ideas.