### PR TITLE
fix: [DHIS2-10870] Check unique attribute filters in attribute params in addition to filter param (2.37)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -739,24 +739,36 @@ public class TrackedEntityInstanceQueryParams
     }
 
     /**
-     * Indicates whether filters are unique attributes.
+     * Checks if there is atleast one unique filter in the params. In attributes
+     * or filters.
+     *
+     * @return true if there is exist atlesast one unique filter in
+     *         filters/attributes, false otherwise.
      */
-    public boolean hasUniqueFilters()
+    public boolean hasUniqueFilter()
     {
-        if ( !hasFilters() )
+        if ( !hasFilters() && !hasAttributes() )
         {
             return false;
         }
 
         for ( QueryItem filter : filters )
         {
-            if ( !filter.isUnique() )
+            if ( filter.isUnique() )
             {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        for ( QueryItem attribute : attributes )
+        {
+            if ( attribute.isUnique() && attribute.hasFilter() )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -773,7 +773,7 @@ public class DefaultTrackedEntityInstanceService
 
     private boolean isProgramMinAttributesViolated( TrackedEntityInstanceQueryParams params )
     {
-        if ( params.hasUniqueFilters() )
+        if ( params.hasUniqueFilter() )
         {
             return false;
         }
@@ -788,7 +788,7 @@ public class DefaultTrackedEntityInstanceService
 
     private boolean isTeTypeMinAttributesViolated( TrackedEntityInstanceQueryParams params )
     {
-        if ( params.hasUniqueFilters() )
+        if ( params.hasUniqueFilter() )
         {
             return false;
         }


### PR DESCRIPTION
When checking for "minimumAttributesForSearch", we ignore the unique parameters passed as part of the "attribute" request parameter. This change makes the change to respect unique attribute passed in "attribute" request parameter in addition to the "filter" parameter. 
Additional change is that, if atleast ONE unique attribute is present in either "filter" or "attribute" parameter, then the minimumAttributesForSearch is not needed. Earlier the behaviour was ALL attributes present in "filter" had to be unique, to be able to bypass the minimumAttributesForSearch validatiton.