### PR TITLE
fix: start/stop jobs when PATCHed [DHIS2-10890]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.scheduling;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.createWebMessage;
+import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
 
 import java.util.Map;
 
@@ -151,7 +152,15 @@ public class JobConfigurationController
     @Override
     protected void postPatchEntity( JobConfiguration jobConfiguration )
     {
+        if ( !jobConfiguration.isEnabled() )
+        {
+            schedulingManager.stopJob( jobConfiguration );
+        }
         jobConfigurationService.refreshScheduling( jobConfiguration );
+        if ( jobConfiguration.getJobStatus() != DISABLED )
+        {
+            schedulingManager.scheduleJob( jobConfiguration );
+        }
     }
 
     private void checkConfigurable( JobConfiguration configuration, HttpStatus status, String message )


### PR DESCRIPTION
Problem was that continues jobs could not be stopped. While one could disable it it would still run in the scheduler which after finishing a round would update the job configuration for the next due time and override the disabled state.

This would not be noticeable since the client began to use PATCH to flip the `enabled` flag. This would no longer trigger the `JobConfigurationObjectBundleHook` which had done this for POST.

I also noticed a thread-safety issue in the `DefaultSchedulingManager`.
It would do a `futures.contains(key)` followed by a `futures.put(key)`. Obviously the state could change between `contains` and `put` allowing for unintended things to happen when multiple threads are involved. This is now done via `computeIfAbsent` which makes sure only one thread will succeed and start/schedule a new task. 