### PR TITLE
feat: gist API 'access' synthetic field

### DIFF
--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/AclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/AclService.java
@@ -277,6 +277,18 @@ public interface AclService
     <T extends IdentifiableObject> Access getAccess( T object, User user );
 
     /**
+     * Return the access object for a object for a specific user assuming the
+     * object would be of the provided object type.
+     *
+     * @param object Object to check for access
+     * @param user User to check against
+     * @param objType type as which the object should be evaluated. This may be
+     *        a subtype of the actual instance type of object.
+     * @return Populated access instance
+     */
+    <T extends IdentifiableObject> Access getAccess( T object, User user, Class<? extends T> objType );
+
+    /**
      * Sets default sharing props on object, disregarding what is already there.
      *
      * @param object Object to update

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -30,7 +30,10 @@ package org.hisp.dhis.security.acl;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.springframework.util.CollectionUtils.containsAny;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -48,7 +51,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
-import org.hisp.dhis.util.*;
+import org.hisp.dhis.util.SharingUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -105,10 +108,10 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean isDataShareable( IdentifiableObject object )
     {
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
-        return schema != null && schema.isDataShareable();
+        return isDataClassShareable( HibernateProxyUtils.getRealClass( object ) );
     }
 
     @Override
@@ -119,14 +122,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canRead( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canRead( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         if ( canAccess( user, schema.getAuthorityByType( AuthorityType.READ ) ) )
         {
@@ -150,12 +159,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canDataRead( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
-            return true;
+        return canDataRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+    private <T extends IdentifiableObject> boolean canDataRead( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
+        {
+            return true;
+        }
+
+        Schema schema = schemaService.getSchema( objType );
 
         if ( canAccess( user, schema.getAuthorityByType( AuthorityType.DATA_READ ) ) )
         {
@@ -185,14 +202,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canWrite( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canWrite( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.CREATE ) );
 
@@ -220,14 +243,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canDataWrite( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canDataWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canDataWrite( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         // returned unmodifiable list does not need to be cloned since it is not
         // modified
@@ -250,14 +279,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canUpdate( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canUpdate( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canUpdate( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.UPDATE ) );
 
@@ -282,14 +317,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public boolean canDelete( User user, IdentifiableObject object )
     {
-        if ( readWriteCommonCheck( user, object ) )
+        return canDelete( user, object, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    private <T extends IdentifiableObject> boolean canDelete( User user, T object, Class<? extends T> objType )
+    {
+        if ( readWriteCommonCheck( user, object, objType ) )
         {
             return true;
         }
 
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
+        Schema schema = schemaService.getSchema( objType );
 
         List<String> anyAuthorities = new ArrayList<>( schema.getAuthorityByType( AuthorityType.DELETE ) );
 
@@ -326,6 +367,11 @@ public class DefaultAclService implements AclService
     public boolean canManage( User user, IdentifiableObject object )
     {
         return canUpdate( user, object );
+    }
+
+    private <T extends IdentifiableObject> boolean canManage( User user, T object, Class<? extends T> objType )
+    {
+        return canUpdate( user, object, objType );
     }
 
     @Override
@@ -388,12 +434,10 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> boolean canMakeExternal( User user, T object )
     {
-        Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
-        return !(schema == null || !schema.isShareable())
-            && ((!schema.getAuthorityByType( AuthorityType.EXTERNALIZE ).isEmpty() && haveOverrideAuthority( user ))
-                || haveAuthority( user, schema.getAuthorityByType( AuthorityType.EXTERNALIZE ) ));
+        return canMakeClassExternal( user, HibernateProxyUtils.getRealClass( object ) );
     }
 
     @Override
@@ -434,13 +478,20 @@ public class DefaultAclService implements AclService
     }
 
     @Override
+    @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> Access getAccess( T object, User user )
+    {
+        return getAccess( object, user, HibernateProxyUtils.getRealClass( object ) );
+    }
+
+    @Override
+    public <T extends IdentifiableObject> Access getAccess( T object, User user, Class<? extends T> objType )
     {
         if ( user == null || user.isSuper() )
         {
             Access access = new Access( true );
 
-            if ( isDataShareable( object ) )
+            if ( isDataClassShareable( objType ) )
             {
                 access.setData( new AccessData( true, true ) );
             }
@@ -449,16 +500,18 @@ public class DefaultAclService implements AclService
         }
 
         Access access = new Access();
-        access.setManage( canManage( user, object ) );
-        access.setExternalize( canMakeExternal( user, object ) );
-        access.setWrite( canWrite( user, object ) );
-        access.setRead( canRead( user, object ) );
-        access.setUpdate( canUpdate( user, object ) );
-        access.setDelete( canDelete( user, object ) );
+        access.setManage( canManage( user, object, objType ) );
+        access.setExternalize( canMakeClassExternal( user, objType ) );
+        access.setWrite( canWrite( user, object, objType ) );
+        access.setRead( canRead( user, object, objType ) );
+        access.setUpdate( canUpdate( user, object, objType ) );
+        access.setDelete( canDelete( user, object, objType ) );
 
-        if ( isDataShareable( object ) )
+        if ( isDataClassShareable( objType ) )
         {
-            AccessData data = new AccessData( canDataRead( user, object ), canDataWrite( user, object ) );
+            AccessData data = new AccessData(
+                canDataRead( user, object, objType ),
+                canDataWrite( user, object, objType ) );
 
             access.setData( data );
         }
@@ -756,14 +809,14 @@ public class DefaultAclService implements AclService
         return accessibleOptions.size() == optionCombo.getCategoryOptions().size();
     }
 
-    private boolean readWriteCommonCheck( User user, IdentifiableObject object )
+    private boolean readWriteCommonCheck( User user, IdentifiableObject object, Class<?> objType )
     {
         if ( object == null || haveOverrideAuthority( user ) )
         {
             return true;
         }
 
-        return schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) ) == null;
+        return schemaService.getSchema( objType ) == null;
     }
 
     private boolean writeCommonCheck( Schema schema, User user, IdentifiableObject object )

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -125,12 +125,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canRead( User user, IdentifiableObject object )
     {
-        return canRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canRead( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canRead( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -162,12 +162,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canDataRead( User user, IdentifiableObject object )
     {
-        return canDataRead( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canDataRead( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canDataRead( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -205,12 +205,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canWrite( User user, IdentifiableObject object )
     {
-        return canWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canWrite( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -246,12 +246,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canDataWrite( User user, IdentifiableObject object )
     {
-        return canDataWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canDataWrite( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canDataWrite( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -282,12 +282,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canUpdate( User user, IdentifiableObject object )
     {
-        return canUpdate( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canUpdate( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canUpdate( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -320,12 +320,12 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public boolean canDelete( User user, IdentifiableObject object )
     {
-        return canDelete( user, object, HibernateProxyUtils.getRealClass( object ) );
+        return object == null || canDelete( user, object, HibernateProxyUtils.getRealClass( object ) );
     }
 
     private <T extends IdentifiableObject> boolean canDelete( User user, T object, Class<? extends T> objType )
     {
-        if ( readWriteCommonCheck( user, object, objType ) )
+        if ( readWriteCommonCheck( user, objType ) )
         {
             return true;
         }
@@ -481,7 +481,9 @@ public class DefaultAclService implements AclService
     @SuppressWarnings( "unchecked" )
     public <T extends IdentifiableObject> Access getAccess( T object, User user )
     {
-        return getAccess( object, user, HibernateProxyUtils.getRealClass( object ) );
+        return object == null
+            ? new Access( true )
+            : getAccess( object, user, HibernateProxyUtils.getRealClass( object ) );
     }
 
     @Override
@@ -809,9 +811,9 @@ public class DefaultAclService implements AclService
         return accessibleOptions.size() == optionCombo.getCategoryOptions().size();
     }
 
-    private boolean readWriteCommonCheck( User user, IdentifiableObject object, Class<?> objType )
+    private boolean readWriteCommonCheck( User user, Class<?> objType )
     {
-        if ( object == null || haveOverrideAuthority( user ) )
+        if ( haveOverrideAuthority( user ) )
         {
             return true;
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -41,10 +41,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.schema.RelativePropertyContext;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.Access;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.sharing.Sharing;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -72,6 +78,8 @@ public class DefaultGistService implements GistService
 
     private final CurrentUserService currentUserService;
 
+    private final AclService aclService;
+
     private final ObjectMapper jsonMapper;
 
     private final GistValidator validator;
@@ -92,11 +100,19 @@ public class DefaultGistService implements GistService
     {
         RelativePropertyContext context = createPropertyContext( query );
         validator.validateQuery( query, context );
-        GistBuilder queryBuilder = createFetchBuilder( query, context, currentUserService.getCurrentUser() );
+        GistBuilder queryBuilder = createFetchBuilder( query, context, currentUserService.getCurrentUser(),
+            this::getAccessFromSharing );
         List<Object[]> rows = fetchWithParameters( query, queryBuilder,
             getSession().createQuery( queryBuilder.buildFetchHQL(), Object[].class ) );
         queryBuilder.transform( rows );
         return rows;
+    }
+
+    private Access getAccessFromSharing( Sharing sharing, User user, Class<? extends IdentifiableObject> type )
+    {
+        BaseIdentifiableObject object = new BaseIdentifiableObject();
+        object.setSharing( sharing );
+        return aclService.getAccess( object, user, type );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -313,7 +313,7 @@ final class GistBuilder
 
     private boolean isFilterBySharing( RelativePropertyContext context )
     {
-        Property sharing = context.resolve( "sharing" );
+        Property sharing = context.resolve( SHARING_PROPERTY );
         return sharing != null && sharing.isPersisted() && user != null && !user.isSuper();
     }
 
@@ -354,6 +354,7 @@ final class GistBuilder
         if ( isAccessProperty( property ) )
         {
             int sharingFieldIndex = getSameParentFieldIndex( path, SHARING_PROPERTY );
+            @SuppressWarnings( "unchecked" )
             Class<? extends IdentifiableObject> objType = isNonNestedPath( path )
                 ? query.getElementType()
                 : (Class<? extends IdentifiableObject>) property.getKlass();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Gist.Include;
 import org.hisp.dhis.schema.annotation.Gist.Transform;
+import org.hisp.dhis.security.acl.Access;
 
 /**
  * Contains the "business logic" aspects of building and running a
@@ -98,6 +99,11 @@ final class GistLogic
     static boolean isHrefProperty( Property p )
     {
         return "href".equals( p.key() ) && p.getKlass() == String.class;
+    }
+
+    static boolean isAccessProperty( Property p )
+    {
+        return "access".equals( p.key() ) && p.getKlass() == Access.class;
     }
 
     static boolean isCollectionSizeFilter( Filter filter, Property property )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -199,6 +199,9 @@ class GistPlanner
         return mapped;
     }
 
+    /**
+     * Transforms {@code field[a,b]} syntax to {@code field.a,field.b}
+     */
     private List<Field> withInnerAsSeparateFields( List<Field> fields )
     {
         List<Field> expanded = new ArrayList<>();

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
@@ -286,6 +286,24 @@ public class GistQueryControllerTest extends DhisControllerConvenienceTest
         assertEquals( "enhet A", displayName.string() );
     }
 
+    @Test
+    public void testGistPropertyList_Access()
+    {
+        JsonArray groups = GET( "/users/{uid}/userGroups/gist?fields=id,access&headless=true",
+            getSuperuserUid() ).content();
+
+        assertEquals( 1, groups.size() );
+        JsonObject group = groups.getObject( 0 );
+        JsonObject access = group.getObject( "access" );
+        assertTrue( access.has( "manage", "externalize", "write", "read", "update", "delete" ) );
+        assertTrue( access.getBoolean( "manage" ).booleanValue() );
+        assertTrue( access.getBoolean( "externalize" ).booleanValue() );
+        assertTrue( access.getBoolean( "write" ).booleanValue() );
+        assertTrue( access.getBoolean( "read" ).booleanValue() );
+        assertTrue( access.getBoolean( "update" ).booleanValue() );
+        assertTrue( access.getBoolean( "delete" ).booleanValue() );
+    }
+
     /*
      * Tests for filters
      */


### PR DESCRIPTION
This PR adds new synthetic field `access` to the Gist API.
It builds on the foundation work of #7951.

Since the `access` property of type `Access` is not persisted in the database it wasn't available in the Gist API until now.
Like other synthetic fields the `access` property can be computed on the basis of persisted columns, in this case the `sharing` information. This PR connects the existing ends so that users now can include `access` in the list of fields.

A controller test was added to assert it works as expected.