### PR TITLE
feat: adds data value followup bulk update API [DHIS2-10658]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.WebClient.Body;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.junit.Before;
+import org.springframework.http.HttpStatus;
+
+public abstract class AbstractDataValueControllerTest extends DhisControllerConvenienceTest
+{
+    protected String dataElementId;
+
+    protected String orgUnitId;
+
+    protected String categoryComboId;
+
+    protected String categoryOptionId;
+
+    @Before
+    public void setUp()
+    {
+        orgUnitId = assertStatus( HttpStatus.CREATED,
+            POST( "/organisationUnits/", "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}" ) );
+
+        // add OU to users hierarchy
+        assertStatus( HttpStatus.NO_CONTENT,
+            POST( "/users/{id}/organisationUnits", getCurrentUser().getUid(),
+                Body( "{'additions':[{'id':'" + orgUnitId + "'}]}" ) ) );
+
+        JsonObject ccDefault = GET(
+            "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
+                .content().getObject( 0 );
+        categoryComboId = ccDefault.getString( "id" ).string();
+        categoryOptionId = ccDefault.getArray( "categoryOptionCombos" ).getString( 0 ).string();
+
+        dataElementId = assertStatus( HttpStatus.CREATED,
+            POST( "/dataElements/",
+                "{'name':'My data element', 'shortName':'DE1', 'code':'DE1', 'valueType':'INTEGER', " +
+                    "'aggregationType':'SUM', 'zeroIsSignificant':false, 'domainType':'AGGREGATE', " +
+                    "'categoryCombo': {'id': '" + categoryComboId + "'}}" ) );
+
+    }
+
+    /**
+     * @return UID of the created {@link org.hisp.dhis.datavalue.DataValue}
+     */
+    protected final void addDataValue( String period, String value, String comment, boolean followup )
+    {
+        addDataValue( period, value, comment, followup, dataElementId, orgUnitId );
+    }
+
+    /**
+     * @return UID of the created {@link org.hisp.dhis.datavalue.DataValue}
+     */
+    protected final void addDataValue( String period, String value, String comment, boolean followup,
+        String dataElementId,
+        String orgUnitId )
+    {
+        assertStatus( HttpStatus.CREATED,
+            POST( "/dataValues?de={de}&pe={pe}&ou={ou}&co={coc}&value={val}&comment={comment}&followUp={followup}",
+                dataElementId, period, orgUnitId, categoryOptionId, value, comment, followup ) );
+    }
+
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataValueControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataValueControllerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.WebClient.Body;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Test for the
+ * {@link org.hisp.dhis.webapi.controller.datavalue.DataValueController}.
+ *
+ * @author Jan Bernitt
+ */
+public class DataValueControllerTest extends AbstractDataValueControllerTest
+{
+
+    @Autowired
+    private DataValueService dataValueService;
+
+    @Test
+    public void testSetDataValuesFollowUp_Empty()
+    {
+        assertEquals( "Follow-up must be specified",
+            PUT( "/dataValues/followups", Body( "{}" ) ).error( HttpStatus.CONFLICT ).getMessage() );
+        assertEquals( "Follow-up must be specified",
+            PUT( "/dataValues/followups", Body( "{'values':null}" ) ).error( HttpStatus.CONFLICT ).getMessage() );
+        assertEquals( "Follow-up must be specified",
+            PUT( "/dataValues/followups", Body( "{'values':[]}" ) ).error( HttpStatus.CONFLICT ).getMessage() );
+    }
+
+    @Test
+    public void testSetDataValuesFollowUp_NonExisting()
+    {
+        addDataValue( "2021-01", "2", null, false );
+        assertEquals( "Data value does not exist",
+            PUT( "/dataValues/followups", Body( String.format( "{'values':[%s]}",
+                dataValueKeyJSON( "2021-02", true ) ) ) ).error( HttpStatus.CONFLICT ).getMessage() );
+    }
+
+    @Test
+    public void testSetDataValuesFollowUp_Single()
+    {
+        addDataValue( "2021-01", "2", null, false );
+
+        assertStatus( HttpStatus.OK, PUT( "/dataValues/followups", Body( String.format( "{'values':[%s]}",
+            dataValueKeyJSON( "2021-01", true ) ) ) ) );
+        assertFollowups( true );
+
+        assertStatus( HttpStatus.OK, PUT( "/dataValues/followups", Body( String.format( "{'values':[%s]}",
+            dataValueKeyJSON( "2021-01", false ) ) ) ) );
+        assertFollowups( false );
+    }
+
+    @Test
+    public void testSetDataValuesFollowUp_Multi()
+    {
+        addDataValue( "2021-01", "2", null, false );
+        addDataValue( "2021-02", "3", null, false );
+        addDataValue( "2021-03", "4", null, false );
+
+        assertStatus( HttpStatus.OK, PUT( "/dataValues/followups", Body( String.format( "{'values':[%s, %s, %s]}",
+            dataValueKeyJSON( "2021-01", true ),
+            dataValueKeyJSON( "2021-02", true ),
+            dataValueKeyJSON( "2021-03", true ) ) ) ) );
+
+        assertFollowups( true, true, true );
+
+        assertStatus( HttpStatus.OK, PUT( "/dataValues/followups", Body( String.format( "{'values':[%s, %s, %s]}",
+            dataValueKeyJSON( "2021-01", false ),
+            dataValueKeyJSON( "2021-02", true ),
+            dataValueKeyJSON( "2021-03", false ) ) ) ) );
+
+        assertFollowups( false, true, false );
+    }
+
+    private void assertFollowups( boolean... expected )
+    {
+        List<DataValue> values = dataValueService.getAllDataValues();
+        assertEquals( expected.length, values.size() );
+        int expectedTrue = 0;
+        int actualTrue = 0;
+        for ( int i = 0; i < expected.length; i++ )
+        {
+            expectedTrue += expected[i] ? 1 : 0;
+            actualTrue += values.get( i ).isFollowup() ? 1 : 0;
+        }
+        assertEquals( "Number of values marked for followup does not match", expectedTrue, actualTrue );
+    }
+
+    private String dataValueKeyJSON( String period, boolean followup )
+    {
+        return String.format(
+            "{'dataElement':'%s', 'period':'%s', 'orgUnit':'%s', 'categoryOptionCombo':'%s', 'followup':%b}",
+            dataElementId, period, orgUnitId, categoryOptionId, followup );
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toSet;
-import static org.hisp.dhis.webapi.WebClient.Body;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -40,13 +39,11 @@ import java.util.Arrays;
 
 import org.hisp.dhis.dataanalysis.FollowupAnalysisRequest;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.JsonList;
 import org.hisp.dhis.webapi.json.JsonObject;
 import org.hisp.dhis.webapi.json.JsonResponse;
 import org.hisp.dhis.webapi.json.domain.JsonError;
 import org.hisp.dhis.webapi.json.domain.JsonFollowupValue;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 
@@ -57,42 +54,8 @@ import org.springframework.http.HttpStatus;
  *
  * @author Jan Bernitt
  */
-public class FollowupAnalysisControllerTest extends DhisControllerConvenienceTest
+public class FollowupAnalysisControllerTest extends AbstractDataValueControllerTest
 {
-
-    private String dataElementId;
-
-    private String orgUnitId;
-
-    private String ccId;
-
-    private String cocId;
-
-    @Before
-    public void setUp()
-    {
-        orgUnitId = assertStatus( HttpStatus.CREATED,
-            POST( "/organisationUnits/", "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}" ) );
-
-        // add OU to users hierarchy
-        assertStatus( HttpStatus.NO_CONTENT,
-            POST( "/users/{id}/organisationUnits", getCurrentUser().getUid(),
-                Body( "{'additions':[{'id':'" + orgUnitId + "'}]}" ) ) );
-
-        JsonObject ccDefault = GET(
-            "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 );
-        ccId = ccDefault.getString( "id" ).string();
-        cocId = ccDefault.getArray( "categoryOptionCombos" ).getString( 0 ).string();
-
-        dataElementId = assertStatus( HttpStatus.CREATED,
-            POST( "/dataElements/",
-                "{'name':'My data element', 'shortName':'DE1', 'code':'DE1', 'valueType':'INTEGER', " +
-                    "'aggregationType':'SUM', 'zeroIsSignificant':false, 'domainType':'AGGREGATE', " +
-                    "'categoryCombo': {'id': '" + ccId + "'}}" ) );
-
-    }
-
     /**
      * This test makes sure the fields returned by a
      * {@link org.hisp.dhis.dataanalysis.FollowupValue} are mapped correctly.
@@ -116,9 +79,9 @@ public class FollowupAnalysisControllerTest extends DhisControllerConvenienceTes
         assertEquals( "Monthly", value.getPe() );
         assertEquals( LocalDate.of( 2021, 03, 01 ).atStartOfDay(), value.getPeStartDate() );
         assertEquals( LocalDate.of( 2021, 03, 31 ).atStartOfDay(), value.getPeEndDate() );
-        assertEquals( cocId, value.getCoc() );
+        assertEquals( categoryOptionId, value.getCoc() );
         assertEquals( "default", value.getCocName() );
-        assertEquals( cocId, value.getAoc() );
+        assertEquals( categoryOptionId, value.getAoc() );
         assertEquals( "default", value.getAocName() );
         assertEquals( "5", value.getValue() );
         assertEquals( "admin", value.getStoredBy() );
@@ -179,7 +142,7 @@ public class FollowupAnalysisControllerTest extends DhisControllerConvenienceTes
             POST( "/dataElements/",
                 "{'name':'Another DE', 'shortName':'DE2', 'code':'DE2', 'valueType':'INTEGER', " +
                     "'aggregationType':'SUM', 'zeroIsSignificant':false, 'domainType':'AGGREGATE', " +
-                    "'categoryCombo': {'id': '" + ccId + "'}}" ) );
+                    "'categoryCombo': {'id': '" + categoryComboId + "'}}" ) );
 
         addDataValue( "2021-01", "13", "Needs check DE1", true, dataElementId, orgUnitId );
         addDataValue( "2021-01", "14", "Needs check DE2", true, de2, orgUnitId );
@@ -273,18 +236,5 @@ public class FollowupAnalysisControllerTest extends DhisControllerConvenienceTes
         JsonObject metadata = body.getObject( "metadata" );
         assertTrue( metadata.exists() );
         assertEquals( asList( "de", "coc", "ou", "startDate", "endDate", "maxResults" ), metadata.names() );
-    }
-
-    private void addDataValue( String period, String value, String comment, boolean followup )
-    {
-        addDataValue( period, value, comment, followup, dataElementId, orgUnitId );
-    }
-
-    private void addDataValue( String period, String value, String comment, boolean followup, String dataElementId,
-        String orgUnitId )
-    {
-        assertStatus( HttpStatus.CREATED,
-            POST( "/dataValues?de={de}&pe={pe}&ou={ou}&co={coc}&value={val}&comment={comment}&followUp={followup}",
-                dataElementId, period, orgUnitId, cocId, value, comment, followup ) );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -531,6 +531,24 @@ public class DataValueController
         dataValueService.updateDataValue( dataValue );
     }
 
+    @PutMapping( value = "/followups" )
+    @ResponseStatus( value = HttpStatus.OK )
+    public void setDataValuesFollowUp( @RequestBody List<DataValueFollowUpRequest> request )
+    {
+        if ( request == null || request.isEmpty() || request.stream().anyMatch( e -> e.getFollowup() == null ) )
+        {
+            throw new IllegalQueryException( ErrorCode.E2033 );
+        }
+
+        List<DataValue> dataValues = new ArrayList<>();
+        for ( DataValueFollowUpRequest e : request )
+        {
+            DataValue dataValue = dataValueValidation.getAndValidateDataValue( e );
+            dataValue.setFollowup( e.getFollowup() );
+        }
+        dataValueService.updateDataValues( dataValues );
+    }
+
     // ---------------------------------------------------------------------
     // GET file
     // ---------------------------------------------------------------------

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -68,6 +68,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.FileResourceUtils;
 import org.hisp.dhis.webapi.webdomain.DataValueFollowUpRequest;
+import org.hisp.dhis.webapi.webdomain.DataValuesFollowUpRequest;
 import org.jclouds.rest.AuthorizationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -533,15 +534,16 @@ public class DataValueController
 
     @PutMapping( value = "/followups" )
     @ResponseStatus( value = HttpStatus.OK )
-    public void setDataValuesFollowUp( @RequestBody List<DataValueFollowUpRequest> request )
+    public void setDataValuesFollowUp( @RequestBody DataValuesFollowUpRequest request )
     {
-        if ( request == null || request.isEmpty() || request.stream().anyMatch( e -> e.getFollowup() == null ) )
+        List<DataValueFollowUpRequest> values = request == null ? null : request.getValues();
+        if ( values == null || values.isEmpty() || values.stream().anyMatch( e -> e.getFollowup() == null ) )
         {
             throw new IllegalQueryException( ErrorCode.E2033 );
         }
 
         List<DataValue> dataValues = new ArrayList<>();
-        for ( DataValueFollowUpRequest e : request )
+        for ( DataValueFollowUpRequest e : values )
         {
             DataValue dataValue = dataValueValidation.getAndValidateDataValue( e );
             dataValue.setFollowup( e.getFollowup() );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/DataValuesFollowUpRequest.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/DataValuesFollowUpRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.webdomain;
+
+import java.util.List;
+
+import lombok.Data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Jan Bernitt
+ */
+@Data
+public class DataValuesFollowUpRequest
+{
+    @JsonProperty
+    private List<DataValueFollowUpRequest> values;
+}


### PR DESCRIPTION
### Summary
Upon request of Médi this PR adds a bulk update for data value followup. 

This is same as single update just that the request takes a list of `values` to update.

To set the `followup` status of multiple data values a `PUT` request is send to `/dataValues/followups` with a request object having just one field `values` each being the same as the existing single update `/dataValues/followup`.

```json
{ "values" : [
  ...
]}
```

Reasoning to not have all updated values share a part of the key is that this method is usually used with a set of data values that is the result of various filter combinations so we do not know what their common set of key parts is or if there even is a common set. 

### Automatic Testing
Controller integration test was added testing the added endpoint.

### Manual Testing
* create data values
* change their follow-up status using added `PUT` `/dataValues/followups` operation
* verify the data values have changed follow-up status
