### PR TITLE
fix: add translations column for ExternalMapLayer

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/ExternalMapLayer.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/ExternalMapLayer.hbm.xml
@@ -34,6 +34,8 @@
 
     <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_externalmaplayer_userid" />
 
+    <property name="translations" type="jblTranslations"/>
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.mapping.*;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -330,5 +331,27 @@ public class TranslationServiceTest
         assertEquals( "translated TargetLineLabel", updated.getDisplayTargetLineLabel() );
         assertEquals( "translated Title", updated.getDisplayTitle() );
         assertEquals( "translated SubTitle", updated.getDisplaySubtitle() );
+    }
+
+    @Test
+    public void testExternalMapLayerTranslations()
+    {
+        ExternalMapLayer map = new ExternalMapLayer();
+        map.setName( "Name" );
+        map.setUrl( "URL" );
+        map.setMapLayerPosition( MapLayerPosition.BASEMAP );
+        map.setImageFormat( ImageFormat.JPG );
+        map.setMapService( MapService.TMS );
+        manager.save( map );
+
+        Set<Translation> translations = new HashSet<>();
+        translations.add( new Translation( locale.getLanguage(), "NAME",
+            "translated Name" ) );
+
+        manager.updateTranslations( map, translations );
+
+        ExternalMapLayer updatedMap = manager.get( ExternalMapLayer.class, map.getUid() );
+        assertEquals( "translated Name", updatedMap.getDisplayName() );
+
     }
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.34/V2_34_38__Add_translations_column_into_externalmaplayer_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.34/V2_34_38__Add_translations_column_into_externalmaplayer_table.sql
@@ -1,0 +1,1 @@
+alter table externalmaplayer add column if not exists translations jsonb default '[]'::jsonb;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1127
Add `translations` column to database table `externalmaplayer`
I add the flyway script to v2.34 so later I can cherry-pick this commit and backport down to 2.34. 