### PR TITLE
fix: keep data value created w/import DHIS2-8379 (#7995)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalue/StreamingXmlDataValue.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalue/StreamingXmlDataValue.java
@@ -54,6 +54,8 @@ public class StreamingXmlDataValue
 
     private static final String FIELD_STOREDBY = "storedBy";
 
+    private static final String FIELD_CREATED = "created";
+
     private static final String FIELD_LAST_UPDATED = "lastUpdated";
 
     private static final String FIELD_COMMENT = "comment";
@@ -130,6 +132,12 @@ public class StreamingXmlDataValue
     public String getStoredBy()
     {
         return storedBy = storedBy == null ? reader.getAttributeValue( FIELD_STOREDBY ) : storedBy;
+    }
+
+    @Override
+    public String getCreated()
+    {
+        return created = created == null ? reader.getAttributeValue( FIELD_CREATED ) : created;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -1390,6 +1390,14 @@ public class DefaultDataValueSetService
             DataValue existingValue = !skipExistingCheck ? dataValueBatchHandler.findObject( internalValue ) : null;
 
             // -----------------------------------------------------------------
+            // Preserve any existing created date unless overwritten by import
+            // -----------------------------------------------------------------
+            if ( existingValue != null && !dataValue.hasCreated() )
+            {
+                internalValue.setCreated( existingValue.getCreated() );
+            }
+
+            // -----------------------------------------------------------------
             // Check soft deleted data values on update and import
             // -----------------------------------------------------------------
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
@@ -27,15 +27,19 @@
  */
 package org.hisp.dhis.dxf2.datavalueset;
 
+import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
 
 import org.hisp.dhis.DhisTest;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
@@ -50,7 +54,6 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -60,7 +63,6 @@ import com.google.common.collect.Sets;
 /**
  * @author Lars Helge Overland
  */
-@Ignore
 public class DataValueSetServiceIntegrationTest
     extends DhisTest
 {
@@ -78,6 +80,9 @@ public class DataValueSetServiceIntegrationTest
 
     @Autowired
     private DataValueService dataValueService;
+
+    @Autowired
+    private CategoryService categoryService;
 
     @Autowired
     private UserService _userService;
@@ -252,6 +257,42 @@ public class DataValueSetServiceIntegrationTest
         assertEquals( ImportStatus.SUCCESS, summary.getStatus() );
 
         assertEquals( 14, dataValueService.getAllDataValues().size() );
+    }
+
+    /**
+     * When updating a data value with a specified created date, the specified
+     * created date should be used.
+     *
+     * When updating a data value without a specified created date, the existing
+     * created date should remain unchanged.
+     */
+    @Test
+    public void testUpdateCreatedDate()
+        throws Exception
+    {
+        // Insert:
+        // deC, peA, ouA created = 2010-01-01
+        // deC, peA, ouB created = 2010-01-01
+
+        in = new ClassPathResource( "datavalueset/dataValueSetB.xml" ).getInputStream();
+
+        dataValueSetService.saveDataValueSet( in );
+
+        // Update:
+        // deC, peA, ouA created = not specified, should remain unchanged
+        // deC, peA, ouB created = 2020-02-02
+
+        in = new ClassPathResource( "datavalueset/dataValueSetBUpdate.xml" ).getInputStream();
+
+        dataValueSetService.saveDataValueSet( in );
+
+        CategoryOptionCombo cc = categoryService.getDefaultCategoryOptionCombo();
+
+        DataValue dv1 = dataValueService.getDataValue( deC, peA, ouA, cc, cc );
+        assertEquals( "2010-01-01", getMediumDateString( dv1.getCreated() ) );
+
+        DataValue dv2 = dataValueService.getDataValue( deC, peA, ouB, cc, cc );
+        assertEquals( "2020-02-02", getMediumDateString( dv2.getCreated() ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetB.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetB.xml
@@ -7,8 +7,8 @@
     <dataValue dataElement="Ix2HsbDMLea" period="201201" orgUnit="BdfsJfj87js" value="10006" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
     <dataValue dataElement="Ix2HsbDMLea" period="201202" orgUnit="DiszpKrYNg8" value="10007" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
     <dataValue dataElement="Ix2HsbDMLea" period="201202" orgUnit="BdfsJfj87js" value="10008" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
-    <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="DiszpKrYNg8" value="10009" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
-    <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="BdfsJfj87js" value="10010" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
+    <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="DiszpKrYNg8" value="10009" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false" created="2010-01-01"/>
+    <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="BdfsJfj87js" value="10010" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false" created="2010-01-01"/>
     <dataValue dataElement="eY5ehpbEsB7" period="201202" orgUnit="DiszpKrYNg8" value="10011" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
     <dataValue dataElement="eY5ehpbEsB7" period="201202" orgUnit="BdfsJfj87js" value="10012" storedBy="john" timestamp="2012-01-01" comment="comment" followup="false"/>
 </dataValueSet>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetBUpdate.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetBUpdate.xml
@@ -1,6 +1,6 @@
 <dataValueSet xmlns="http://dhis2.org/schema/dxf/2.0">
     <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="DiszpKrYNg8" value="20009" storedBy="john" timestamp="2012-05-01" comment="comment09" followup="false"/>
-    <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="BdfsJfj87js" value="20010" storedBy="john" timestamp="2012-05-01" comment="comment10" followup="false"/>
+    <dataValue dataElement="eY5ehpbEsB7" period="201201" orgUnit="BdfsJfj87js" value="20010" storedBy="john" timestamp="2012-05-01" comment="comment10" followup="false" created="2020-02-02"/>
     <dataValue dataElement="eY5ehpbEsB7" period="201202" orgUnit="DiszpKrYNg8" value="20011" storedBy="john" timestamp="2012-05-01" comment="comment11" followup="false"/>
     <dataValue dataElement="eY5ehpbEsB7" period="201202" orgUnit="BdfsJfj87js" value="20012" storedBy="john" timestamp="2012-05-01" comment="comment12" followup="false"/>
     <dataValue dataElement="eY5ehpbEsB7" period="201203" orgUnit="DiszpKrYNg8" value="20013" storedBy="john" timestamp="2012-05-01" comment="comment13" followup="false"/>

--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/batchhandler/DataValueBatchHandler.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/batchhandler/DataValueBatchHandler.java
@@ -162,6 +162,7 @@ public class DataValueBatchHandler
 
         dv.setValue( resultSet.getString( "value" ) );
         dv.setStoredBy( resultSet.getString( "storedBy" ) );
+        dv.setCreated( resultSet.getTimestamp( "created" ) );
         dv.setComment( resultSet.getString( "comment" ) );
         dv.setFollowup( resultSet.getBoolean( "followup" ) );
         dv.setDeleted( resultSet.getBoolean( "deleted" ) );


### PR DESCRIPTION
When data import updates an existing data value, it sets the created date to the current timestamp, instead of retaining the original data value created date. (By contrast, when data entry updates a data value, it keeps the original data value created date.)

(cherry picked from commit f7fa94becf32359b2257ca365aaf9a4b3f2d6a24)