### PR TITLE
fix: add missing createdBy field to hbm files

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/transformer/UserPropertyTransformer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/transformer/UserPropertyTransformer.java
@@ -107,7 +107,8 @@ public class UserPropertyTransformer
         UserDto.UserDtoBuilder builder = UserDto.builder()
             .id( user.getUid() )
             .code( user.getCode() )
-            .displayName( user.getDisplayName() );
+            .displayName( user.getDisplayName() )
+            .name( user.getName() );
 
         if ( userCredentials != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
@@ -50,6 +50,8 @@
     <!-- Dynamic attribute values -->
     <property name="attributeValues" type="jsbAttributeValues"/>
 
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_dataelementcategory_userid" />
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroup.hbm.xml
@@ -30,6 +30,8 @@
 
     <many-to-one name="optionSet" class="org.hisp.dhis.option.OptionSet" column="optionsetid" foreign-key="fk_optiongroup_optionsetid" />
 
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_optiongroup_userid" />
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroupSet.hbm.xml
@@ -33,6 +33,8 @@
 
     <many-to-one name="optionSet" class="org.hisp.dhis.option.OptionSet" column="optionsetid" foreign-key="fk_optiongroupset_optionsetid" />
 
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_optiongroupset_userid" />
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRule.hbm.xml
@@ -64,6 +64,8 @@
       <element column="organisationunitlevel" type="int" />
     </set>
 
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_validationrule_userid" />
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRuleGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRuleGroup.hbm.xml
@@ -28,6 +28,8 @@
                     foreign-key="fk_validationrulegroup_validationruleid" />
     </set>
 
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_validationrulegroup_userid" />
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10998
- Add missing  `createdBy` field   in hbm mapping file for metadata objects which have userid column in database.
- Front-end apps request `fields=user[id,name]` got name = null, need to add ` .name( user.getName() );` in UserPropertyTransformer. 