### PR TITLE
fix: [DHIS2-10841] explicit tei uid causes sql syntax error (2.35)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -1019,6 +1019,11 @@ public class HibernateTrackedEntityInstanceStore
             .append( "ON OU.organisationunitid = " )
             .append( (params.hasProgram() ? "PO.organisationunitid " : "TEI.organisationunitid ") );
 
+        if ( !params.hasOrganisationUnits() )
+        {
+            return orgUnits.toString();
+        }
+
         if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) )
         {
             SqlHelper orHlp = new SqlHelper( true );


### PR DESCRIPTION
When using api/trackedEntityInstances, it is possible to not give any organisationUnits or organisationUnitSelectionMode if explicit tei uids are sent in the params. This causes syntax error in the sql formed.