### PR TITLE
fix: login page translations [2.35]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultTranslateSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultTranslateSystemSettingManager.java
@@ -33,7 +33,6 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import java.util.Hashtable;
 import java.util.Map;
 
-import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -47,7 +46,7 @@ public class DefaultTranslateSystemSettingManager
     // Dependencies
     // -------------------------------------------------------------------------
 
-    private SystemSettingManager systemSettingManager;
+    private final SystemSettingManager systemSettingManager;
 
     public DefaultTranslateSystemSettingManager( SystemSettingManager systemSettingManager )
     {
@@ -85,11 +84,7 @@ public class DefaultTranslateSystemSettingManager
 
     private String getSystemSettingWithFallbacks( SettingKey keyName, String localeStr, String defaultValue )
     {
-        String settingValue = EMPTY;
-
-        settingValue = (String) ObjectUtils.firstNonNull( systemSettingManager.getSystemSetting( keyName ),
-            defaultValue );
-
-        return settingValue;
+        return systemSettingManager.getSystemSettingTranslation( keyName, localeStr )
+            .orElse( defaultValue );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-8712

locale was not used in function call for getting translation