### PR TITLE
fix: [DHIS2-10870] Check unique attribute filters in attribute params in addition to filter param (2.36.0)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -739,24 +739,36 @@ public class TrackedEntityInstanceQueryParams
     }
 
     /**
-     * Indicates whether filters are unique attributes.
+     * Checks if there is atleast one unique filter in the params. In attributes
+     * or filters.
+     *
+     * @return true if there is exist atlesast one unique filter in
+     *         filters/attributes, false otherwise.
      */
-    public boolean hasUniqueFilters()
+    public boolean hasUniqueFilter()
     {
-        if ( !hasFilters() )
+        if ( !hasFilters() && !hasAttributes() )
         {
             return false;
         }
 
         for ( QueryItem filter : filters )
         {
-            if ( !filter.isUnique() )
+            if ( filter.isUnique() )
             {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        for ( QueryItem attribute : attributes )
+        {
+            if ( attribute.isUnique() && attribute.hasFilter() )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -767,7 +767,7 @@ public class DefaultTrackedEntityInstanceService
 
     private boolean isProgramMinAttributesViolated( TrackedEntityInstanceQueryParams params )
     {
-        if ( params.hasUniqueFilters() )
+        if ( params.hasUniqueFilter() )
         {
             return false;
         }
@@ -782,7 +782,7 @@ public class DefaultTrackedEntityInstanceService
 
     private boolean isTeTypeMinAttributesViolated( TrackedEntityInstanceQueryParams params )
     {
-        if ( params.hasUniqueFilters() )
+        if ( params.hasUniqueFilter() )
         {
             return false;
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryTest.java
@@ -27,8 +27,16 @@
  */
 package org.hisp.dhis.trackedentityinstance;
 
+import static org.junit.Assert.assertEquals;
+
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -52,5 +60,39 @@ public class TrackedEntityInstanceQueryTest
         params.setTrackedEntityType( trackedEntityTypeA );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );
         instanceService.validate( params );
+    }
+
+    @Test
+    public void testIfUniqueFiltersArePresentInAttributesOrFilters()
+    {
+        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
+        QueryItem nonUniq1 = new QueryItem( new TrackedEntityAttribute(), null, ValueType.TEXT, AggregationType.NONE,
+            null, false );
+        QueryItem nonUniq2 = new QueryItem( new TrackedEntityAttribute(), null, ValueType.TEXT, AggregationType.NONE,
+            null, false );
+        QueryItem uniq1 = new QueryItem( new TrackedEntityAttribute(), null, ValueType.TEXT, AggregationType.NONE, null,
+            true );
+
+        QueryFilter qf = new QueryFilter( QueryOperator.EQ, "test" );
+        nonUniq1.getFilters().add( qf );
+        nonUniq2.getFilters().add( qf );
+        params.addAttribute( nonUniq1 );
+        params.addAttribute( nonUniq2 );
+        params.addAttribute( uniq1 );
+
+        assertEquals( params.hasUniqueFilter(), false );
+
+        uniq1.getFilters().add( qf );
+        assertEquals( params.hasUniqueFilter(), true );
+
+        params.getAttributes().clear();
+
+        params.addFilter( nonUniq1 );
+        params.addFilter( nonUniq2 );
+
+        assertEquals( params.hasUniqueFilter(), false );
+        params.addFilter( uniq1 );
+        assertEquals( params.hasUniqueFilter(), true );
+
     }
 }


### PR DESCRIPTION
When checking for "minimumAttributesForSearch", we ignore the unique parameters passed as part of the "attribute" request parameter. This change makes the change to respect unique attribute passed in "attribute" request parameter in addition to the "filter" parameter.
Additional change is that, if atleast ONE unique attribute is present in either "filter" or "attribute" parameter, then the minimumAttributesForSearch is not needed. Earlier the behaviour was ALL attributes present in "filter" had to be unique, to be able to bypass the minimumAttributesForSearch validation
