### PR TITLE
feat: add OrgUnit image property

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.common.coordinate.CoordinateObject;
 import org.hisp.dhis.common.coordinate.CoordinateUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.organisationunit.comparator.OrganisationUnitDisplayNameComparator;
 import org.hisp.dhis.organisationunit.comparator.OrganisationUnitDisplayShortNameComparator;
 import org.hisp.dhis.program.Program;
@@ -128,6 +129,11 @@ public class OrganisationUnit
     private Set<CategoryOption> categoryOptions = new HashSet<>();
 
     private Geometry geometry;
+
+    /**
+     * A reference to the Image file associated with this OrganisationUnit.
+     */
+    private FileResource image;
 
     // -------------------------------------------------------------------------
     // Transient fields
@@ -1097,6 +1103,18 @@ public class OrganisationUnit
     public boolean hasCoordinates()
     {
         return this.geometry != null;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public FileResource getImage()
+    {
+        return image;
+    }
+
+    public void setImage( FileResource image )
+    {
+        this.image = image;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
@@ -87,6 +87,8 @@
 
     <property name="translations" type="jblTranslations"/>
 
+    <many-to-one name="image" class="org.hisp.dhis.fileresource.FileResource" column="image" foreign-key="fk_organisationUnit_fileresourceid" />
+
     <!-- Access properties -->
     <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_organisationunit_userid" />
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitServiceTest.java
@@ -45,12 +45,16 @@ import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceDomain;
+import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.MimeTypeUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -73,6 +77,9 @@ public class OrganisationUnitServiceTest
 
     @Autowired
     private DataSetService dataSetService;
+
+    @Autowired
+    private FileResourceService fileResourceService;
 
     @Autowired
     private OrganisationUnitGroupService organisationUnitGroupService;
@@ -1113,5 +1120,27 @@ public class OrganisationUnitServiceTest
         expected = ouB.getUid() + "/" + ouC.getUid();
 
         assertEquals( expected, ouD.getParentGraph( Sets.newHashSet( ouB ) ) );
+    }
+
+    @Test
+    public void testSaveImage()
+    {
+        byte[] content = "<<png data>>".getBytes();
+        FileResource fileResource = new FileResource( "testOrgUnitImage.png", MimeTypeUtils.IMAGE_PNG.getType(),
+            content.length,
+            "md5", FileResourceDomain.ORG_UNIT );
+        fileResource.setAssigned( false );
+        fileResource.setCreated( new Date() );
+        fileResource.setAutoFields();
+        fileResourceService.saveFileResource( fileResource, content );
+
+        OrganisationUnit orgUnit = createOrganisationUnit( 'A' );
+        orgUnit.setImage( fileResource );
+        organisationUnitService.addOrganisationUnit( orgUnit );
+
+        OrganisationUnit savedOU = organisationUnitService.getOrganisationUnit( orgUnit.getUid() );
+
+        assertEquals( fileResource.getUid(), savedOU.getImage().getUid() );
+
     }
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_14__Add_image_column_into_organisationunit_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_14__Add_image_column_into_organisationunit_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE organisationunit
+  ADD COLUMN IF NOT EXISTS image bigint;
+
+ALTER TABLE organisationunit
+  ADD CONSTRAINT fk_organisationUnit_fileresourceid FOREIGN KEY (image) REFERENCES fileresource(fileresourceid);


### PR DESCRIPTION
This is 2nd of two PRs needed for supporting OrgUnit image upload feature in back-end https://jira.dhis2.org/browse/DHIS2-11172

- [x]  Add support for upload image file with `api/fileResource?domain=ORG_UNIT`  ( https://github.com/dhis2/dhis2-core/pull/8090  ).
- [x]  Add `image` property to OrgnanisationUnit, which is linked to a `FileResource` ( this PR ) .
- [x] Add unit test.
- [ ] Add document for the changes.

Test steps:
1. Use api/fileResource to upload an image file to server as in [this doc](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-234/web-api.html#webapi_file_resources) . With request parameter `/fileResources?domain=ORG_UNIT`. Take note of the create fileResourceId from the response.
2. Send POST request to `/api/organisationUnit` to create an OrgUnit, the payload should include required properties to create new OrgUnit and a new property `"image":"fileResourceUid created from step 1"`
3. Verify if OrgUnit is created and linked with created fileResource from step 1
4. Do as step 1 but with a new image. Take note of the create fileResourceId from the response.
5. Send PUT request to `/api/organisationUnit/<OrgUnitUid created in step 2>` the payload should include required properties to update OrgUnit and `"image":"fileResourceUid created from step 3"`.
6. Verify if OrgUnit is updated and linked with created fileResource from step 4