### PR TITLE
fix: DHIS2-10858: Removing extra comma from period label YESTERDAY

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -540,7 +540,7 @@ username_email_in_password=Username/Email cannot be part of password
 #-- Relative periods -----------------------------------------------------------#
 
 TODAY=Today
-YESTERDAY=Yesterday,
+YESTERDAY=Yesterday
 LAST_3_DAYS=Last 3 days
 LAST_7_DAYS=Last 7 days
 LAST_14_DAYS=Last 14 days


### PR DESCRIPTION
Fixing a small typo in translations.