### PR TITLE
fix: Add dhis-web-api tot he pom-full.xml

### DIFF
--- a/dhis-2/pom-full.xml
+++ b/dhis-2/pom-full.xml
@@ -19,6 +19,7 @@
 		<module>dhis-api</module>
 		<module>dhis-services</module>
 		<module>dhis-support</module>
+		<module>dhis-web-api</module>
 		<module>dhis-web</module>
 	</modules>
 


### PR DESCRIPTION
After we moved dhis-web-api to the root, the pom-full.xml need to include this.