### PR TITLE
fix: skipSharing & skipTranslations not working properly

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translation.java
@@ -31,7 +31,6 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.EmbeddedObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -43,7 +42,7 @@ import com.google.common.base.MoreObjects;
  */
 @JacksonXmlRootElement( localName = "translations", namespace = DxfNamespaces.DXF_2_0 )
 public class Translation
-    implements Serializable, EmbeddedObject
+    implements Serializable
 {
     private String locale;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
@@ -43,7 +43,6 @@ import lombok.NoArgsConstructor;
 
 import org.apache.commons.collections.MapUtils;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.user.User;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -56,7 +55,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 @NoArgsConstructor
 @JacksonXmlRootElement( localName = "sharing", namespace = DxfNamespaces.DXF_2_0 )
 public class Sharing
-    implements Serializable, EmbeddedObject
+    implements Serializable
 {
     private static final long serialVersionUID = 6977793211734844477L;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -46,6 +46,7 @@ import javax.xml.xpath.XPathExpressionException;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.collections4.*;
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -77,7 +78,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.visualization.Visualization;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -256,12 +256,17 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         MetadataImportParams params = new MetadataImportParams();
         params.setImportMode( ObjectBundleMode.COMMIT );
         params.setImportStrategy( ImportStrategy.CREATE );
-        params.setSkipSharing( true );
+        params.setSkipSharing( false );
         params.setObjects( metadata );
         params.setUser( user );
 
         ImportReport report = importService.importMetadata( params );
         assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 1, dataSet.getSharing().getUserGroups().size() );
+        assertEquals( "fvz8d3u6jFd", dataSet.getSharing().getUserGroups().values().iterator().next().getId() );
 
         metadata = renderService.fromMetadata(
             new ClassPathResource( "dxf2/dataset_with_accesses_update_skipSharing.json" ).getInputStream(),
@@ -276,6 +281,143 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
 
         report = importService.importMetadata( params );
         assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSetUpdated = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSetUpdated.getSharing().getUserGroups() );
+        assertEquals( 1, dataSetUpdated.getSharing().getUserGroups().size() );
+        assertNotNull( dataSetUpdated.getSharing().getUserGroups().get( "fvz8d3u6jFd" ) );
+    }
+
+    @Test
+    public void testImportWithSkipSharingIsFalse()
+        throws IOException
+    {
+        User user = createUser( "A", "ALL" );
+        manager.save( user );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE );
+        params.setSkipSharing( false );
+        params.setObjects( metadata );
+        params.setUser( user );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 1, dataSet.getSharing().getUserGroups().size() );
+        assertEquals( "fvz8d3u6jFd", dataSet.getSharing().getUserGroups().values().iterator().next().getId() );
+
+        metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_update_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.UPDATE );
+        params.setSkipSharing( false );
+        params.setObjects( metadata );
+        params.setUser( user );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSetUpdated = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertTrue( MapUtils.isEmpty( dataSetUpdated.getSharing().getUserGroups() ) );
+    }
+
+    @Test
+    public void testImportWithSkipTranslationIsTrue()
+        throws IOException
+    {
+        User user = createUser( "A", "ALL" );
+        manager.save( user );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE );
+        params.setSkipTranslation( true );
+        params.setObjects( metadata );
+        params.setUser( user );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 2, dataSet.getTranslations().size() );
+
+        metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_update_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.UPDATE );
+        params.setSkipTranslation( true );
+        params.setObjects( metadata );
+        params.setUser( user );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 2, dataSet.getTranslations().size() );
+    }
+
+    @Test
+    public void testImportWithSkipTranslationIsFalse()
+        throws IOException
+    {
+        User user = createUser( "A", "ALL" );
+        manager.save( user );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE );
+        params.setSkipTranslation( true );
+        params.setObjects( metadata );
+        params.setUser( user );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 2, dataSet.getTranslations().size() );
+
+        metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_update_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.UPDATE );
+        params.setSkipTranslation( false );
+        params.setObjects( metadata );
+        params.setUser( user );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 0, dataSet.getTranslations().size() );
     }
 
     @Test( expected = IllegalArgumentException.class )
@@ -327,7 +469,6 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    @Ignore
     public void testImportEmbeddedObjectWithSkipSharingIsTrue()
         throws IOException
     {
@@ -359,14 +500,14 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( user.getUid(), visualization.getUserAccesses().iterator().next().getUserUid() );
         assertEquals( userGroup.getUid(), visualization.getUserGroupAccesses().iterator().next().getUserGroupUid() );
 
-        // Visualization dataElementOperandVisualization = manager.get(
-        // Visualization.class, "qD72aBqsHvt" );
-        // assertNotNull( dataElementOperandVisualization );
-        // assertEquals( 2,
-        // dataElementOperandVisualization.getDataDimensionItems().size() );
-        // dataElementOperandVisualization.getDataDimensionItems()
-        // .stream()
-        // .forEach( item -> assertNotNull( item.getDataElementOperand() ) );
+        Visualization dataElementOperandVisualization = manager.get(
+            Visualization.class, "qD72aBqsHvt" );
+        assertNotNull( dataElementOperandVisualization );
+        assertEquals( 2,
+            dataElementOperandVisualization.getDataDimensionItems().size() );
+        dataElementOperandVisualization.getDataDimensionItems()
+            .stream()
+            .forEach( item -> assertNotNull( item.getDataElementOperand() ) );
 
         metadata = renderService.fromMetadata(
             new ClassPathResource( "dxf2/favorites/metadata_visualization_with_accesses_update.json" ).getInputStream(),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_accesses_skipSharing.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_accesses_skipSharing.json
@@ -5,14 +5,14 @@
       "user": {
         "id": "T12jeH7KPzk"
       },
-      "aggregationLevels": [ ],
+      "aggregationLevels": [],
       "publicAccess": "rw------",
       "aggregationType": "SUM",
       "lastUpdated": "2016-03-08T07:30:07.699+0000",
       "created": "2016-03-08T07:30:07.698+0000",
       "name": "Simple Value",
       "shortName": "Simple Value",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "zeroIsSignificant": false,
       "userGroupAccesses": [
         {
@@ -29,12 +29,12 @@
       "created": "2016-03-08T07:30:58.416+0000",
       "lastUpdated": "2016-03-08T07:30:58.417+0000",
       "zeroIsSignificant": false,
-      "userGroupAccesses": [ ],
+      "userGroupAccesses": [],
       "id": "VolAzjFe5zP",
       "domainType": "AGGREGATE",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "shortName": "Value with CC",
-      "aggregationLevels": [ ],
+      "aggregationLevels": [],
       "user": {
         "id": "T12jeH7KPzk"
       },
@@ -88,7 +88,7 @@
       "shortName": "Country",
       "description": "",
       "id": "x3gVvpbVgqy",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "path": "/x3gVvpbVgqy",
       "featureType": "NONE",
       "user": {
@@ -100,13 +100,13 @@
   "categoryOptions": [
     {
       "id": "JYiFOMKa25J",
-      "userGroupAccesses": [ ],
-      "attributeValues": [ ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
       "shortName": "Female",
       "name": "Female",
       "created": "2016-03-08T07:28:50.372+0000",
       "lastUpdated": "2016-03-08T07:28:50.374+0000",
-      "organisationUnits": [ ],
+      "organisationUnits": [],
       "user": {
         "id": "T12jeH7KPzk"
       },
@@ -121,13 +121,13 @@
     },
     {
       "shortName": "Male",
-      "userGroupAccesses": [ ],
+      "userGroupAccesses": [],
       "id": "tdaMRD34m8o",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "lastUpdated": "2016-03-08T07:28:44.217+0000",
       "name": "Male",
       "created": "2016-03-08T07:28:44.214+0000",
-      "organisationUnits": [ ],
+      "organisationUnits": [],
       "user": {
         "id": "T12jeH7KPzk"
       },
@@ -146,9 +146,9 @@
       "name": "Superuser",
       "created": "2016-03-08T07:26:51.925+0000",
       "lastUpdated": "2016-03-08T07:26:51.925+0000",
-      "userGroupAccesses": [ ],
+      "userGroupAccesses": [],
       "id": "wSdzlWUHmEu",
-      "dataSets": [ ],
+      "dataSets": [],
       "authorities": [
         "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
         "ALL",
@@ -183,7 +183,7 @@
         "F_TRACKED_ENTITY_DATAVALUE_DELETE"
       ],
       "publicAccess": "--------",
-      "programs": [ ]
+      "programs": []
     }
   ],
   "categories": [
@@ -220,7 +220,7 @@
     {
       "description": "Person",
       "id": "MDvmqCKmXQM",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "name": "Person",
       "created": "2016-03-08T07:28:58.738+0000",
       "lastUpdated": "2016-03-08T07:28:58.740+0000"
@@ -230,7 +230,7 @@
     {
       "sortOrder": 0,
       "id": "JwcV2ZifEQf",
-      "indicators": [ ],
+      "indicators": [],
       "lastUpdated": "2016-03-08T07:32:29.362+0000",
       "created": "2016-03-08T07:32:29.361+0000",
       "name": "Section Default",
@@ -242,21 +242,21 @@
           "id": "nHwIqKAudKN"
         }
       ],
-      "greyedFields": [ ]
+      "greyedFields": []
     },
     {
       "lastUpdated": "2016-03-08T07:32:42.140+0000",
       "created": "2016-03-08T07:32:42.140+0000",
       "name": "Section Gender",
       "id": "C50M0WxaI7y",
-      "indicators": [ ],
+      "indicators": [],
       "sortOrder": 0,
       "dataElements": [
         {
           "id": "VolAzjFe5zP"
         }
       ],
-      "greyedFields": [ ],
+      "greyedFields": [],
       "dataSet": {
         "id": "em8Bg4LCr5k"
       }
@@ -325,7 +325,7 @@
           }
         }
       ],
-      "compulsoryDataElementOperands": [ ],
+      "compulsoryDataElementOperands": [],
       "timelyDays": 15,
       "fieldCombinationRequired": false,
       "version": 4,
@@ -338,14 +338,26 @@
       "publicAccess": "rw------",
       "noValueRequiresComment": false,
       "shortName": "Data Set",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "id": "em8Bg4LCr5k",
-      "indicators": [ ],
+      "indicators": [],
       "userGroupAccesses": [
         {
           "access": "rwrw----",
           "userGroupUid": "fvz8d3u6jFd",
           "id": "fvz8d3u6jFd"
+        }
+      ],
+      "translations": [
+        {
+          "property": "NAME",
+          "locale": "en_GB",
+          "value": "ART monthly summary"
+        },
+        {
+          "property": "SHORT_NAME",
+          "locale": "en_GB",
+          "value": "ART 2010"
         }
       ],
       "periodType": "Monthly",
@@ -365,6 +377,21 @@
       }
     }
   ],
+  "userGroups": [
+    {
+      "name": "Administrators",
+      "id": "fvz8d3u6jFd",
+      "displayName": "Administrators",
+      "publicAccess": "rw------",
+      "externalAccess": false,
+      "favorite": false,
+      "users": [
+        {
+          "id": "T12jeH7KPzk"
+        }
+      ]
+    }
+  ],
   "users": [
     {
       "organisationUnits": [
@@ -372,10 +399,10 @@
           "id": "x3gVvpbVgqy"
         }
       ],
-      "dataViewOrganisationUnits": [ ],
+      "dataViewOrganisationUnits": [],
       "userCredentials": {
         "id": "m3ww4DWJtMf",
-        "catDimensionConstraints": [ ],
+        "catDimensionConstraints": [],
         "userInfo": {
           "id": "T12jeH7KPzk"
         },
@@ -383,7 +410,7 @@
         "username": "admin",
         "created": "2016-03-08T07:26:52.033+0000",
         "selfRegistered": false,
-        "cogsDimensionConstraints": [ ],
+        "cogsDimensionConstraints": [],
         "passwordLastUpdated": "2016-03-08T07:26:51.942+0000",
         "userRoles": [
           {
@@ -395,12 +422,12 @@
         "lastLogin": "2016-03-08T07:26:51.942+0000"
       },
       "surname": "admin",
-      "attributeValues": [ ],
+      "attributeValues": [],
       "id": "T12jeH7KPzk",
       "created": "2016-03-08T07:26:51.909+0000",
       "firstName": "admin",
       "lastUpdated": "2016-03-08T07:26:51.909+0000",
-      "teiSearchOrganisationUnits": [ ]
+      "teiSearchOrganisationUnits": []
     }
   ],
   "date": "2016-03-08T07:34:13.552+0000"

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_accesses_update_skipSharing.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_accesses_update_skipSharing.json
@@ -38,13 +38,6 @@
       "attributeValues": [ ],
       "id": "em8Bg4LCr5k",
       "indicators": [ ],
-      "userGroupAccesses": [
-        {
-          "access": "rwrw----",
-          "userGroupUid": "fvz8d3u6jFd",
-          "id": "fvz8d3u6jFd"
-        }
-      ],
       "periodType": "Monthly",
       "mobile": false,
       "lastUpdated": "2016-03-08T07:32:42.146+0000",
@@ -59,15 +52,7 @@
       "renderHorizontally": false,
       "user": {
         "id": "T12jeH7KPzk"
-      },
-      "userAccesses": [
-        {
-          "access": "rwrw----",
-          "displayName": "admin",
-          "id": "T12jeH7KPzk",
-          "userUid": "T12jeH7KPzk"
-        }
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Issue : 
- Sharing & Translation objects are defined as `EmbeddedObject` but they are not embedded object.
- In metadata import service, embedded objects will always be cleared and re-create when update
- So removing this makes skipSharing & skipTranslations work as expected
- Added tests for both skip = false and true

