### PR TITLE
feat: adds efficient periods by ISO strings database lookup

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
@@ -136,6 +136,25 @@ public interface PeriodStore
     List<Period> getPeriodsByPeriodType( PeriodType periodType );
 
     /**
+     * Returns all {@link Period} matching the given ISO expressions that
+     * actually exist in the database.
+     *
+     * It tries to provide an efficient way to get fully initialised
+     * {@link Period} instances for a given set of ISO expressions.
+     *
+     * In contrast to {@link PeriodType#getPeriodsFromIsoStrings(List)} the
+     * {@link Period}s returned by this method are persistent entities and as
+     * such usable as arguments to queries or as part of other persistent
+     * objects.
+     *
+     * @param isoPeriods The ISO expressions to find {@link Period}s for
+     * @return a list of matching {@link Period} not necessarily in the order of
+     *         ISO expressions nor necessarily having all items of the ISO
+     *         expressions.
+     */
+    List<Period> getPeriodsFromIsoStrings( List<String> isoPeriods );
+
+    /**
      * Checks if the given period is associated with the current session and
      * loads it if not. Null is returned if the period does not exist.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -37,6 +37,8 @@ import java.util.stream.IntStream;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
@@ -56,8 +58,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Implements the PeriodStore interface.


### PR DESCRIPTION
Added this for #7906 but then ended up not needing it there but in general this should be something we should be in need of.

The motivation here is that when `Period`s are passed to persistence to e.g. be used as filters or when being stored/updated as (referenced) part of another object the `Period` must be a non transient instance (with ID). The front-end would usually provide this reference to the period as ISO strings. Hence, there should be a need to do this conversion. 