### PR TITLE
feat: Gist API missing features and bugfixes [DHIS2-10740]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.gist.GistBuilder.createCountBuilder;
 import static org.hisp.dhis.gist.GistBuilder.createFetchBuilder;
 
 import java.net.URI;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -151,11 +152,21 @@ public class DefaultGistService implements GistService
         return query.getSingleResult().intValue();
     }
 
+    @SuppressWarnings( "unchecked" )
     private <T> T parseFilterArgument( String value, Class<T> type )
     {
+        if ( type == Date.class && "now".equals( value ) )
+        {
+            return (T) new Date();
+        }
+        String valueAsJson = value;
+        if ( !(Number.class.isAssignableFrom( type ) || type == Boolean.class || type == boolean.class) )
+        {
+            valueAsJson = '"' + value + '"';
+        }
         try
         {
-            return jsonMapper.readValue( value, type );
+            return jsonMapper.readValue( valueAsJson, type );
         }
         catch ( JsonProcessingException e )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -60,6 +60,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class DefaultGistService implements GistService
 {
 
+    /**
+     * Instead of an actual date value users may use string {@code now} to
+     * always get current moment as time for a {@link Date} value.
+     */
+    private static final String NOW_PARAMETER_VALUE = "now";
+
     private final SessionFactory sessionFactory;
 
     private final SchemaService schemaService;
@@ -155,7 +161,7 @@ public class DefaultGistService implements GistService
     @SuppressWarnings( "unchecked" )
     private <T> T parseFilterArgument( String value, Class<T> type )
     {
-        if ( type == Date.class && "now".equals( value ) )
+        if ( type == Date.class && NOW_PARAMETER_VALUE.equals( value ) )
         {
             return (T) new Date();
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.gist.GistLogic.isHrefProperty;
 import static org.hisp.dhis.gist.GistLogic.isNonNestedPath;
 import static org.hisp.dhis.gist.GistLogic.isPersistentCollectionField;
 import static org.hisp.dhis.gist.GistLogic.isPersistentReferenceField;
+import static org.hisp.dhis.gist.GistLogic.isStringLengthFilter;
 import static org.hisp.dhis.gist.GistLogic.parentPath;
 import static org.hisp.dhis.gist.GistLogic.pathOnSameParent;
 
@@ -630,17 +631,17 @@ final class GistBuilder
     private String createFilterHQL( int index, Filter filter, String field )
     {
         StringBuilder str = new StringBuilder();
-        boolean sizeOp = isCollectionSizeFilter( filter,
-            context.resolveMandatory( filter.getPropertyPath() ) );
-        if ( sizeOp )
+        Property property = context.resolveMandatory( filter.getPropertyPath() );
+        String fieldTemplate = "%s";
+        if ( isStringLengthFilter( filter, property ) )
         {
-            str.append( "size(" );
+            fieldTemplate = "length(%s)";
         }
-        str.append( field );
-        if ( sizeOp )
+        else if ( isCollectionSizeFilter( filter, property ) )
         {
-            str.append( ")" );
+            fieldTemplate = "size(%s)";
         }
+        str.append( String.format( fieldTemplate, field ) );
         Comparison operator = filter.getOperator();
         str.append( " " ).append( createOperatorLeftSideHQL( operator ) );
         if ( !operator.isUnary() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -106,6 +106,11 @@ final class GistLogic
             (filter.getOperator().isNumericCompare() && property.isCollection());
     }
 
+    static boolean isStringLengthFilter( Filter filter, Property property )
+    {
+        return filter.getOperator().isSizeCompare() && property.isSimple() && property.getKlass() == String.class;
+    }
+
     static Transform effectiveTransform( Property property, Transform fallback, Transform target )
     {
         if ( target == Transform.AUTO )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -102,9 +102,8 @@ final class GistLogic
 
     static boolean isCollectionSizeFilter( Filter filter, Property property )
     {
-        return isNonNestedPath( filter.getPropertyPath() )
-            && (filter.getOperator().isSizeCompare() ||
-                (filter.getOperator().isOrderCompare() && property.isCollection()));
+        return filter.getOperator().isSizeCompare() ||
+            (filter.getOperator().isNumericCompare() && property.isCollection());
     }
 
     static Transform effectiveTransform( Property property, Transform fallback, Transform target )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -314,7 +314,7 @@ public final class GistQuery
 
         public boolean isCollectionCompare()
         {
-            return this == IN || this == NOT_IN || isSizeCompare();
+            return isContainsCompare() || isSizeCompare();
         }
 
         public boolean isSizeCompare()
@@ -325,6 +325,11 @@ public final class GistQuery
         public boolean isStringCompare()
         {
             return ordinal() >= LIKE.ordinal();
+        }
+
+        public boolean isContainsCompare()
+        {
+            return this == IN || this == NOT_IN;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -224,6 +224,11 @@ public final class GistQuery
         return toBuilder().fields( fields ).build();
     }
 
+    public GistQuery withFilters( List<Filter> filters )
+    {
+        return toBuilder().filters( filters ).build();
+    }
+
     private <E> GistQuery withAddedItem( E e, List<E> collection,
         BiFunction<GistQueryBuilder, List<E>, GistQueryBuilder> setter )
     {
@@ -268,9 +273,9 @@ public final class GistQuery
         ILIKE( "ilike" ),
         NOT_ILIKE( "!ilike" ),
         STARTS_WITH( "$ilike", "startswith" ),
-        NOT_STARTS_WITH( "!$ilike" ),
+        NOT_STARTS_WITH( "!$ilike", "!startswith" ),
         ENDS_WITH( "ilike$", "endswith" ),
-        NOT_ENDS_WITH( "!ilike$" );
+        NOT_ENDS_WITH( "!ilike$", "!endswith" );
 
         private final String[] symbols;
 
@@ -470,6 +475,11 @@ public final class GistQuery
             this.propertyPath = propertyPath;
             this.operator = operator;
             this.value = value;
+        }
+
+        public Filter withPropertyPath( String path )
+        {
+            return new Filter( path, operator, value );
         }
 
         public static Filter parse( String filter )

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
@@ -37,12 +37,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.JsonArray;
 import org.hisp.dhis.webapi.json.JsonObject;
 import org.hisp.dhis.webapi.json.JsonString;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -53,6 +56,9 @@ import org.springframework.http.HttpStatus;
  */
 public class GistQueryControllerTest extends DhisControllerConvenienceTest
 {
+    @Autowired
+    private OrganisationUnitService organisationUnitService;
+
     private String userGroupId;
 
     private String orgUnitId;
@@ -312,6 +318,28 @@ public class GistQueryControllerTest extends DhisControllerConvenienceTest
         assertEquals( 1, GET( "/users/gist?filter=code:neq:Paul&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=code:ne:Paul&headless=true" ).content().size() );
         assertEquals( 0, GET( "/users/gist?filter=code:ne:admin&headless=true" ).content().size() );
+    }
+
+    @Test
+    public void testGistObjectList_FilterBy_Empty()
+    {
+        OrganisationUnit ou = organisationUnitService.getOrganisationUnit( orgUnitId );
+        ou.setComment( "" );
+        organisationUnitService.updateOrganisationUnit( ou );
+
+        assertEquals( 1, GET( "/organisationUnits/gist?filter=comment:empty&headless=true" ).content().size() );
+        assertEquals( 0, GET( "/users/gist?filter=surname:empty&headless=true" ).content().size() );
+    }
+
+    @Test
+    public void testGistObjectList_FilterBy_NotEmpty()
+    {
+        OrganisationUnit ou = organisationUnitService.getOrganisationUnit( orgUnitId );
+        ou.setComment( "" );
+        organisationUnitService.updateOrganisationUnit( ou );
+
+        assertEquals( 1, GET( "/users/gist?filter=surname:!empty&headless=true" ).content().size() );
+        assertEquals( 0, GET( "/organisationUnits/gist?filter=comment:!empty&headless=true" ).content().size() );
     }
 
     @Test

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.JsonArray;
 import org.hisp.dhis.webapi.json.JsonObject;
 import org.hisp.dhis.webapi.json.JsonResponse;
+import org.hisp.dhis.webapi.json.JsonString;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -324,6 +325,23 @@ public class GistQueryControllerTest extends DhisControllerConvenienceTest
         JsonObject group = groups.getObject( 0 );
         assertEquals( asList( "displayName", "id" ), group.names() );
         assertEquals( "groupX", group.getString( "displayName" ).string() );
+    }
+
+    @Test
+    public void testGistPropertyList_DisplayNameWithLocale()
+    {
+        assertStatus( HttpStatus.NO_CONTENT, PUT( "/organisationUnits/" + orgUnitId + "/translations",
+            "{'translations': [" +
+                "{'locale':'sv', 'property':'name', 'value':'enhet A'}, " +
+                "{'locale':'de', 'property':'name', 'value':'Einheit A'}]}" ) );
+
+        JsonString displayName = GET( "/organisationUnits/{id}/gist?fields=displayName&locale=de&headless=true",
+            orgUnitId ).content();
+        assertEquals( "Einheit A", displayName.string() );
+
+        displayName = GET( "/organisationUnits/{id}/gist?fields=displayName&locale=sv&headless=true",
+            orgUnitId ).content();
+        assertEquals( "enhet A", displayName.string() );
     }
 
     private void createDataSetsForOrganisationUnit( int count, String organisationUnitId, String namePrefix )

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -300,11 +300,14 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         Class<? extends IdentifiableObject> elementType, GistAutoType autoDefault )
     {
         NamedParams params = new NamedParams( request::getParameter, request::getParameterValues );
+        Locale translationLocale = !params.getString( "locale", "" ).isEmpty()
+            ? Locale.forLanguageTag( params.getString( "locale" ) )
+            : UserContext.getUserSetting( UserSettingKey.DB_LOCALE );
         return GistQuery.builder()
             .elementType( elementType )
             .autoType( params.getEnum( "auto", autoDefault ) )
             .contextRoot( ContextUtils.getRootPath( request ) )
-            .translationLocale( UserContext.getUserSetting( UserSettingKey.DB_LOCALE ) )
+            .translationLocale( translationLocale )
             .build()
             .with( params );
     }


### PR DESCRIPTION
### Adds Missing Features
* allow setting translation locale via `locale` parameter
* allow `filter`s where property filtered on is a simple property of a collection property, for example `filter=organisationUnits.name:like:{name}` on `dataSets` where `organisationUnits` is a collection in the listed item type `dataSet` and the filter `name` is on items of `organisationUnits` collection (not on `dataSet` items any more).
* expansion of field presets (like `*`) skips all explicitly named fields (before and after the expanded preset). This allows now to use same column twice when mapped to different aliases using `rename` transformer
* filters on an identifiable collection is implicitly understood as filtering ids, `filter=organisationUnits:in:[...]` is same as `filter=organisationUnits.id:in:[...]`
* properties of collection items are understood as `::ids` or `::pluck(name)` transformation with alias
* adds operator alias `!startsWith` and `!endsWith` to be symmetric to `startsWith` and `endsWith` and all other operators that can be negated using `!`
* `empty` and `!empty` filters allowed on `String` properties

### Bugfixes
* filter arguments non longer use wrong alias when used with multiple filters where one is unary (loop counter wrongly only got incremented for binary operators)
* `ILIKE` and `NOT_ILIKE` filter types compute correct SQL expression (simply were forgotten in switch)
* `EMPTY` uses correct `=` to compare equality in SQL (not wrongly `==`)

### Automatic Testing
Each type of filter and operator combination got at least one test. Also special collection related cases got test coverage.