### PR TITLE
fix: Gist API access filters authority check [DHIS2-11024]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
@@ -36,6 +36,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.gist.GistQuery.Comparison;
@@ -49,8 +51,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.sharing.Sharing;
-
-import lombok.AllArgsConstructor;
 
 /**
  * Encapsulates all access control related logic of gist API request processing.
@@ -80,6 +80,12 @@ public class DefaultGistAccessControl implements GistAccessControl
     private final UserService userService;
 
     private final GistService gistService;
+
+    @Override
+    public String getCurrentUserUid()
+    {
+        return currentUser.getUid();
+    }
 
     @Override
     public boolean isSuperuser()
@@ -131,7 +137,7 @@ public class DefaultGistAccessControl implements GistAccessControl
     @Override
     public boolean canFilterByAccessOfUser( String userUid )
     {
-        User user = userService.getUser( userUid );
+        User user = getCurrentUserUid().equals( userUid ) ? currentUser : userService.getUser( userUid );
         return user != null && aclService.canRead( currentUser, user );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
@@ -36,8 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import lombok.AllArgsConstructor;
-
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.gist.GistQuery.Comparison;
@@ -51,6 +49,8 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.sharing.Sharing;
+
+import lombok.AllArgsConstructor;
 
 /**
  * Encapsulates all access control related logic of gist API request processing.
@@ -132,7 +132,7 @@ public class DefaultGistAccessControl implements GistAccessControl
     public boolean canFilterByAccessOfUser( String userUid )
     {
         User user = userService.getUser( userUid );
-        return user != null && currentUser.canManage( user );
+        return user != null && aclService.canRead( currentUser, user );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistAccessControl.java
@@ -37,9 +37,15 @@ import org.hisp.dhis.user.sharing.Sharing;
  * Access for the current user within the currently processed gist API request.
  *
  * This encapsulates all access related logic of gist API request processing.
+ *
+ * @author Jan Bernitt
  */
 public interface GistAccessControl
 {
+    /**
+     * @return ID of the current user
+     */
+    String getCurrentUserUid();
 
     /**
      * Whether or not the current user is a superuser.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -184,7 +184,7 @@ final class GistValidator
             }
             if ( operator == Comparison.CAN_ACCESS && ids.length != 2 )
             {
-                throw createIllegalFilter( f, "Filter `%s` requires a user ID and a access pattern argument." );
+                throw createIllegalFilter( f, "Filter `%s` requires a user ID and an access pattern argument." );
             }
             if ( operator == Comparison.CAN_ACCESS )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
@@ -55,8 +55,6 @@ import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.CopyMapper;
 import org.hisp.dhis.tracker.preheat.mappers.ProgramMapper;
 import org.hisp.dhis.tracker.preheat.mappers.RelationshipTypeMapper;
-import org.hisp.dhis.tracker.preheat.supplier.strategy.ProgramStrategy;
-import org.hisp.dhis.tracker.preheat.supplier.strategy.RelationshipTypeStrategy;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategyTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategyTest.java
@@ -41,7 +41,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.preheat.supplier.strategy.TrackerEntityInstanceStrategy;
 import org.hisp.dhis.user.User;
 import org.junit.Rule;
 import org.junit.Test;

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
@@ -85,8 +85,8 @@ public class GistValidationControllerTest extends AbstractGistControllerTest
     public void testValidation_Filter_CanAccessMissingPattern()
     {
         assertEquals(
-            "Filter `surname:canaccess:[fake-UID]` requires a user ID and a access pattern argument.",
-            GET( "/users/gist?filter=surname:canAccess:fake-UID" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
+            "Filter `surname:canaccess:[" + getSuperuserUid() + "]` requires a user ID and an access pattern argument.",
+            GET( "/users/gist?filter=surname:canAccess" ).error( HttpStatus.BAD_REQUEST ).getMessage() );
     }
 
     @Test


### PR DESCRIPTION
Noticed a bug for the access filter like `canAccess`, `canRead` etcetera when looking into Gist API equivalent for DHIS2-7734.
This PR fixes the access check which no longer uses `User#canManage` is this often would not allow the filter even though the user is an admin that has read access to all involved data. 

Testing this I also noticed that in order for e.g. `canRead` to work closer to the read filter of the metadata API the current user should be the default argument if no user ID is supplied.