### PR TITLE
fix: sharing/search default page size DHIS2-10836 (#7961)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.system.paging.Paging;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
@@ -389,7 +390,7 @@ public class SharingController
             throw new WebMessageException( WebMessageUtils.conflict( "Search key not specified" ) );
         }
 
-        int max = pageSize != null ? pageSize : Integer.MAX_VALUE;
+        int max = pageSize != null ? pageSize : Paging.DEFAULT_PAGE_SIZE;
 
         List<SharingUserGroupAccess> userGroupAccesses = getSharingUserGroups( key, max );
         List<SharingUserAccess> userAccesses = getSharingUser( key, max );


### PR DESCRIPTION
* fix: sharing/search defalut page size DHIS2-10836

* refactor: use Paging.DEFAULT_PAGE_SIZE

(cherry picked from commit 4a2fc89bc372c268104fd3ce9cce769ae709ab5f)