### PR TITLE
fix: [DHIS2-10764] add missing and clause when using lastupdateddate in tei query param (2.37)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -791,12 +791,12 @@ public class HibernateTrackedEntityInstanceStore
         {
             if ( params.hasLastUpdatedStartDate() )
             {
-                trackedEntity.append( " TEI.lastupdated >= '" )
+                trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated >= '" )
                     .append( getMediumDateString( params.getLastUpdatedStartDate() ) ).append( SINGLE_QUOTE );
             }
             if ( params.hasLastUpdatedEndDate() )
             {
-                trackedEntity.append( " TEI.lastupdated < '" )
+                trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated < '" )
                     .append( getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) )
                     .append( SINGLE_QUOTE );
             }


### PR DESCRIPTION
AND was missing when adding the clauses for lastupdatedstart and end dates when querying teis.