### PR TITLE
fix: FileResourceCleanUpJob aborts DHIS2-7700

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -180,15 +180,22 @@ public class DefaultFileResourceService
     @Transactional
     public void deleteFileResource( FileResource fileResource )
     {
-        if ( fileResource == null || fileResourceStore.get( fileResource.getId() ) == null )
+        if ( fileResource == null )
         {
             return;
         }
 
-        FileDeletedEvent deleteFileEvent = new FileDeletedEvent( fileResource.getStorageKey(),
-            fileResource.getContentType(), fileResource.getDomain() );
+        FileResource existingResource = fileResourceStore.get( fileResource.getId() );
 
-        fileResourceStore.delete( fileResource );
+        if ( existingResource == null )
+        {
+            return;
+        }
+
+        FileDeletedEvent deleteFileEvent = new FileDeletedEvent( existingResource.getStorageKey(),
+            existingResource.getContentType(), existingResource.getDomain() );
+
+        fileResourceStore.delete( existingResource );
 
         fileEventPublisher.publishEvent( deleteFileEvent );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.fileresource;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +42,6 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,14 +55,29 @@ import org.springframework.stereotype.Component;
 public class FileResourceCleanUpJob
     extends AbstractJob
 {
-    @Autowired
-    private FileResourceService fileResourceService;
+    private final FileResourceService fileResourceService;
 
-    @Autowired
-    private SystemSettingManager systemSettingManager;
+    private final SystemSettingManager systemSettingManager;
 
-    @Autowired
-    private FileResourceContentStore fileResourceContentStore;
+    private final FileResourceContentStore fileResourceContentStore;
+
+    // -------------------------------------------------------------------------
+    // Consructor
+    // -------------------------------------------------------------------------
+
+    public FileResourceCleanUpJob(
+        FileResourceService fileResourceService,
+        SystemSettingManager systemSettingManager,
+        FileResourceContentStore fileResourceContentStore )
+    {
+        checkNotNull( fileResourceService );
+        checkNotNull( systemSettingManager );
+        checkNotNull( fileResourceContentStore );
+
+        this.fileResourceService = fileResourceService;
+        this.systemSettingManager = systemSettingManager;
+        this.fileResourceContentStore = fileResourceContentStore;
+    }
 
     // -------------------------------------------------------------------------
     // Implementation
@@ -154,5 +170,4 @@ public class FileResourceCleanUpJob
 
         return false;
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -27,11 +27,10 @@
  */
 package org.hisp.dhis.fileresource;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -51,6 +50,7 @@ import org.springframework.stereotype.Component;
  * @author Halvdan Hoem Grelland
  */
 @Slf4j
+@AllArgsConstructor
 @Component( "fileResourceCleanUpJob" )
 public class FileResourceCleanUpJob
     extends AbstractJob
@@ -60,24 +60,6 @@ public class FileResourceCleanUpJob
     private final SystemSettingManager systemSettingManager;
 
     private final FileResourceContentStore fileResourceContentStore;
-
-    // -------------------------------------------------------------------------
-    // Consructor
-    // -------------------------------------------------------------------------
-
-    public FileResourceCleanUpJob(
-        FileResourceService fileResourceService,
-        SystemSettingManager systemSettingManager,
-        FileResourceContentStore fileResourceContentStore )
-    {
-        checkNotNull( fileResourceService );
-        checkNotNull( systemSettingManager );
-        checkNotNull( fileResourceContentStore );
-
-        this.fileResourceService = fileResourceService;
-        this.systemSettingManager = systemSettingManager;
-        this.fileResourceContentStore = fileResourceContentStore;
-    }
 
     // -------------------------------------------------------------------------
     // Implementation

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.fileresource;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -55,7 +57,11 @@ import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -64,7 +70,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class FileResourceCleanUpJobTest
     extends IntegrationTestBase
 {
-    @Autowired
     private FileResourceCleanUpJob cleanUpJob;
 
     @Autowired
@@ -98,6 +103,12 @@ public class FileResourceCleanUpJobTest
     @Autowired
     private ExternalFileResourceService externalFileResourceService;
 
+    @Mock
+    private FileResourceContentStore fileResourceContentStore;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     private DataValue dataValueA;
 
     private DataValue dataValueB;
@@ -109,6 +120,8 @@ public class FileResourceCleanUpJobTest
     @Before
     public void init()
     {
+        cleanUpJob = new FileResourceCleanUpJob( fileResourceService, systemSettingManager, fileResourceContentStore );
+
         period = createPeriod( PeriodType.getPeriodTypeByName( "Monthly" ), new Date(), new Date() );
         periodService.addPeriod( period );
     }
@@ -116,6 +129,8 @@ public class FileResourceCleanUpJobTest
     @Test
     public void testNoRetention()
     {
+        when( fileResourceContentStore.fileResourceContentExists( any( String.class ) ) ).thenReturn( true );
+
         systemSettingManager.saveSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY,
             FileResourceRetentionStrategy.NONE );
 
@@ -133,6 +148,8 @@ public class FileResourceCleanUpJobTest
     @Test
     public void testRetention()
     {
+        when( fileResourceContentStore.fileResourceContentExists( any( String.class ) ) ).thenReturn( true );
+
         systemSettingManager.saveSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY,
             FileResourceRetentionStrategy.THREE_MONTHS );
 
@@ -161,6 +178,26 @@ public class FileResourceCleanUpJobTest
         assertNull( dataValueService.getDataValue( dataValueA.getDataElement(), dataValueA.getPeriod(),
             dataValueA.getSource(), null ) );
         assertNull( fileResourceService.getFileResource( dataValueB.getValue() ) );
+    }
+
+    @Test
+    public void testOrphan()
+    {
+        when( fileResourceContentStore.fileResourceContentExists( any( String.class ) ) ).thenReturn( false );
+
+        systemSettingManager.saveSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY,
+            FileResourceRetentionStrategy.NONE );
+
+        content = "filecontentA".getBytes( StandardCharsets.UTF_8 );
+        FileResource fileResource = createFileResource( 'A', content );
+        fileResource.setCreated( DateTime.now().minus( Days.ONE ).toDate() );
+        String uid = fileResourceService.saveFileResource( fileResource, content );
+
+        assertNotNull( fileResourceService.getFileResource( uid ) );
+
+        cleanUpJob.execute( null );
+
+        assertNull( fileResourceService.getFileResource( uid ) );
     }
 
     @Test
@@ -226,9 +263,9 @@ public class FileResourceCleanUpJobTest
         return dataValue;
     }
 
-    private ExternalFileResource createExternal( char uniqueeChar, byte[] constant )
+    private ExternalFileResource createExternal( char uniqueChar, byte[] content )
     {
-        ExternalFileResource externalFileResource = createExternalFileResource( uniqueeChar, content );
+        ExternalFileResource externalFileResource = createExternalFileResource( uniqueChar, content );
 
         fileResourceService.saveFileResource( externalFileResource.getFileResource(), content );
         externalFileResourceService.saveExternalFileResource( externalFileResource );


### PR DESCRIPTION
### Symptom

When executing the `FileResourceCleanUpJob` on the SL Demo database, the following exception was logged:

`javax.persistence.EntityExistsException: A different object with the same identifier value was already associated with the session : [org.hisp.dhis.fileresource.FileResource#906799]`

This exception was generated during `HibernateGenericStore.delete` while trying to delete the first orphaned `FileResource`. The result was that no `FileResources` were deleted.

### Cause 

Searching StackOverflow for the error, and stepping into the Hibernate code, both revealed the same thing: this exception is generated when the item is already in the hibernate context (`session.persistenceContext.entitiesByKey`) but in a different Java object as the one requested for deletion (same database primary key but a different Java object).

`FileResourceCleanUpJob.execute` called `fileResourceService.getOrphanedFileResources()` which returned a list of orphaned file resources using a HQL query. These `FileResource` objects were not entered into the `session.persistenceContext.entitiesByKey` map. Then a call was made through `FileResourceCleanUpJob.safeDelete` to `fileResourceService.deleteFileResource`.

In `DefaultFileResourceService.deleteFileResource`, it tested to see if the `FileResource` was present by comparing null with `fileResourceStore.get( fileResource.getId() )`. This call caused the `FileResource` object to be loaded from the database into a Java object that was placed into the Map `session.persistenceContext.entitiesByKey`. Then  `fileResourceStore.delete` was called with the `FileResource` object originally returned in the list from HQL. This object was compared by Hibernate with the object just stored by the get. Since it was a different Java object with the same primary key, the `NonUniqueObjectException` was thrown (from the Hibernate `StatefulPersistenceContext.class:692`).

### Fix

In `DefaultFileResourceService.deleteFileResource`, the object from a successful `fileResourceStore.get( fileResource.getId() ) `is saved, and this object is used for the `fileResourceStore.delete`. This avoids the exception, and all orphaned `FileResources` are deleted.

### Test

`FileResourceCleanUpJobTest` only tested for _expired_ `FileResources`. However `FileResourceCleanUpJob` deletes both _expired_ and _orphaned_ `FileResources`. So I added a `testOrphan()` to test for deleting the orphans. I added the test before making the fix, hoping to reproduce the problem in the test. However the test did not trigger the exception. This is because the test orphan `FileResource` object was already in the Map `session.persistenceContext.entitiesByKey` as a result of its creation for the test. When `fileResourceService.getOrphanedFileResources()` was called, the HQL query returned the same object as in the Map. Then Hibernate had no problem deleting the object because it matched what was in the Map. But I left the test in anyway, because deleting orphans should be tested.

I Mocked `FileResourceContentStore` to show that the `FileResource` in the orphan test was an orphan. This necessitated adding the services needed by `FileResourceCleanUpJob` to its constructor, rather than having them `@Autowired`.

I tried to see if I could remove the `@Ignore` from both `testFalsePositive()` and `testFailedUpload()` in `FileResourceCleanUpJobTest`. They both hit a foreign key exception that the `FileResource` could not be deleted because it was still referenced by the `ExternalFileResource`. The problem seemed to be that the `ExternalFileResourceDeletionHandler` was not invoked during the JUnit test (a breakpoint placed there was never reached). This would explain why the linked `ExternalFileResource` wasn't deleted before deleting the `FileResource`. I did not soon see a way to fix this, so I left it as is.