### PR TITLE
fix: Custom date labels in event reports downloads [DHIS2-9641]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -646,14 +646,17 @@ public class DefaultEventAnalyticsService
         grid.addHeader( new GridHeader( ITEM_EVENT, NAME_EVENT, ValueType.TEXT, String.class.getName(), false, true ) )
             .addHeader( new GridHeader( ITEM_PROGRAM_STAGE, NAME_PROGRAM_STAGE, ValueType.TEXT, String.class.getName(),
                 false, true ) )
-            .addHeader(
-                new GridHeader( ITEM_EVENT_DATE, NAME_EVENT_DATE, ValueType.DATE, Date.class.getName(), false, true ) );
+            .addHeader( new GridHeader( ITEM_EVENT_DATE,
+                LabelMapper.getEventDateLabel( params.getProgramStage(), NAME_EVENT_DATE ), ValueType.DATE,
+                Date.class.getName(), false, true ) );
 
         if ( params.getProgram().isRegistration() )
         {
-            grid.addHeader( new GridHeader( ITEM_ENROLLMENT_DATE, NAME_ENROLLMENT_DATE, ValueType.DATE,
+            grid.addHeader( new GridHeader( ITEM_ENROLLMENT_DATE,
+                LabelMapper.getEnrollmentDateLabel( params.getProgramStage(), NAME_ENROLLMENT_DATE ), ValueType.DATE,
                 Date.class.getName(), false, true ) )
-                .addHeader( new GridHeader( ITEM_INCIDENT_DATE, NAME_INCIDENT_DATE, ValueType.DATE,
+                .addHeader( new GridHeader( ITEM_INCIDENT_DATE,
+                    LabelMapper.getIncidentDateLabel( params.getProgramStage(), NAME_INCIDENT_DATE ), ValueType.DATE,
                     Date.class.getName(), false, true ) )
                 .addHeader( new GridHeader( ITEM_TRACKED_ENTITY_INSTANCE, NAME_TRACKED_ENTITY_INSTANCE, ValueType.TEXT,
                     String.class.getName(), false, true ) )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.event.data;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.hisp.dhis.program.ProgramStage;
+
+/**
+ * Specific component responsible mapping custom labels for specific cases where
+ * the user is able to customize them.
+ *
+ * @author maikel arabori
+ */
+public class LabelMapper
+{
+    private LabelMapper()
+    {
+    }
+
+    /**
+     * Finds for a custom label for event date if one exists.
+     *
+     * @param programStage
+     * @return the custom label, otherwise the default one
+     */
+    static String getEventDateLabel( final ProgramStage programStage, final String defaultLabel )
+    {
+        if ( programStage != null && isNotBlank( programStage.getExecutionDateLabel() ) )
+        {
+            return programStage.getExecutionDateLabel();
+        }
+
+        return defaultLabel;
+    }
+
+    /**
+     * Finds for a custom label for enrollment date if one exists.
+     *
+     * @param programStage
+     * @return the custom label, otherwise the default one
+     */
+    static String getEnrollmentDateLabel( final ProgramStage programStage, final String defaultLabel )
+    {
+        if ( programStage != null && programStage.getProgram() != null
+            && isNotBlank( programStage.getProgram().getEnrollmentDateLabel() ) )
+        {
+            return programStage.getProgram().getEnrollmentDateLabel();
+        }
+
+        return defaultLabel;
+    }
+
+    /**
+     * Finds for a custom label for incident date if one exists.
+     *
+     * @param programStage
+     * @return the custom label, otherwise the default one
+     */
+    static String getIncidentDateLabel( final ProgramStage programStage, final String defaultLabel )
+    {
+        if ( programStage != null && programStage.getProgram() != null
+            && isNotBlank( programStage.getProgram().getIncidentDateLabel() ) )
+        {
+            return programStage.getProgram().getIncidentDateLabel();
+        }
+
+        return defaultLabel;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.event.data;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.junit.Test;
+
+/**
+ * Unit tests for LabelMapper.
+ *
+ * @author maikel arabori
+ */
+public class LabelMapperTest
+{
+
+    public static final String EVENT_DATE = "Event date";
+
+    public static final String INCIDENT_DATE = "Incident date";
+
+    public static final String ENROLLMENT_DATE = "Enrollment date";
+
+    @Test
+    public void testGetHeaderNameFor_NAME_EVENT_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+
+        // When
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithLabels, EVENT_DATE );
+
+        // Then
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getExecutionDateLabel() ) );
+    }
+
+    @Test
+    public void testGetHeaderNameFor_NAME_ENROLLMENT_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+
+        // When
+        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithLabels,
+            ENROLLMENT_DATE );
+
+        // Then
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getEnrollmentDateLabel() ) );
+    }
+
+    @Test
+    public void testGetHeaderNameFor_NAME_INCIDENT_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+
+        // When
+        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithLabels, INCIDENT_DATE );
+
+        // Then
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getIncidentDateLabel() ) );
+    }
+
+    @Test
+    public void testGetHeaderNameWhenNoLabelIsSetFor_NAME_EVENT_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+
+        // When
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithNoLabels, EVENT_DATE );
+
+        // Then
+        assertThat( actualName, is( EVENT_DATE ) );
+    }
+
+    @Test
+    public void testGetHeaderNameWhenNoLabelIsSetFor_NAME_ENROLLMENT_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+
+        // When
+        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithNoLabels,
+            ENROLLMENT_DATE );
+
+        // Then
+        assertThat( actualName, is( ENROLLMENT_DATE ) );
+    }
+
+    @Test
+    public void testGetHeaderNameWhenNoLabelIsSetFor_NAME_INCIDENT_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+
+        // When
+        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithNoLabels, INCIDENT_DATE );
+
+        // Then
+        assertThat( actualName, is( INCIDENT_DATE ) );
+    }
+
+    @Test
+    public void testGetHeaderNameWhenProgramStageIsNull()
+    {
+        // Given
+        final ProgramStage nullProgramStage = null;
+
+        // When
+        final String actualName = LabelMapper.getIncidentDateLabel( nullProgramStage, INCIDENT_DATE );
+
+        // Then
+        assertThat( actualName, is( INCIDENT_DATE ) );
+    }
+
+    @Test
+    public void testGetHeaderNameWhenProgramIsNull()
+    {
+        // Given
+        final ProgramStage programStageWithNullProgram = mockProgramStageWithNullProgram();
+
+        // When
+        final String actualName = LabelMapper.getEnrollmentDateLabel( programStageWithNullProgram, ENROLLMENT_DATE );
+
+        // Then
+        assertThat( actualName, is( ENROLLMENT_DATE ) );
+    }
+
+    private ProgramStage mockProgramStageWithLabels()
+    {
+        final ProgramStage programStage = new ProgramStage();
+        programStage.setExecutionDateLabel( "execution date label" );
+
+        final Program program = new Program();
+        program.setEnrollmentDateLabel( "enrollment date label" );
+        program.setIncidentDateLabel( "incident date label" );
+
+        programStage.setProgram( program );
+
+        return programStage;
+    }
+
+    private ProgramStage mockProgramStageWithoutLabels()
+    {
+        final ProgramStage programStage = new ProgramStage();
+        final Program program = new Program();
+
+        programStage.setProgram( program );
+
+        return programStage;
+    }
+
+    private ProgramStage mockProgramStageWithNullProgram()
+    {
+        final ProgramStage programStage = new ProgramStage();
+
+        programStage.setProgram( null );
+
+        return programStage;
+    }
+}


### PR DESCRIPTION
Follows the same standard as the UI/frontend, which uses predefined labels defined by the user, in order to render the event report columns.

**_Backporting from master._**