### PR TITLE
fix: add sharing check for empty query in JpaCriteriaQueryEngine

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -115,10 +115,19 @@ public class JpaCriteriaQueryEngine<T extends IdentifiableObject>
 
         if ( query.isEmpty() )
         {
+            Predicate predicate = builder.conjunction();
+
+            predicate.getExpressions().addAll( store
+                .getSharingPredicates( builder, query.getUser() ).stream().map( t -> t.apply( root ) )
+                .collect( Collectors.toList() ) );
+
+            criteriaQuery.where( predicate );
+
             TypedQuery<T> typedQuery = sessionFactory.getCurrentSession().createQuery( criteriaQuery );
 
             typedQuery.setFirstResult( query.getFirstResult() );
             typedQuery.setMaxResults( query.getMaxResults() );
+
             return typedQuery.getResultList();
         }
 


### PR DESCRIPTION
Issue: 
- In `JpaCriteriaQueryEngine`  the sharing check by passed when query.isEmpty = true