### PR TITLE
fix: Set relative API endpoint for UserCredentials

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/UserCredentialsSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/UserCredentialsSchemaDescriptor.java
@@ -45,6 +45,8 @@ public class UserCredentialsSchemaDescriptor implements SchemaDescriptor
     @Override
     public Schema getSchema()
     {
-        return new Schema( UserCredentials.class, SINGULAR, PLURAL );
+        Schema schema = new Schema( UserCredentials.class, SINGULAR, PLURAL );
+        schema.setRelativeApiEndpoint( API_ENDPOINT );
+        return schema;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -73,6 +73,7 @@ public class SchemaBasedControllerTest extends DhisControllerConvenienceTest
             "programStageInstanceFilter", // generator insufficient
             "interpretation", // required ObjectReport not required in schema
             "user", // generator insufficient to understand userCredentials
+            "userCredentials", // see above
             "jobConfiguration", // API requires configurable=true
             "messageConversation", // needs recipients (not a required field)
             "validationRule", // generator insufficient (embedded fields)


### PR DESCRIPTION
Looking at the output of #7987 I noticed that there is a endpoint for `UserCredentials` but I remember from Gist API that it did not link between `User` and `UserCredentials` because it concluded that there would not be an endpoint for it which is because the `Schema#relativeApiEndpoint` is not set. This PR does just that.

As far as I can tell there was no reason to intentionally not set the `relativeApiEndpoint` for `UserCredentials`.