### PR TITLE
perf: avoid intermediate collections during dxf2 import validation [TECH-547]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -290,8 +290,7 @@ public class UserCredentials
      */
     public boolean hasAnyAuthority( Collection<String> auths )
     {
-        Set<String> all = new HashSet<>( getAllAuthorities() );
-        return all.removeAll( auths );
+        return getAllAuthorities().stream().anyMatch( auths::contains );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
@@ -27,32 +27,31 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
+
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
 /**
  * @author Luciano Fiandesio
  */
-public class CreationCheck
-    implements
-    ValidationCheck
+public class CreationCheck implements ObjectValidationCheck
 {
     @Override
-    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+    public void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext ctx )
+        ImportStrategy importStrategy, ValidationContext ctx, Consumer<ObjectReport> addReports )
     {
-        TypeReport typeReport = new TypeReport( klass );
-
         if ( persistedObjects == null || persistedObjects.isEmpty() )
         {
-            return typeReport;
+            return;
         }
 
         for ( IdentifiableObject identifiableObject : persistedObjects )
@@ -65,12 +64,10 @@ public class CreationCheck
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
                         .setMainId( identifiableObject.getUid() );
 
-                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                addReports.accept( createObjectReport( errorReport, object, bundle ) );
 
                 ctx.markForRemoval( object );
             }
         }
-
-        return typeReport;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
@@ -27,32 +27,31 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
+
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
 /**
  * @author Luciano Fiandesio
  */
-public class DeletionCheck
-    implements
-    ValidationCheck
+public class DeletionCheck implements ObjectValidationCheck
 {
     @Override
-    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+    public void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext ctx )
+        ImportStrategy importStrategy, ValidationContext ctx, Consumer<ObjectReport> addReports )
     {
-        TypeReport typeReport = new TypeReport( klass );
-
         if ( nonPersistedObjects == null || nonPersistedObjects.isEmpty() )
         {
-            return typeReport;
+            return;
         }
 
         for ( IdentifiableObject identifiableObject : nonPersistedObjects )
@@ -64,11 +63,9 @@ public class DeletionCheck
                 ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
                         .setMainId( object != null ? object.getUid() : null );
-                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                addReports.accept( createObjectReport( errorReport, object, bundle ) );
                 ctx.markForRemoval( object );
             }
         }
-
-        return typeReport;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ObjectValidationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ObjectValidationCheck.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+
+/**
+ * Base interface for a {@link ValidationCheck} that only checks objects and
+ * creates {@link ObjectReport}s for those that are ignored.
+ * <p>
+ * Instead of returning a full {@link TypeReport} its
+ * {@link #check(ObjectBundle, Class, List, List, ImportStrategy, ValidationContext, Consumer)}
+ * has an extra {@link Consumer} argument which is called by implementations to
+ * add {@link ObjectReport}s.
+ * <p>
+ * This is used to avoid to create and return an empty {@link TypeReport} that
+ * is not the null object created by {@link TypeReport#empty(Class)}.
+ *
+ * @author Jan Bernitt
+ */
+@FunctionalInterface
+public interface ObjectValidationCheck extends ValidationCheck
+{
+
+    @Override
+    default TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context )
+    {
+        // NB. The box is there so we only create an instance of TypeReport
+        // when it is actually needed which we must assume is not often
+        TypeReport[] reportBox = new TypeReport[1];
+        check( bundle, klass, persistedObjects, nonPersistedObjects, importStrategy, context, objectReport -> {
+            TypeReport report = reportBox[0];
+            if ( report == null )
+            {
+                report = new TypeReport( klass );
+                reportBox[0] = report;
+            }
+            report.addObjectReport( objectReport );
+            report.getStats().incIgnored();
+        } );
+        return reportBox[0] == null ? TypeReport.empty( klass ) : reportBox[0];
+    }
+
+    /**
+     * Same as
+     * {@link ValidationCheck#check(ObjectBundle, Class, List, List, ImportStrategy, ValidationContext)}
+     * except that instead of returning a {@link TypeReport} it as an extra
+     * parameter that consumes {@link ObjectReport} for which it will assume
+     * that an object has errors and is ignored.
+     *
+     * @see ValidationCheck#check(ObjectBundle, Class, List, List,
+     *      ImportStrategy, ValidationContext)
+     *
+     * @param addReports called by the implementation for each object which has
+     *        errors and should be ignored. The passed {@link ObjectReport} is
+     *        added to the outer {@link TypeReport}.
+     */
+    void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+        List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext context, Consumer<ObjectReport> addReports );
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SchemaCheck.java
@@ -27,35 +27,32 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
 /**
  * @author Luciano Fiandesio
  */
-public class SchemaCheck
-    implements
-    ValidationCheck
+public class SchemaCheck implements ObjectValidationCheck
 {
     @Override
-    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+    public void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext context, Consumer<ObjectReport> addReports )
     {
-        TypeReport typeReport = new TypeReport( klass );
-
         List<IdentifiableObject> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
 
         if ( objects == null || objects.isEmpty() )
         {
-            return typeReport;
+            return;
         }
 
         for ( IdentifiableObject object : objects )
@@ -64,12 +61,9 @@ public class SchemaCheck
 
             if ( !validationErrorReports.isEmpty() )
             {
-                addObjectReports( validationErrorReports, typeReport, object, bundle );
+                addReports.accept( createObjectReport( validationErrorReports, object, bundle ) );
                 context.markForRemoval( object );
             }
         }
-
-        return typeReport;
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueMultiPropertiesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueMultiPropertiesCheck.java
@@ -27,34 +27,32 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
-import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.addObjectReports;
+import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.feedback.ErrorCode.E5005;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.schema.Schema;
 
-public class UniqueMultiPropertiesCheck implements ValidationCheck
+public class UniqueMultiPropertiesCheck implements ObjectValidationCheck
 {
     @Override
-    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+    public void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext context, Consumer<ObjectReport> addReports )
     {
-        TypeReport typeReport = new TypeReport( klass );
-
         Schema schema = context.getSchemaService().getSchema( klass );
 
         Map<List<String>, List<IdentifiableObject>> propertyValuesToObjects = new HashMap<>();
@@ -68,57 +66,26 @@ public class UniqueMultiPropertiesCheck implements ValidationCheck
                     .map( valueExtractor -> valueExtractor.apply( identifiableObject ) )
                     .collect( Collectors.toList() );
 
-                if ( !propertyValuesToObjects.containsKey( propertyValues ) )
-                {
-                    propertyValuesToObjects.put( propertyValues, new ArrayList<>() );
-                }
-
-                propertyValuesToObjects.get( propertyValues ).add( identifiableObject );
+                propertyValuesToObjects.computeIfAbsent( propertyValues, key -> new ArrayList<>() )
+                    .add( identifiableObject );
             }
         }
 
-        propertyValuesToObjects.entrySet()
-            .forEach(
-                pValuesObjectsEntry -> addErrorIfNecessary( context, bundle, klass, typeReport, pValuesObjectsEntry ) );
-
-        return typeReport;
-    }
-
-    private void addErrorIfNecessary( ValidationContext context, ObjectBundle bundle,
-        Class<? extends IdentifiableObject> klass, TypeReport typeReport,
-        Map.Entry<List<String>, List<IdentifiableObject>> pValuesObjectsEntry )
-    {
-        if ( pValuesObjectsEntry.getValue().size() > 1 )
+        for ( Map.Entry<List<String>, List<IdentifiableObject>> entry : propertyValuesToObjects.entrySet() )
         {
-            pValuesObjectsEntry.getValue()
-                .forEach( identifiableObject -> addErrorToTypeReport(
-                    typeReport,
-                    klass,
-                    identifiableObject,
-                    pValuesObjectsEntry,
-                    bundle,
-                    context ) );
+            List<IdentifiableObject> objects = entry.getValue();
+            if ( objects.size() > 1 )
+            {
+                for ( IdentifiableObject object : objects )
+                {
+                    ErrorReport errorReport = new ErrorReport( klass, E5005,
+                        String.join( ", ", entry.getKey() ),
+                        objects.stream().map( IdentifiableObject::getUid )
+                            .collect( joining( ", " ) ) );
+                    addReports.accept( ValidationUtils.createObjectReport( errorReport, object, bundle ) );
+                    context.markForRemoval( object );
+                }
+            }
         }
-    }
-
-    private void addErrorToTypeReport( TypeReport typeReport, Class<? extends IdentifiableObject> klass,
-        IdentifiableObject identifiableObject, Map.Entry<List<String>, List<IdentifiableObject>> pValuesObjectsEntry,
-        ObjectBundle bundle, ValidationContext context )
-    {
-        addObjectReports( toErrorReports( klass, pValuesObjectsEntry ), typeReport, identifiableObject, bundle );
-        context.markForRemoval( identifiableObject );
-    }
-
-    private List<ErrorReport> toErrorReports( Class<? extends IdentifiableObject> klass,
-        Map.Entry<List<String>, List<IdentifiableObject>> entry )
-    {
-        return Collections.singletonList(
-            new ErrorReport(
-                klass,
-                E5005,
-                String.join( ", ", entry.getKey() ),
-                entry.getValue().stream()
-                    .map( IdentifiableObject::getUid )
-                    .collect( Collectors.joining( ", " ) ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
@@ -27,32 +27,31 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
+
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
 /**
  * @author Luciano Fiandesio
  */
-public class UpdateCheck
-    implements
-    ValidationCheck
+public class UpdateCheck implements ObjectValidationCheck
 {
     @Override
-    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+    public void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext ctx )
+        ImportStrategy importStrategy, ValidationContext ctx, Consumer<ObjectReport> addReports )
     {
-        TypeReport typeReport = new TypeReport( klass );
-
         if ( nonPersistedObjects == null || nonPersistedObjects.isEmpty() )
         {
-            return typeReport;
+            return;
         }
 
         for ( IdentifiableObject identifiableObject : nonPersistedObjects )
@@ -65,11 +64,9 @@ public class UpdateCheck
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
                         .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() );
 
-                ValidationUtils.addObjectReport( errorReport, typeReport, object, bundle );
+                addReports.accept( createObjectReport( errorReport, object, bundle ) );
                 ctx.markForRemoval( object );
             }
         }
-
-        return typeReport;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationCheck.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.importexport.ImportStrategy;
  *
  * @author Luciano Fiandesio
  */
+@FunctionalInterface
 public interface ValidationCheck
 {
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationUtils.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
+import static java.util.Collections.singletonList;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -36,39 +38,42 @@ import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
-import org.hisp.dhis.feedback.TypeReport;
 
 /**
  * @author Luciano Fiandesio
  */
 public class ValidationUtils
 {
-
-    public static List<IdentifiableObject> joinObjects( List<IdentifiableObject> persistedObjects,
-        List<IdentifiableObject> nonPersistedObjects )
+    private ValidationUtils()
     {
+        throw new UnsupportedOperationException( "util" );
+    }
+
+    public static <T> List<T> joinObjects( List<T> persistedObjects,
+        List<T> nonPersistedObjects )
+    {
+        if ( persistedObjects.isEmpty() )
+        {
+            return nonPersistedObjects;
+        }
+        if ( nonPersistedObjects.isEmpty() )
+        {
+            return persistedObjects;
+        }
         return Stream.concat( persistedObjects.stream(), nonPersistedObjects.stream() ).collect( Collectors.toList() );
     }
 
-    public static void addObjectReports( List<ErrorReport> reports, TypeReport typeReport, IdentifiableObject object,
+    public static ObjectReport createObjectReport( List<ErrorReport> reports, IdentifiableObject object,
         ObjectBundle bundle )
     {
         ObjectReport objectReport = new ObjectReport( object, bundle );
         objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
         objectReport.addErrorReports( reports );
-
-        typeReport.addObjectReport( objectReport );
-        typeReport.getStats().incIgnored();
+        return objectReport;
     }
 
-    public static void addObjectReport( ErrorReport report, TypeReport typeReport, IdentifiableObject object,
-        ObjectBundle bundle )
+    public static ObjectReport createObjectReport( ErrorReport report, IdentifiableObject object, ObjectBundle bundle )
     {
-        ObjectReport objectReport = new ObjectReport( object, bundle );
-        objectReport.setDisplayName( IdentifiableObjectUtils.getDisplayName( object ) );
-        objectReport.addErrorReport( report );
-
-        typeReport.addObjectReport( objectReport );
-        typeReport.getStats().incIgnored();
+        return createObjectReport( singletonList( report ), object, bundle );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DummyCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DummyCheck.java
@@ -27,45 +27,40 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
+
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.TypeReport;
+import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 
 /**
  * @author Luciano Fiandesio
  */
-public class DummyCheck
-    implements
-    ValidationCheck
+public class DummyCheck implements ObjectValidationCheck
 {
 
     @Override
-    public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
+    public void check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
         List<IdentifiableObject> persistedObjects, List<IdentifiableObject> nonPersistedObjects,
-        ImportStrategy importStrategy, ValidationContext context )
+        ImportStrategy importStrategy, ValidationContext context, Consumer<ObjectReport> addReports )
     {
-
-        TypeReport typeReport = new TypeReport( klass );
-
         for ( IdentifiableObject nonPersistedObject : nonPersistedObjects )
         {
             if ( nonPersistedObject.getUid().startsWith( "u" ) )
             {
-
                 ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( nonPersistedObject ) )
                         .setMainId( nonPersistedObject.getUid() );
-                ValidationUtils.addObjectReport( errorReport, typeReport, nonPersistedObject, bundle );
+                addReports.accept( createObjectReport( errorReport, nonPersistedObject, bundle ) );
 
                 context.markForRemoval( nonPersistedObject );
             }
         }
-
-        return typeReport;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/UserCredentialsSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/UserCredentialsSchemaDescriptor.java
@@ -45,6 +45,8 @@ public class UserCredentialsSchemaDescriptor implements SchemaDescriptor
     @Override
     public Schema getSchema()
     {
-        return new Schema( UserCredentials.class, SINGULAR, PLURAL );
+        Schema schema = new Schema( UserCredentials.class, SINGULAR, PLURAL );
+        schema.setRelativeApiEndpoint( API_ENDPOINT );
+        return schema;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/UserCredentialsSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/UserCredentialsSchemaDescriptor.java
@@ -45,8 +45,6 @@ public class UserCredentialsSchemaDescriptor implements SchemaDescriptor
     @Override
     public Schema getSchema()
     {
-        Schema schema = new Schema( UserCredentials.class, SINGULAR, PLURAL );
-        schema.setRelativeApiEndpoint( API_ENDPOINT );
-        return schema;
+        return new Schema( UserCredentials.class, SINGULAR, PLURAL );
     }
 }


### PR DESCRIPTION
### Summary
Goal of this PR is to avoid creation of intermediate collections where possible while making the code more readable and easier to debug.

Changes include:
* using `emptyList()` and such where possible
* avoid creating empty `TypeReport` objects (which indirectly also create lots of other objects inclduing collections)
* avoid creating collection that we might need by changing algorithm a bit so that we only create them when we need them
* avoid creating collection copies to allow modification as part of finding out if they have a certain quality, for example by using stream `anyMatch` instead

For all but one `ValidationCheck` the newly created variant `ObjectValidationCheck` could be used.
There instead of returning `TypeReport` which are merged to a single one an extra consumer argument was added that accepts the `ObjectResport`s and adds them to a `TypeReport` which is only created when needed. Otherwise new null object `TypeReport.empty()` is used.

`ReferencesCheck` had a large method sonar wasn't happy about so I extracted some further helper methods.

For readability I replaced:
```java
if (!map.containsKey(key)) {
  map.put(key, new SomeCollectionOrMap());
}
```
with
```java
map.computeIfAbsent(key, k -> new SomeCollectionOrMap();
```

Validation should now be easier to debug since `TypeReport#merge` now can distinguish between a no-op merge and a merge that actually adds something. 

### Automatic Testing
As far as I can see the bundle validation has quite a number of tests covering it so I did not add further tests.
