### PR TITLE
refactor: Removing uid field from tracker entities [TECH-579]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/config/TrackerValidationConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/config/TrackerValidationConfig.java
@@ -65,7 +65,7 @@ public class TrackerValidationConfig
     public List<Class<? extends TrackerValidationHook>> getValidationOrder()
     {
         return ImmutableList.of(
-            PreCheckValidateAndGenerateUidHook.class,
+            PreCheckUidValidationHook.class,
             PreCheckExistenceValidationHook.class,
             PreCheckMandatoryFieldsValidationHook.class,
             PreCheckMetaValidationHook.class,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Enrollment.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Enrollment.java
@@ -31,10 +31,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.locationtech.jts.geom.Geometry;
 
@@ -49,8 +46,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @AllArgsConstructor
 public class Enrollment implements TrackerDto
 {
-    private String uid;
-
     @JsonProperty
     private String enrollment;
 
@@ -123,4 +118,10 @@ public class Enrollment implements TrackerDto
     @JsonProperty
     @Builder.Default
     private List<Note> notes = new ArrayList<>();
+
+    @Override
+    public String getUid()
+    {
+        return this.enrollment;
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -58,8 +58,6 @@ public class Event
     extends BaseLinkableObject
     implements TrackerDto
 {
-    private String uid;
-
     @JsonProperty
     private String event;
 
@@ -149,5 +147,11 @@ public class Event
     public boolean isCreatableInSearchScope()
     {
         return this.getStatus() == EventStatus.SCHEDULE && this.getDataValues().isEmpty() && this.occurredAt == null;
+    }
+
+    @Override
+    public String getUid()
+    {
+        return this.event;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/TrackedEntity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/TrackedEntity.java
@@ -49,8 +49,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @AllArgsConstructor
 public class TrackedEntity implements TrackerDto
 {
-    private String uid;
-
     @JsonProperty
     private String trackedEntity;
 
@@ -99,4 +97,10 @@ public class TrackedEntity implements TrackerDto
     @JsonProperty
     @Builder.Default
     private List<ProgramOwner> programOwners = new ArrayList<>();
+
+    @Override
+    public String getUid()
+    {
+        return this.trackedEntity;
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/mapper/EnrollmentMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/mapper/EnrollmentMapper.java
@@ -39,7 +39,7 @@ import org.mapstruct.Mapping;
     InstantMapper.class } )
 public interface EnrollmentMapper extends DomainMapper<org.hisp.dhis.dxf2.events.enrollment.Enrollment, Enrollment>
 {
-    @Mapping( target = "uid", source = "enrollment" )
+    @Mapping( target = "enrollment", source = "enrollment" )
     @Mapping( target = "createdAt", source = "created" )
     @Mapping( target = "createdAtClient", source = "createdAtClient" )
     @Mapping( target = "updatedAt", source = "lastUpdated" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/mapper/TrackedEntityMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/mapper/TrackedEntityMapper.java
@@ -40,7 +40,6 @@ import org.mapstruct.Mapping;
     InstantMapper.class } )
 public interface TrackedEntityMapper extends DomainMapper<TrackedEntityInstance, TrackedEntity>
 {
-    @Mapping( target = "uid", source = "trackedEntityInstance" )
     @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
     @Mapping( target = "createdAt", source = "created" )
     @Mapping( target = "createdAtClient", source = "createdAtClient" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
@@ -120,10 +120,4 @@ public class DefaultTrackerPreheatService implements TrackerPreheatService, Appl
             log.warn( message, e );
         }
     }
-
-    @Override
-    public void validate( TrackerImportParams params )
-    {
-        // TODO: Implement validation
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheatService.java
@@ -41,11 +41,4 @@ public interface TrackerPreheatService
      * @param params Params for preheating
      */
     TrackerPreheat preheat( TrackerImportParams params );
-
-    /**
-     * Validate PreheatParams.
-     *
-     * @param params PreheatParams
-     */
-    void validate( TrackerImportParams params );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -91,13 +91,13 @@ public class EventDateValidationHook
         checkNotNull( event, TrackerImporterAssertErrors.EVENT_CANT_BE_NULL );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 
+        if ( actingUser.isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
+        {
+            return;
+        }
+
         if ( (program.getCompleteEventsExpiryDays() > 0 && EventStatus.COMPLETED == event.getStatus()) )
         {
-            if ( actingUser.isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
-            {
-                return;
-            }
-
             if ( event.getCompletedAt() == null )
             {
                 addErrorIfNull( event.getCompletedAt(), reporter, E1042, event );
@@ -129,7 +129,11 @@ public class EventDateValidationHook
             .map( Event::getOccurredAt )
             .orElseGet( event::getScheduledAt );
 
-        addErrorIfNull( referenceDate, reporter, E1046, event );
+        if ( referenceDate == null )
+        {
+            addError( reporter, E1046, event );
+            return;
+        }
 
         Period period = periodType.createPeriod( new Date() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -29,15 +29,11 @@ package org.hisp.dhis.tracker;
 
 import static org.junit.Assert.assertTrue;
 
-import java.beans.Introspector;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hisp.dhis.TransactionalIntegrationTest;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
@@ -49,7 +45,6 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationR
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -147,53 +142,7 @@ public abstract class TrackerTest extends TransactionalIntegrationTest
     protected TrackerImportParams _fromJson( String path )
         throws IOException
     {
-        return syncIdentifiers( renderService.fromJson(
-            new ClassPathResource( path ).getInputStream(),
-            TrackerImportParams.class ) );
-    }
-
-    /**
-     * Makes sure that the Tracker entities in the provided TrackerBundle have
-     * the 'uid' attribute identical to the json identifier.
-     */
-    protected TrackerImportParams syncIdentifiers( TrackerImportParams trackerImportParams )
-    {
-        trackerImportParams.getTrackedEntities().forEach( this::syncUid );
-        trackerImportParams.getEnrollments().forEach( this::syncUid );
-        trackerImportParams.getEvents().forEach( this::syncUid );
-
-        return trackerImportParams;
-    }
-
-    private void syncUid( TrackerDto trackerDto )
-    {
-        try
-        {
-            String field = Introspector.decapitalize( trackerDto.getClass().getSimpleName() );
-            Object val = FieldUtils.readDeclaredField( trackerDto, field, true );
-            String identifier = val != null ? val.toString() : null;
-            if ( StringUtils.isEmpty( trackerDto.getUid() )
-                && StringUtils.isEmpty( identifier ) )
-            {
-                String uid = CodeGenerator.generateUid();
-                FieldUtils.writeDeclaredField( trackerDto, "uid", uid, true );
-                FieldUtils.writeDeclaredField( trackerDto, field, uid, true );
-            }
-            if ( StringUtils.isEmpty( trackerDto.getUid() )
-                && StringUtils.isNotEmpty( identifier ) )
-            {
-                FieldUtils.writeDeclaredField( trackerDto, "uid", identifier, true );
-            }
-            if ( StringUtils.isNotEmpty( trackerDto.getUid() )
-                && StringUtils.isEmpty( identifier ) )
-            {
-                FieldUtils.writeDeclaredField( trackerDto, field, trackerDto.getUid(), true );
-            }
-        }
-        catch ( IllegalAccessException e )
-        {
-            e.printStackTrace();
-        }
+        return renderService.fromJson( new ClassPathResource( path ).getInputStream(), TrackerImportParams.class );
     }
 
     protected void assertNoImportErrors( TrackerImportReport report )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
@@ -135,7 +135,7 @@ public class EventDataValueTest
         // make sure that the uid property is populated as well - otherwise
         // update will
         // not work
-        trackerImportParams.getEvents().get( 0 ).setUid( trackerImportParams.getEvents().get( 0 ).getEvent() );
+        trackerImportParams.getEvents().get( 0 ).setEvent( trackerImportParams.getEvents().get( 0 ).getEvent() );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegration.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegration.java
@@ -139,8 +139,6 @@ public class TrackerPreheatServiceIntegration
                 .build() )
             .build();
 
-        trackerPreheatService.validate( trackerPreheatParams );
-
         TrackerPreheat preheat = trackerPreheatService.preheat( trackerPreheatParams );
 
         assertNotNull( preheat );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -188,8 +188,6 @@ public class TrackerPreheatServiceTest
         assertTrue( params.getEnrollments().isEmpty() );
         assertFalse( params.getEvents().isEmpty() );
 
-        trackerPreheatService.validate( params );
-
         TrackerPreheat preheat = trackerPreheatService.preheat( params );
 
         assertNotNull( preheat );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -246,7 +246,6 @@ public class TrackerPreheatTest
         {
             {
                 String uid = CodeGenerator.generateUid();
-                setUid( uid );
                 setEnrollment( uid );
                 setTrackedEntity( allEntities.get( 0 ) );
             }
@@ -255,7 +254,6 @@ public class TrackerPreheatTest
         {
             {
                 String uid = CodeGenerator.generateUid();
-                setUid( uid );
                 setEnrollment( uid );
                 setTrackedEntity( allEntities.get( 0 ) );
             }
@@ -274,7 +272,6 @@ public class TrackerPreheatTest
         {
             {
                 String uid = CodeGenerator.generateUid();
-                setUid( uid );
                 setEvent( uid );
                 setEnrollment( allPs.get( 0 ).getEnrollment() );
             }
@@ -283,7 +280,6 @@ public class TrackerPreheatTest
         {
             {
                 String uid = CodeGenerator.generateUid();
-                setUid( uid );
                 setEvent( uid );
                 setEnrollment( allPs.get( 0 ).getEnrollment() );
             }
@@ -292,7 +288,6 @@ public class TrackerPreheatTest
         {
             {
                 String uid = CodeGenerator.generateUid();
-                setUid( uid );
                 setEvent( uid );
                 setEnrollment( allPs.get( 1 ).getEnrollment() );
             }
@@ -301,7 +296,6 @@ public class TrackerPreheatTest
         {
             {
                 String uid = CodeGenerator.generateUid();
-                setUid( uid );
                 setEvent( uid );
                 setEnrollment( allPs.get( 1 ).getEnrollment() );
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
@@ -392,7 +392,6 @@ public class AssignValueImplementerTest
     private Event getEventWithDataValueSet()
     {
         Event event = new Event();
-        event.setUid( FIRST_EVENT_ID );
         event.setEvent( FIRST_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( firstProgramStage.getUid() );
@@ -404,7 +403,6 @@ public class AssignValueImplementerTest
     private Event getEventWithDataValueSetSameValue()
     {
         Event event = new Event();
-        event.setUid( FIRST_EVENT_ID );
         event.setEvent( FIRST_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( firstProgramStage.getUid() );
@@ -416,7 +414,6 @@ public class AssignValueImplementerTest
     private Event getEventWithDataValueNOTSet()
     {
         Event event = new Event();
-        event.setUid( SECOND_EVENT_ID );
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( firstProgramStage.getUid() );
@@ -427,7 +424,6 @@ public class AssignValueImplementerTest
     private Event getEventWithDataValueNOTSetInDifferentProgramStage()
     {
         Event event = new Event();
-        event.setUid( SECOND_EVENT_ID );
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( secondProgramStage.getUid() );
@@ -454,7 +450,6 @@ public class AssignValueImplementerTest
     private Enrollment getEnrollmentWithAttributeSet()
     {
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( FIRST_ENROLLMENT_ID );
         enrollment.setEnrollment( FIRST_ENROLLMENT_ID );
         enrollment.setStatus( EnrollmentStatus.ACTIVE );
         enrollment.setAttributes( getAttributes() );
@@ -465,7 +460,6 @@ public class AssignValueImplementerTest
     private Enrollment getEnrollmentWithAttributeSetSameValue()
     {
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( FIRST_ENROLLMENT_ID );
         enrollment.setEnrollment( FIRST_ENROLLMENT_ID );
         enrollment.setStatus( EnrollmentStatus.ACTIVE );
         enrollment.setAttributes( getAttributesSameValue() );
@@ -476,7 +470,6 @@ public class AssignValueImplementerTest
     private TrackedEntity getTrackedEntitiesWithAttributeSet()
     {
         TrackedEntity trackedEntity = new TrackedEntity();
-        trackedEntity.setUid( TRACKED_ENTITY_ID );
         trackedEntity.setTrackedEntity( TRACKED_ENTITY_ID );
         trackedEntity.setAttributes( getAttributes() );
 
@@ -486,7 +479,6 @@ public class AssignValueImplementerTest
     private TrackedEntity getTrackedEntitiesWithAttributeNOTSet()
     {
         TrackedEntity trackedEntity = new TrackedEntity();
-        trackedEntity.setUid( TRACKED_ENTITY_ID );
         trackedEntity.setTrackedEntity( TRACKED_ENTITY_ID );
 
         return trackedEntity;
@@ -495,7 +487,6 @@ public class AssignValueImplementerTest
     private Enrollment getEnrollmentWithAttributeNOTSet()
     {
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( SECOND_ENROLLMENT_ID );
         enrollment.setEnrollment( SECOND_ENROLLMENT_ID );
         enrollment.setStatus( EnrollmentStatus.COMPLETED );
         enrollment.setTrackedEntity( TRACKED_ENTITY_ID );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -210,7 +210,6 @@ public class SetMandatoryFieldValidatorTest
     private Event getEventWithMandatoryValueSet()
     {
         Event event = new Event();
-        event.setUid( FIRST_EVENT_ID );
         event.setEvent( FIRST_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( firstProgramStage.getUid() );
@@ -222,7 +221,6 @@ public class SetMandatoryFieldValidatorTest
     private Event getEventWithMandatoryValueNOTSet()
     {
         Event event = new Event();
-        event.setUid( SECOND_EVENT_ID );
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( firstProgramStage.getUid() );
@@ -233,7 +231,6 @@ public class SetMandatoryFieldValidatorTest
     private Event getEventWithMandatoryValueNOTSetInDifferentProgramStage()
     {
         Event event = new Event();
-        event.setUid( SECOND_EVENT_ID );
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
         event.setProgramStage( secondProgramStage.getUid() );
@@ -252,7 +249,6 @@ public class SetMandatoryFieldValidatorTest
     private Enrollment getEnrollmentWithMandatoryAttributeSet()
     {
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( ACTIVE_ENROLLMENT_ID );
         enrollment.setEnrollment( ACTIVE_ENROLLMENT_ID );
         enrollment.setTrackedEntity( TEI_ID );
         enrollment.setStatus( EnrollmentStatus.ACTIVE );
@@ -264,7 +260,6 @@ public class SetMandatoryFieldValidatorTest
     private Enrollment getEnrollmentWithMandatoryAttributeNOTSet()
     {
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( COMPLETED_ENROLLMENT_ID );
         enrollment.setEnrollment( COMPLETED_ENROLLMENT_ID );
         enrollment.setTrackedEntity( TEI_ID );
         enrollment.setStatus( EnrollmentStatus.COMPLETED );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -268,13 +268,11 @@ public class ShowErrorWarningImplementerTest
     private List<Event> getEvents()
     {
         Event activeEvent = new Event();
-        activeEvent.setUid( ACTIVE_EVENT_ID );
         activeEvent.setEvent( ACTIVE_EVENT_ID );
         activeEvent.setStatus( EventStatus.ACTIVE );
         activeEvent.setProgramStage( PROGRAM_STAGE_ID );
 
         Event completedEvent = new Event();
-        completedEvent.setUid( COMPLETED_EVENT_ID );
         completedEvent.setEvent( COMPLETED_EVENT_ID );
         completedEvent.setStatus( EventStatus.COMPLETED );
         completedEvent.setProgramStage( PROGRAM_STAGE_ID );
@@ -285,12 +283,10 @@ public class ShowErrorWarningImplementerTest
     private List<Enrollment> getEnrollments()
     {
         Enrollment activeEnrollment = new Enrollment();
-        activeEnrollment.setUid( ACTIVE_ENROLLMENT_ID );
         activeEnrollment.setEnrollment( ACTIVE_ENROLLMENT_ID );
         activeEnrollment.setStatus( EnrollmentStatus.ACTIVE );
 
         Enrollment completedEnrollment = new Enrollment();
-        completedEnrollment.setUid( COMPLETED_ENROLLMENT_ID );
         completedEnrollment.setEnrollment( COMPLETED_ENROLLMENT_ID );
         completedEnrollment.setStatus( EnrollmentStatus.COMPLETED );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
@@ -136,7 +136,7 @@ public class TeTaValidationTest
         fileResource = fileResourceService.getFileResource( fileResource.getUid() );
         assertTrue( fileResource.isAssigned() );
 
-        TrackerValidationReport report = validate( "tracker/validations/te-program_with_tea_fileresource_data.json" );
+        TrackerValidationReport report = validate( "tracker/validations/te-program_with_tea_fileresource_data2.json" );
 
         assertEquals( 1, report.getErrorReports().size() );
 
@@ -265,7 +265,7 @@ public class TeTaValidationTest
 
         trackerBundleService.commit( trackerBundle );
 
-        TrackerValidationReport report = validate( "tracker/validations/te-program_with_tea_unique_data.json" );
+        TrackerValidationReport report = validate( "tracker/validations/te-program_with_tea_unique_data2.json" );
 
         assertEquals( 1, report.getErrorReports().size() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation.hooks;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.period.DailyPeriodType;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.security.Authorities;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAuthorityGroup;
+import org.hisp.dhis.user.UserCredentials;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.Sets;
+
+/**
+ * @author Enrico Colasante
+ */
+public class EventDateValidationHookTest
+    extends DhisConvenienceTest
+{
+    private static final String PROGRAM_STAGE = "ProgramStage";
+
+    private static final String PROGRAM_WITH_REGISTRATION_ID = "ProgramWithRegistration";
+
+    private static final String PROGRAM_WITHOUT_REGISTRATION_ID = "ProgramWithoutRegistration";
+
+    private EventDateValidationHook hookToTest;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private TrackerImportValidationContext validationContext;
+
+    @Before
+    public void setUp()
+    {
+        hookToTest = new EventDateValidationHook();
+
+        User user = createUser( 'A' );
+
+        TrackerBundle bundle = TrackerBundle.builder().user( user ).build();
+
+        when( validationContext.getBundle() ).thenReturn( bundle );
+
+        when( validationContext.getProgram( PROGRAM_WITHOUT_REGISTRATION_ID ) )
+            .thenReturn( getProgramWithoutRegistration() );
+
+        when( validationContext.getProgram( PROGRAM_WITH_REGISTRATION_ID ) )
+            .thenReturn( getProgramWithRegistration() );
+    }
+
+    @Test
+    public void testEventIsValid()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITHOUT_REGISTRATION_ID );
+        event.setOccurredAt( now() );
+        event.setStatus( EventStatus.ACTIVE );
+
+        TrackerBundle bundle = TrackerBundle.builder().user( getEditExpiredUser() ).build();
+
+        when( validationContext.getBundle() ).thenReturn( bundle );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenOccurredDateIsNotPresentAndProgramIsWithoutRegistration()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITHOUT_REGISTRATION_ID );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1031 ) );
+
+    }
+
+    @Test
+    public void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsActive()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setStatus( EventStatus.ACTIVE );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1031 ) );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsCompleted()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setStatus( EventStatus.COMPLETED );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1031 ) );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenScheduledDateIsNotPresentAndEventIsSchedule()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setOccurredAt( Instant.now() );
+        event.setStatus( EventStatus.SCHEDULE );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1050 ) );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenCompletedAtIsNotPresentAndEventIsCompleted()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setOccurredAt( now() );
+        event.setStatus( EventStatus.COMPLETED );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1042 ) );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenCompletedAtIsTooSoonAndEventIsCompleted()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setOccurredAt( now() );
+        event.setCompletedAt( sevenDaysAgo() );
+        event.setStatus( EventStatus.COMPLETED );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1043 ) );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenOccurredAtAndScheduledAtAreNotPresent()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setOccurredAt( null );
+        event.setScheduledAt( null );
+        event.setStatus( EventStatus.SKIPPED );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1046 ) );
+    }
+
+    @Test
+    public void testEventIsNotValidWhenDateBelongsToExpiredPeriod()
+    {
+        // given
+        Event event = new Event();
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
+        event.setOccurredAt( sevenDaysAgo() );
+        event.setStatus( EventStatus.ACTIVE );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+
+        // when
+        this.hookToTest.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1047 ) );
+    }
+
+    private Program getProgramWithRegistration()
+    {
+        Program program = createProgram( 'A' );
+        program.setUid( PROGRAM_WITH_REGISTRATION_ID );
+        program.setProgramType( ProgramType.WITH_REGISTRATION );
+        program.setCompleteEventsExpiryDays( 5 );
+        program.setExpiryDays( 5 );
+        program.setExpiryPeriodType( new DailyPeriodType() );
+        return program;
+    }
+
+    private Program getProgramWithoutRegistration()
+    {
+        Program program = createProgram( 'A' );
+        program.setUid( PROGRAM_WITHOUT_REGISTRATION_ID );
+        program.setProgramType( ProgramType.WITHOUT_REGISTRATION );
+        return program;
+    }
+
+    private User getEditExpiredUser()
+    {
+        User user = createUser( 'A' );
+        UserCredentials userCredentials = createUserCredentials( 'A', user );
+        UserAuthorityGroup userAuthorityGroup = createUserAuthorityGroup( 'A' );
+        userAuthorityGroup.setAuthorities( Sets.newHashSet( Authorities.F_EDIT_EXPIRED.getAuthority() ) );
+
+        userCredentials.setUserAuthorityGroups( Sets.newHashSet( userAuthorityGroup ) );
+        user.setUserCredentials( userCredentials );
+
+        return user;
+    }
+
+    private Instant now()
+    {
+        return Instant.now();
+    }
+
+    private Instant sevenDaysAgo()
+    {
+        return LocalDateTime.now().minus( 7, ChronoUnit.DAYS ).toInstant( ZoneOffset.UTC );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation.hooks;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.*;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+/**
+ * @author Enrico Colasante
+ */
+public class PreCheckUidValidationHookTest
+{
+    private static final String INVALID_UID = "InvalidUID";
+
+    private PreCheckUidValidationHook validationHook;
+
+    private TrackerImportValidationContext ctx;
+
+    @Before
+    public void setUp()
+    {
+        validationHook = new PreCheckUidValidationHook();
+        ctx = new TrackerImportValidationContext( new TrackerBundle() );
+    }
+
+    @Test
+    public void verifyTrackedEntityValidationSuccess()
+    {
+        // given
+        TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( CodeGenerator.generateUid() )
+            .orgUnit( CodeGenerator.generateUid() )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, trackedEntity );
+
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void verifyTrackedEntityWithInvalidUidFails()
+    {
+        // given
+        TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( INVALID_UID )
+            .orgUnit( CodeGenerator.generateUid() )
+            .build();
+
+        // when
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, trackedEntity );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+
+    }
+
+    @Test
+    public void verifyEnrollmentValidationSuccess()
+    {
+        // given
+        Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
+            .notes( Lists.newArrayList( note ) )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        validationHook.validateEnrollment( reporter, enrollment );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void verifyEnrollmentWithInvalidUidFails()
+    {
+        // given
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( INVALID_UID )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        validationHook.validateEnrollment( reporter, enrollment );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+    }
+
+    @Test
+    public void verifyEnrollmentWithNoteWithInvalidUidFails()
+    {
+        // given
+        Note note = Note.builder().note( INVALID_UID ).build();
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
+            .notes( Lists.newArrayList( note ) )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        validationHook.validateEnrollment( reporter, enrollment );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+    }
+
+    @Test
+    public void verifyEventValidationSuccess()
+    {
+        // given
+        Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
+        Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
+            .notes( Lists.newArrayList( note ) )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        validationHook.validateEvent( reporter, event );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void verifyEventWithInvalidUidFails()
+    {
+        // given
+        Event event = Event.builder()
+            .event( INVALID_UID )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        validationHook.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+    }
+
+    @Test
+    public void verifyEventWithNoteWithInvalidUidFails()
+    {
+        // given
+        Note note = Note.builder().note( INVALID_UID ).build();
+        Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
+            .notes( Lists.newArrayList( note ) )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        validationHook.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+    }
+
+    @Test
+    public void verifyRelationshipValidationSuccess()
+    {
+        // given
+        Relationship relationship = Relationship.builder()
+            .relationship( CodeGenerator.generateUid() )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        validationHook.validateRelationship( reporter, relationship );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void verifyRelationshipWithInvalidUidFails()
+    {
+        // given
+        Relationship relationship = Relationship.builder()
+            .relationship( INVALID_UID )
+            .build();
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        validationHook.validateRelationship( reporter, relationship );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -217,7 +217,6 @@ public class RepeatedEventsValidationHookTest
     {
         Event event = new Event();
         event.setEvent( uid );
-        event.setUid( uid );
         event.setProgram( PROGRAM_WITHOUT_REGISTRATION );
         event.setProgramStage( NOT_REPEATABLE_PROGRAM_STAGE );
         return event;
@@ -227,7 +226,6 @@ public class RepeatedEventsValidationHookTest
     {
         Event event = new Event();
         event.setEvent( uid );
-        event.setUid( uid );
         event.setProgram( PROGRAM_WITH_REGISTRATION );
         event.setEnrollment( ENROLLMENT_A );
         event.setProgramStage( NOT_REPEATABLE_PROGRAM_STAGE );
@@ -238,7 +236,6 @@ public class RepeatedEventsValidationHookTest
     {
         Event event = new Event();
         event.setEvent( uid );
-        event.setUid( uid );
         event.setProgram( PROGRAM_WITH_REGISTRATION );
         event.setEnrollment( ENROLLMENT_A );
         event.setProgramStage( REPEATABLE_PROGRAM_STAGE );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackerValidationHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackerValidationHookServiceTest.java
@@ -60,14 +60,14 @@ public class TrackerValidationHookServiceTest
     public void shouldSortList()
     {
         ReflectionTestUtils.setField( trackerValidationHookService, "validationOrder",
-            Arrays.asList( PreCheckValidateAndGenerateUidHook.class, EnrollmentAttributeValidationHook.class,
+            Arrays.asList( PreCheckUidValidationHook.class, EnrollmentAttributeValidationHook.class,
                 TrackedEntityAttributeValidationHook.class, EventDataValuesValidationHook.class ) );
 
         ReflectionTestUtils.setField( trackerValidationHookService, "validationOrderMap",
             new HashMap<Class<? extends TrackerValidationHook>, Integer>()
             {
                 {
-                    put( PreCheckValidateAndGenerateUidHook.class, 0 );
+                    put( PreCheckUidValidationHook.class, 0 );
                     put( EnrollmentAttributeValidationHook.class, 1 );
                     put( TrackedEntityAttributeValidationHook.class, 2 );
                     put( EventDataValuesValidationHook.class, 3 );
@@ -79,10 +79,10 @@ public class TrackerValidationHookServiceTest
                 Arrays.asList( new EventDataValuesValidationHook(),
                     new TrackedEntityAttributeValidationHook( null, mock( ReservedValueService.class ),
                         mock( DhisConfigurationProvider.class ) ),
-                    new EnrollmentAttributeValidationHook( null ), new PreCheckValidateAndGenerateUidHook() ) );
+                    new EnrollmentAttributeValidationHook( null ), new PreCheckUidValidationHook() ) );
 
         assertEquals( 4, validationHooks.size() );
-        assertThat( validationHooks.get( 0 ), instanceOf( PreCheckValidateAndGenerateUidHook.class ) );
+        assertThat( validationHooks.get( 0 ), instanceOf( PreCheckUidValidationHook.class ) );
         assertThat( validationHooks.get( 1 ), instanceOf( EnrollmentAttributeValidationHook.class ) );
         assertThat( validationHooks.get( 2 ), instanceOf( TrackedEntityAttributeValidationHook.class ) );
         assertThat( validationHooks.get( 3 ), instanceOf( EventDataValuesValidationHook.class ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data-add.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data-add.json
@@ -16,15 +16,19 @@
       "dataValues": [],
       "notes": [
         {
+          "note": "noteUid0001",
           "value": "this is the first note"
         },
         {
+          "note": "noteUid0002",
           "value": "this is the second note"
         },
         {
+          "note": "noteUid0003",
           "value": "this is the third note"
         },
         {
+          "note": "noteUid0004",
           "value": ""
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
@@ -17,15 +17,19 @@
       "dataValues": [],
       "notes": [
         {
+          "note": "noteUid0001",
           "value": "this is the first note"
         },
         {
+          "note": "noteUid0002",
           "value": "this is the second note"
         },
         {
+          "note": "noteUid0003",
           "value": "this is the third note"
         },
         {
+          "note": "noteUid0004",
           "value": ""
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
@@ -17,15 +17,19 @@
       "dataValues": [],
       "notes": [
         {
+          "note": "noteUid0004",
           "value": "this is the 4th note"
         },
         {
+          "note": "noteUid0005",
           "value": "this is the 5th note"
         },
         {
+          "note": "noteUid0006",
           "value": "this is the 6th note"
         },
         {
+          "note": "noteUid0007",
           "value": ""
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
@@ -1,6 +1,7 @@
 {
   "events": [
     {
+      "event": "E8o1E9tApYY",
       "storedBy": "admin",
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_data.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "EEFkxTWB55A",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_data2.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_data2.json
@@ -1,7 +1,7 @@
 {
   "trackedEntities": [
     {
-      "trackedEntity": "cNEZTkdAvre",
+      "trackedEntity": "EEFkxTWB55B",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",
@@ -23,9 +23,11 @@
         {
           "lastUpdated": "2020-02-20T12:09:21.850",
           "storedBy": "admin",
-          "displayName": "Attribute_Image",
+          "displayName": "Attribute_FileResource",
           "created": "2020-02-20T12:09:21.850",
-          "attribute": "ccccc5ttttt"
+          "valueType": "FILE_RESOURCE",
+          "attribute": "zmdwVu2aXj2",
+          "value": "Jzf6hHNP7jx"
         }
       ]
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_generated_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_generated_data.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "cNEZTkdAvre",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_invalid_format_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_invalid_format_value.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "cNEZTkdAvre",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_invalid_image_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_invalid_image_value.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "cNEZTkdAvre",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_too_long_text_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_too_long_text_value.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "cNEZTkdAvre",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_unique_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_unique_data.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "EEFkxTWB55A",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_unique_data2.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_unique_data2.json
@@ -1,7 +1,7 @@
 {
   "trackedEntities": [
     {
-      "trackedEntity": "cNEZTkdAvre",
+      "trackedEntity": "EEFkxTWB55B",
       "created": "2020-02-20T12:09:21.844",
       "orgUnit": "cNEZTkdAvmg",
       "createdAtClient": "2020-02-20T12:09:21.844",
@@ -21,11 +21,13 @@
       "relationships": [],
       "attributes": [
         {
-          "lastUpdated": "2020-02-20T12:09:21.850",
+          "lastUpdated": "2020-02-20T12:09:21.848",
           "storedBy": "admin",
-          "displayName": "Attribute_Image",
-          "created": "2020-02-20T12:09:21.850",
-          "attribute": "ccccc5ttttt"
+          "displayName": "Attribute_Identifier_Integer",
+          "created": "2020-02-20T12:09:21.848",
+          "valueType": "INTEGER_POSITIVE",
+          "attribute": "p5TPww5Uhrd",
+          "value": "321"
         }
       ]
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-with_invalid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-with_invalid_option_value.json
@@ -1,6 +1,7 @@
 {
   "trackedEntities": [
     {
+      "trackedEntity": "cNEZTkdAvre",
       "trackedEntityType": "bPJ0FMtcnEh",
       "attributes": [
         {
@@ -13,6 +14,7 @@
       "inactive": false
     },
     {
+      "trackedEntity": "cNEZTkdAvrf",
       "trackedEntityType": "bPJ0FMtcnEh",
       "attributes": [
         {


### PR DESCRIPTION
Create unit tests for 2 validation hooks:
- EventDateValidationHook
- PreCheckUidValidationHook

In order to test the second one I needed to refactor some code
- Removing uid as a field in TrackedEntity, Enrollment and Event
- Remove the logic that creates the uid if it is null. This is already done when flattening the payload