### PR TITLE
fix: DHIS2-10177: Make old Axes elements read-only

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/AxisV2.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/AxisV2.java
@@ -27,11 +27,14 @@
  */
 package org.hisp.dhis.visualization;
 
+import static java.lang.Integer.MAX_VALUE;
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 
 import java.io.Serializable;
 
 import lombok.Data;
+
+import org.hisp.dhis.schema.annotation.PropertyRange;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -68,10 +71,12 @@ public class AxisV2 implements Serializable
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
+    @PropertyRange( min = -MAX_VALUE )
     private Integer maxValue;
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
+    @PropertyRange( min = -MAX_VALUE )
     private Integer minValue;
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/CompatibilityGuard.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/CompatibilityGuard.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+/**
+ * Responsible for maintaining read compatibility for certain Visualization
+ * attributes for required use cases, specially when new refactoring affects the
+ * existing contract.
+ *
+ * @author maikel arabori
+ */
+public class CompatibilityGuard
+{
+    private CompatibilityGuard()
+    {
+    }
+
+    static void keepLegendReadingCompatibility( final Visualization visualization )
+    {
+        if ( visualization.getLegend() != null && visualization.getLegend().getLabel() != null )
+        {
+            if ( visualization.getFontStyle() == null )
+            {
+                visualization.setFontStyle( new VisualizationFontStyle() );
+            }
+
+            visualization.getFontStyle().setLegend( visualization.getLegend().getLabel().getFontStyle() );
+        }
+    }
+
+    static void keepAxesReadingCompatibility( final Visualization visualization )
+    {
+        if ( isNotEmpty( visualization.getAxes() ) )
+        {
+            if ( visualization.getFontStyle() == null )
+            {
+                visualization.setFontStyle( new VisualizationFontStyle() );
+            }
+
+            keepFirstAxisReadCompatible( visualization );
+            keepSecondAxisReadCompatible( visualization );
+        }
+    }
+
+    private static void keepSecondAxisReadCompatible( final Visualization visualization )
+    {
+        if ( visualization.getAxes().size() > 1 )
+        {
+            final AxisV2 secondAxis = visualization.getAxes().get( 1 );
+
+            if ( secondAxis != null && secondAxis.getLabel() != null )
+            {
+                visualization.getFontStyle().setCategoryAxisLabel( secondAxis.getLabel().getFontStyle() );
+            }
+
+            if ( secondAxis != null && secondAxis.getTitle() != null )
+            {
+                visualization.getFontStyle().setHorizontalAxisTitle( secondAxis.getTitle().getFontStyle() );
+                visualization.setDomainAxisLabel( secondAxis.getTitle().getText() );
+            }
+        }
+    }
+
+    private static void keepFirstAxisReadCompatible( final Visualization visualization )
+    {
+        final AxisV2 firstAxis = visualization.getAxes().get( 0 );
+
+        if ( firstAxis != null )
+        {
+            if ( firstAxis.getLabel() != null )
+            {
+                visualization.getFontStyle().setSeriesAxisLabel( firstAxis.getLabel().getFontStyle() );
+            }
+
+            if ( firstAxis.getTitle() != null )
+            {
+                visualization.getFontStyle().setVerticalAxisTitle( firstAxis.getTitle().getFontStyle() );
+                visualization.setRangeAxisLabel( firstAxis.getTitle().getText() );
+            }
+
+            if ( firstAxis.getBaseLine() != null && firstAxis.getBaseLine().getTitle() != null )
+            {
+                copyBaseLine( visualization, firstAxis );
+            }
+
+            if ( firstAxis.getTargetLine() != null
+                && firstAxis.getTargetLine().getTitle() != null )
+            {
+                copyTargetLine( visualization, firstAxis );
+            }
+
+            visualization.setRangeAxisDecimals( firstAxis.getDecimals() );
+            visualization.setRangeAxisMaxValue( firstAxis.getMaxValue() != null
+                ? Double.valueOf( firstAxis.getMaxValue() )
+                : null );
+            visualization.setRangeAxisMinValue( firstAxis.getMinValue() != null
+                ? Double.valueOf( firstAxis.getMinValue() )
+                : null );
+            visualization.setRangeAxisSteps( firstAxis.getSteps() );
+        }
+    }
+
+    private static void copyTargetLine( final Visualization visualization, final AxisV2 firstAxis )
+    {
+        visualization.getFontStyle().setTargetLineLabel( firstAxis.getTargetLine().getTitle().getFontStyle() );
+        visualization.setTargetLineLabel( firstAxis.getTargetLine().getTitle().getText() );
+        visualization.setTargetLineValue(
+            firstAxis.getTargetLine().getValue() != null
+                ? Double.valueOf( firstAxis.getTargetLine().getValue() )
+                : null );
+    }
+
+    private static void copyBaseLine( final Visualization visualization, final AxisV2 firstAxis )
+    {
+        visualization.getFontStyle().setBaseLineLabel( firstAxis.getBaseLine().getTitle().getFontStyle() );
+        visualization.setBaseLineLabel( firstAxis.getBaseLine().getTitle().getText() );
+        visualization.setBaseLineValue(
+            firstAxis.getBaseLine().getValue() != null
+                ? Double.valueOf( firstAxis.getBaseLine().getValue() )
+                : null );
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -46,6 +46,8 @@ import static org.hisp.dhis.common.DimensionalObjectUtils.getSortedKeysMap;
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
+import static org.hisp.dhis.visualization.CompatibilityGuard.keepAxesReadingCompatibility;
+import static org.hisp.dhis.visualization.CompatibilityGuard.keepLegendReadingCompatibility;
 import static org.hisp.dhis.visualization.DimensionDescriptor.getDimensionIdentifierFor;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 
@@ -239,25 +241,25 @@ public class Visualization
     // Display items for graphics/charts
     // -------------------------------------------------------------------------
 
-    private Double targetLineValue;
+    private transient Double targetLineValue;
 
-    private Double baseLineValue;
+    private transient Double baseLineValue;
 
-    private String baseLineLabel;
+    private transient String baseLineLabel;
 
-    private String targetLineLabel;
+    private transient String targetLineLabel;
 
-    private Double rangeAxisMaxValue;
+    private transient Double rangeAxisMaxValue;
 
-    private Double rangeAxisMinValue;
+    private transient Double rangeAxisMinValue;
 
-    private Integer rangeAxisSteps; // Minimum 1
+    private transient Integer rangeAxisSteps; // Minimum 1
 
-    private Integer rangeAxisDecimals;
+    private transient Integer rangeAxisDecimals;
 
-    private String domainAxisLabel;
+    private transient String domainAxisLabel;
 
-    private String rangeAxisLabel;
+    private transient String rangeAxisLabel;
 
     private LegendDefinitions legend;
 
@@ -873,7 +875,7 @@ public class Visualization
         this.series = series;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public String getDomainAxisLabel()
     {
@@ -893,7 +895,7 @@ public class Visualization
         this.domainAxisLabel = domainAxisLabel;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public String getRangeAxisLabel()
     {
@@ -949,7 +951,7 @@ public class Visualization
         this.noSpaceBetweenColumns = noSpaceBetweenColumns;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public String getBaseLineLabel()
     {
@@ -969,7 +971,7 @@ public class Visualization
         this.baseLineLabel = baseLineLabel;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public String getTargetLineLabel()
     {
@@ -1037,7 +1039,7 @@ public class Visualization
         this.showData = showData;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     @PropertyRange( min = -Double.MAX_VALUE )
     public Double getTargetLineValue()
@@ -1050,7 +1052,7 @@ public class Visualization
         this.targetLineValue = targetLineValue;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     @PropertyRange( min = -Double.MAX_VALUE )
     public Double getBaseLineValue()
@@ -1075,7 +1077,7 @@ public class Visualization
         this.percentStackedValues = percentStackedValues;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     @PropertyRange( min = -Double.MAX_VALUE )
     public Double getRangeAxisMaxValue()
@@ -1088,7 +1090,7 @@ public class Visualization
         this.rangeAxisMaxValue = rangeAxisMaxValue;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     @PropertyRange( min = -Double.MAX_VALUE )
     public Double getRangeAxisMinValue()
@@ -1101,7 +1103,7 @@ public class Visualization
         this.rangeAxisMinValue = rangeAxisMinValue;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public Integer getRangeAxisSteps()
     {
@@ -1113,7 +1115,7 @@ public class Visualization
         this.rangeAxisSteps = rangeAxisSteps;
     }
 
-    @JsonProperty
+    @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public Integer getRangeAxisDecimals()
     {
@@ -1160,6 +1162,8 @@ public class Visualization
     public void setLegend( LegendDefinitions legend )
     {
         this.legend = legend;
+
+        keepLegendReadingCompatibility( this );
     }
 
     @JsonProperty( value = "axes" )
@@ -1172,6 +1176,8 @@ public class Visualization
     public void setAxes( List<AxisV2> axes )
     {
         this.axes = axes;
+
+        keepAxesReadingCompatibility( this );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/VisualizationFontStyle.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/VisualizationFontStyle.java
@@ -51,19 +51,19 @@ public class VisualizationFontStyle
 
     private FontStyle visualizationSubtitle;
 
-    private FontStyle horizontalAxisTitle;
+    private transient FontStyle horizontalAxisTitle;
 
-    private FontStyle verticalAxisTitle;
+    private transient FontStyle verticalAxisTitle;
 
-    private FontStyle targetLineLabel;
+    private transient FontStyle targetLineLabel;
 
-    private FontStyle baseLineLabel;
+    private transient FontStyle baseLineLabel;
 
-    private FontStyle seriesAxisLabel;
+    private transient FontStyle seriesAxisLabel;
 
-    private FontStyle categoryAxisLabel;
+    private transient FontStyle categoryAxisLabel;
 
-    private FontStyle legend;
+    private transient FontStyle legend;
 
     public VisualizationFontStyle()
     {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/CompatibilityGuardTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/CompatibilityGuardTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hisp.dhis.visualization.AxisType.RANGE;
+import static org.hisp.dhis.visualization.CompatibilityGuard.keepAxesReadingCompatibility;
+import static org.hisp.dhis.visualization.CompatibilityGuard.keepLegendReadingCompatibility;
+
+import java.util.List;
+
+import org.hisp.dhis.common.Font;
+import org.hisp.dhis.common.FontStyle;
+import org.junit.Test;
+
+/**
+ * Unit tests to check the conversions related to CompatibilityGuard.
+ *
+ * @author maikel arabori
+ */
+public class CompatibilityGuardTest
+{
+    @Test
+    public void testKeepLegendReadingCompatibility()
+    {
+        // Given
+        final Visualization visualization = mockVisualizationWithLegend();
+
+        // When
+        keepLegendReadingCompatibility( visualization );
+
+        // Then
+        assertThat( visualization.getFontStyle().getLegend(),
+            is( equalTo( visualization.getLegend().getLabel().getFontStyle() ) ) );
+        assertThat( visualization.getFontStyle().getLegend().getFont(),
+            is( equalTo( visualization.getLegend().getLabel().getFontStyle().getFont() ) ) );
+    }
+
+    @Test
+    public void testKeepAxesReadingCompatibility()
+    {
+        // Given
+        final Visualization visualization = mockVisualizationWithAxes();
+
+        // When
+        keepAxesReadingCompatibility( visualization );
+
+        // Then
+
+        // # Fist axis assertions
+        assertThat( visualization.getFontStyle().getSeriesAxisLabel(),
+            is( equalTo( visualization.getAxes().get( 0 ).getLabel().getFontStyle() ) ) );
+        assertThat( visualization.getFontStyle().getVerticalAxisTitle(),
+            is( equalTo( visualization.getAxes().get( 0 ).getTitle().getFontStyle() ) ) );
+
+        // Ranges
+        assertThat( visualization.getRangeAxisDecimals(),
+            is( equalTo( visualization.getAxes().get( 0 ).getDecimals() ) ) );
+        assertThat( visualization.getRangeAxisMaxValue(),
+            is( equalTo( visualization.getAxes().get( 0 ).getMaxValue().doubleValue() ) ) );
+        assertThat( visualization.getRangeAxisMinValue(),
+            is( equalTo( visualization.getAxes().get( 0 ).getMinValue().doubleValue() ) ) );
+        assertThat( visualization.getRangeAxisSteps(),
+            is( equalTo( visualization.getAxes().get( 0 ).getSteps() ) ) );
+
+        // Target line
+        assertThat( visualization.getFontStyle().getTargetLineLabel(),
+            is( equalTo( visualization.getAxes().get( 0 ).getTargetLine().getTitle().getFontStyle() ) ) );
+        assertThat( visualization.getTargetLineLabel(),
+            is( equalTo( visualization.getAxes().get( 0 ).getTargetLine().getTitle().getText() ) ) );
+        assertThat( visualization.getTargetLineValue(),
+            is( equalTo( visualization.getAxes().get( 0 ).getTargetLine().getValue().doubleValue() ) ) );
+
+        // Base line
+        assertThat( visualization.getFontStyle().getBaseLineLabel(),
+            is( equalTo( visualization.getAxes().get( 0 ).getBaseLine().getTitle().getFontStyle() ) ) );
+        assertThat( visualization.getBaseLineLabel(),
+            is( equalTo( visualization.getAxes().get( 0 ).getBaseLine().getTitle().getText() ) ) );
+        assertThat( visualization.getBaseLineValue(),
+            is( equalTo( visualization.getAxes().get( 0 ).getBaseLine().getValue().doubleValue() ) ) );
+
+        // # Second axis assertions
+        assertThat( visualization.getFontStyle().getHorizontalAxisTitle(),
+            is( equalTo( visualization.getAxes().get( 1 ).getTitle().getFontStyle() ) ) );
+        assertThat( visualization.getDomainAxisLabel(),
+            is( equalTo( visualization.getAxes().get( 1 ).getTitle().getText() ) ) );
+    }
+
+    private Visualization mockVisualizationWithLegend()
+    {
+        final LegendDefinitions legend = new LegendDefinitions();
+        final StyledObject label = new StyledObject();
+        final FontStyle fontStyle = new FontStyle();
+        fontStyle.setFont( Font.ARIAL );
+        label.setFontStyle( fontStyle );
+        legend.setLabel( label );
+
+        final Visualization visualization = new Visualization();
+        visualization.setLegend( legend );
+
+        return visualization;
+    }
+
+    private Visualization mockVisualizationWithAxes()
+    {
+        final StyledObject title = new StyledObject();
+        title.setText( "Some title" );
+
+        final StyledObject label = new StyledObject();
+        label.setText( "Some label" );
+
+        final Line baseLine = new Line();
+        baseLine.setTitle( title );
+        baseLine.setValue( 20 );
+
+        final Line targetLine = new Line();
+        targetLine.setTitle( title );
+        targetLine.setValue( 40 );
+
+        final AxisV2 firstAxis = new AxisV2();
+        firstAxis.setMaxValue( 1 );
+        firstAxis.setDecimals( 2 );
+        firstAxis.setIndex( 0 );
+        firstAxis.setMinValue( 3 );
+        firstAxis.setSteps( 4 );
+        firstAxis.setBaseLine( baseLine );
+        firstAxis.setLabel( label );
+        firstAxis.setTargetLine( targetLine );
+        firstAxis.setTitle( title );
+        firstAxis.setType( RANGE );
+
+        final AxisV2 secondAxis = new AxisV2();
+        secondAxis.setLabel( label );
+        secondAxis.setTitle( title );
+
+        final List<AxisV2> axes = newArrayList( firstAxis, secondAxis );
+
+        final Visualization visualization = new Visualization();
+        visualization.setAxes( axes );
+
+        return visualization;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
@@ -226,18 +226,6 @@
 
     <property name="percentStackedValues"/>
 
-    <property name="rangeAxisMaxValue"/>
-
-    <property name="rangeAxisMinValue"/>
-
-    <property name="rangeAxisSteps"/>
-
-    <property name="rangeAxisDecimals"/>
-
-    <property name="targetLineValue"/>
-
-    <property name="baseLineValue"/>
-
     <property name="title"/>
 
     <property name="subtitle"/>
@@ -257,14 +245,6 @@
     <property name="hideLegend"/>
 
     <property name="noSpaceBetweenColumns"/>
-
-    <property name="targetLineLabel"/>
-
-    <property name="baseLineLabel"/>
-
-    <property name="domainAxisLabel"/>
-
-    <property name="rangeAxisLabel"/>
 
     <many-to-one name="legendSet" class="org.hisp.dhis.legend.LegendSet" column="legendsetid"
       foreign-key="fk_visualization_legendsetid"/>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceFavoritesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceFavoritesTest.java
@@ -147,15 +147,18 @@ public class ObjectBundleServiceFavoritesTest
         assertNotNull( visualizations.get( 0 ).getSeries() );
         assertNotNull( visualizations.get( 1 ).getSeries() );
         assertNotNull( visualizations.get( 2 ).getSeries() );
+        assertNotNull( visualizations.get( 0 ).getAxes() );
+        assertNotNull( visualizations.get( 1 ).getAxes() );
+        assertNotNull( visualizations.get( 2 ).getAxes() );
+        assertNotNull( visualizations.get( 0 ).getLegend() );
+        assertNotNull( visualizations.get( 1 ).getLegend() );
+        assertNotNull( visualizations.get( 2 ).getLegend() );
         assertEquals( 2, visualizations.get( 0 ).getSeries().size() );
         assertEquals( 2, visualizations.get( 1 ).getSeries().size() );
         assertEquals( 2, visualizations.get( 2 ).getSeries().size() );
-        assertTrue( visualizations.get( 0 ).getRangeAxisMinValue() < 0 );
-        assertTrue( visualizations.get( 1 ).getRangeAxisMinValue() < 0 );
-        assertTrue( visualizations.get( 2 ).getRangeAxisMinValue() < 0 );
-        assertTrue( visualizations.get( 0 ).getBaseLineValue() < 0 );
-        assertTrue( visualizations.get( 1 ).getBaseLineValue() < 0 );
-        assertTrue( visualizations.get( 2 ).getBaseLineValue() < 0 );
+        assertEquals( 2, visualizations.get( 0 ).getAxes().size() );
+        assertEquals( 2, visualizations.get( 1 ).getAxes().size() );
+        assertEquals( 2, visualizations.get( 2 ).getAxes().size() );
 
         assertNotNull( visualizations.get( 0 ).getFontStyle() );
         assertNotNull( visualizations.get( 1 ).getFontStyle() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization.json
@@ -350,7 +350,69 @@
       "rangeAxisMinValue": -10,
       "rangeAxisMaxValue": 20,
       "baseLineValue": -5,
-      "targetLineValue": 15
+      "targetLineValue": 15,
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ]
     },
     {
       "organisationUnits": [
@@ -500,7 +562,69 @@
       "rangeAxisMinValue": -10,
       "rangeAxisMaxValue": 20,
       "baseLineValue": -5,
-      "targetLineValue": 15
+      "targetLineValue": 15,
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ]
     },
     {
       "aggregationType": "SUM",
@@ -608,6 +732,68 @@
       "organisationUnitGroups": [ ],
       "name": "ChartC",
       "organisationUnitLevels": [ ],
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ],
       "fontStyle": {
         "visualizationTitle": {
           "font": "VERDANA",


### PR DESCRIPTION
This is needed to avoid issues in the future. Otherwise, users will be able to save the same information on different DB columns. Making old attributes read-only will block that, and at the same time keep the compatibility during the next few releases.

I added the annotation `@JsonIgnoreProperties( ignoreUnknown = true )` just to prevent errors in case of any inconsistency, so the request will not fail. Any invalid property at the DB level will be ignored.

**Was already approved by the Release Control Committee, can go into patch/2.36.0.**