### PR TITLE
fix: [DHIS2-11197] add ownership record when enrolling into a program for the first time (2.37)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -115,6 +115,11 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
                 //
                 persistComments( bundle.getPreheat(), convertedDto );
 
+                //
+                // Handle ownership records, if required
+                //
+                persistOwnership( bundle.getPreheat(), convertedDto );
+
                 updateDataValues( session, bundle.getPreheat(), trackerDto, convertedDto );
 
                 //
@@ -199,6 +204,11 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
      * Persists the comments for the given entity, if the entity has comments
      */
     protected abstract void persistComments( TrackerPreheat preheat, V entity );
+
+    /**
+     * Persists ownership records for the given entity
+     */
+    protected abstract void persistOwnership( TrackerPreheat preheat, V entity );
 
     /**
      * Execute the persistence of Data values linked to the entity being

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import org.hibernate.Session;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
+import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
 import org.hisp.dhis.tracker.TrackerIdScheme;
@@ -59,16 +60,19 @@ public class EnrollmentPersister extends AbstractTrackerPersister<Enrollment, Pr
 
     private final TrackerSideEffectConverterService sideEffectConverterService;
 
+    private final TrackerOwnershipManager trackerOwnershipManager;
+
     public EnrollmentPersister( ReservedValueService reservedValueService,
         TrackerConverterService<Enrollment, ProgramInstance> enrollmentConverter,
         TrackedEntityCommentService trackedEntityCommentService,
-        TrackerSideEffectConverterService sideEffectConverterService )
+        TrackerSideEffectConverterService sideEffectConverterService, TrackerOwnershipManager trackerOwnershipManager )
     {
         super( reservedValueService );
 
         this.enrollmentConverter = enrollmentConverter;
         this.trackedEntityCommentService = trackedEntityCommentService;
         this.sideEffectConverterService = sideEffectConverterService;
+        this.trackerOwnershipManager = trackerOwnershipManager;
     }
 
     @Override
@@ -141,5 +145,15 @@ public class EnrollmentPersister extends AbstractTrackerPersister<Enrollment, Pr
     protected TrackerType getType()
     {
         return TrackerType.ENROLLMENT;
+    }
+
+    @Override
+    protected void persistOwnership( TrackerPreheat preheat, ProgramInstance entity )
+    {
+        if ( isNew( preheat, entity.getUid() ) )
+        {
+            trackerOwnershipManager.assignOwnership( entity.getEntityInstance(), entity.getProgram(),
+                entity.getOrganisationUnit(), false, true );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
@@ -209,4 +209,10 @@ public class EventPersister extends AbstractTrackerPersister<Event, ProgramStage
             .map( DateUtils::fromInstant )
             .orElseGet( Date::new );
     }
+
+    @Override
+    protected void persistOwnership( TrackerPreheat preheat, ProgramStageInstance entity )
+    {
+        // DO NOTHING. Event creation does not create ownership records.
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/RelationshipPersister.java
@@ -122,4 +122,11 @@ public class RelationshipPersister
     {
         return TrackerType.RELATIONSHIP;
     }
+
+    @Override
+    protected void persistOwnership( TrackerPreheat preheat, org.hisp.dhis.relationship.Relationship entity )
+    {
+        // NOTHING TO DO
+
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/TrackedEntityPersister.java
@@ -113,4 +113,11 @@ public class TrackedEntityPersister extends AbstractTrackerPersister<TrackedEnti
     {
         return TrackerSideEffectDataBundle.builder().build();
     }
+
+    @Override
+    protected void persistOwnership( TrackerPreheat preheat, TrackedEntityInstance entity )
+    {
+        // DO NOTHING, Tei alone does not have ownership records
+
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EnrollmentTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EnrollmentTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
@@ -81,6 +82,36 @@ public class EnrollmentTest
         assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
 
         manager.flush();
+    }
+
+    @Test
+    public void testProgramOwnerWhenEnrolled()
+        throws IOException
+    {
+
+        TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json", userA.getUid() );
+
+        List<TrackedEntityInstance> teis = manager.getAll( TrackedEntityInstance.class );
+        assertEquals( 1, teis.size() );
+
+        TrackedEntityInstance tei = teis.get( 0 );
+
+        assertNotNull( tei.getProgramOwners() );
+
+        Set<TrackedEntityProgramOwner> tepos = tei.getProgramOwners();
+        assertEquals( 1, tepos.size() );
+        TrackedEntityProgramOwner tepo = tepos.iterator().next();
+
+        assertNotNull( tepo.getEntityInstance() );
+        assertNotNull( tepo.getProgram() );
+        assertNotNull( tepo.getOrganisationUnit() );
+
+        assertEquals( enrollmentParams.getEnrollments().get( 0 ).getProgram(),
+            tepo.getProgram().getUid() );
+        assertEquals( enrollmentParams.getEnrollments().get( 0 ).getOrgUnit(),
+            tepo.getOrganisationUnit().getUid() );
+        assertEquals( enrollmentParams.getEnrollments().get( 0 ).getTrackedEntity(),
+            tepo.getEntityInstance().getUid() );
     }
 
     @Test


### PR DESCRIPTION
There is no ownership record added when enrolling a tei into a program through the new tracker importer. This PR aims at filling that gap.