### PR TITLE
fix: Add back pager in metadata for enrollments [DHIS2-11159]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -77,7 +77,7 @@ public class EnrollmentAnalyticsQueryCriteria
 
     private Integer pageSize;
 
-    private Boolean paging = true;
+    private boolean paging;
 
     private DisplayProperty displayProperty;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -77,6 +77,8 @@ public class EnrollmentAnalyticsQueryCriteria
 
     private Integer pageSize;
 
+    private Boolean paging = true;
+
     private DisplayProperty displayProperty;
 
     private Date relativePeriodDate;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -232,7 +232,7 @@ public class EventDataQueryRequest
                 .programStatus( criteria.getProgramStatus() )
                 .page( criteria.getPage() )
                 .pageSize( criteria.getPageSize() )
-                .paging( criteria.getPaging() == null ? true : criteria.getPaging() )
+                .paging( criteria.isPaging() )
                 .displayProperty( criteria.getDisplayProperty() )
                 .relativePeriodDate( criteria.getRelativePeriodDate() )
                 .userOrgUnit( criteria.getUserOrgUnit() )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -232,6 +232,7 @@ public class EventDataQueryRequest
                 .programStatus( criteria.getProgramStatus() )
                 .page( criteria.getPage() )
                 .pageSize( criteria.getPageSize() )
+                .paging( criteria.getPaging() == null ? true : criteria.getPaging() )
                 .displayProperty( criteria.getDisplayProperty() )
                 .relativePeriodDate( criteria.getRelativePeriodDate() )
                 .userOrgUnit( criteria.getUserOrgUnit() )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -261,7 +261,7 @@ public class EventsAnalyticsQueryCriteria
     /**
      * The page size.
      */
-    private Integer pageSize = 50;
+    private Integer pageSize;
 
     /**
      * The paging parameter. When set to false we should not paginate. The

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -709,7 +709,7 @@ public class EventQueryParams
 
     public boolean isPaging()
     {
-        return paging && (page != null || pageSize != null);
+        return paging || page != null || pageSize != null;
     }
 
     public int getPageWithDefault()


### PR DESCRIPTION
As pagination is the default behaviour to most of the endpoints, we have to keep the same behaviour.

The same logic from other endpoints was added to the method `public boolean isPaging()`.
In that way, we respect the paging for Events and Enrollments.
