### PR TITLE
fix: remove workaround fix for sharing in AbstractCrudController [2.36]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -35,7 +35,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -816,22 +815,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             .setUser( user )
             .setImportStrategy( ImportStrategy.UPDATE )
             .addObject( parsed );
-
-        if ( params.isSkipTranslation() )
-        {
-            // TODO this is a workaround to keep translations, preheat needs fix
-            params.setSkipTranslation( false );
-            T entity = manager.get( getEntityClass(), pvUid );
-            ((BaseIdentifiableObject) parsed).setTranslations( new HashSet<>( entity.getTranslations() ) );
-        }
-
-        if ( params.isSkipSharing() )
-        {
-            // TODO this is a workaround to keep sharing
-            params.setSkipSharing( false );
-            T entity = manager.get( getEntityClass(), pvUid );
-            ((BaseIdentifiableObject) parsed).setSharing( entity.getSharing() );
-        }
 
         ImportReport importReport = importService.importMetadata( params );
         WebMessage webMessage = WebMessageUtils.objectReport( importReport );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -138,7 +138,10 @@ public class MapController
         Map newMap = deserializeJsonEntity( request, response );
         newMap.setUid( uid );
 
-        mergeService.merge( new MergeParams<>( newMap, map ).setMergeMode( params.getMergeMode() ) );
+        mergeService.merge( new MergeParams<>( newMap, map )
+            .setMergeMode( params.getMergeMode() )
+            .setSkipSharing( params.isSkipSharing() )
+            .setSkipTranslation( params.isSkipTranslation() ) );
         mappingService.updateMap( map );
     }
 


### PR DESCRIPTION
Issues: 
 - A fix for forwarding skipSharing to mergeService in MapController was not backport from 2.37
 - A work around fix for sharing revert issue in AbstractCrudController always reset the value of skipSharing flag. This need to be removed in order for the fix https://github.com/dhis2/dhis2-core/pull/7898 works