### PR TITLE
fix: explicit TEI UID causes SQL syntax error [DHIS2-10841] (2.36.0)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -1013,6 +1013,11 @@ public class HibernateTrackedEntityInstanceStore
             .append( "ON OU.organisationunitid = " )
             .append( (params.hasProgram() ? "PO.organisationunitid " : "TEI.organisationunitid ") );
 
+        if ( !params.hasOrganisationUnits() )
+        {
+            return orgUnits.toString();
+        }
+
         if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) )
         {
             SqlHelper orHlp = new SqlHelper( true );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hibernate.SessionFactory;
@@ -140,6 +141,43 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
             .getTrackedEntityInstances( queryParams, params, false, true );
 
         assertThat( limitedTTrackedEntityInstances, hasSize( 2 ) );
+    }
+
+    @Test
+    public void testFetchTrackedEntityInstancesWithExplicitUid()
+    {
+        final String[] teiUid = new String[2];
+
+        doInTransaction( () -> {
+            org.hisp.dhis.trackedentity.TrackedEntityInstance t1 = this.persistTrackedEntityInstance();
+            org.hisp.dhis.trackedentity.TrackedEntityInstance t2 = this.persistTrackedEntityInstance();
+            this.persistRelationship( t1, t2 );
+            teiUid[0] = t1.getUid();
+            teiUid[1] = t2.getUid();
+        } );
+
+        TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
+        queryParams.getTrackedEntityInstanceUids().add( teiUid[0] );
+
+        TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
+
+        final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
+            .getTrackedEntityInstances( queryParams, params, false, true );
+
+        assertThat( trackedEntityInstances, hasSize( 1 ) );
+        assertThat( trackedEntityInstances.get( 0 ).getTrackedEntityInstance(), is( teiUid[0] ) );
+
+        // Query 2 tei uid explicitly
+        queryParams.getTrackedEntityInstanceUids().add( teiUid[1] );
+
+        final List<TrackedEntityInstance> multiTrackedEntityInstances = trackedEntityInstanceService
+            .getTrackedEntityInstances( queryParams, params, false, true );
+
+        assertThat( multiTrackedEntityInstances, hasSize( 2 ) );
+        Set<String> teis = multiTrackedEntityInstances.stream().map( t -> t.getTrackedEntityInstance() )
+            .collect( Collectors.toSet() );
+        assertTrue( teis.contains( teiUid[0] ) );
+        assertTrue( teis.contains( teiUid[1] ) );
     }
 
     @Test


### PR DESCRIPTION
When using api/trackedEntityInstances, it is possible to not give any organisationUnits or organisationUnitSelectionMode if explicit tei uids are sent in the params. This causes syntax error in the sql formed.