### PR TITLE
fix: can't update publicAccess

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -27,40 +27,28 @@
  */
 package org.hisp.dhis.common;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.Immutable;
-import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.attribute.AttributeValue;
-import org.hisp.dhis.audit.AuditAttribute;
-import org.hisp.dhis.common.annotation.Description;
-import org.hisp.dhis.schema.PropertyType;
+import org.apache.commons.lang3.*;
+import org.hibernate.annotations.*;
+import org.hisp.dhis.attribute.*;
+import org.hisp.dhis.audit.*;
+import org.hisp.dhis.common.annotation.*;
+import org.hisp.dhis.schema.*;
+import org.hisp.dhis.schema.annotation.*;
 import org.hisp.dhis.schema.annotation.Property;
-import org.hisp.dhis.schema.annotation.Property.Value;
-import org.hisp.dhis.schema.annotation.PropertyRange;
+import org.hisp.dhis.schema.annotation.Property.*;
 import org.hisp.dhis.schema.annotation.PropertyTransformer;
-import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
+import org.hisp.dhis.schema.transformer.*;
 import org.hisp.dhis.security.acl.Access;
-import org.hisp.dhis.translation.Translatable;
-import org.hisp.dhis.translation.Translation;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserSettingKey;
-import org.hisp.dhis.user.sharing.Sharing;
-import org.hisp.dhis.util.SharingUtils;
+import org.hisp.dhis.translation.*;
+import org.hisp.dhis.user.*;
+import org.hisp.dhis.user.sharing.*;
+import org.hisp.dhis.util.*;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.*;
+import com.fasterxml.jackson.dataformat.xml.annotation.*;
 
 /**
  * @author Bob Jolliffe
@@ -127,7 +115,7 @@ public class BaseIdentifiableObject
     /**
      * This object is available as external read-only.
      */
-    protected transient boolean externalAccess;
+    protected transient Boolean externalAccess;
 
     /**
      * Access string for public access.
@@ -476,7 +464,6 @@ public class BaseIdentifiableObject
     public void setUser( User user )
     {
         // TODO remove this after implementing functions for using Owner
-        // property
         setCreatedBy( createdBy == null ? user : createdBy );
         setOwner( user != null ? user.getUid() : null );
     }
@@ -492,11 +479,12 @@ public class BaseIdentifiableObject
     @PropertyRange( min = 8, max = 8 )
     public String getPublicAccess()
     {
-        return getSharing().getPublicAccess();
+        return SharingUtils.getDtoPublicAccess( publicAccess, getSharing() );
     }
 
     public void setPublicAccess( String publicAccess )
     {
+        this.publicAccess = publicAccess;
         getSharing().setPublicAccess( publicAccess );
     }
 
@@ -505,15 +493,12 @@ public class BaseIdentifiableObject
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean getExternalAccess()
     {
-        if ( sharing == null )
-        {
-            sharing = new Sharing();
-        }
-        return sharing.isExternal();
+        return SharingUtils.getDtoExternalAccess( externalAccess, getSharing() );
     }
 
     public void setExternalAccess( boolean externalAccess )
     {
+        this.externalAccess = externalAccess;
         getSharing().setExternal( externalAccess );
     }
 
@@ -523,7 +508,7 @@ public class BaseIdentifiableObject
     @JacksonXmlProperty( localName = "userGroupAccess", namespace = DxfNamespaces.DXF_2_0 )
     public Set<org.hisp.dhis.user.UserGroupAccess> getUserGroupAccesses()
     {
-        return SharingUtils.getDtoUserGroupAccesses( getSharing() );
+        return SharingUtils.getDtoUserGroupAccesses( userGroupAccesses, getSharing() );
     }
 
     public void setUserGroupAccesses( Set<org.hisp.dhis.user.UserGroupAccess> userGroupAccesses )
@@ -538,7 +523,7 @@ public class BaseIdentifiableObject
     @JacksonXmlProperty( localName = "userAccess", namespace = DxfNamespaces.DXF_2_0 )
     public Set<org.hisp.dhis.user.UserAccess> getUserAccesses()
     {
-        return SharingUtils.getDtoUserAccess( sharing );
+        return SharingUtils.getDtoUserAccesses( userAccesses, getSharing() );
     }
 
     public void setUserAccesses( Set<org.hisp.dhis.user.UserAccess> userAccesses )
@@ -591,7 +576,7 @@ public class BaseIdentifiableObject
     {
         if ( sharing == null )
         {
-            sharing = SharingUtils.generateSharingFromIdentifiableObject( this );
+            sharing = new Sharing();
         }
 
         return sharing;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
@@ -57,19 +57,14 @@ public class SharingUtils
             return dto;
         }
 
-        if ( dto == null )
+        if ( !sharing.hasUserGroupAccesses() )
         {
-            dto = new HashSet<>();
+            return dto;
         }
 
-        if ( sharing.hasUserGroupAccesses() )
-        {
-            dto = new HashSet<>( sharing.getUserGroups().values()
-                .stream().map( org.hisp.dhis.user.sharing.UserGroupAccess::toDtoObject )
-                .collect( Collectors.toSet() ) );
-        }
-
-        return dto;
+        return sharing.getUserGroups().values()
+            .stream().map( org.hisp.dhis.user.sharing.UserGroupAccess::toDtoObject )
+            .collect( Collectors.toSet() );
     }
 
     public static Set<org.hisp.dhis.user.UserAccess> getDtoUserAccesses( Set<org.hisp.dhis.user.UserAccess> dto,
@@ -80,13 +75,14 @@ public class SharingUtils
             return dto;
         }
 
-        if ( sharing.hasUserAccesses() )
+        if ( !sharing.hasUserAccesses() )
         {
-            dto = new HashSet<>( sharing.getUsers().values()
-                .stream().map( org.hisp.dhis.user.sharing.UserAccess::toDtoObject ).collect( Collectors.toSet() ) );
+            return dto;
         }
 
-        return dto;
+        return sharing.getUsers().values()
+            .stream().map( org.hisp.dhis.user.sharing.UserAccess::toDtoObject )
+            .collect( Collectors.toSet() );
     }
 
     public static String getDtoPublicAccess( String dto, Sharing sharing )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
@@ -27,20 +27,18 @@
  */
 package org.hisp.dhis.util;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
 
-import org.hisp.dhis.common.IdentifiableObject;
+import org.apache.commons.collections4.*;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.user.UserGroupAccess;
-import org.hisp.dhis.user.sharing.Sharing;
-import org.hisp.dhis.user.sharing.UserAccess;
+import org.hisp.dhis.user.sharing.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.*;
+import com.google.common.collect.*;
 
 public class SharingUtils
 {
@@ -51,17 +49,64 @@ public class SharingUtils
         throw new UnsupportedOperationException( "utility" );
     }
 
-    public static Set<UserGroupAccess> getDtoUserGroupAccesses( Sharing sharing )
+    public static Set<UserGroupAccess> getDtoUserGroupAccesses( Set<org.hisp.dhis.user.UserGroupAccess> dto,
+        Sharing sharing )
     {
-        return sharing.hasUserGroupAccesses() ? sharing.getUserGroups().values()
-            .stream().map( org.hisp.dhis.user.sharing.UserGroupAccess::toDtoObject ).collect( Collectors.toSet() )
-            : new HashSet<>();
+        if ( !CollectionUtils.isEmpty( dto ) )
+        {
+            return dto;
+        }
+
+        if ( dto == null )
+        {
+            dto = new HashSet<>();
+        }
+
+        if ( sharing.hasUserGroupAccesses() )
+        {
+            dto = new HashSet<>( sharing.getUserGroups().values()
+                .stream().map( org.hisp.dhis.user.sharing.UserGroupAccess::toDtoObject )
+                .collect( Collectors.toSet() ) );
+        }
+
+        return dto;
     }
 
-    public static Set<org.hisp.dhis.user.UserAccess> getDtoUserAccess( Sharing sharing )
+    public static Set<org.hisp.dhis.user.UserAccess> getDtoUserAccesses( Set<org.hisp.dhis.user.UserAccess> dto,
+        Sharing sharing )
     {
-        return sharing.hasUserAccesses() ? sharing.getUsers().values()
-            .stream().map( UserAccess::toDtoObject ).collect( Collectors.toSet() ) : new HashSet<>();
+        if ( !CollectionUtils.isEmpty( dto ) )
+        {
+            return dto;
+        }
+
+        if ( sharing.hasUserAccesses() )
+        {
+            dto = new HashSet<>( sharing.getUsers().values()
+                .stream().map( org.hisp.dhis.user.sharing.UserAccess::toDtoObject ).collect( Collectors.toSet() ) );
+        }
+
+        return dto;
+    }
+
+    public static String getDtoPublicAccess( String dto, Sharing sharing )
+    {
+        if ( dto == null )
+        {
+            dto = sharing.getPublicAccess();
+        }
+
+        return dto;
+    }
+
+    public static boolean getDtoExternalAccess( Boolean dto, Sharing sharing )
+    {
+        if ( dto == null )
+        {
+            dto = sharing.isExternal();
+        }
+
+        return dto;
     }
 
     public static Sharing generateSharingFromIdentifiableObject( IdentifiableObject object )
@@ -73,6 +118,12 @@ public class SharingUtils
         sharing.setDtoUserGroupAccesses( object.getUserGroupAccesses() );
         sharing.setDtoUserAccesses( object.getUserAccesses() );
         return sharing;
+    }
+
+    public static void resetAccessCollections( BaseIdentifiableObject identifiableObject )
+    {
+        identifiableObject.setUserAccesses( Sets.newHashSet() );
+        identifiableObject.setUserGroupAccesses( Sets.newHashSet() );
     }
 
     public static String withAccess( String jsonb, UnaryOperator<String> accessTransformation )

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -30,11 +30,9 @@ package org.hisp.dhis.security.acl;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.springframework.util.CollectionUtils.containsAny;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
+import org.apache.commons.collections4.*;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -51,7 +49,10 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
+import org.hisp.dhis.util.*;
 import org.springframework.stereotype.Service;
+
+import com.sun.tools.rngom.parse.host.*;
 
 /**
  * Default ACL implementation that uses SchemaDescriptors to get authorities /
@@ -482,16 +483,15 @@ public class DefaultAclService implements AclService
 
         if ( object.getSharing().getOwner() == null )
         {
-            baseIdentifiableObject.getSharing().setOwner( user );
+            baseIdentifiableObject.setOwner( user.getUid() );
         }
 
         if ( canMakePublic( user, object ) && defaultPublic( object ) )
         {
-            baseIdentifiableObject.getSharing().setPublicAccess( AccessStringHelper.READ_WRITE );
+            baseIdentifiableObject.setPublicAccess( AccessStringHelper.READ_WRITE );
         }
 
-        object.getSharing().getUsers().clear();
-        object.getSharing().getUserGroups().clear();
+        SharingUtils.resetAccessCollections( baseIdentifiableObject );
     }
 
     @Override
@@ -503,12 +503,10 @@ public class DefaultAclService implements AclService
         }
 
         BaseIdentifiableObject baseIdentifiableObject = (BaseIdentifiableObject) object;
-        baseIdentifiableObject.getSharing().setOwner( user );
-        baseIdentifiableObject.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
-        baseIdentifiableObject.getSharing().setExternal( false );
-
-        object.getSharing().resetUserAccesses();
-        object.getSharing().resetUserGroupAccesses();
+        baseIdentifiableObject.setUser( user );
+        baseIdentifiableObject.setPublicAccess( AccessStringHelper.DEFAULT );
+        baseIdentifiableObject.setExternalAccess( false );
+        SharingUtils.resetAccessCollections( baseIdentifiableObject );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -70,6 +70,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserInfo;
+import org.hisp.dhis.util.*;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -157,8 +158,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
             if ( clearSharing )
             {
                 identifiableObject.setPublicAccess( AccessStringHelper.DEFAULT );
-                identifiableObject.getSharing().resetUserGroupAccesses();
-                identifiableObject.getSharing().resetUserAccesses();
+                SharingUtils.resetAccessCollections( identifiableObject );
             }
 
             if ( identifiableObject.getCreatedBy() == null )
@@ -182,12 +182,12 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
                 {
                     if ( aclService.defaultPublic( identifiableObject ) )
                     {
-                        identifiableObject.getSharing().setPublicAccess( AccessStringHelper.READ_WRITE );
+                        identifiableObject.setPublicAccess( AccessStringHelper.READ_WRITE );
                     }
                 }
                 else if ( aclService.canMakePrivate( user, identifiableObject ) )
                 {
-                    identifiableObject.getSharing().setPublicAccess( AccessStringHelper.newInstance().build() );
+                    identifiableObject.setPublicAccess( AccessStringHelper.newInstance().build() );
                 }
             }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -50,8 +50,7 @@ import org.hisp.dhis.schema.*;
 import org.hisp.dhis.system.util.*;
 import org.hisp.dhis.trackedentity.*;
 import org.hisp.dhis.user.*;
-import org.hisp.dhis.user.sharing.UserAccess;
-import org.hisp.dhis.user.sharing.UserGroupAccess;
+import org.hisp.dhis.util.*;
 import org.springframework.context.annotation.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
@@ -268,7 +267,7 @@ public class DefaultPreheatService implements PreheatService
         }
 
         handleAttributes( params.getObjects(), preheat );
-        handleSecurity( params.getObjects(), params.getPreheatIdentifier(), preheat );
+        handleSharing( params.getObjects() );
 
         periodStore.getAll().forEach( period -> preheat.getPeriodMap().put( period.getName(), period ) );
         periodStore.getAllPeriodTypes()
@@ -280,42 +279,10 @@ public class DefaultPreheatService implements PreheatService
         return preheat;
     }
 
-    private void handleSecurity( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects,
-        PreheatIdentifier identifier, Preheat preheat )
+    private void handleSharing( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects )
     {
-        objects.forEach( ( klass, list ) -> list.forEach( object -> {
-            object.getSharing().setExternal( object.getExternalAccess() );
-            object.getSharing().setOwner( object.getCreatedBy() );
-            object.getSharing().setPublicAccess( object.getPublicAccess() );
-
-            object.getUserAccesses().forEach( ua -> {
-                User user = preheat.get( PreheatIdentifier.UID, User.class, ua.getUserUid() );
-
-                if ( user != null )
-                {
-                    ua.setUser( user );
-                    ua.setUid( user.getUid() );
-                    ua.setDisplayName( user.getDisplayName() );
-                }
-
-                // Copy legacy sharing to new jsonb sharing
-                object.getSharing().getUsers().put( ua.getUid(), new UserAccess( ua ) );
-            } );
-
-            object.getUserGroupAccesses().forEach( uga -> {
-                UserGroup userGroup = preheat.get( PreheatIdentifier.UID, UserGroup.class, uga.getUserGroupUid() );
-
-                if ( userGroup != null )
-                {
-                    uga.setUserGroup( userGroup );
-                    uga.setUid( userGroup.getUid() );
-                    uga.setDisplayName( userGroup.getDisplayName() );
-                }
-
-                // Copy legacy sharing to new jsonb sharing
-                object.getSharing().getUserGroups().put( uga.getUid(), new UserGroupAccess( uga ) );
-            } );
-        } ) );
+        objects.forEach( ( klass, list ) -> list.forEach( object -> ((BaseIdentifiableObject) object)
+            .setSharing( SharingUtils.generateSharingFromIdentifiableObject( object ) ) ) );
     }
 
     private void handleAttributes( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sharing/DefaultSharingService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sharing/DefaultSharingService.java
@@ -134,7 +134,7 @@ public class DefaultSharingService implements SharingService
 
         if ( aclService.canMakePublic( user, object ) )
         {
-            object.getSharing().setPublicAccess( sharing.getPublicAccess() );
+            object.setPublicAccess( sharing.getPublicAccess() );
         }
 
         if ( !schema.isDataShareable() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityTypeAttribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityTypeAttribute.hbm.xml
@@ -17,7 +17,7 @@
       column="trackedentitytypeid" foreign-key="fk_trackedentitytypeattribute_trackedentitytypeid" />
 
     <many-to-one name="trackedEntityAttribute" class="org.hisp.dhis.trackedentity.TrackedEntityAttribute"
-      column="trackedentityattributeid" foreign-key="fk_trackedentitytypeattribute_trackedentityattributeid" />      
+      column="trackedentityattributeid" foreign-key="fk_trackedentitytypeattribute_trackedentityattributeid" />
     
     <property name="displayInList" column="displayinlist" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -180,6 +180,42 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
+    public void testImportUpdatePublicAccess()
+        throws IOException
+    {
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses.json" ).getInputStream(), RenderFormat.JSON );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE );
+        params.setObjects( metadata );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+
+        assertEquals( "rw------", dataSet.getPublicAccess() );
+
+        metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_publicAccess_update.json" ).getInputStream(), RenderFormat.JSON );
+
+        params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.UPDATE );
+        params.setObjects( metadata );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet updatedDataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+
+        assertEquals( "r-------", updatedDataSet.getPublicAccess() );
+
+    }
+
+    @Test
     public void testImportWithAccessObjects()
         throws IOException
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_publicAccess_update.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_publicAccess_update.json
@@ -1,0 +1,67 @@
+{
+  "dataSets": [
+    {
+      "dataSetElements": [
+        {
+          "id": "WTOZ7gqbASV",
+          "dataElement": {
+            "id": "nHwIqKAudKN"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        },
+        {
+          "id": "rSChycu6mOY",
+          "dataElement": {
+            "id": "VolAzjFe5zP"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        }
+      ],
+      "compulsoryDataElementOperands": [ ],
+      "timelyDays": 15,
+      "fieldCombinationRequired": false,
+      "version": 4,
+      "renderAsTabs": false,
+      "name": "Data Set",
+      "expiryDays": 0,
+      "skipOffline": false,
+      "dataElementDecoration": false,
+      "validCompleteOnly": false,
+      "publicAccess": "r-------",
+      "noValueRequiresComment": false,
+      "shortName": "Data Set",
+      "description" : "update data set",
+      "attributeValues": [ ],
+      "id": "em8Bg4LCr5k",
+      "indicators": [ ],
+      "userGroupAccesses": [ ],
+      "periodType": "Monthly",
+      "mobile": false,
+      "lastUpdated": "2016-03-08T07:32:42.146+0000",
+      "notifyCompletingUser": false,
+      "openFuturePeriods": 0,
+      "created": "2016-03-08T07:31:30.424+0000",
+      "organisationUnits": [
+        {
+          "id": "x3gVvpbVgqy"
+        }
+      ],
+      "renderHorizontally": false,
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "userAccesses": [
+        {
+          "user": {
+            "id": "T12jeH7KPzk"
+          },
+          "access":"rwrw----"
+        }
+      ]
+    }
+  ]
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -181,7 +181,8 @@ public class SharingController
             sharing.getObject().getUser().setName( object.getCreatedBy().getDisplayName() );
         }
 
-        for ( org.hisp.dhis.user.UserGroupAccess userGroupAccess : object.getUserGroupAccesses() )
+        for ( org.hisp.dhis.user.UserGroupAccess userGroupAccess : SharingUtils
+            .getDtoUserGroupAccesses( object.getUserGroupAccesses(), object.getSharing() ) )
         {
             String userGroupDisplayName = userGroupService.getDisplayName( userGroupAccess.getId() );
 
@@ -199,7 +200,8 @@ public class SharingController
             sharing.getObject().getUserGroupAccesses().add( sharingUserGroupAccess );
         }
 
-        for ( org.hisp.dhis.user.UserAccess userAccess : SharingUtils.getDtoUserAccess( object.getSharing() ) )
+        for ( org.hisp.dhis.user.UserAccess userAccess : SharingUtils.getDtoUserAccesses( object.getUserAccesses(),
+            object.getSharing() ) )
         {
             String userDisplayName = userService.getDisplayName( userAccess.getUid() );
 


### PR DESCRIPTION
Issue:  https://jira.dhis2.org/browse/DHIS2-10464
- When user import sharing with old format, the import service didn't take the value from legacy `publicAccess` property in `BaseIdentifiableObject`

Fix:
- Fix the code to take values from legacy `publicAccess` property
- Also move the logics for copying values between new and old format to `SharingUtils` so later it would be easier to remove this legacy codes.

