### PR TITLE
fix: Class cast exception in Program Indicators [DHIS2-11292]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handling/DataHandler.java
@@ -1032,7 +1032,8 @@ public class DataHandler
                 else
                 {
                     result.put( join( remove( row.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP ),
-                        new DimensionItemObjectValue( dimensionalItems.get( 0 ), (Double) row.get( valueIndex ) ) );
+                        new DimensionItemObjectValue( dimensionalItems.get( 0 ),
+                            ((Number) row.get( valueIndex )).doubleValue() ) );
                 }
             }
         }
@@ -1111,7 +1112,7 @@ public class DataHandler
             if ( periodOffsetRow != null )
             {
                 result.put( key, new DimensionItemObjectValue( dimensionalItemObject,
-                    (Double) periodOffsetRow.get( valueIndex ) ) );
+                    ((Number) row.get( valueIndex )).doubleValue() ) );
             }
 
             clone = SerializationUtils.clone( dimensionalItemObject );


### PR DESCRIPTION
This happens when Program Indicators have decimal digits set to ZERO. In such cases, they are evaluated as Long and not Double. So, the code should be prepared to expect Long or Double.