### PR TITLE
chore: Remove redundant call to set user in UserContext

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/I18nInterceptor.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/I18nInterceptor.java
@@ -34,14 +34,11 @@ import java.util.Map;
 import ognl.NoSuchPropertyException;
 import ognl.Ognl;
 
-import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.i18n.locale.LocaleManager;
 import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
 
 import com.opensymphony.xwork2.Action;
@@ -49,14 +46,8 @@ import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.interceptor.Interceptor;
 
 /**
- * This was deprecated in favour of the new
- * {@link org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor}.
- *
  * @author Nguyen Dang Quang
- * @version $Id: WebWorkI18nInterceptor.java 6335 2008-11-20 11:11:26Z larshelg
- *          $
  */
-@Deprecated
 public class I18nInterceptor
     implements Interceptor
 {
@@ -162,16 +153,6 @@ public class I18nInterceptor
         catch ( NoSuchPropertyException ignored )
         {
         }
-
-        // ---------------------------------------------------------------------
-        // Set the current User DB Locale in UserContext
-        // ---------------------------------------------------------------------
-
-        User currentUser = currentUserService.getCurrentUser();
-        Locale dbLocale = (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE, currentUser );
-
-        UserContext.setUser( currentUser );
-        UserContext.setUserSetting( UserSettingKey.DB_LOCALE, dbLocale );
 
         return invocation.invoke();
     }


### PR DESCRIPTION
The I18nInterceptor class was wrongly annotated as deprecated.
It's still needed for setting the i18n translation lookup for Struts actions.
The redundant part, i.e. setting the logged-in user into the UserContext is now removed, this is now handled by the UserContextInterceptor

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>