### PR TITLE
fix: [DHIS2-10764] add missing and clause when using lastupdateddate in tei query param (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -789,12 +789,12 @@ public class HibernateTrackedEntityInstanceStore
         {
             if ( params.hasLastUpdatedStartDate() )
             {
-                trackedEntity.append( " TEI.lastupdated >= '" )
+                trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated >= '" )
                     .append( getMediumDateString( params.getLastUpdatedStartDate() ) ).append( SINGLE_QUOTE );
             }
             if ( params.hasLastUpdatedEndDate() )
             {
-                trackedEntity.append( " TEI.lastupdated < '" )
+                trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated < '" )
                     .append( getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) )
                     .append( SINGLE_QUOTE );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -37,6 +37,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -138,6 +140,39 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
             .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( limitedTTrackedEntityInstances, hasSize( 2 ) );
+    }
+
+    @Test
+    public void testFetchTrackedEntityInstancesWithLastUpdatedParameter()
+    {
+        doInTransaction( () -> {
+            this.persistTrackedEntityInstance();
+            this.persistTrackedEntityInstance();
+            this.persistTrackedEntityInstance();
+            this.persistTrackedEntityInstance();
+        } );
+
+        TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
+        queryParams.setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
+        queryParams.setTrackedEntityType( trackedEntityTypeA );
+        queryParams.setLastUpdatedStartDate( Date.from( Instant.now().minus( 1, ChronoUnit.DAYS ) ) );
+        queryParams.setLastUpdatedEndDate( new Date() );
+
+        TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
+
+        final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
+            .getTrackedEntityInstances( queryParams, params, false, true );
+
+        assertThat( trackedEntityInstances, hasSize( 4 ) );
+        assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 0 ) );
+
+        // Update last updated start date to today
+        queryParams.setLastUpdatedStartDate( Date.from( Instant.now().plus( 1, ChronoUnit.DAYS ) ) );
+
+        final List<TrackedEntityInstance> limitedTTrackedEntityInstances = trackedEntityInstanceService
+            .getTrackedEntityInstances( queryParams, params, false, true );
+
+        assertThat( limitedTTrackedEntityInstances, hasSize( 0 ) );
     }
 
     @Test


### PR DESCRIPTION
AND was missing when adding the clauses for lastupdatedstart and end dates when querying teis.