### PR TITLE
fix: Set default job parameters when none exist for validation [DHIS2-10768]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -190,17 +190,16 @@ public enum ErrorCode
 
     /* Scheduling */
     E7000(
-        "Failed to add/update job configuration, another job of the same job type is already scheduled with this cron expression: `{0}`" ),
+        "Failed to add/update job configuration, another job of the same type already scheduled with cron expression: `{0}`" ),
     E7002( "Failed to add/update job configuration, UID does not exist" ),
     E7003(
         "Failed to add/update job configuration, only interval can be configured for non configurable job type: `{0}`" ),
     E7004(
         "Failed to add/update job configuration, cron expression must be not null for job with scheduling type CRON: `{0}`" ),
     E7005( "Failed to add/update job configuration, cron expression is invalid: `{0}` " ),
-    E7006( "Failed to execute job `{0}`." ),
-    E7007(
-        "Failed to add/update job configuration - Delay must be not null for jobs with scheduling type FIXED_DELAY: `{0}`" ),
-    E7010( "Failed to validate job runtime - `{0}`" ),
+    E7006( "Failed to execute job: `{0}`." ),
+    E7007( "Failed to add/update job configuration, delay must be not null with scheduling type FIXED_DELAY: `{0}`" ),
+    E7010( "Failed to validate job runtime: `{0}`" ),
 
     /* Aggregate analytics */
     E7100( "Query parameters cannot be null" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -215,6 +215,7 @@ public class JobConfigurationObjectBundleHook
         final JobConfiguration tempJobConfiguration = validatePersistedAndPrepareTempJobConfiguration( errorReports,
             jobConfiguration, persistedJobConfiguration );
 
+        setDefaultJobParameters( tempJobConfiguration );
         validateJobConfigurationCronOrFixedDelay( errorReports, tempJobConfiguration );
         validateCronExpressionWithinJobType( errorReports, tempJobConfiguration );
 
@@ -301,6 +302,12 @@ public class JobConfigurationObjectBundleHook
         }
     }
 
+    /**
+     * Sets default job parameters on the given job configuration if no
+     * parameters exist.
+     *
+     * @param jobConfiguration the {@link JobConfiguration}.
+     */
     private void setDefaultJobParameters( JobConfiguration jobConfiguration )
     {
         if ( !jobConfiguration.isInMemoryJob() && jobConfiguration.getJobParameters() == null )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -84,7 +84,7 @@ public class JobConfigurationObjectBundleHook
         JobConfiguration jobConfiguration = (JobConfiguration) object;
         List<ErrorReport> errorReports = new ArrayList<>( validateInternal( jobConfiguration ) );
 
-        if ( errorReports.size() == 0 )
+        if ( errorReports.isEmpty() )
         {
             jobConfiguration.setNextExecutionTime( null );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -43,7 +43,11 @@ import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.scheduling.*;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobParameters;
+import org.hisp.dhis.scheduling.SchedulingManager;
 import org.springframework.scheduling.support.CronSequenceGenerator;
 import org.springframework.stereotype.Component;
 
@@ -84,11 +88,11 @@ public class JobConfigurationObjectBundleHook
         {
             jobConfiguration.setNextExecutionTime( null );
 
-            log.info( "Validation of '" + jobConfiguration.getName() + "' succeeded" );
+            log.info( "Validation succeeded for job configuration: '{}'", jobConfiguration.getName() );
         }
         else
         {
-            log.info( "Validation of '" + jobConfiguration.getName() + "' failed." );
+            log.info( "Validation failed for job configuration: '{}'", jobConfiguration.getName() );
             log.info( errorReports.toString() );
         }
 
@@ -104,7 +108,8 @@ public class JobConfigurationObjectBundleHook
         }
 
         JobConfiguration jobConfiguration = (JobConfiguration) object;
-        ensureDefaultJobParametersAreUsedIfNoOtherArePresent( jobConfiguration );
+
+        setDefaultJobParameters( jobConfiguration );
     }
 
     @Override
@@ -122,7 +127,7 @@ public class JobConfigurationObjectBundleHook
         newObject.setLastExecutedStatus( persObject.getLastExecutedStatus() );
         newObject.setLastRuntimeExecution( persObject.getLastRuntimeExecution() );
 
-        ensureDefaultJobParametersAreUsedIfNoOtherArePresent( newObject );
+        setDefaultJobParameters( newObject );
 
         schedulingManager.stopJob( (JobConfiguration) persistedObject );
     }
@@ -202,8 +207,7 @@ public class JobConfigurationObjectBundleHook
     {
         List<ErrorReport> errorReports = new ArrayList<>();
 
-        // Check whether jobConfiguration already exists in the system and if so
-        // validate it
+        // Check whether jobConfiguration already exists
 
         JobConfiguration persistedJobConfiguration = jobConfigurationService
             .getJobConfigurationByUid( jobConfiguration.getUid() );
@@ -297,14 +301,11 @@ public class JobConfigurationObjectBundleHook
         }
     }
 
-    private void ensureDefaultJobParametersAreUsedIfNoOtherArePresent( JobConfiguration jobConfiguration )
+    private void setDefaultJobParameters( JobConfiguration jobConfiguration )
     {
-        if ( !jobConfiguration.isInMemoryJob() )
+        if ( !jobConfiguration.isInMemoryJob() && jobConfiguration.getJobParameters() == null )
         {
-            if ( jobConfiguration.getJobParameters() == null )
-            {
-                jobConfiguration.setJobParameters( getDefaultJobParameters( jobConfiguration ) );
-            }
+            jobConfiguration.setJobParameters( getDefaultJobParameters( jobConfiguration ) );
         }
     }
 
@@ -321,7 +322,7 @@ public class JobConfigurationObjectBundleHook
         }
         catch ( InstantiationException | IllegalAccessException ex )
         {
-            log.error( DebugUtils.getStackTrace( ex ) );
+            log.error( "Failed to instantiate job configuration", DebugUtils.getStackTrace( ex ) );
         }
 
         return null;


### PR DESCRIPTION
For `JobConfiguration` there is a concept of adding a default instance of job parameters when no parameters exist. This was not set during the validation stage, leading to validation failing for job configurations which would otherwise import well. 