### PR TITLE
fix: DHIS2-10871: Fixing report rate calculation for 'single periods'

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -63,6 +63,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.getRoundedValueObject;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.hasPeriod;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.isPeriodInPeriods;
 import static org.hisp.dhis.analytics.util.PeriodOffsetUtils.getPeriodOffsetRow;
+import static org.hisp.dhis.analytics.util.ReportRatesHelper.getCalculatedTarget;
 import static org.hisp.dhis.common.DataDimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DataDimensionItemType.DATA_ELEMENT_OPERAND;
 import static org.hisp.dhis.common.DataDimensionItemType.INDICATOR;
@@ -95,7 +96,6 @@ import static org.hisp.dhis.common.ReportingRateMetric.REPORTING_RATE_ON_TIME;
 import static org.hisp.dhis.commons.util.DebugUtils.getStackTrace;
 import static org.hisp.dhis.commons.util.SystemUtils.getCpuCores;
 import static org.hisp.dhis.dataelement.DataElementOperand.TotalType.values;
-import static org.hisp.dhis.period.DailyPeriodType.NAME;
 import static org.hisp.dhis.period.PeriodType.getPeriodTypeFromIsoString;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_MAX_LIMIT;
 import static org.hisp.dhis.setting.SettingKey.DATABASE_SERVER_CPUS;
@@ -654,72 +654,6 @@ public class DataHandler
                 .addValue( PERCENT )
                 .addNullValues( 2 );
         }
-    }
-
-    /**
-     * Use number of days for daily data sets as target, as query periods might
-     * often span/contain different numbers of days.
-     *
-     * @param periodIndex the index of the period in the "dataRow".
-     * @param timeUnits the time unit size found in the current DataQueryParams.
-     *        See {@link #getTimeUnits(DataQueryParams)}.
-     * @param dataRow the current dataRow, based on the key map built by
-     *        {@link #getAggregatedCompletenessTargetMap(DataQueryParams)).
-     * @param target the current value of the respective key ("dataRow"). See
-     *        {@link #getAggregatedCompletenessTargetMap(DataQueryParams).
-     * @param queryPt the filter period in the current "dataRow". See
-     *        {@link PeriodType#getPeriodTypeFromIsoString}.
-     * @param dataSetPt the dataset period.
-     * @param filterPeriods the filter "pe" in the params.
-     *
-     * @return the calculate target
-     */
-    private Double getCalculatedTarget( Integer periodIndex, int timeUnits, List<String> dataRow, Double target,
-        PeriodType queryPt, PeriodType dataSetPt, List<DimensionalItemObject> filterPeriods )
-    {
-        if ( dataSetPt.equalsName( NAME ) )
-        {
-            boolean hasPeriodInDimension = periodIndex != -1;
-
-            // If we enter here, it means there is a "pe" in the dimension
-            // parameter.
-            if ( hasPeriodInDimension )
-            {
-                final Period period = PeriodType.getPeriodFromIsoString( dataRow.get( periodIndex ) );
-
-                target = consolidateTarget( timeUnits, target, period.getDaysInPeriod() );
-            }
-            else
-            {
-                // If we reach here, it means that we should have a "pe"
-                // dimension as filter parameter.
-                final List<DimensionalItemObject> periods = filterPeriods;
-
-                if ( isNotEmpty( periods ) )
-                {
-                    int totalOfDaysInPeriod = 0;
-
-                    for ( final DimensionalItemObject itemObject : periods )
-                    {
-                        final Period period = (Period) itemObject;
-                        totalOfDaysInPeriod += period.getDaysInPeriod();
-                    }
-
-                    target = consolidateTarget( timeUnits, target, totalOfDaysInPeriod );
-                }
-            }
-        }
-        else
-        {
-            target = consolidateTarget( timeUnits, target, queryPt.getPeriodSpan( dataSetPt ) );
-        }
-
-        return target;
-    }
-
-    private double consolidateTarget( final int timeUnits, final double target, final int daysInPeriod )
-    {
-        return target * daysInPeriod * timeUnits;
     }
 
     private Double getReportRate( ReportingRateMetric metric, Double target, Double actual )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -687,34 +687,39 @@ public class DataHandler
             {
                 final Period period = PeriodType.getPeriodFromIsoString( dataRow.get( periodIndex ) );
 
-                target = target * period.getDaysInPeriod() * timeUnits;
+                target = consolidateTarget( timeUnits, target, period.getDaysInPeriod() );
             }
             else
             {
                 // If we reach here, it means that we should have a "pe"
-                // dimension in the filter
-                // parameter.
+                // dimension as filter parameter.
                 final List<DimensionalItemObject> periods = filterPeriods;
 
                 if ( isNotEmpty( periods ) )
                 {
-                    int totalOfDayInPeriod = 0;
+                    int totalOfDaysInPeriod = 0;
 
                     for ( final DimensionalItemObject itemObject : periods )
                     {
                         final Period period = (Period) itemObject;
-                        totalOfDayInPeriod += period.getDaysInPeriod();
+                        totalOfDaysInPeriod += period.getDaysInPeriod();
                     }
 
-                    target += target * totalOfDayInPeriod;
+                    target = consolidateTarget( timeUnits, target, totalOfDaysInPeriod );
                 }
             }
         }
         else
         {
-            target = target * queryPt.getPeriodSpan( dataSetPt ) * timeUnits;
+            target = consolidateTarget( timeUnits, target, queryPt.getPeriodSpan( dataSetPt ) );
         }
+
         return target;
+    }
+
+    private double consolidateTarget( final int timeUnits, final double target, final int daysInPeriod )
+    {
+        return target * daysInPeriod * timeUnits;
     }
 
     private Double getReportRate( ReportingRateMetric metric, Double target, Double actual )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/ReportRatesHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/ReportRatesHelper.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.period.DailyPeriodType.NAME;
+
+import java.util.List;
+
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+
+/**
+ * Just a helper class responsible for providing methods that hides specific
+ * Report Rates logic and calculation.
+ *
+ * @author maikel arabori
+ */
+public class ReportRatesHelper
+{
+    private ReportRatesHelper()
+    {
+    }
+
+    /**
+     * Use number of days for daily data sets as target, as query periods might
+     * often span/contain different numbers of days.
+     *
+     * @param periodIndex the index of the period in the "dataRow".
+     * @param timeUnits the time unit size found in the current DataQueryParams.
+     *        See {@link #DataHandler.getTimeUnits(DataQueryParams)}.
+     * @param dataRow the current dataRow, based on the key map built by
+     *        {@link #DataHandler.getAggregatedCompletenessTargetMap(DataQueryParams)).
+     * @param target the current value of the respective key ("dataRow"). See
+     *        {@link #DataHandler.getAggregatedCompletenessTargetMap(DataQueryParams).
+     * @param queryPt the filter period in the current "dataRow". See
+     *        {@link PeriodType#getPeriodTypeFromIsoString}.
+     * @param dataSetPt the dataset period.
+     * @param filterPeriods the filter "pe" in the params.
+     *
+     * @return the calculate target
+     */
+    public static Double getCalculatedTarget( final int periodIndex, final int timeUnits, final List<String> dataRow,
+        final Double target, final PeriodType queryPt, final PeriodType dataSetPt,
+        final List<DimensionalItemObject> filterPeriods )
+    {
+        if ( dataSetPt.equalsName( NAME ) )
+        {
+            boolean hasPeriodInDimension = periodIndex != -1;
+
+            // If we enter here, it means there is a "pe" in the dimension
+            // parameter.
+            if ( hasPeriodInDimension )
+            {
+                return getTargetFromDimension( periodIndex, timeUnits, dataRow, target );
+            }
+            else
+            {
+                // If we reach here, it means that we should have a "pe"
+                // dimension as filter parameter.
+                return getTargetFromFilter( timeUnits, target, filterPeriods );
+            }
+        }
+        else
+        {
+            return consolidateTarget( timeUnits, target, queryPt.getPeriodSpan( dataSetPt ) );
+        }
+    }
+
+    private static Double getTargetFromDimension( final int periodIndex, final int timeUnits,
+        final List<String> dataRow, final Double target )
+    {
+        final Period period = PeriodType.getPeriodFromIsoString( dataRow.get( periodIndex ) );
+
+        return consolidateTarget( timeUnits, target, period.getDaysInPeriod() );
+    }
+
+    private static Double getTargetFromFilter( final int timeUnits, final Double target,
+        final List<DimensionalItemObject> filterPeriods )
+    {
+        final List<DimensionalItemObject> periods = filterPeriods;
+
+        if ( isNotEmpty( periods ) )
+        {
+            int totalOfDaysInPeriod = 0;
+
+            for ( final DimensionalItemObject itemObject : periods )
+            {
+                final Period period = (Period) itemObject;
+                totalOfDaysInPeriod += period.getDaysInPeriod();
+            }
+
+            return consolidateTarget( timeUnits, target, totalOfDaysInPeriod );
+        }
+
+        return target;
+    }
+
+    private static Double consolidateTarget( final int timeUnits, final Double target, final int daysInPeriod )
+    {
+        return target * daysInPeriod * timeUnits;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/ReportRatesHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/ReportRatesHelper.java
@@ -104,13 +104,11 @@ public class ReportRatesHelper
     private static Double getTargetFromFilter( final int timeUnits, final Double target,
         final List<DimensionalItemObject> filterPeriods )
     {
-        final List<DimensionalItemObject> periods = filterPeriods;
-
-        if ( isNotEmpty( periods ) )
+        if ( isNotEmpty( filterPeriods ) )
         {
             int totalOfDaysInPeriod = 0;
 
-            for ( final DimensionalItemObject itemObject : periods )
+            for ( final DimensionalItemObject itemObject : filterPeriods )
             {
                 final Period period = (Period) itemObject;
                 totalOfDaysInPeriod += period.getDaysInPeriod();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/ReportRatesHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/ReportRatesHelperTest.java
@@ -56,7 +56,7 @@ public class ReportRatesHelperTest
         final List<DimensionalItemObject> theFilterPeriods = asList( stubPeriod() );
         final PeriodType theDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
 
-        // Relates to "aDailyDataRow" objects
+        // Relates to "aDailyDataPeriodRow" objects
         final int anyPositivePeriodInDimensionIndex = 1;
         final List<String> aDailyDataPeriodRow = asList( "TuL8IOPzpHh", "20210415" );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/ReportRatesHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/ReportRatesHelperTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hisp.dhis.analytics.util.ReportRatesHelper.getCalculatedTarget;
+
+import java.util.Date;
+import java.util.List;
+
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.period.DailyPeriodType;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.junit.Test;
+
+/**
+ * Unit tests for ReportRatesHelper.
+ *
+ * @author maikel arabori
+ */
+public class ReportRatesHelperTest
+{
+    @Test
+    public void testGetCalculatedTargetWhenDataSetIsDailyAndHasPeriodInDimension()
+    {
+        // Given
+        final Double theTarget = 10d;
+        final List<DimensionalItemObject> theFilterPeriods = asList( stubPeriod() );
+        final PeriodType theDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
+
+        // Relates to "aDailyDataRow" objects
+        final int anyPositivePeriodInDimensionIndex = 1;
+        final List<String> aDailyDataPeriodRow = asList( "TuL8IOPzpHh", "20210415" );
+
+        final int anyTimeUnits = 2;
+        final PeriodType aDataSetDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
+
+        // When
+        final Double actualResult = getCalculatedTarget( anyPositivePeriodInDimensionIndex, anyTimeUnits,
+            aDailyDataPeriodRow, theTarget, theDailyPeriodType, aDataSetDailyPeriodType, theFilterPeriods );
+
+        // Then
+        assertThat( actualResult, is( 20.0d ) );
+    }
+
+    @Test
+    public void testGetCalculatedTargetWhenDataSetIsDailyAndHasPeriodInFilter()
+    {
+        // Given
+        final Double theTarget = 10d;
+        final List<DimensionalItemObject> theFilterPeriods = asList( stubPeriod() );
+        final PeriodType theDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
+        final int anyNegativePeriodInDimensionIndex = -1;
+        final int anyTimeUnits = 1;
+        final List<String> anyDataRow = asList( "TuL8IOPzpHh" );
+        final PeriodType aDataSetDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
+
+        // When
+        final Double actualResult = getCalculatedTarget( anyNegativePeriodInDimensionIndex, anyTimeUnits,
+            anyDataRow, theTarget, theDailyPeriodType, aDataSetDailyPeriodType, theFilterPeriods );
+
+        // Then
+        assertThat( actualResult, is( 10.0d ) );
+    }
+
+    @Test
+    public void testGetCalculatedTargetWhenDataSetIsDailyAndHasPeriodInFilterAndMultiplePeriods()
+    {
+        // Given
+        final Double theTarget = 10d;
+        final List<DimensionalItemObject> multipleFilterPeriods = asList( stubPeriod(), stubPeriod(), stubPeriod() );
+        final PeriodType theDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
+        final int anyNegativePeriodInDimensionIndex = -1;
+        final int anyTimeUnits = 2;
+        final List<String> anyDataRow = asList( "TuL8IOPzpHh" );
+        final PeriodType aDataSetDailyPeriodType = DailyPeriodType.getByNameIgnoreCase( "Daily" );
+
+        // When
+        final Double actualResult = getCalculatedTarget( anyNegativePeriodInDimensionIndex, anyTimeUnits,
+            anyDataRow, theTarget, theDailyPeriodType, aDataSetDailyPeriodType, multipleFilterPeriods );
+
+        // Then
+        assertThat( actualResult, is( 60.0d ) );
+    }
+
+    public Period stubPeriod()
+    {
+        final Period p = new Period();
+        p.setStartDate( new Date() );
+        p.setEndDate( new Date() );
+        p.setPeriodType( DailyPeriodType.getByNameIgnoreCase( "daily" ) );
+
+        return p;
+    }
+}


### PR DESCRIPTION
This fix adds a new and reusable tiny method to centralize and consolidate the target value used on report rates/dataSets.
Previously we had a calculation mistake that was doubling the target value causing the final result being 50% lower than the expected result.

I also extracted the calculation into a separate class making the changes unit testable.