### PR TITLE
fix: Fix coordinates and org. unit in event enrollments [DHIS2-10228]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -96,7 +97,9 @@ public class IdentifiableObjectUtils
      */
     public static <T extends IdentifiableObject> List<String> getUids( Collection<T> objects )
     {
-        return objects != null ? objects.stream().map( o -> o.getUid() ).collect( Collectors.toList() ) : null;
+        return objects != null
+                ? objects.stream().filter( Objects::nonNull ).map(o -> o.getUid() ).collect( Collectors.toList() )
+                : null;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
-import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_NAME_COL_SUFFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ORG_UNIT_STRUCT_ALIAS;
@@ -269,7 +268,8 @@ public abstract class AbstractJdbcEventAnalyticsManager
             }
             else if ( ValueType.ORGANISATION_UNIT == queryItem.getValueType() )
             {
-                columns.add( getColumn( queryItem, OU_NAME_COL_SUFFIX ) );
+                // In 2.33 we do not export OrgUnit name, so we query the uid
+                columns.add( getColumn( queryItem ) );
             }
             else if ( ValueType.COORDINATE == queryItem.getValueType() )
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
+import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_NAME_COL_SUFFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ORG_UNIT_STRUCT_ALIAS;
@@ -266,13 +267,13 @@ public abstract class AbstractJdbcEventAnalyticsManager
                 }
                 
             }
+            else if ( ValueType.ORGANISATION_UNIT == queryItem.getValueType() )
+            {
+                columns.add( getColumn( queryItem, OU_NAME_COL_SUFFIX ) );
+            }
             else if ( ValueType.COORDINATE == queryItem.getValueType() )
             {
-                String colName = quote( queryItem.getItemName() );
-
-                String coordSql =  "'[' || round(ST_X(" + colName + ")::numeric, 6) || ',' || round(ST_Y(" + colName + ")::numeric, 6) || ']' as " + colName;
-
-                columns.add( coordSql );
+                columns.add( getCoordinateColumn( queryItem ) );
             }
             else
             {
@@ -521,6 +522,33 @@ public abstract class AbstractJdbcEventAnalyticsManager
     protected String getColumn( QueryItem item )
     {
         return quoteAlias( item.getItemName() );
+    }
+
+    /**
+     * Creates a coordinate base column "selector" for the given item name. The
+     * item is expected to be of type Coordinate.
+     *
+     * @param item the {@link QueryItem}
+     * @return the column select statement for the given item
+     */
+    protected String getCoordinateColumn( final QueryItem item )
+    {
+        final String colName = quote( item.getItemName() );
+
+        return "'[' || round(ST_X(" + colName + ")::numeric, 6) || ',' || round(ST_Y(" + colName
+                + ")::numeric, 6) || ']' as " + colName;
+    }
+
+    /**
+     * Creates a column "selector" for the given item name. The suffix will be
+     * appended as part of the item name.
+     *
+     * @param item
+     * @return the the column select statement for the given item
+     */
+    protected String getColumn( final QueryItem item, final String suffix )
+    {
+        return quote( item.getItemName() + suffix );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryTimeoutException;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
@@ -335,6 +336,64 @@ public class JdbcEnrollmentAnalyticsManager
     }
 
     /**
+     * Returns an encoded column name respecting the geometry/coordinate format.
+     * The given QueryItem must be of type COORDINATE.
+     *
+     * @param item the {@link QueryItem}
+     * @return the column selector or EMPTY if the item valueType is not
+     *         COORDINATE. ie.: ( select '[' ||
+     *         round(ST_X("GyJHQUWZ9Rl")::numeric, 6) || ',' ||
+     *         round(ST_Y("GyJHQUWZ9Rl")::numeric, 6) || ']' as "GyJHQUWZ9Rl"
+     *         from analytics_event_qDkgAbB5Jlk where
+     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "SzVk2KvkSSd" is not
+     *         null and ps = 'hYyB7FUS5eR' order by executiondate desc limit 1 )
+     *
+     * @throws NullPointerException if item is null
+     */
+    @Override
+    protected String getCoordinateColumn( final QueryItem item )
+    {
+        if ( ValueType.COORDINATE == item.getValueType() && item.getProgram() != null )
+        {
+            String colName = quote( item.getItemName() );
+
+            final String eventTableName = "analytics_event_" + item.getProgram().getUid();
+
+            String psCondition = "";
+
+            if ( item.hasProgramStage() )
+            {
+                Assert.isTrue( item.hasProgram(),
+                        "Can not query item with program stage but no program:" + item.getItemName() );
+
+                psCondition = "and ps = '" + item.getProgramStage().getUid() + "' ";
+            }
+
+            return "(select " +
+                    "'[' || round(ST_X(" + colName + ")::numeric, 6) || ',' || round(ST_Y(" + colName
+                    + ")::numeric, 6) || ']' as " + colName +
+                    " from " + eventTableName +
+                    " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+                    "and " + colName + " is not null " + psCondition +
+                    "order by executiondate " + "desc limit 1 )";
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Returns a column "selector" for the given item and the given suffix.
+     *
+     * @param item the {@link QueryItem}
+     * @return the selector column statement
+     */
+    @Override
+    protected String getColumn( QueryItem item, String suffix )
+    {
+        return getColumnStatement( item, suffix );
+    }
+
+    /**
      * Returns an quoted column name.
      *
      * @param item the {@link QueryItem}.
@@ -342,17 +401,40 @@ public class JdbcEnrollmentAnalyticsManager
     @Override
     protected String getColumn( QueryItem item )
     {
-        String colName = item.getItemName();
+        return getColumnStatement( item, null );
+    }
+
+    /**
+     * Creates a column "selector" for the given item name. The suffix will be
+     * appended as part of the item name. The column selection is based on events
+     * analytics tables.
+     *
+     * @param item the {@link QueryItem}
+     * @return 1) when there is a program stage: returns the column select statement
+     *         for the given item and suffix. ie.: ( select "GyJHQUWZ9Rl_name" from
+     *         analytics_event_qDkgAbB5Jlk where analytics_event_qDkgAbB5Jlk.pi =
+     *         ax.pi and "GyJHQUWZ9Rl_name" is not null and ps = 'hYyB7FUS5eR' order
+     *         by executiondate desc limit
+     *
+     *         2) when there is no program stage associated: returns the item name
+     *         quoted and prefixed with the table prefix. ie.: ax."enrollmentdate"
+     */
+    private String getColumnStatement( final QueryItem item, final String suffix )
+    {
+        String colName = item.getItemName() + StringUtils.trimToEmpty( suffix );
 
         if ( item.hasProgramStage() )
         {
+            Assert.isTrue( item.hasProgram(),
+                "Can not query item with program stage but no program:" + item.getItemName() );
+
             colName = quote( colName );
-            Assert.isTrue( item.hasProgram(), "Can not query item with program stage but no program:" + item.getItemName() );
-            String eventTableName = "analytics_event_" + item.getProgram().getUid();
-            return "(select " +  colName  + " from " + eventTableName +
-            " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
-            "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() + "' " +
-            "order by executiondate " + "desc limit 1 )";
+
+            final String eventTableName = "analytics_event_" + item.getProgram().getUid();
+
+            return "(select " + colName + " from " + eventTableName + " where " + eventTableName + ".pi = "
+                + ANALYTICS_TBL_ALIAS + ".pi " + "and " + colName + " is not null " + "and ps = '"
+                + item.getProgramStage().getUid() + "' " + "order by executiondate " + "desc limit 1 )";
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -89,8 +89,6 @@ public class JdbcEventAnalyticsTableManager
 
     private static final String OU_GEOMETRY_COL_SUFFIX = "_geom";
 
-    public static final String OU_NAME_COL_SUFFIX = "_name";
-
     public JdbcEventAnalyticsTableManager( IdentifiableObjectManager idObjectManager,
         OrganisationUnitService organisationUnitService, CategoryService categoryService,
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -89,6 +89,8 @@ public class JdbcEventAnalyticsTableManager
 
     private static final String OU_GEOMETRY_COL_SUFFIX = "_geom";
 
+    public static final String OU_NAME_COL_SUFFIX = "_name";
+
     public JdbcEventAnalyticsTableManager( IdentifiableObjectManager idObjectManager,
         OrganisationUnitService organisationUnitService, CategoryService categoryService,
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.hisp.dhis.analytics.AnalyticsAggregationType.fromAggregationType;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -149,6 +150,25 @@ public class AbstractJdbcEventAnalyticsManagerTest
         String column = subject.getColumn( item );
 
         assertThat( column, is( "ax.\"" + dataElementA.getUid() + "\"" ) );
+    }
+
+    @Test
+    public void verifyGetCoordinateColumn()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+        QueryItem item = new QueryItem( dio );
+
+        // When
+        String column = subject.getCoordinateColumn( item );
+
+        // Then
+        String colName = quote( item.getItemName() );
+
+        assertThat( column, is( "'[' || round(ST_X(" + colName + ")::numeric, 6) || ',' || round(ST_Y(" + colName
+                + ")::numeric, 6) || ']' as " + colName ) );
+
+        return;
     }
 
     @Override


### PR DESCRIPTION
This fix also includes DHIS2-10066.
With this fix, the event reports will bring results when DE of type Coordinate and OrgUnit are added as part of the columns.

* NOTE that this filter is not usable. It will be used only for display purposes, and show the actual results instead of a blank page. The org unit `uid` will be used in this case, as in 2.33 we do not have support for OrgUnit name.

**This merge is needed before the code freeze of 2.33.**