### PR TITLE
fix default charset UTF-8 [2.33]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/resources/META-INF/dhis/servlet.xml
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/resources/META-INF/dhis/servlet.xml
@@ -75,7 +75,7 @@
   <bean id="jsonPMessageConverter" class="org.hisp.dhis.webapi.mvc.messageconverter.JsonPMessageConverter" />
 
   <bean id="stringHttpMessageConverter" class="org.springframework.http.converter.StringHttpMessageConverter" >
-    <constructor-arg name="defaultCharset" value="java.nio.charset.StandardCharsets.UTF_8"/>
+    <constructor-arg name="defaultCharset" value="UTF-8"/>
   </bean>
 
   <bean id="byteArrayHttpMessageConverter" class="org.springframework.http.converter.ByteArrayHttpMessageConverter" />


### PR DESCRIPTION
`java.nio.charset.StandardCharsets.UTF_8` is not available in servlet.xml, have to use `UTF-8` string