### PR TITLE
ci: remove global variable causing race condition

### DIFF
--- a/Jenkinsfile-publish-image
+++ b/Jenkinsfile-publish-image
@@ -14,7 +14,7 @@ pipeline {
         DOCKER_CORE_IMAGE_FULL_NAME = ''
         DOCKER_BASE_IMAGE_FULL_NAME = ''
         COMPOSE_PARAMETER = ''
-        TESTS_IMAGE_FULL_NAME = ''
+        TESTS_IMAGE_NAME = 'core-api-tests'
     }
 
     stages {
@@ -114,11 +114,11 @@ pipeline {
                     stage('Run tests') {
                         steps {
                             script {
-                                TESTS_IMAGE_FULL_NAME = "core-api-tests:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
+                                def tests_image_full_name = "${TESTS_IMAGE_NAME}:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
 
                                 dir("dhis-2/dhis-e2e-test") {
-                                    sh "docker build -t ${TESTS_IMAGE_FULL_NAME} ."
-                                    sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
+                                    sh "docker build -t ${tests_image_full_name} ."
+                                    sh "IMAGE_NAME=${tests_image_full_name} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} -f docker-compose.e2e.yml up --exit-code-from e2e-test"
                                 }
                             }
                         }
@@ -135,9 +135,10 @@ pipeline {
                             }
                             cleanup {
                                 script {
+                                    def tests_image_full_name = "${TESTS_IMAGE_NAME}:${DOCKER_IMAGE_TAG}${DOCKER_VARIANT}"
                                     dir("dhis-2/dhis-e2e-test") {
                                         sh "IMAGE_NAME=${DOCKER_CORE_IMAGE_FULL_NAME} docker-compose -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} down -v --remove-orphans"
-                                        sh "IMAGE_NAME=${TESTS_IMAGE_FULL_NAME} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} down --rmi all -v --remove-orphans"
+                                        sh "IMAGE_NAME=${tests_image_full_name} docker-compose -f docker-compose.e2e.yml -p ${COMPOSE_PARAMETER}${DOCKER_VARIANT} down --rmi all -v --remove-orphans"
                                     }
                                 }
 


### PR DESCRIPTION
When both matrix stages run at the same time, the variable for test image is overwritten and the pipeline fails, because one stage either tries to remove a running docker container or start another one. Making the variable local scoped should fix that. 