### PR TITLE
fix: DHIS2-11113: Missing conversion to STACKED_AREA chart

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/chart/ChartType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/chart/ChartType.java
@@ -36,6 +36,7 @@ public enum ChartType
     STACKED_COLUMN,
     BAR,
     STACKED_BAR,
+    STACKED_AREA,
     LINE,
     AREA,
     PIE,

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -184,6 +184,7 @@ public class DashboardController
                     case PIE:
                     case RADAR:
                     case SINGLE_VALUE:
+                    case STACKED_AREA:
                     case STACKED_BAR:
                     case STACKED_COLUMN:
                     case YEAR_OVER_YEAR_COLUMN:


### PR DESCRIPTION
These missing enum values were causing conversion issues and as consequence, the item cannot be read by the frontend and displayed on the Dashboard.