### PR TITLE
fix: sharing is overwritten with mergeMode=MERGE

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/BaseIdentifiableObject_.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/BaseIdentifiableObject_.java
@@ -39,4 +39,6 @@ public class BaseIdentifiableObject_
 
     public static final String TRANSLATIONS = "translations";
 
+    public static final String SHARING = "sharing";
+
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
@@ -129,6 +129,12 @@ public class SharingUtils
         return FROM_AND_TO_JSON.writeValueAsString( value.withAccess( accessTransformation ) );
     }
 
+    public static boolean isUseLegacySharing( BaseIdentifiableObject object )
+    {
+        return !CollectionUtils.isEmpty( object.getUserAccesses() )
+            || !CollectionUtils.isEmpty( object.getUserGroupAccesses() );
+    }
+
     private static ObjectMapper createMapper()
     {
         ObjectMapper mapper = new ObjectMapper();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -49,8 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.*;
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dataset.Section;
@@ -593,6 +592,97 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertNotNull( visualization );
         assertEquals( 0, visualization.getUserGroupAccesses().size() );
         assertEquals( 0, visualization.getUserAccesses().size() );
+    }
+
+    /**
+     * 1. Create an object with UserGroupAccessA 2. Update object with only
+     * UserGroupAccessB in payload and mergeMode=MERGE Expected: updated object
+     * will have two UserGroupAccesses
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testImportSharingWithMergeModeMerge()
+        throws IOException
+    {
+        User user = createUser( "A", "ALL" );
+        manager.save( user );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        MetadataImportParams params = createParams( ImportStrategy.CREATE, metadata );
+        params.setUser( user );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 1, dataSet.getSharing().getUserGroups().size() );
+
+        metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_merge_mode.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        params = createParams( ImportStrategy.CREATE_AND_UPDATE, metadata );
+        params.setMergeMode( MergeMode.MERGE );
+        params.setUser( user );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+
+        assertEquals( 2, dataSet.getSharing().getUserGroups().size() );
+    }
+
+    /**
+     * 1. Create an object with UserGroupAccessA 2. Update object with only
+     * UserGroupAccessB in payload and mergeMode=REPLACE Expected: updated
+     * object will have only UserGroupAccessB
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testImportSharingWithMergeModeReplace()
+        throws IOException
+    {
+        User user = createUser( "A", "ALL" );
+        manager.save( user );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_skipSharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        MetadataImportParams params = createParams( ImportStrategy.CREATE, metadata );
+        params.setUser( user );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        DataSet dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+        assertEquals( 1, dataSet.getSharing().getUserGroups().size() );
+
+        metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/dataset_with_accesses_merge_mode.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        params = createParams( ImportStrategy.CREATE_AND_UPDATE, metadata );
+        params.setMergeMode( MergeMode.REPLACE );
+        params.setUser( user );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        dataSet = manager.get( DataSet.class, "em8Bg4LCr5k" );
+        assertNotNull( dataSet.getSharing().getUserGroups() );
+
+        assertEquals( 1, dataSet.getSharing().getUserGroups().size() );
+        assertNotNull( dataSet.getSharing().getUserGroups().get( "FnJeHbPOtVF" ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_accesses_merge_mode.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/dataset_with_accesses_merge_mode.json
@@ -1,0 +1,93 @@
+{
+  "dataSets": [
+    {
+      "dataSetElements": [
+        {
+          "id": "WTOZ7gqbASV",
+          "dataElement": {
+            "id": "nHwIqKAudKN"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        },
+        {
+          "id": "rSChycu6mOY",
+          "dataElement": {
+            "id": "VolAzjFe5zP"
+          },
+          "dataSet": {
+            "id": "em8Bg4LCr5k"
+          }
+        }
+      ],
+      "compulsoryDataElementOperands": [],
+      "timelyDays": 15,
+      "fieldCombinationRequired": false,
+      "version": 4,
+      "renderAsTabs": false,
+      "name": "Data Set",
+      "expiryDays": 0,
+      "skipOffline": false,
+      "dataElementDecoration": false,
+      "validCompleteOnly": false,
+      "publicAccess": "rw------",
+      "noValueRequiresComment": false,
+      "shortName": "Data Set",
+      "attributeValues": [],
+      "id": "em8Bg4LCr5k",
+      "indicators": [],
+      "userGroupAccesses": [
+        {
+          "access": "rwrw----",
+          "userGroupUid": "FnJeHbPOtVF",
+          "id": "FnJeHbPOtVF"
+        }
+      ],
+      "translations": [
+        {
+          "property": "NAME",
+          "locale": "en_GB",
+          "value": "ART monthly summary"
+        },
+        {
+          "property": "SHORT_NAME",
+          "locale": "en_GB",
+          "value": "ART 2010"
+        }
+      ],
+      "periodType": "Monthly",
+      "mobile": false,
+      "lastUpdated": "2016-03-08T07:32:42.146+0000",
+      "notifyCompletingUser": false,
+      "openFuturePeriods": 0,
+      "created": "2016-03-08T07:31:30.424+0000",
+      "organisationUnits": [
+        {
+          "id": "x3gVvpbVgqy"
+        }
+      ],
+      "renderHorizontally": false,
+      "user": {
+        "id": "T12jeH7KPzk"
+      }
+    }
+  ],
+  "userGroups": [
+    {
+      "name": "Administrators 1",
+      "id": "FnJeHbPOtVF",
+      "displayName": "Administrators 1",
+      "publicAccess": "rw------",
+      "externalAccess": false,
+      "favorite": false,
+      "users": [
+        {
+          "id": "T12jeH7KPzk"
+        }
+      ]
+    }
+  ],
+
+  "date": "2016-03-08T07:34:13.552+0000"
+}

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -33,9 +33,11 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.common.MergeMode;
+import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.adapter.*;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.util.*;
 import org.springframework.stereotype.Service;
 
 /**
@@ -64,6 +66,12 @@ public class DefaultMergeService implements MergeService
         {
             if ( schema.isIdentifiableObject() )
             {
+                if ( BaseIdentifiableObject_.SHARING.equals( property.getFieldName() )
+                    && SharingUtils.isUseLegacySharing( (BaseIdentifiableObject) target ) )
+                {
+                    continue;
+                }
+
                 if ( mergeParams.isSkipSharing() && ReflectionUtils.isSharingProperty( property ) )
                 {
                     continue;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10657
Issue: 
- MergeService is merging both new sharing and legacy sharing collections so when importing, the legacy objects are being overwritten.
Fix:
- Add a sharing util method to detect if payload use legacy sharing objects then mergeService will ignore new sharing property. 
- If payload doesn't include legacy sharing objects then new sharing property will be used for updating. But it will not be affected by the mergeMode. This needs json patch service.
- Add unit tests for both case mergeMode=MERGE and REPLACE