### PR TITLE
fix: checksum mismatch due to different linefeed characters

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_20__Drop_legacy_sharing_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_20__Drop_legacy_sharing_tables.sql
@@ -97,4 +97,4 @@ DROP TABLE IF EXISTS reporttableusergroupaccesses;
 DROP TABLE IF EXISTS patienttabularreportusergroupaccesses;
 DROP TABLE IF EXISTS patientaggregatereportusergroupacceses;
 DROP TABLE IF EXISTS useraccess CASCADE;
-DROP TABLE IF EXISTS usergroupaccess CASCADE; 
+DROP TABLE IF EXISTS usergroupaccess CASCADE; 


### PR DESCRIPTION
Flyway checksum mismatch error was being thrown even though the sql scripts seemed identical to each other. The new line or line feed character seems to have been different which caused for different checksum calculations. 