### PR TITLE
fix: Remove programUid for PROGRAM_INDICATOR types [DHIS2-11156]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ResultProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ResultProcessor.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dataitem.query;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_INDICATOR;
 import static org.hisp.dhis.common.DimensionItemType.valueOf;
 import static org.hisp.dhis.common.ValueType.fromString;
 import static org.hisp.dhis.dataitem.DataItem.builder;
@@ -108,7 +109,9 @@ class ResultProcessor
 
     private static String getUid( final SqlRowSet rowSet )
     {
-        if ( isNotBlank( rowSet.getString( PROGRAM_UID ) ) )
+        final boolean ignoreProgramUid = PROGRAM_INDICATOR.name().equalsIgnoreCase( rowSet.getString( "item_type" ) );
+
+        if ( isNotBlank( rowSet.getString( PROGRAM_UID ) ) && !ignoreProgramUid )
         {
             return rowSet.getString( PROGRAM_UID ) + "." + rowSet.getString( "item_uid" );
         }


### PR DESCRIPTION
The `programUid` is not needed and is causing issues in the frontend. The `programUid` will not be concatenated in the `id` attribute anymore.