### PR TITLE
feat: create Access object for target type

### DIFF
--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/AclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/AclService.java
@@ -277,6 +277,18 @@ public interface AclService
     <T extends IdentifiableObject> Access getAccess( T object, User user );
 
     /**
+     * Return the access object for a object for a specific user assuming the
+     * object would be of the provided object type.
+     *
+     * @param object Object to check for access
+     * @param user User to check against
+     * @param objType type as which the object should be evaluated. This may be
+     *        a subtype of the actual instance type of object.
+     * @return Populated access instance
+     */
+    <T extends IdentifiableObject> Access getAccess( T object, User user, Class<? extends T> objType );
+
+    /**
      * Sets default sharing props on object, disregarding what is already there.
      *
      * @param object Object to update

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -30,7 +30,10 @@ package org.hisp.dhis.security.acl;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.springframework.util.CollectionUtils.containsAny;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -48,7 +51,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
-import org.hisp.dhis.util.*;
+import org.hisp.dhis.util.SharingUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -105,10 +108,10 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean isDataShareable( IdentifiableObject object )
     {
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
-        return schema != null && schema.isDataShareable();
+        return isDataClassShareable( HibernateProxyUtils.getRealClass( object ) );
     }
 
     @Override
@@ -119,14 +122,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canRead( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canRead( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         if ( canAccess( user, schema.getAuthorityByType( AuthorityType.READ ) ) )
         {
@@ -150,12 +159,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canDataRead( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
-            return true;
+        return canDataRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+    private <T extends IdentifiableObject> boolean canDataRead( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
+        {
+            return true;
+        }
+
+        Schema schema = schemaService.getSchema( objType );
 
         if ( canAccess( user, schema.getAuthorityByType( AuthorityType.DATA_READ ) ) )
         {
@@ -185,14 +202,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canWrite( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canWrite( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.CREATE ) );
 
@@ -220,14 +243,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canDataWrite( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canDataWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canDataWrite( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         // returned unmodifiable list does not need to be cloned since it is not
         // modified
@@ -250,14 +279,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canUpdate( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canUpdate( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canUpdate( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.UPDATE ) );
 
@@ -282,14 +317,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canDelete( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canDelete( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canDelete( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.DELETE ) );
 
@@ -326,6 +367,11 @@ public class DefaultAclService implements AclService
     public boolean canManage( User user, IdentifiableObject object )
     {
         return canUpdate( user, object );
+    }
+
+    private <T extends IdentifiableObject> boolean canManage( User user, T object, Class<? extends T> objType )
+    {
+        return canUpdate( user, object, objType );
     }
 
     @Override
@@ -388,12 +434,10 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> boolean canMakeExternal( User user, T object )
     {
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
-        return !(schema == null || !schema.isShareable())
-            && ((!schema.getAuthorityByType( AuthorityType.EXTERNALIZE ).isEmpty() && haveOverrideAuthority( user ))
-                || haveAuthority( user, schema.getAuthorityByType( AuthorityType.EXTERNALIZE ) ));
+        return canMakeClassExternal( user, HibernateProxyUtils.getRealClass( object ) );
     }
 
     @Override
@@ -434,13 +478,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> Access getAccess( T object, User user )
+    {
+        return getAccess( object, user, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    @Override
+    public <T extends IdentifiableObject> Access getAccess( T object, User user, Class<? extends T> objType )
     {
         if ( user == null || user.isSuper() )
         {
             Access access = new Access( true );
 
-            if ( isDataShareable( object ) )
+            if ( isDataClassShareable( objType ) )
             {
                 access.setData( new AccessData( true, true ) );
             }
@@ -449,16 +500,18 @@ public class DefaultAclService implements AclService
         }
 
         Access access = new Access();
-        access.setManage( canManage( user, object ) );
-        access.setExternalize( canMakeExternal( user, object ) );
-        access.setWrite( canWrite( user, object ) );
-        access.setRead( canRead( user, object ) );
-        access.setUpdate( canUpdate( user, object ) );
-        access.setDelete( canDelete( user, object ) );
+        access.setManage( canManage( user, object, objType ) );
+        access.setExternalize( canMakeClassExternal( user, objType ) );
+        access.setWrite( canWrite( user, object, objType ) );
+        access.setRead( canRead( user, object, objType ) );
+        access.setUpdate( canUpdate( user, object, objType ) );
+        access.setDelete( canDelete( user, object, objType ) );
 
-        if ( isDataShareable( object ) )
+        if ( isDataClassShareable( objType ) )
         {
-            AccessData data = new AccessData( canDataRead( user, object ), canDataWrite( user, object ) );
+            AccessData data = new AccessData(
+                canDataRead( user, object, objType ),
+                canDataWrite( user, object, objType ) );
 
             access.setData( data );
         }
@@ -756,14 +809,14 @@ public class DefaultAclService implements AclService
         return accessibleOptions.size() == optionCombo.getCategoryOptions().size();
     }
 
-    private boolean readWriteCommonCheck( User user, IdentifiableObject object )
+    private boolean readWriteCommonCheck( User user, IdentifiableObject object, Class<?> objType )
     {
         if ( object == null || haveOverrideAuthority( user ) )
         {
             return true;
         }
 
-        return schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) ) == null;
+        return schemaService.getSchema( objType ) == null;
     }
 
     private boolean writeCommonCheck( Schema schema, User user, IdentifiableObject object )

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -125,12 +125,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canRead( User user, IdentifiableObject object )
     {
-        return canRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canRead( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canRead( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -162,12 +162,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canDataRead( User user, IdentifiableObject object )
     {
-        return canDataRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canDataRead( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canDataRead( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -205,12 +205,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canWrite( User user, IdentifiableObject object )
     {
-        return canWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canWrite( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -246,12 +246,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canDataWrite( User user, IdentifiableObject object )
     {
-        return canDataWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canDataWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canDataWrite( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -282,12 +282,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canUpdate( User user, IdentifiableObject object )
     {
-        return canUpdate( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canUpdate( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canUpdate( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -320,12 +320,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canDelete( User user, IdentifiableObject object )
     {
-        return canDelete( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canDelete( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canDelete( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -481,7 +481,9 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> Access getAccess( T object, User user )
     {
-        return getAccess( object, user, HibernateProxyUtils.getRealClass( object ) );
+        return object == null
+            ? new Access( true )
+            : getAccess( object, user, HibernateProxyUtils.getRealClass( object ) );
     }
 
     @Override
@@ -809,9 +811,9 @@ public class DefaultAclService implements AclService
         return accessibleOptions.size() == optionCombo.getCategoryOptions().size();
     }
 
-    private boolean readWriteCommonCheck( User user, IdentifiableObject object, Class<?> objType )
+    private boolean readWriteCommonCheck( User user, Class<?> objType )
     {
-        if ( object == null || haveOverrideAuthority( user ) )
+        if ( haveOverrideAuthority( user ) )
         {
             return true;
         }


### PR DESCRIPTION
This PR adds a variant of `getAccess` with an additional argument for the object type.

```java
<T extends IdentifiableObject> Access getAccess( T object, User user, Class<? extends T> objType );
```

It is added in preparation for a PR to allow using `Access` in the Gist API without having the actual object. Instead the gist will build an object (e.g. `BaseIndentifiableObject` around the `Sharing` value) and pass in the `Class` of the object the `Sharing` value belongs to. This way one can do the evaluations without actually having the full object.

For example when listing `DataElement`s it would do something like:
```java
IdentifiableObject obj = new BaseIdentifiableObject();
obj.setSharing(sharing);
getAccess(obj, currrentUser, DataElement.class);
```

As the `getAccess` only uses the `Sharing` property of the passed object this is effectively the same as passing the actual `DateElement` to the method that only has 2 arguments.

The exception to this is the special handling for `CategoryOptionCombo` which will not be considered.