### PR TITLE
feat: Gist API canRead/canWrite filters

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.gist;
 
+import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.gist.GistBuilder.createCountBuilder;
 import static org.hisp.dhis.gist.GistBuilder.createFetchBuilder;
 
@@ -41,10 +42,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.schema.RelativePropertyContext;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -70,6 +73,8 @@ public class DefaultGistService implements GistService
 
     private final SchemaService schemaService;
 
+    private final UserService userService;
+
     private final CurrentUserService currentUserService;
 
     private final ObjectMapper jsonMapper;
@@ -92,7 +97,8 @@ public class DefaultGistService implements GistService
     {
         RelativePropertyContext context = createPropertyContext( query );
         validator.validateQuery( query, context );
-        GistBuilder queryBuilder = createFetchBuilder( query, context, currentUserService.getCurrentUser() );
+        GistBuilder queryBuilder = createFetchBuilder( query, context, currentUserService.getCurrentUser(),
+            this::getUserGroupIdsByUserId );
         List<Object[]> rows = fetchWithParameters( query, queryBuilder,
             getSession().createQuery( queryBuilder.buildFetchHQL(), Object[].class ) );
         queryBuilder.transform( rows );
@@ -116,7 +122,8 @@ public class DefaultGistService implements GistService
             else
             {
                 RelativePropertyContext context = createPropertyContext( query );
-                GistBuilder countBuilder = createCountBuilder( query, context, currentUserService.getCurrentUser() );
+                GistBuilder countBuilder = createCountBuilder( query, context, currentUserService.getCurrentUser(),
+                    this::getUserGroupIdsByUserId );
                 total = countWithParameters( countBuilder,
                     getSession().createQuery( countBuilder.buildCountHQL(), Long.class ) );
             }
@@ -179,5 +186,10 @@ public class DefaultGistService implements GistService
             throw new IllegalArgumentException(
                 String.format( "Type %s is not compatible with provided filter value: `%s`", type, value ) );
         }
+    }
+
+    private List<String> getUserGroupIdsByUserId( String userId )
+    {
+        return userService.getUser( userId ).getGroups().stream().map( IdentifiableObject::getUid ).collect( toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -714,12 +714,28 @@ final class GistBuilder
 
     private String createAccessFilterHQL( Filter filter, String tableName )
     {
-        String access = filter.getOperator() == Comparison.CAN_READ
-            ? AclService.LIKE_READ_METADATA
-            : AclService.LIKE_WRITE_METADATA;
+        String access = getAccessPattern( filter );
         String userId = filter.getValue()[0];
         return JpaQueryUtils.generateHqlQueryForSharingCheck( tableName, access, userId,
             userGroupsByUserId.apply( userId ) );
+    }
+
+    private String getAccessPattern( Filter filter )
+    {
+        switch ( filter.getOperator() )
+        {
+        default:
+        case CAN_READ:
+            return AclService.LIKE_READ_METADATA;
+        case CAN_WRITE:
+            return AclService.LIKE_WRITE_METADATA;
+        case CAN_DATA_READ:
+            return AclService.LIKE_READ_DATA;
+        case CAN_DATA_WRITE:
+            return AclService.LIKE_WRITE_DATA;
+        case CAN_ACCESS:
+            return filter.getValue()[1];
+        }
     }
 
     private String createOrdersHQL()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -93,21 +93,33 @@ class GistPlanner
 
     private List<Filter> planFilters()
     {
-        List<Filter> filters = new ArrayList<>();
-        for ( Filter f : query.getFilters() )
+        List<Filter> filters = query.getFilters();
+        filters = withIdentifiableCollectionAutoIdFilters( filters ); // 1:1
+        return filters;
+    }
+
+    /**
+     * Understands {@code collection} property as synonym for
+     * {@code collection.id}
+     */
+    private List<Filter> withIdentifiableCollectionAutoIdFilters( List<Filter> filters )
+    {
+        List<Filter> mapped = new ArrayList<>();
+        for ( Filter f : filters )
         {
             Property p = context.resolveMandatory( f.getPropertyPath() );
-            if ( p.isCollection() && !isCollectionSizeFilter( f, p )
+            if ( !f.getOperator().isAccessCompare()
+                && p.isCollection() && !isCollectionSizeFilter( f, p )
                 && IdentifiableObject.class.isAssignableFrom( p.getItemKlass() ) )
             {
-                filters.add( f.withPropertyPath( f.getPropertyPath() + ".id" ) );
+                mapped.add( f.withPropertyPath( f.getPropertyPath() + ".id" ) );
             }
             else
             {
-                filters.add( f );
+                mapped.add( f );
             }
         }
-        return filters;
+        return mapped;
     }
 
     private static int propertyTypeOrder( Property a, Property b )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -279,7 +279,10 @@ public final class GistQuery
 
         // access checks
         CAN_READ( "canread" ),
-        CAN_WRITE( "canwrite" );
+        CAN_WRITE( "canwrite" ),
+        CAN_DATA_READ( "candataread" ),
+        CAN_DATA_WRITE( "candatawrite" ),
+        CAN_ACCESS( "canaccess" );
 
         private final String[] symbols;
 
@@ -308,7 +311,7 @@ public final class GistQuery
 
         public boolean isMultiValue()
         {
-            return this == IN || this == NOT_IN;
+            return this == IN || this == NOT_IN || this == CAN_ACCESS;
         }
 
         public boolean isIdentityCompare()
@@ -338,7 +341,7 @@ public final class GistQuery
 
         public boolean isStringCompare()
         {
-            return ordinal() >= LIKE.ordinal();
+            return ordinal() >= LIKE.ordinal() && ordinal() < CAN_READ.ordinal();
         }
 
         public boolean isContainsCompare()
@@ -348,7 +351,7 @@ public final class GistQuery
 
         public boolean isAccessCompare()
         {
-            return this == CAN_READ || this == CAN_WRITE;
+            return ordinal() >= CAN_READ.ordinal();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -275,7 +275,11 @@ public final class GistQuery
         STARTS_WITH( "$ilike", "startswith" ),
         NOT_STARTS_WITH( "!$ilike", "!startswith" ),
         ENDS_WITH( "ilike$", "endswith" ),
-        NOT_ENDS_WITH( "!ilike$", "!endswith" );
+        NOT_ENDS_WITH( "!ilike$", "!endswith" ),
+
+        // access checks
+        CAN_READ( "canread" ),
+        CAN_WRITE( "canwrite" );
 
         private final String[] symbols;
 
@@ -300,6 +304,11 @@ public final class GistQuery
         public boolean isUnary()
         {
             return this == NULL || this == NOT_NULL || this == EMPTY || this == NOT_EMPTY;
+        }
+
+        public boolean isMultiValue()
+        {
+            return this == IN || this == NOT_IN;
         }
 
         public boolean isIdentityCompare()
@@ -335,6 +344,11 @@ public final class GistQuery
         public boolean isContainsCompare()
         {
             return this == IN || this == NOT_IN;
+        }
+
+        public boolean isAccessCompare()
+        {
+            return this == CAN_READ || this == CAN_WRITE;
         }
     }
 
@@ -482,6 +496,11 @@ public final class GistQuery
             return new Filter( path, operator, value );
         }
 
+        public Filter withValue( String... value )
+        {
+            return new Filter( propertyPath, operator, value );
+        }
+
         public static Filter parse( String filter )
         {
             String[] parts = filter.split( "(?:::|:|~|@)" );
@@ -505,7 +524,8 @@ public final class GistQuery
         @Override
         public String toString()
         {
-            return propertyPath + ":" + operator.name().toLowerCase() + ":" + Arrays.toString( value );
+            return propertyPath + ":" + operator.symbols[0] + ":" + Arrays.toString( value );
         }
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -175,10 +175,11 @@ final class GistValidator
             {
                 throw createIllegalFilter( f, "User for filter `%s` does not exist." );
             }
-            if ( !aclService.canRead( currentUserService.getCurrentUser(), user ) )
+            User currentUser = currentUserService.getCurrentUser();
+            if ( currentUser.canManage( user ) || currentUser.getUid().equals( user.getCreatedBy().getUid() ) )
             {
                 throw createIllegalFilter( f,
-                    "Filtering by user access in filter `%s` requires read permissions to the user filter by." );
+                    "Filtering by user access in filter `%s` requires permissions to manage the user filtered by." );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -36,6 +36,7 @@ import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.gist.GistQuery.Field;
+import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.gist.GistQuery.Owner;
 import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
 import org.hisp.dhis.schema.Property;
@@ -43,6 +44,7 @@ import org.hisp.dhis.schema.RelativePropertyContext;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -59,6 +61,8 @@ final class GistValidator
 
     private final AclService aclService;
 
+    private final UserService userService;
+
     private final IdentifiableObjectManager objectManager;
 
     public void validateQuery( GistQuery query, RelativePropertyContext context )
@@ -70,7 +74,7 @@ final class GistValidator
             validateCollection(
                 context.switchedTo( owner.getType() ).resolveMandatory( owner.getCollectionProperty() ) );
         }
-        query.getFilters().forEach( filter -> validateFilter( context.resolveMandatory( filter.getPropertyPath() ) ) );
+        query.getFilters().forEach( filter -> validateFilter( filter, context ) );
         query.getOrders().forEach( order -> validateOrder( context.resolveMandatory( order.getPropertyPath() ) ) );
         query.getFields().forEach( field -> validateField( field, context ) );
     }
@@ -127,11 +131,56 @@ final class GistValidator
         }
     }
 
-    private void validateFilter( Property filter )
+    private void validateFilter( Filter f, RelativePropertyContext context )
     {
+        Property filter = context.resolveMandatory( f.getPropertyPath() );
         if ( !filter.isPersisted() )
         {
             throw createIllegalProperty( filter, "Property `%s` cannot be used as filter property." );
+        }
+
+        validateFilterArgument( f );
+        validateFilterAccess( f );
+    }
+
+    private void validateFilterAccess( Filter f )
+    {
+        if ( f.getOperator().isAccessCompare() )
+        {
+            String[] ids = f.getValue();
+            if ( ids.length != 1 )
+            {
+                throw createIllegalFilter( f, "Filter `%s` requires a single user ID as argument." );
+            }
+            User user = userService.getUser( ids[0] );
+            if ( user == null )
+            {
+                throw createIllegalFilter( f, "User for filter `%s` does not exist." );
+            }
+            if ( !aclService.canRead( currentUserService.getCurrentUser(), user ) )
+            {
+                throw createIllegalFilter( f,
+                    "Filtering by user access in filter `%s` requires read permissions to the user filter by." );
+            }
+        }
+    }
+
+    private void validateFilterArgument( Filter f )
+    {
+        if ( f.getOperator().isUnary() )
+        {
+            if ( f.getValue().length > 0 )
+            {
+                throw createIllegalFilter( f, "Filter `%s` uses an unary operator and does not need an argument." );
+            }
+        }
+        else if ( f.getValue().length == 0 )
+        {
+            throw createIllegalFilter( f, "Filter `%s` uses a binary operator that does need an argument." );
+        }
+        if ( !f.getOperator().isMultiValue() && f.getValue().length > 1 )
+        {
+            throw createIllegalFilter( f, "Filter `%s` can only be used with a single argument." );
         }
     }
 
@@ -146,6 +195,11 @@ final class GistValidator
     private IllegalArgumentException createIllegalProperty( Property property, String message )
     {
         return new IllegalArgumentException( String.format( message, property.getName() ) );
+    }
+
+    private IllegalArgumentException createIllegalFilter( Filter filter, String message )
+    {
+        return new IllegalArgumentException( String.format( message, filter.toString() ) );
     }
 
     private ReadAccessDeniedException createNoReadAccess( Owner owner )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.query;
 
-import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
+import static java.util.stream.Collectors.toList;
 
 import java.util.Collection;
 import java.util.List;
@@ -372,13 +372,16 @@ public class JpaQueryUtils
      */
     public static String generateSQlQueryForSharingCheck( String sharingColumn, User user, String access )
     {
-        List<Long> userGroupIds = getIdentifiers( user.getGroups() );
+        return generateSQlQueryForSharingCheck( sharingColumn, access, user.getUid(),
+            user.getGroups().stream().map( BaseIdentifiableObject::getUid ).collect( toList() ) );
+    }
 
-        String groupsIds = CollectionUtils.isEmpty( userGroupIds ) ? null
-            : "{" + org.apache.commons.lang3.StringUtils
-                .join( user.getGroups().stream().map( BaseIdentifiableObject::getUid )
-                    .collect( Collectors.toList() ), "," )
-                + "}";
+    private static String generateSQlQueryForSharingCheck( String sharingColumn, String access, String userId,
+        List<String> userGroupIds )
+    {
+        String groupsIds = CollectionUtils.isEmpty( userGroupIds )
+            ? null
+            : "{" + String.join( ",", userGroupIds ) + "}";
 
         String sql = " ( %1$s->>'owner' is not null and %1$s->>'owner' = '%2$s') "
             + " or %1$s->>'public' like '%4$s' or %1$s->>'public' is null "
@@ -387,8 +390,7 @@ public class JpaQueryUtils
             + (StringUtils.isEmpty( groupsIds ) ? ""
                 : " or ( " + JsonbFunctions.HAS_USER_GROUP_IDS + "( %1$s, '%3$s') = true "
                     + " and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( %1$s, '%3$s', '%4$s') = true )");
-
-        return String.format( sql, sharingColumn, user.getUid(), groupsIds, access );
+        return String.format( sql, sharingColumn, userId, groupsIds, access );
     }
 
     public static String generateHqlQueryForSharingCheck( String tableName, User user, String access )
@@ -397,12 +399,23 @@ public class JpaQueryUtils
         {
             return "1=1";
         }
-        String hql = generateSQlQueryForSharingCheck( tableName + ".sharing", user, access );
+        return "(" + sqlToHql( tableName,
+            generateSQlQueryForSharingCheck( tableName + ".sharing", user, access ) ) + ")";
+    }
+
+    public static String generateHqlQueryForSharingCheck( String tableName, String access, String userId,
+        List<String> userGroupIds )
+    {
+        return "(" + sqlToHql( tableName,
+            generateSQlQueryForSharingCheck( tableName + ".sharing", access, userId, userGroupIds ) ) + ")";
+    }
+
+    private static String sqlToHql( String tableName, String sql )
+    {
         // HQL does not allow the ->> syntax so we have to substitute with the
         // named function: jsonb_extract_path_text
-        hql = hql.replaceAll( tableName + "\\.sharing->>'([^']+)'",
+        return sql.replaceAll( tableName + "\\.sharing->>'([^']+)'",
             JsonbFunctions.EXTRACT_PATH_TEXT + "(" + tableName + ".sharing, '$1')" );
-        return "(" + hql + ")";
     }
 
     private static boolean isIgnoreCase( org.hisp.dhis.query.Order o )

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
@@ -560,6 +560,45 @@ public class GistQueryControllerTest extends DhisControllerConvenienceTest
                 getSuperuserUid() ).content().string() );
     }
 
+    /*
+     * Validation
+     */
+
+    @Test
+    public void testGistObjectList_Filter_MisplacedArgument()
+    {
+        assertEquals( "Filter `surname:null:[value]` uses an unary operator and does not need an argument.",
+            GET( "/users/gist?filter=surname:null:value" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+    }
+
+    @Test
+    public void testGistObjectList_Filter_MissingArgument()
+    {
+        assertEquals( "Filter `surname:eq:[]` uses a binary operator that does need an argument.",
+            GET( "/users/gist?filter=surname:eq" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+    }
+
+    @Test
+    public void testGistObjectList_Filter_TooManyArguments()
+    {
+        assertEquals( "Filter `surname:gt:[a, b]` can only be used with a single argument.",
+            GET( "/users/gist?filter=surname:gt:[a,b]" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+    }
+
+    @Test
+    public void testGistObjectList_Filter_UserDoesNotExist()
+    {
+        assertEquals( "User for filter `surname:canread:[not-a-UID]` does not exist.",
+            GET( "/users/gist?filter=surname:canRead:not-a-UID" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+    }
+
+    @Test
+    public void testGistObjectList_Order_CollectionProperty()
+    {
+        assertEquals( "Property `userGroup` cannot be used as order property.",
+            GET( "/users/gist?order=userGroups" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+    }
+
     private void createDataSetsForOrganisationUnit( int count, String organisationUnitId, String namePrefix )
     {
         for ( int i = 0; i < count; i++ )

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistQueryControllerTest.java
@@ -611,6 +611,23 @@ public class GistQueryControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    public void testGistObjectList_Filter_CanAccessMissingPattern()
+    {
+        assertEquals(
+            "Filter `surname:canaccess:[fake-UID]` requires a user ID and a access pattern argument.",
+            GET( "/users/gist?filter=surname:canAccess:fake-UID" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+    }
+
+    @Test
+    public void testGistObjectList_Filter_CanAccessMaliciousPattern()
+    {
+        assertEquals(
+            "Filter `surname:canaccess:[fake-UID, drop tables]` pattern argument must be 2 to 8 letters allowing letters 'r', 'w', '_' and '%'.",
+            GET( "/users/gist?filter=surname:canAccess:[fake-UID,drop tables]" ).error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
     public void testGistObjectList_Order_CollectionProperty()
     {
         assertEquals( "Property `userGroup` cannot be used as order property.",


### PR DESCRIPTION
### Summary
PR adds two new filter operators, `canRead` and `canWrite` to the list of possible filters.

Usage:

    {field}:canRead:{userID}
    {field}:canWrite:{userID}
    {field}:canDataRead:{userID}
    {field}:canDataWrite:{userID}
    {field}:canAccess:[{userID},{pattern}]


There are 3 cases depending on the type of field:
* simple field: checks if the user given by ID has read/write access to the owning object
* reference field to an identifiable object field: checks if the user given by ID has read/write access to the referenced object
* collection of identifiable objects field: checks if there are elements in the collection the user given by ID has read/write access to

This is slightly different take on Metadata API filters like `access.data.read:eq:true` which has to be processed in memory while the Gist API filters are processed in the database trying to give the user a similar filter tool.

To prevent information leaking to users only a user that is allowed to see the user object used as filter is allowed to do so.

I also added a more general filter parameter validations to give users better feedback in case the use filters formally wrong.

### Automatic Testing
Filter validation is tested with controller integration tests.
The `canRead`/`canWrite` filters themselves cannot be used in controller tests since H2 does not support the JSONB functions needed. I tested these manually.

### Manual Testing
Following examples were used for manual testing (demo database IDs)

* simple field: http://localhost:8080/api/dataElements/gist?total=true&filter=code:canWrite:OYLGMiazHtW
* simple field with `canAccess` and pattern: http://localhost:8080/api/dataElements/gist?total=true&filter=code:canAccess:[OYLGMiazHtW,rw______]
* reference field: http://localhost:8080/api/dataElements/gist?total=true&filter=categoryCombo:canWrite:OYLGMiazHtW
* collection field: http://localhost:8080/api/dataElements/gist?total=true&filter=dataElementGroups:canWrite:OYLGMiazHtW

To see an effect one has to edit the sharing of one or more data elements so that the user `OYLGMiazHtW` no longer has read or write access. The total count can be used to easily notice when changes in data elements filter elements from the view. The user this is tested with must itself have access (best to use admin user).

### Documentation
https://github.com/dhis2/dhis2-docs/pull/699, once merged can be found here https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata-gist.html#gist_parameters_filter