### PR TITLE
feat: provide period ID in followup analysis API [DHIS2-10658]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
@@ -32,6 +32,10 @@ import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import org.hisp.dhis.calendar.DateInterval;
+import org.hisp.dhis.calendar.DateTimeUnit;
+import org.hisp.dhis.period.PeriodType;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -55,7 +59,7 @@ public final class FollowupValue
     private String deName;
 
     @JsonProperty
-    private String pe;
+    private String peType;
 
     @JsonProperty
     private Date peStartDate;
@@ -105,4 +109,13 @@ public final class FollowupValue
     @JsonProperty
     private Integer max;
 
+    @JsonProperty
+    public String getPe()
+    {
+        return peType == null ? null
+            : PeriodType.getPeriodTypeByName( peType )
+                .createPeriod(
+                    new DateInterval( DateTimeUnit.fromJdkDate( peStartDate ), DateTimeUnit.fromJdkDate( peEndDate ) ) )
+                .getIsoDate();
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
@@ -27,13 +27,13 @@
  */
 package org.hisp.dhis.dataanalysis;
 
+import static org.hisp.dhis.calendar.DateTimeUnit.fromJdkDate;
+
 import java.util.Date;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import org.hisp.dhis.calendar.DateInterval;
-import org.hisp.dhis.calendar.DateTimeUnit;
 import org.hisp.dhis.period.PeriodType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -112,10 +112,8 @@ public final class FollowupValue
     @JsonProperty
     public String getPe()
     {
-        return peType == null ? null
-            : PeriodType.getPeriodTypeByName( peType )
-                .createPeriod(
-                    new DateInterval( DateTimeUnit.fromJdkDate( peStartDate ), DateTimeUnit.fromJdkDate( peEndDate ) ) )
-                .getIsoDate();
+        return peType == null
+            ? null
+            : PeriodType.getPeriodTypeByName( peType ).getIsoDate( fromJdkDate( peStartDate ) );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.dataanalysis;
 
-import static org.hisp.dhis.calendar.DateTimeUnit.fromJdkDate;
-
 import java.util.Date;
 
 import lombok.AllArgsConstructor;
@@ -114,6 +112,6 @@ public final class FollowupValue
     {
         return peType == null
             ? null
-            : PeriodType.getPeriodTypeByName( peType ).getIsoDate( fromJdkDate( peStartDate ) );
+            : PeriodType.getIsoPeriod( PeriodType.getCalendar(), peType, peStartDate );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodType.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.period;
 
 import java.io.Serializable;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.DayOfWeek;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -258,7 +257,6 @@ public abstract class PeriodType
      * @return the ISO period name.
      */
     public static String getIsoPeriod( org.hisp.dhis.calendar.Calendar calendar, String periodType, Date startDate )
-        throws SQLException
     {
         final PeriodType pt = PeriodType.getPeriodTypeByName( periodType );
         return pt.createPeriod( startDate, calendar ).getIsoDate();

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonFollowupValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonFollowupValue.java
@@ -69,6 +69,11 @@ public interface JsonFollowupValue extends JsonObject
         return getString( "pe" ).string();
     }
 
+    default String getPeType()
+    {
+        return getString( "peType" ).string();
+    }
+
     default LocalDateTime getPeStartDate()
     {
         return get( "peStartDate", JsonDate.class ).date();

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
@@ -76,7 +76,8 @@ public class FollowupAnalysisControllerTest extends AbstractDataValueControllerT
         assertEquals( orgUnitId, value.getOu() );
         assertEquals( "My Unit", value.getOuName() );
         assertEquals( "/" + orgUnitId, value.getOuPath() );
-        assertEquals( "Monthly", value.getPe() );
+        assertEquals( "202103", value.getPe() );
+        assertEquals( "Monthly", value.getPeType() );
         assertEquals( LocalDate.of( 2021, 03, 01 ).atStartOfDay(), value.getPeStartDate() );
         assertEquals( LocalDate.of( 2021, 03, 31 ).atStartOfDay(), value.getPeEndDate() );
         assertEquals( categoryOptionId, value.getCoc() );


### PR DESCRIPTION
Upon request and in conversation with Mèdi the period ISO "ID" was added to the returned items of the followup data analysis.

The field previously named `pe` was renamed to `peType` and the property `pe` (from getter) now holds the ISO ID. 
This is also more consistent with request parameters where `pe` is usually used as the period ISO ID.