### PR TITLE
fix: NPE in ProgramRule deletion hook

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleDeletionHandler.java
@@ -79,8 +79,13 @@ public class ProgramRuleDeletionHandler
 
     private DeletionVeto allowDeleteProgramStageSection( ProgramStageSection programStageSection )
     {
+        ProgramStage programStage = programStageSection.getProgramStage();
+        if ( programStage == null )
+        {
+            return DeletionVeto.ACCEPT;
+        }
         String programRules = programRuleService
-            .getProgramRule( programStageSection.getProgramStage().getProgram() )
+            .getProgramRule( programStage.getProgram() )
             .stream()
             .filter( pr -> isLinkedToProgramStageSection( programStageSection, pr ) )
             .map( BaseIdentifiableObject::getName )


### PR DESCRIPTION
NPE that keeps showing in test runs but that will not fail test since it is part of a deletion handler and as such all exceptions are caught.

Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>