### PR TITLE
feat: allow ISO date with 4 digits 'nanos in second' part

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -84,6 +84,8 @@ public class DateUtils
 
     private static final DateTimeParser[] SUPPORTED_DATE_FORMAT_PARSERS = {
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ).getParser(),
+        DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSSZ" ).getParser(),
+        DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSS" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSS" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ssZ" ).getParser(),

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/config/jackson/JacksonObjectMapperConfigTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/config/jackson/JacksonObjectMapperConfigTest.java
@@ -27,12 +27,14 @@
  */
 package org.hisp.dhis.commons.config.jackson;
 
+import static java.time.ZoneId.systemDefault;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 
@@ -60,13 +62,12 @@ public class JacksonObjectMapperConfigTest
         assertParsedAsDate( DateUtils.parseDate( "2019-01-01" ), "2019-01-01" );
         assertParsedAsDate( DateUtils.parseDate( "2019-01-01T11:55" ), "2019-01-01T11:55" );
         assertParsedAsDate( DateUtils.parseDate( "2019-01-01T11:55:01.444Z" ), "2019-01-01T11:55:01.444Z" );
-
-    }
-
-    @Test
-    public void testIsoDateSupport_UnsupportedFormats()
-    {
-        assertNotParsedAsDate( "2019-01-01T11:55:01.4444" );
+        assertParsedAsDate( DateUtils.parseDate( "2019-01-01T11:55:01.4444" ), "2019-01-01T11:55:01.4444" );
+        Date expected = DateUtils.parseDate( "2019-01-01T11:55:01.4444Z" );
+        assertParsedAsDate( expected, "2019-01-01T11:55:01.4444Z" );
+        assertParsedAsDate( expected,
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                .format( expected.toInstant().atZone( systemDefault() ).toLocalDateTime() ) );
     }
 
     @Test


### PR DESCRIPTION
Reason the 4 digit 'nanos in second' is special is that `DateTimeFormatter.ISO_LOCAL_DATE_TIME.format` uses 4 digits nanos of second. This might only be the case if the provided date has a non zero sub-second time part but its important nonetheless to make sure DHIS2 accepts dates there were formatted with java's `DateTimeFormatter.ISO_LOCAL_DATE_TIME`.