### PR TITLE
fix: [DHIS2-11073] malformed sql if tei query params has event filters (2.35)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -1194,7 +1194,6 @@ public class HibernateTrackedEntityInstanceStore
         {
             String start = getMediumDateString( params.getEventStartDate() );
             String end = getMediumDateString( params.getEventEndDate() );
-            events.append( whereHlp.whereAnd() );
 
             if ( params.isEventStatus( EventStatus.COMPLETED ) )
             {


### PR DESCRIPTION
When eventStatus,eventStartDate and eventEndDate are present in the TEI queryParams including the program, then muliple "hlp.whereAnd()" call is invoked which caused unnecessary "and" in the formed sql.