### PR TITLE
fix: don't encode proxied App Hub requests

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/AppHubService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/AppHubService.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.apphub;
 
-import java.util.List;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import org.hisp.dhis.appmanager.AppStatus;
 
@@ -47,7 +47,8 @@ public interface AppHubService
      *        slashes.
      * @return the App Hub API response as a string.
      */
-    String getAppHubApiResponse( String apiVersion, String query ) throws URISyntaxException;
+    String getAppHubApiResponse( String apiVersion, String query )
+        throws URISyntaxException;
 
     List<WebApp> getAppHub();
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/AppHubService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/AppHubService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.apphub;
 
 import java.util.List;
+import java.net.URISyntaxException;
 
 import org.hisp.dhis.appmanager.AppStatus;
 
@@ -46,7 +47,7 @@ public interface AppHubService
      *        slashes.
      * @return the App Hub API response as a string.
      */
-    String getAppHubApiResponse( String apiVersion, String query );
+    String getAppHubApiResponse( String apiVersion, String query ) throws URISyntaxException;
 
     List<WebApp> getAppHub();
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/DefaultAppHubService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/DefaultAppHubService.java
@@ -84,7 +84,8 @@ public class DefaultAppHubService
     }
 
     @Override
-    public String getAppHubApiResponse( String apiVersion, String query ) throws URISyntaxException
+    public String getAppHubApiResponse( String apiVersion, String query )
+        throws URISyntaxException
     {
         validateApiVersion( apiVersion );
         validateQuery( query );
@@ -101,7 +102,7 @@ public class DefaultAppHubService
 
         log.info( "App Hub proxy request URL: '{}'", url );
 
-        ResponseEntity<String> response = restTemplate.exchange( new URI(url), HttpMethod.GET, getJsonRequestEntity(),
+        ResponseEntity<String> response = restTemplate.exchange( new URI( url ), HttpMethod.GET, getJsonRequestEntity(),
             String.class );
 
         return response.getBody();

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/DefaultAppHubService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/DefaultAppHubService.java
@@ -37,6 +37,8 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
@@ -82,7 +84,7 @@ public class DefaultAppHubService
     }
 
     @Override
-    public String getAppHubApiResponse( String apiVersion, String query )
+    public String getAppHubApiResponse( String apiVersion, String query ) throws URISyntaxException
     {
         validateApiVersion( apiVersion );
         validateQuery( query );
@@ -99,7 +101,7 @@ public class DefaultAppHubService
 
         log.info( "App Hub proxy request URL: '{}'", url );
 
-        ResponseEntity<String> response = restTemplate.exchange( url, HttpMethod.GET, getJsonRequestEntity(),
+        ResponseEntity<String> response = restTemplate.exchange( new URI(url), HttpMethod.GET, getJsonRequestEntity(),
             String.class );
 
         return response.getBody();

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import java.io.IOException;
 import java.util.List;
+import java.net.URISyntaxException;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -80,6 +81,7 @@ public class AppHubController
     @GetMapping( value = "/{apiVersion}/**", produces = "application/json" )
     public String getAppHubApiResponse(
         @PathVariable String apiVersion, HttpServletRequest request )
+		throws URISyntaxException
     {
         String query = ContextUtils.getWildcardPathValue( request );
 

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -28,8 +28,8 @@
 package org.hisp.dhis.webapi.controller;
 
 import java.io.IOException;
-import java.util.List;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -81,7 +81,7 @@ public class AppHubController
     @GetMapping( value = "/{apiVersion}/**", produces = "application/json" )
     public String getAppHubApiResponse(
         @PathVariable String apiVersion, HttpServletRequest request )
-		throws URISyntaxException
+        throws URISyntaxException
     {
         String query = ContextUtils.getWildcardPathValue( request );
 


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-10767

Spring's [RestTemplate](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html) encodes the URL passed as a first argument to its `exchange` method if it is a `String`. This means that any URL query components that have been previously encoded are double encoded, resulting in incorrect queries.

By passing the requested App Hub API URL as a `URI`, this encoding does not occur.