### PR TITLE
chore: Add a DHIS2 controlled Maven repository

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -264,17 +264,12 @@
       </releases>
     </repository>
     <repository>
-      <id>geotoolkit</id>
-      <name>Geotoolkit</name>
-      <url>https://maven.geotoolkit.org</url>
+      <id>DHIS2_MAVEN_REPO_MIRROR</id>
+      <url>https://raw.githubusercontent.com/dhis2/maven-repo-mirror/master/</url>
       <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>daily</updatePolicy>
-      </snapshots>
-      <releases>
         <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
     </repository>
     <repository>
       <id>ossrh</id>


### PR DESCRIPTION
Due to random connection issues in the GitHub CI pipeline with the Geotools repo. we now host the dep. ourselves.