### PR TITLE
fix: avoid reflective access to String for 'sizeof' calculations

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/GenericSizeof.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/GenericSizeof.java
@@ -106,6 +106,7 @@ public final class GenericSizeof implements Sizeof
         fixedSizeOfType.put( Method.class, 0L );
         fixedSizeOfType.put( Field.class, 0L );
         fixedSizeOfType.put( Pattern.class, 0L );
+        sizeofByType.put( String.class, str -> 52L + ((String) str).length() );
     }
 
     @Override


### PR DESCRIPTION
Tests cause error because of reflective access to `String` fields by `sizeof` calculations.
To avoid this we provide a dedicated computation for `String`s so that no reflection is needed/used.