### PR TITLE
fix: DHIS2-10766: Remove unnecessary 'group by' causing duplicated rows

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramIndicatorQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramIndicatorQuery.java
@@ -85,9 +85,8 @@ import org.springframework.stereotype.Component;
 public class ProgramIndicatorQuery implements DataItemQuery
 {
     private static final String COMMON_COLUMNS = "programindicator.name, programindicator.uid, programindicator.code,"
-        + " program.name as program_name, program.uid as program_uid, program.sharing as program_sharing,"
-        + " programindicator.sharing as programindicator_sharing,"
-        + " programindicator.shortname, program.shortname as program_shortname";
+        + " program.uid as program_uid, program.sharing as program_sharing, programindicator.sharing as programindicator_sharing,"
+        + " programindicator.shortname";
 
     private static final String COMMON_UIDS = "program.uid, programindicator.uid";
 
@@ -190,9 +189,9 @@ public class ProgramIndicatorQuery implements DataItemQuery
         }
 
         sql.append(
-            " group by program.name, program.shortname, programindicator.name, " + COMMON_UIDS
-                + ", programindicator.code, p_i18n_name, i18n_name, program_sharing, programindicator_sharing, programindicator.shortname,"
-                + " i18n_shortname, p_i18n_shortname" );
+            " group by programindicator.name, " + COMMON_UIDS
+                + ", programindicator.code, i18n_name, program_sharing, programindicator_sharing, programindicator.shortname,"
+                + " i18n_shortname" );
 
         // Closing the temp table.
         sql.append( " ) t" );
@@ -249,8 +248,7 @@ public class ProgramIndicatorQuery implements DataItemQuery
     {
         return new StringBuilder()
             .append( SPACED_SELECT + COMMON_COLUMNS )
-            .append( ", program.name as p_i18n_name, programindicator.name as i18n_name," +
-                " program.shortname as p_i18n_shortname, programindicator.shortname as i18n_shortname" )
+            .append( ", programindicator.name as i18n_name, programindicator.shortname as i18n_shortname" )
             .append( SPACED_FROM_PROGRAM_INDICATOR )
             .append( JOINS ).toString();
     }


### PR DESCRIPTION
Found also an issue regarding aggregate type during the tests, which was also fixed as part of this PR. This fix aims to mimic the /dataElements endpoint.

Highly recommended being part of patch/2.36.0.

cc @Philip-Larsen-Donnelly