### PR TITLE
ci: use concurrency key in github actions

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -9,17 +9,10 @@ on:
     branches:
       - master
       - '2.3[1-9]'
-
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
 jobs:
-  cleanup-runs:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: rokroskar/workflow-run-cleanup-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-
   sonarqube:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -3,15 +3,10 @@ name: Run api tests
 on:
   pull_request: 
     types: [ labeled, synchronize ]
-jobs:
-  cleanup-runs:
-   runs-on: ubuntu-latest
-   steps:
-   - uses: rokroskar/workflow-run-cleanup-action@master
-     env:
-       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-     
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+jobs:    
   api-test:
     env:
       CORE_IMAGE_NAME: "dhis2/core:local"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,16 +1,10 @@
 name: Test
 
 on: [ pull_request ]
-
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
 jobs:
-  cleanup-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rokroskar/workflow-run-cleanup-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-
   unit-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR replaces custom third-party action with the newly supported GH key (concurrency). PR should not change any of the workflows - when a new commit is added, checks running for old commits are still canceled, freeing up GH workers. 