### PR TITLE
fix: acl query with owner = null

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -383,7 +383,7 @@ public class JpaQueryUtils
             ? null
             : "{" + String.join( ",", userGroupIds ) + "}";
 
-        String sql = " ( %1$s->>'owner' is not null and %1$s->>'owner' = '%2$s') "
+        String sql = " ( %1$s->>'owner' is null or %1$s->>'owner' = '%2$s') "
             + " or %1$s->>'public' like '%4$s' or %1$s->>'public' is null "
             + " or (" + JsonbFunctions.HAS_USER_ID + "( %1$s, '%2$s') = true "
             + " and " + JsonbFunctions.CHECK_USER_ACCESS + "( %1$s, '%2$s', '%4$s' ) = true )  "


### PR DESCRIPTION
- Fix ACL query when object's owner is null. The correct condition for `owner` field should be : `user is null || user is owner`
- Added unit tested for both JPA API query and Native SQL in `JpaQueryUtils` 