### PR TITLE
fix: Missed sufix in enrollments query [DHIS2-11291]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -426,7 +426,7 @@ public class JdbcEnrollmentAnalyticsManager
      * events analytics tables.
      *
      * @param item the {@link QueryItem}
-     * @param suffix is currently ignored. Not currently used for enrollments
+     * @param suffix to be appended to the item name (column)
      * @return when there is a program stage: returns the column select
      *         statement for the given item and suffix, otherwise returns the
      *         item name quoted and prefixed with the table prefix. ie.:
@@ -441,7 +441,7 @@ public class JdbcEnrollmentAnalyticsManager
         {
             assertProgram( item );
 
-            colName = quote( colName );
+            colName = quote( colName + suffix );
 
             final String eventTableName = ANALYTICS_EVENT + item.getProgram().getUid();
 


### PR DESCRIPTION
Small bug regarding org unit column selection in Enrollments query.
The is returning the org unit UID, but the correct is behaviour is returning the NAME. This code addresses this issue.