### PR TITLE
chore: proper thread-safety for Notifier implementation

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.system.notification;
 
 import java.util.Date;
-import java.util.List;
+import java.util.Deque;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +43,7 @@ import org.hisp.dhis.scheduling.JobType;
 @Slf4j
 public class InMemoryNotifier implements Notifier
 {
-    private NotificationMap notificationMap = new NotificationMap();
+    private final NotificationMap notificationMap = new NotificationMap();
 
     // -------------------------------------------------------------------------
     // Notifier implementation
@@ -111,19 +111,19 @@ public class InMemoryNotifier implements Notifier
     }
 
     @Override
-    public Map<JobType, Map<String, List<Notification>>> getNotifications()
+    public Map<JobType, Map<String, Deque<Notification>>> getNotifications()
     {
         return notificationMap.getNotifications();
     }
 
     @Override
-    public List<Notification> getNotificationsByJobId( JobType jobType, String jobId )
+    public Deque<Notification> getNotificationsByJobId( JobType jobType, String jobId )
     {
         return notificationMap.getNotificationsByJobId( jobType, jobId );
     }
 
     @Override
-    public Map<String, List<Notification>> getNotificationsByJobType( JobType jobType )
+    public Map<String, Deque<Notification>> getNotificationsByJobType( JobType jobType )
     {
         return notificationMap.getNotificationsWithType( jobType );
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
@@ -27,8 +27,15 @@
  */
 package org.hisp.dhis.system.notification;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import static java.util.Arrays.stream;
+import static java.util.Collections.unmodifiableMap;
+
+import java.util.Deque;
+import java.util.EnumMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
@@ -38,87 +45,69 @@ import org.hisp.dhis.scheduling.JobType;
  */
 public class NotificationMap
 {
-    public final static int MAX_POOL_TYPE_SIZE = 500;
+    public static final int MAX_POOL_TYPE_SIZE = 500;
 
-    private Map<JobType, Map<String, List<Notification>>> notificationsWithType;
+    private final Map<JobType, Map<String, Deque<Notification>>> notificationsWithType = new EnumMap<>( JobType.class );
 
-    private Map<JobType, Map<String, Object>> summariesWithType;
+    private final Map<JobType, Map<String, Object>> summariesWithType = new EnumMap<>( JobType.class );
+
+    private final Map<JobType, Deque<String>> notificationsJobIdOrder = new EnumMap<>( JobType.class );
+
+    private final Map<JobType, Deque<String>> summariesJobIdOrder = new EnumMap<>( JobType.class );
 
     NotificationMap()
     {
-        notificationsWithType = new HashMap<>();
-        Arrays.stream( JobType.values() )
-            .forEach( jobType -> notificationsWithType.put( jobType, new LinkedHashMap<>() ) );
-
-        summariesWithType = new HashMap<>();
-        Arrays.stream( JobType.values() )
-            .forEach( jobType -> summariesWithType.put( jobType, new LinkedHashMap<>() ) );
+        stream( JobType.values() ).forEach( jobType -> {
+            notificationsWithType.put( jobType, new ConcurrentHashMap<>() );
+            summariesWithType.put( jobType, new ConcurrentHashMap<>() );
+            notificationsJobIdOrder.put( jobType, new ConcurrentLinkedDeque<>() );
+            summariesJobIdOrder.put( jobType, new ConcurrentLinkedDeque<>() );
+        } );
     }
 
-    public Map<JobType, Map<String, List<Notification>>> getNotifications()
+    public Map<JobType, Map<String, Deque<Notification>>> getNotifications()
     {
-        return notificationsWithType;
+        return unmodifiableMap( notificationsWithType );
     }
 
-    public synchronized List<Notification> getNotificationsByJobId( JobType jobType, String jobId )
+    public Deque<Notification> getNotificationsByJobId( JobType jobType, String jobId )
     {
-        return Optional.ofNullable( notificationsWithType.get( jobType ) )
-            .map( n -> n.get( jobId ) )
-            .map( LinkedList::new )
-            .orElse( new LinkedList<>() );
+        Deque<Notification> notifications = notificationsWithType.get( jobType ).get( jobId );
+        // return a defensive copy
+        return notifications == null ? new LinkedList<>() : new LinkedList<>( notifications );
     }
 
-    public synchronized Map<String, List<Notification>> getNotificationsWithType( JobType jobType )
+    public Map<String, Deque<Notification>> getNotificationsWithType( JobType jobType )
     {
-        return notificationsWithType.get( jobType )
-            .entrySet()
-            .stream()
-            .collect( Collectors.toMap(
-                Map.Entry::getKey,
-                e -> e.getValue() != null ? new LinkedList<>( e.getValue() ) : new LinkedList<>() ) );
+        return unmodifiableMap( notificationsWithType.get( jobType ) );
     }
 
-    public synchronized void add( JobConfiguration jobConfiguration, Notification notification )
+    public void add( JobConfiguration configuration, Notification notification )
     {
-        String uid = jobConfiguration.getUid();
-
-        Map<String, List<Notification>> uidNotifications = notificationsWithType
-            .get( jobConfiguration.getJobType() );
-
-        LinkedList<Notification> notifications;
-        if ( uidNotifications.containsKey( uid ) )
+        JobType jobType = configuration.getJobType();
+        String jobId = configuration.getUid();
+        Deque<String> notifications = notificationsJobIdOrder.get( jobType );
+        if ( notifications.size() > MAX_POOL_TYPE_SIZE )
         {
-            notifications = (LinkedList<Notification>) uidNotifications.get( uid );
+            notificationsWithType.get( jobType ).remove( notifications.removeLast() );
         }
-        else
-        {
-            notifications = new LinkedList<>();
-        }
-
-        notifications.addFirst( notification );
-
-        if ( uidNotifications.size() >= MAX_POOL_TYPE_SIZE )
-        {
-            String key = (String) uidNotifications.keySet().toArray()[0];
-            uidNotifications.remove( key );
-        }
-
-        uidNotifications.put( uid, notifications );
-
-        notificationsWithType.put( jobConfiguration.getJobType(), uidNotifications );
+        notifications.addFirst( jobId );
+        notificationsWithType.get( jobType )
+            .computeIfAbsent( jobId, key -> new ConcurrentLinkedDeque<>() )
+            .add( notification );
     }
 
-    public synchronized void addSummary( JobConfiguration jobConfiguration, Object summary )
+    public void addSummary( JobConfiguration configuration, Object summary )
     {
-        Map<String, Object> summaries = summariesWithType.get( jobConfiguration.getJobType() );
-
+        JobType jobType = configuration.getJobType();
+        String jobId = configuration.getUid();
+        Deque<String> summaries = summariesJobIdOrder.get( jobType );
         if ( summaries.size() >= MAX_POOL_TYPE_SIZE )
         {
-            String key = (String) summaries.keySet().toArray()[0];
-            summaries.remove( key );
+            summariesWithType.get( jobType ).remove( summaries.removeLast() );
         }
-
-        summaries.put( jobConfiguration.getUid(), summary );
+        summaries.addFirst( jobId );
+        summariesWithType.get( jobType ).put( jobId, summary );
     }
 
     public Object getSummary( JobType jobType, String jobId )
@@ -128,12 +117,16 @@ public class NotificationMap
 
     public Map<String, Object> getJobSummariesForJobType( JobType jobType )
     {
-        return summariesWithType.get( jobType );
+        return unmodifiableMap( summariesWithType.get( jobType ) );
     }
 
-    public void clear( JobConfiguration jobConfiguration )
+    public void clear( JobConfiguration configuration )
     {
-        notificationsWithType.get( jobConfiguration.getJobType() ).remove( jobConfiguration.getUid() );
-        summariesWithType.get( jobConfiguration.getJobType() ).remove( jobConfiguration.getUid() );
+        JobType jobType = configuration.getJobType();
+        String jobId = configuration.getUid();
+        notificationsWithType.get( jobType ).remove( jobId );
+        notificationsJobIdOrder.get( jobType ).removeIf( e -> e.equals( jobId ) );
+        summariesWithType.get( jobType ).remove( jobId );
+        summariesJobIdOrder.get( jobType ).removeIf( e -> e.equals( jobId ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.system.notification;
 
-import java.util.List;
+import java.util.Deque;
 import java.util.Map;
 
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -52,11 +52,11 @@ public interface Notifier
 
     Notifier update( JobConfiguration id, NotificationLevel level, String message, boolean completed );
 
-    Map<JobType, Map<String, List<Notification>>> getNotifications();
+    Map<JobType, Map<String, Deque<Notification>>> getNotifications();
 
-    List<Notification> getNotificationsByJobId( JobType jobType, String jobId );
+    Deque<Notification> getNotificationsByJobId( JobType jobType, String jobId );
 
-    Map<String, List<Notification>> getNotificationsByJobType( JobType jobType );
+    Map<String, Deque<Notification>> getNotificationsByJobType( JobType jobType );
 
     Notifier clear( JobConfiguration id );
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationMapTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationMapTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 
 public class NotificationMapTest
 {
-    private NotificationMap mapToTest = new NotificationMap();
+    private final NotificationMap mapToTest = new NotificationMap();
 
     @Test
     public void testFirstSummaryToBeCreatedIsTheFirstOneToBeRemoved()

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.system.notification;
 
-import static org.hisp.dhis.scheduling.JobType.*;
+import static org.hisp.dhis.scheduling.JobType.ANALYTICS_TABLE;
+import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
+import static org.hisp.dhis.scheduling.JobType.METADATA_IMPORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import java.util.List;
+import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -54,21 +55,19 @@ public class NotifierTest extends DhisSpringTest
     @Autowired
     private Notifier notifier;
 
-    private User user = createUser( 'A' );
+    private final User user = createUser( 'A' );
 
-    private JobConfiguration dataValueImportJobConfig;
+    private final JobConfiguration dataValueImportJobConfig;
 
-    private JobConfiguration analyticsTableJobConfig;
+    private final JobConfiguration analyticsTableJobConfig;
 
-    private JobConfiguration metadataImportJobConfig;
+    private final JobConfiguration metadataImportJobConfig;
 
-    private JobConfiguration dataValueImportSecondJobConfig;
+    private final JobConfiguration dataValueImportSecondJobConfig;
 
-    private JobConfiguration dataValueImportThirdJobConfig;
+    private final JobConfiguration dataValueImportThirdJobConfig;
 
-    private JobConfiguration dataValueImportFourthConfig;
-
-    private JobConfiguration dataValueImportFifthConfig;
+    private final JobConfiguration dataValueImportFourthConfig;
 
     public NotifierTest()
     {
@@ -84,7 +83,8 @@ public class NotifierTest extends DhisSpringTest
         dataValueImportThirdJobConfig.setUid( "dvi3" );
         dataValueImportFourthConfig = new JobConfiguration( null, DATAVALUE_IMPORT, user.getUid(), false );
         dataValueImportFourthConfig.setUid( "dvi4" );
-        dataValueImportFifthConfig = new JobConfiguration( null, DATAVALUE_IMPORT, user.getUid(), false );
+        JobConfiguration dataValueImportFifthConfig = new JobConfiguration( null, DATAVALUE_IMPORT, user.getUid(),
+            false );
         dataValueImportFifthConfig.setUid( "dvi5" );
     }
 
@@ -97,7 +97,7 @@ public class NotifierTest extends DhisSpringTest
         notifier.notify( analyticsTableJobConfig, "Process started" );
         notifier.notify( analyticsTableJobConfig, "Process done" );
 
-        Map<JobType, Map<String, List<Notification>>> notificationsMap = notifier.getNotifications();
+        Map<JobType, Map<String, Deque<Notification>>> notificationsMap = notifier.getNotifications();
 
         assertNotNull( notificationsMap );
         assertEquals( 3, notifier.getNotificationsByJobId( dataValueImportJobConfig.getJobType(),
@@ -142,21 +142,22 @@ public class NotifierTest extends DhisSpringTest
         notifier.notify( dataValueImportJobConfig, "Import done" );
         notifier.notify( analyticsTableJobConfig, "Process started" );
         notifier.notify( analyticsTableJobConfig, "Process done" );
-        List<Notification> notifications = notifier.getNotificationsByJobType( DATAVALUE_IMPORT )
+        Deque<Notification> notifications = notifier.getNotificationsByJobType( DATAVALUE_IMPORT )
             .get( dataValueImportJobConfig.getUid() );
         assertNotNull( notifications );
         assertEquals( 4, notifications.size() );
 
         notifier.notify( dataValueImportThirdJobConfig, "Completed1" );
 
-        Map<String, List<Notification>> notificationsByJobType = notifier.getNotificationsByJobType( DATAVALUE_IMPORT );
+        Map<String, Deque<Notification>> notificationsByJobType = notifier
+            .getNotificationsByJobType( DATAVALUE_IMPORT );
         assertNotNull( notificationsByJobType );
         assertEquals( 3, notificationsByJobType.size() );
         assertEquals( 4, notificationsByJobType.get( dataValueImportJobConfig.getUid() ).size() );
         assertEquals( 1, notificationsByJobType.get( dataValueImportSecondJobConfig.getUid() ).size() );
         assertEquals( 1, notificationsByJobType.get( dataValueImportThirdJobConfig.getUid() ).size() );
-        assertTrue( "Completed1"
-            .equals( notificationsByJobType.get( dataValueImportThirdJobConfig.getUid() ).get( 0 ).getMessage() ) );
+        assertEquals( "Completed1",
+            notificationsByJobType.get( dataValueImportThirdJobConfig.getUid() ).getFirst().getMessage() );
 
         notifier.notify( dataValueImportFourthConfig, "Completed2" );
 
@@ -166,8 +167,8 @@ public class NotifierTest extends DhisSpringTest
         assertEquals( 1, notificationsByJobType.get( dataValueImportSecondJobConfig.getUid() ).size() );
         assertEquals( 1, notificationsByJobType.get( dataValueImportThirdJobConfig.getUid() ).size() );
         assertEquals( 1, notificationsByJobType.get( dataValueImportFourthConfig.getUid() ).size() );
-        assertTrue( "Completed2"
-            .equals( notificationsByJobType.get( dataValueImportFourthConfig.getUid() ).get( 0 ).getMessage() ) );
+        assertEquals( "Completed2",
+            notificationsByJobType.get( dataValueImportFourthConfig.getUid() ).getFirst().getMessage() );
 
     }
 
@@ -188,13 +189,12 @@ public class NotifierTest extends DhisSpringTest
             .getJobSummariesForJobType( METADATA_IMPORT );
         assertNotNull( jobSummariesForMetadataImportType );
         assertEquals( 1, jobSummariesForMetadataImportType.size() );
-        assertTrue( "somethingid3"
-            .equals( jobSummariesForMetadataImportType.get( metadataImportJobConfig.getUid() ) ) );
+        assertEquals( "somethingid3", jobSummariesForMetadataImportType.get( metadataImportJobConfig.getUid() ) );
 
         Object summary = notifier.getJobSummaryByJobId( dataValueImportJobConfig.getJobType(),
             dataValueImportJobConfig.getUid() );
         assertNotNull( summary );
-        assertTrue( "True", "somethingid1".equals( summary ) );
+        assertEquals( "True", "somethingid1", summary );
 
         notifier.addJobSummary( dataValueImportThirdJobConfig, "summarry3", String.class );
 
@@ -218,23 +218,19 @@ public class NotifierTest extends DhisSpringTest
 
         notifier.notify( jobConfig, "somethingid" );
 
-        IntStream.range( 0, 100 ).forEach( i -> {
-            e.execute( () -> {
-                notifier.notify( jobConfig, "somethingid" + i );
-            } );
-        } );
+        IntStream.range( 0, 100 ).forEach( i -> e.execute(
+            () -> notifier.notify( jobConfig, "somethingid" + i ) ) );
         IntStream.range( 0, 100 ).forEach( i -> {
             for ( Notification notification : notifier.getNotificationsByJobType( METADATA_IMPORT )
                 .get( jobConfig.getUid() ) )
             {
                 // Iterate over notifications when new notification are added
-                notification.getUid();
+                assertNotNull( notification.getUid() );
             }
         } );
 
-        e.awaitTermination( 200, TimeUnit.MILLISECONDS );
-        assertEquals( 101,
-            notifier.getNotificationsByJobType( METADATA_IMPORT ).get( jobConfig.getUid() ).size() );
+        awaitTermination( e );
+        assertEquals( 101, notifier.getNotificationsByJobType( METADATA_IMPORT ).get( jobConfig.getUid() ).size() );
     }
 
     @Test
@@ -247,7 +243,7 @@ public class NotifierTest extends DhisSpringTest
                 notifier.notify( createJobConfig( i ), "somethingid" );
             } );
         } );
-        e.awaitTermination( 200, TimeUnit.MILLISECONDS );
+        awaitTermination( e );
         assertEquals( 500, notifier.getNotificationsByJobType( METADATA_IMPORT ).size() );
     }
 
@@ -256,5 +252,22 @@ public class NotifierTest extends DhisSpringTest
         JobConfiguration jobConfig = new JobConfiguration( null, METADATA_IMPORT, user.getUid(), false );
         jobConfig.setUid( "jobId" + i );
         return jobConfig;
+    }
+
+    public void awaitTermination( ExecutorService threadPool )
+    {
+        threadPool.shutdown();
+        try
+        {
+            if ( !threadPool.awaitTermination( 60, TimeUnit.SECONDS ) )
+            {
+                threadPool.shutdownNow();
+            }
+        }
+        catch ( InterruptedException ex )
+        {
+            threadPool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
@@ -27,12 +27,14 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -212,12 +214,9 @@ public class SystemController
     public void getTasksExtendedJson( @PathVariable( "jobType" ) String jobType, HttpServletResponse response )
         throws IOException
     {
-        Map<String, List<Notification>> notifications = new HashMap<>();
-
-        if ( jobType != null )
-        {
-            notifications = notifier.getNotificationsByJobType( JobType.valueOf( jobType.toUpperCase() ) );
-        }
+        Map<String, Deque<Notification>> notifications = jobType == null
+            ? emptyMap()
+            : notifier.getNotificationsByJobType( JobType.valueOf( jobType.toUpperCase() ) );
 
         setNoStore( response );
         response.setContentType( CONTENT_TYPE_JSON );
@@ -231,12 +230,9 @@ public class SystemController
         HttpServletResponse response )
         throws IOException
     {
-        List<Notification> notifications = new ArrayList<>();
-
-        if ( jobType != null )
-        {
-            notifications = notifier.getNotificationsByJobId( JobType.valueOf( jobType.toUpperCase() ), jobId );
-        }
+        Collection<Notification> notifications = jobType == null
+            ? emptyList()
+            : notifier.getNotificationsByJobId( JobType.valueOf( jobType.toUpperCase() ), jobId );
 
         setNoStore( response );
         response.setContentType( CONTENT_TYPE_JSON );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Deque;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
@@ -139,7 +139,7 @@ public class TrackerImportController
     }
 
     @GetMapping( value = "/jobs/{uid}", produces = APPLICATION_JSON_VALUE )
-    public List<Notification> getJob( @PathVariable String uid, HttpServletResponse response )
+    public Deque<Notification> getJob( @PathVariable String uid, HttpServletResponse response )
         throws HttpStatusCodeException
     {
         setNoStore( response );

--- a/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -27,20 +27,23 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportController.TRACKER_JOB_ADDED;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.commons.config.JacksonObjectMapperConfig;
@@ -50,8 +53,13 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.system.notification.Notification;
 import org.hisp.dhis.system.notification.Notifier;
-import org.hisp.dhis.tracker.report.*;
 import org.hisp.dhis.tracker.report.DefaultTrackerImportService;
+import org.hisp.dhis.tracker.report.TrackerBundleReport;
+import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.hisp.dhis.tracker.report.TrackerImportReportFinalizer;
+import org.hisp.dhis.tracker.report.TrackerStatus;
+import org.hisp.dhis.tracker.report.TrackerTimingsStats;
+import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport;
 import org.hisp.dhis.webapi.service.DefaultContextService;
@@ -200,7 +208,7 @@ public class TrackerImportControllerTest
         String uid = CodeGenerator.generateUid();
         // When
         when( notifier.getNotificationsByJobId( JobType.TRACKER_IMPORT_JOB, uid ) )
-            .thenReturn( Collections.singletonList( new Notification() ) );
+            .thenReturn( new LinkedList<>( singletonList( new Notification() ) ) );
 
         // Then
         mockMvc.perform( get( ENDPOINT + "/jobs/" + uid )


### PR DESCRIPTION
Came across the `NotificationMap` recently and noticed the implementation was doing several questionable things when it comes to choice of collection type and thread-safety. 

Trying to fix that cascaded a bit mainly because the proper contract for the list of notifications in this case was not `List` but `Deque`. Main reason is that we want add and remove from both start and end and that we want a concurrent implementation.

To ensure the max size limit in `NotificationMap` we now maintain a `Deque<String>` for the job UIDs with insert-order. If max size is reached the last (oldest) item from that deque is removed and that UID is used as key to remove the oldest map entry. This does not make sure the map never grows beyond the size limit as map and deque operations are independent but it should make sure they only can grow beyond the size limit for some milliseconds and that overall consistency and thread-safety is maintained.
