### PR TITLE
fix: UserDeletionHandler check avatar DHIS2-7700

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
@@ -27,30 +27,30 @@
  */
 package org.hisp.dhis.user;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
+import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
+@AllArgsConstructor
 @Component( "org.hisp.dhis.user.UserDeletionHandler" )
 public class UserDeletionHandler
     extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
 
-    public UserDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
+    private final JdbcTemplate jdbcTemplate;
 
-        this.idObjectManager = idObjectManager;
-    }
+    private static final DeletionVeto VETO = new DeletionVeto( User.class );
 
     @Override
     protected void register()
@@ -59,6 +59,7 @@ public class UserDeletionHandler
         whenDeleting( OrganisationUnit.class, this::deleteOrganisationUnit );
         whenDeleting( UserGroup.class, this::deleteUserGroup );
         whenVetoing( UserAuthorityGroup.class, this::allowDeleteUserAuthorityGroup );
+        whenVetoing( FileResource.class, this::allowDeleteFileResource );
     }
 
     private void deleteUserAuthorityGroup( UserAuthorityGroup authorityGroup )
@@ -101,5 +102,12 @@ public class UserDeletionHandler
             }
         }
         return ACCEPT;
+    }
+
+    private DeletionVeto allowDeleteFileResource( FileResource fileResource )
+    {
+        String sql = "SELECT COUNT(*) FROM userinfo where avatar=" + fileResource.getId();
+
+        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.user;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.organisationunit.OrganisationUnit;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -53,6 +53,8 @@ import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.junit.Before;
@@ -103,6 +105,9 @@ public class FileResourceCleanUpJobTest
     @Autowired
     private ExternalFileResourceService externalFileResourceService;
 
+    @Autowired
+    private UserService _userService;
+
     @Mock
     private FileResourceContentStore fileResourceContentStore;
 
@@ -120,6 +125,8 @@ public class FileResourceCleanUpJobTest
     @Before
     public void init()
     {
+        userService = _userService;
+
         cleanUpJob = new FileResourceCleanUpJob( fileResourceService, systemSettingManager, fileResourceContentStore );
 
         period = createPeriod( PeriodType.getPeriodTypeByName( "Monthly" ), new Date(), new Date() );
@@ -189,15 +196,33 @@ public class FileResourceCleanUpJobTest
             FileResourceRetentionStrategy.NONE );
 
         content = "filecontentA".getBytes( StandardCharsets.UTF_8 );
-        FileResource fileResource = createFileResource( 'A', content );
-        fileResource.setCreated( DateTime.now().minus( Days.ONE ).toDate() );
-        String uid = fileResourceService.saveFileResource( fileResource, content );
+        FileResource fileResourceA = createFileResource( 'A', content );
+        fileResourceA.setCreated( DateTime.now().minus( Days.ONE ).toDate() );
+        String uidA = fileResourceService.saveFileResource( fileResourceA, content );
 
-        assertNotNull( fileResourceService.getFileResource( uid ) );
+        content = "filecontentB".getBytes( StandardCharsets.UTF_8 );
+        FileResource fileResourceB = createFileResource( 'A', content );
+        fileResourceB.setCreated( DateTime.now().minus( Days.ONE ).toDate() );
+        String uidB = fileResourceService.saveFileResource( fileResourceB, content );
+
+        User userB = createUser( 'B' );
+        userB.setAvatar( fileResourceB );
+        userService.addUser( userB );
+
+        assertNotNull( fileResourceService.getFileResource( uidA ) );
+        assertNotNull( fileResourceService.getFileResource( uidB ) );
 
         cleanUpJob.execute( null );
 
-        assertNull( fileResourceService.getFileResource( uid ) );
+        assertNull( fileResourceService.getFileResource( uidA ) );
+        assertNotNull( fileResourceService.getFileResource( uidB ) );
+
+        // The following is needed because HibernateDbmsManager.emptyDatabase
+        // empties fileresource before userinfo (which it must because
+        // fileresource references userinfo).
+
+        userB.setAvatar( null );
+        userService.updateUser( userB );
     }
 
     @Test


### PR DESCRIPTION
This relates to follow-up testing of [DHIS2-7700 Fileresource Cleanup Job doesn't delete correct/any files](https://jira.dhis2.org/browse/DHIS2-7700). No errors were found in 2.37, 6, or 5. But in 2.34 the test was failing because of an orphaned `FileResource` that was being used as a user's `avatar`.

I added the check for user avatar to `UserDeletionHandler`, and included testing this to `FileResourceCleanUpJobTest`. (The new test failed before the fix, and succeeded after the fix.)