### PR TITLE
fix: Fix coordinates and org. unit in event enrollments [DHIS2-10228]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -73,6 +73,10 @@ public class JdbcEnrollmentAnalyticsManager
     extends AbstractJdbcEventAnalyticsManager
     implements EnrollmentAnalyticsManager
 {
+    private static final String ANALYTICS_EVENT = "analytics_event_";
+
+    private static final String ORDER_BY_EXECUTION_DATE_DESC_LIMIT_1 = "order by executiondate desc limit 1";
+
     private List<String> COLUMNS = Lists.newArrayList( "pi", "tei", "enrollmentdate", "incidentdate",
         "ST_AsGeoJSON(pigeometry)", "longitude", "latitude", "ouname", "oucode" );
 
@@ -344,6 +348,119 @@ public class JdbcEnrollmentAnalyticsManager
     }
 
     /**
+     * Returns an encoded column name respecting the geometry/coordinate format.
+     * The given QueryItem must be of type COORDINATE.
+     *
+     * @param item the {@link QueryItem}
+     * @return the column selector or EMPTY if the item valueType is not
+     *         COORDINATE. ie.: ( select '[' ||
+     *         round(ST_X("GyJHQUWZ9Rl")::numeric, 6) || ',' ||
+     *         round(ST_Y("GyJHQUWZ9Rl")::numeric, 6) || ']' as "GyJHQUWZ9Rl"
+     *         from analytics_event_qDkgAbB5Jlk where
+     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "SzVk2KvkSSd" is not
+     *         null and ps = 'hYyB7FUS5eR' order by executiondate desc limit 1 )
+     *
+     * @throws NullPointerException if item is null
+     */
+    @Override
+    protected String getCoordinateColumn( final QueryItem item )
+    {
+        return getCoordinateColumn( item, null );
+    }
+
+    /**
+     * Returns an encoded column name respecting the geometry/coordinate format.
+     * The given QueryItem can be of type COORDINATE or ORGANISATION_UNIT.
+     *
+     * @param suffix is currently ignored. Not currently used for enrollments
+     * @param item the {@link QueryItem}
+     * @return the column selector or EMPTY if the item valueType is not
+     *         COORDINATE. ie.: ( select '[' || round(ST_X("colName")::numeric,
+     *         6) || ',' || round(ST_Y("colName")::numeric, 6) || ']' as
+     *         "colName" from analytics_event_qDkgAbB5Jlk where
+     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "colName" is not null
+     *         and ps = 'hYyB7FUS5eR' order by executiondate desc limit 1 )
+     *
+     * @throws NullPointerException if item is null
+     */
+    @Override
+    protected String getCoordinateColumn( final QueryItem item, final String suffix )
+    {
+        if ( item.getProgram() != null )
+        {
+            final String eventTableName = ANALYTICS_EVENT + item.getProgram().getUid();
+            final String colName = quote( item.getItemId() );
+
+            String psCondition = "";
+
+            if ( item.hasProgramStage() )
+            {
+                assertProgram( item );
+
+                psCondition = "and ps = '" + item.getProgramStage().getUid() + "' ";
+            }
+
+            String stCentroidFunction = "";
+
+            if ( ValueType.ORGANISATION_UNIT == item.getValueType() )
+            {
+                stCentroidFunction = "ST_Centroid";
+
+            }
+
+            return "(select " +
+                "'[' || round(ST_X(" + stCentroidFunction + "(" + colName + "))::numeric, 6) || ',' || round(ST_Y("
+                + stCentroidFunction + "(" + colName + "))::numeric, 6) || ']' as " + colName + " from "
+                + eventTableName + " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+                "and " + colName + " is not null " + psCondition + ORDER_BY_EXECUTION_DATE_DESC_LIMIT_1 + " )";
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Creates a column "selector" for the given item name. The suffix will be
+     * appended as part of the item name. The column selection is based on
+     * events analytics tables.
+     *
+     * @param item the {@link QueryItem}
+     * @param suffix is currently ignored. Not currently used for enrollments
+     * @return 1) when there is a program stage: returns the column select
+     *         statement for the given item and suffix. ie.: ( select
+     *         "GyJHQUWZ9Rl_name" from analytics_event_qDkgAbB5Jlk where
+     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "GyJHQUWZ9Rl_name" is
+     *         not null and ps = 'hYyB7FUS5eR' order by executiondate desc limit
+     *         1
+     *
+     *         2) when there is no program stage associated: returns the item
+     *         name quoted and prefixed with the table prefix. ie.:
+     *         ax."enrollmentdate"
+     */
+    @Override
+    protected String getColumn( final QueryItem item, final String suffix )
+    {
+        String colName = item.getItemName();
+
+        if ( item.hasProgramStage() )
+        {
+            assertProgram( item );
+
+            colName = quote( colName );
+
+            final String eventTableName = ANALYTICS_EVENT + item.getProgram().getUid();
+
+            return "(select " + colName + " from " + eventTableName +
+                " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+                "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() + "' " +
+                ORDER_BY_EXECUTION_DATE_DESC_LIMIT_1 + " )";
+        }
+        else
+        {
+            return quoteAlias( colName );
+        }
+    }
+
+    /**
      * Returns an encoded column name wrapped in lower directive if not numeric
      * or boolean.
      *
@@ -357,9 +474,11 @@ public class JdbcEnrollmentAnalyticsManager
         if ( item.hasProgramStage() )
         {
             colName = quote( colName );
-            Assert.isTrue( item.hasProgram(),
-                "Can not query item with program stage but no program:" + item.getItemName() );
-            String eventTableName = "analytics_event_" + item.getProgram().getUid();
+
+            assertProgram( item );
+
+            String eventTableName = ANALYTICS_EVENT + item.getProgram().getUid();
+
             return "(select " + colName + " from " + eventTableName +
                 " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
                 "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() + "' " +
@@ -369,6 +488,12 @@ public class JdbcEnrollmentAnalyticsManager
         {
             return quoteAlias( colName );
         }
+    }
+
+    private void assertProgram( final QueryItem item )
+    {
+        Assert.isTrue( item.hasProgram(),
+            "Can not query item with program stage but no program:" + item.getItemName() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.*;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
@@ -44,7 +46,16 @@ import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryRuntimeException;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
@@ -352,13 +363,8 @@ public class JdbcEnrollmentAnalyticsManager
      * The given QueryItem must be of type COORDINATE.
      *
      * @param item the {@link QueryItem}
-     * @return the column selector or EMPTY if the item valueType is not
-     *         COORDINATE. ie.: ( select '[' ||
-     *         round(ST_X("GyJHQUWZ9Rl")::numeric, 6) || ',' ||
-     *         round(ST_Y("GyJHQUWZ9Rl")::numeric, 6) || ']' as "GyJHQUWZ9Rl"
-     *         from analytics_event_qDkgAbB5Jlk where
-     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "SzVk2KvkSSd" is not
-     *         null and ps = 'hYyB7FUS5eR' order by executiondate desc limit 1 )
+     * @return the column selector (SQL query) or EMPTY if the item valueType is
+     *         not COORDINATE.
      *
      * @throws NullPointerException if item is null
      */
@@ -374,12 +380,8 @@ public class JdbcEnrollmentAnalyticsManager
      *
      * @param suffix is currently ignored. Not currently used for enrollments
      * @param item the {@link QueryItem}
-     * @return the column selector or EMPTY if the item valueType is not
-     *         COORDINATE. ie.: ( select '[' || round(ST_X("colName")::numeric,
-     *         6) || ',' || round(ST_Y("colName")::numeric, 6) || ']' as
-     *         "colName" from analytics_event_qDkgAbB5Jlk where
-     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "colName" is not null
-     *         and ps = 'hYyB7FUS5eR' order by executiondate desc limit 1 )
+     * @return the column selector (SQL query) or EMPTY if the item valueType is
+     *         not COORDINATE.
      *
      * @throws NullPointerException if item is null
      */
@@ -408,10 +410,10 @@ public class JdbcEnrollmentAnalyticsManager
 
             }
 
-            return "(select " +
-                "'[' || round(ST_X(" + stCentroidFunction + "(" + colName + "))::numeric, 6) || ',' || round(ST_Y("
-                + stCentroidFunction + "(" + colName + "))::numeric, 6) || ']' as " + colName + " from "
-                + eventTableName + " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+            return "(select '[' || round(ST_X(" + stCentroidFunction + "(" + colName
+                + "))::numeric, 6) || ',' || round(ST_Y("
+                + stCentroidFunction + "(" + colName + "))::numeric, 6) || ']' as " + colName
+                + " from " + eventTableName + " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
                 "and " + colName + " is not null " + psCondition + ORDER_BY_EXECUTION_DATE_DESC_LIMIT_1 + " )";
         }
 
@@ -425,15 +427,9 @@ public class JdbcEnrollmentAnalyticsManager
      *
      * @param item the {@link QueryItem}
      * @param suffix is currently ignored. Not currently used for enrollments
-     * @return 1) when there is a program stage: returns the column select
-     *         statement for the given item and suffix. ie.: ( select
-     *         "GyJHQUWZ9Rl_name" from analytics_event_qDkgAbB5Jlk where
-     *         analytics_event_qDkgAbB5Jlk.pi = ax.pi and "GyJHQUWZ9Rl_name" is
-     *         not null and ps = 'hYyB7FUS5eR' order by executiondate desc limit
-     *         1
-     *
-     *         2) when there is no program stage associated: returns the item
-     *         name quoted and prefixed with the table prefix. ie.:
+     * @return when there is a program stage: returns the column select
+     *         statement for the given item and suffix, otherwise returns the
+     *         item name quoted and prefixed with the table prefix. ie.:
      *         ax."enrollmentdate"
      */
     @Override
@@ -449,8 +445,9 @@ public class JdbcEnrollmentAnalyticsManager
 
             final String eventTableName = ANALYTICS_EVENT + item.getProgram().getUid();
 
-            return "(select " + colName + " from " + eventTableName +
-                " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+            return "(select " + colName
+                + " from " + eventTableName
+                + " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
                 "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() + "' " +
                 ORDER_BY_EXECUTION_DATE_DESC_LIMIT_1 + " )";
         }
@@ -479,8 +476,9 @@ public class JdbcEnrollmentAnalyticsManager
 
             String eventTableName = ANALYTICS_EVENT + item.getProgram().getUid();
 
-            return "(select " + colName + " from " + eventTableName +
-                " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+            return "(select " + colName
+                + " from " + eventTableName
+                + " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
                 "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() + "' " +
                 "order by executiondate " + "desc limit 1 )";
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.DhisConvenienceTest.*;
 import static org.hisp.dhis.analytics.AnalyticsAggregationType.fromAggregationType;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -148,6 +149,25 @@ public class AbstractJdbcEventAnalyticsManagerTest
         String column = subject.getSelectSql( item, from, to );
 
         assertThat( column, is( "ax.\"" + dataElementA.getUid() + "\"" ) );
+    }
+
+    @Test
+    public void verifyGetCoordinateColumn()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+        QueryItem item = new QueryItem( dio );
+
+        // When
+        String column = subject.getCoordinateColumn( item );
+
+        // Then
+        String colName = quote( item.getItemName() );
+
+        assertThat( column, is( "'[' || round(ST_X(" + colName + ")::numeric, 6) || ',' || round(ST_Y(" + colName
+            + ")::numeric, 6) || ']' as " + colName ) );
+
+        return;
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -27,9 +27,12 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,6 +41,9 @@ import java.util.Date;
 
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.programindicator.DefaultProgramIndicatorSubqueryBuilder;
+import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
@@ -348,5 +354,114 @@ public class EnrollmentAnalyticsManagerTest
             " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate <= '2017-04-08' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
+    }
+
+    @Test
+    public void verifyGetColumnOfTypeCoordinateAndNoProgramStages()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+
+        QueryItem item = new QueryItem( dio );
+        item.setValueType( ValueType.COORDINATE );
+
+        // When
+        String columnSql = subject.getColumn( item );
+
+        // Then
+        assertThat( columnSql, is( "ax.\"" + dataElementA.getUid() + "\"" ) );
+    }
+
+    @Test
+    public void verifyGetColumnOfTypeCoordinateAndWithProgramStages()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+
+        QueryItem item = new QueryItem( dio );
+        item.setValueType( ValueType.COORDINATE );
+        item.setProgramStage( programStage );
+        item.setProgram( programA );
+
+        // When
+        String columnSql = subject.getColumn( item );
+
+        // Then
+        assertThat( columnSql,
+            is( "(select \"" + dataElementA.getUid()
+                + "\" from analytics_event_" + programA.getUid() + " where analytics_event_" + programA.getUid()
+                + ".pi = ax.pi and \"" + dataElementA.getUid() + "\" is not null and ps = '" + programStage.getUid()
+                + "' order by executiondate desc limit 1 )" ) );
+    }
+
+    @Test
+    public void verifyGetCoordinateColumnAndNoProgramStage()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+
+        QueryItem item = new QueryItem( dio );
+        item.setValueType( ValueType.COORDINATE );
+        item.setProgram( programA );
+
+        // When
+        String columnSql = subject.getCoordinateColumn( item );
+
+        // Then
+        String colName = quote( item.getItemName() );
+        String eventTableName = "analytics_event_" + item.getProgram().getUid();
+
+        assertThat( columnSql,
+            is( "(select " +
+                "'[' || round(ST_X((" + colName + "))::numeric, 6) || ',' || round(ST_Y((" + colName
+                + "))::numeric, 6) || ']' as " + colName +
+                " from " + eventTableName +
+                " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+                "and " + colName + " is not null " +
+                "order by executiondate " + "desc limit 1 )" ) );
+    }
+
+    @Test
+    public void verifyGetCoordinateColumnWithProgramStage()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+
+        QueryItem item = new QueryItem( dio );
+        item.setValueType( ValueType.COORDINATE );
+        item.setProgramStage( programStage );
+        item.setProgram( programA );
+
+        // When
+        String columnSql = subject.getCoordinateColumn( item );
+
+        // Then
+        String colName = quote( item.getItemName() );
+        String eventTableName = "analytics_event_" + item.getProgram().getUid();
+
+        assertThat( columnSql,
+            is( "(select " +
+                "'[' || round(ST_X((" + colName + "))::numeric, 6) || ',' || round(ST_Y((" + colName
+                + "))::numeric, 6) || ']' as " + colName + " from " + eventTableName +
+                " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi " +
+                "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() +
+                "' order by executiondate " + "desc limit 1 )" ) );
+    }
+
+    @Test
+    public void verifyGetCoordinateColumnWithNoProgram()
+    {
+        // Given
+        DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
+
+        QueryItem item = new QueryItem( dio );
+        item.setValueType( ValueType.COORDINATE );
+        item.setProgramStage( programStage );
+
+        // When
+        String columnSql = subject.getCoordinateColumn( item );
+
+        // Then
+        assertThat( columnSql, is( EMPTY ) );
     }
 }


### PR DESCRIPTION
This fix also includes DHIS2-10066.
With this fix, the event reports will bring results when DE of type Coordinate and OrgUnit are added as part of the columns.

This is just a "forward-porting" from 2.33. It was already reviewed and merged in that version.