### PR TITLE
fix: null userCredentials.createdBy when create user

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -256,6 +256,14 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
                 (Set<OrganisationUnit>) userReferenceMap.get( "dataViewOrganisationUnits" ) );
             userCredentials
                 .setCreatedBy( (User) userCredentialsReferenceMap.get( BaseIdentifiableObject_.CREATED_BY ) );
+
+            if ( userCredentials.getCreatedBy() == null )
+            {
+                userCredentials.setCreatedBy( bundle.getUser() );
+            }
+
+            userCredentials.setLastUpdatedBy( bundle.getUser() );
+
             userCredentials.setUserInfo( user );
 
             preheatService.connectReferences( user, bundle.getPreheat(), bundle.getPreheatIdentifier() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -788,4 +788,28 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( "TA user group updated", userGroup.getName() );
         assertEquals( userA.getUid(), userGroup.getCreatedBy().getUid() );
     }
+
+    @Test
+    public void testImportUser()
+        throws IOException
+    {
+        User userF = createUser( 'F', Lists.newArrayList( "ALL" ) );
+        userService.addUser( userF );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/create_user_without_createdBy.json" ).getInputStream(), RenderFormat.JSON );
+
+        MetadataImportParams params = new MetadataImportParams();
+        params.setImportMode( ObjectBundleMode.COMMIT );
+        params.setImportStrategy( ImportStrategy.CREATE_AND_UPDATE );
+        params.setUser( userF );
+        params.setObjects( metadata );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        User user = manager.get( User.class, "MwhEJUnTHkn" );
+        assertNotNull( user.getUserCredentials().getCreatedBy() );
+
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/create_user_without_createdBy.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/create_user_without_createdBy.json
@@ -1,0 +1,203 @@
+{
+  "userRoles": [
+    {
+      "dataSets": [ ],
+      "publicAccess": "--------",
+      "name": "Superuser",
+      "programs": [ ],
+      "lastUpdated": "2016-03-12T06:18:41.386+0000",
+      "created": "2016-03-12T06:18:41.386+0000",
+      "userGroupAccesses": [ ],
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_MAP_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_PROGRAM_ENROLLMENT",
+        "F_SQLVIEW_EXTERNAL",
+        "F_GIS_ADMIN",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_VISUALIZATION_PUBLIC_ADD",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_VISUALIZATION_EXTERNAL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_MAP_EXTERNAL",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE"
+      ],
+      "id": "tHEWGwIMsJk"
+    }
+  ],
+  "date": "2016-03-12T06:21:34.667+0000",
+  "organisationUnits": [
+    {
+      "path": "/inVD5SdytkT",
+      "openingDate": "2016-03-11T17:00:00.000+0000",
+      "lastUpdated": "2016-03-12T06:19:49.665+0000",
+      "created": "2016-03-12T06:19:49.649+0000",
+      "shortName": "Country",
+      "user": {
+        "id": "enHApD3I6Ho"
+      },
+      "attributeValues": [ ],
+      "id": "inVD5SdytkT",
+      "name": "Country",
+      "description": "",
+      "featureType": "NONE",
+      "uuid": "0f2d7a85-3b6e-4cae-9d5a-e2903331629b"
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "id": "xjZaLLspj2r",
+      "attributeValues": [ ],
+      "description": "Person",
+      "name": "Person",
+      "created": "2016-03-09T09:56:10.596+0000",
+      "lastUpdated": "2016-03-09T09:56:10.597+0000"
+    }
+  ],
+  "users": [
+    {
+      "email": "user@b.org",
+      "surname": "BB",
+      "firstName": "User",
+      "created": "2016-03-12T06:21:02.324+0000",
+      "lastUpdated": "2016-03-12T06:21:02.325+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "yqJHNnkF3SJ",
+        "cogsDimensionConstraints": [ ],
+        "selfRegistered": false,
+        "catDimensionConstraints": [ ],
+        "lastLogin": "2016-03-12T06:21:02.226+0000",
+        "created": "2016-03-12T06:21:02.329+0000",
+        "passwordLastUpdated": "2016-03-12T06:21:02.226+0000",
+        "userInfo": {
+          "id": "MwhEJUnTHkn"
+        },
+        "userRoles": [
+          {
+            "id": "tHEWGwIMsJk"
+          }
+        ],
+        "username": "UserB",
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false
+      },
+      "teiSearchOrganisationUnits": [ ],
+      "id": "MwhEJUnTHkn",
+      "attributeValues": [ ]
+    },
+    {
+      "firstName": "User",
+      "email": "user@a.org",
+      "surname": "AA",
+      "attributeValues": [ ],
+      "id": "sPWjoHSY03y",
+      "created": "2016-03-12T06:20:43.502+0000",
+      "lastUpdated": "2016-03-12T06:20:43.502+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "username": "UserA",
+        "userRoles": [
+          {
+            "id": "tHEWGwIMsJk"
+          }
+        ],
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false,
+        "cogsDimensionConstraints": [ ],
+        "selfRegistered": false,
+        "catDimensionConstraints": [ ],
+        "lastLogin": "2016-03-12T06:20:43.407+0000",
+        "created": "2016-03-12T06:20:43.508+0000",
+        "userInfo": {
+          "id": "sPWjoHSY03y"
+        },
+        "passwordLastUpdated": "2016-03-12T06:20:43.407+0000"
+      },
+      "teiSearchOrganisationUnits": [ ]
+    },
+    {
+      "surname": "admin",
+      "firstName": "admin",
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "EgBSdwGi7rr",
+        "externalAuth": false,
+        "disabled": false,
+        "invitation": false,
+        "userRoles": [
+          {
+            "id": "tHEWGwIMsJk"
+          }
+        ],
+        "username": "admin",
+        "passwordLastUpdated": "2016-03-12T06:18:41.403+0000",
+        "userInfo": {
+          "id": "enHApD3I6Ho"
+        },
+        "created": "2016-03-12T06:18:41.505+0000",
+        "lastLogin": "2016-03-12T06:18:41.401+0000",
+        "catDimensionConstraints": [ ],
+        "selfRegistered": false,
+        "user": {
+          "id": "enHApD3I6Ho"
+        },
+        "cogsDimensionConstraints": [ ]
+      },
+      "lastUpdated": "2016-03-12T06:20:18.336+0000",
+      "created": "2016-03-12T06:18:41.374+0000",
+      "teiSearchOrganisationUnits": [ ],
+      "id": "enHApD3I6Ho",
+      "attributeValues": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-6167

Issue : 
- After created a user, `UserCredentials.createdBy` is always null. 
- This is because the current code doesn't handle the case where payload doesn't include `UserCredentials.user` or `UserCredentials.createdBy`.

Fix:
- Update `UserCredentials.createdBy` = currentUser if its null.
- Also add code to always update `lastUpdatedBy` field.
- Add unit test 