### PR TITLE
fix: Get correct program stage from preheated Program [DHIS2-11225]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/events/EventValidationTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/events/EventValidationTests.java
@@ -171,6 +171,16 @@ public class EventValidationTests
                 .body( "errorCode", hasItem( equalTo( "E1079" ) ) );
     }
 
+    @Test
+    public void eventImportShouldPassValidationWhenOnlyEventProgramIsDefined()
+    {
+        JsonObject jsonObject = trackerActions.buildEvent( OU_ID, eventProgramId, null );
+
+        TrackerApiResponse response = trackerActions.postAndGetJobReport( jsonObject );
+
+        response.validateSuccessfulImport();
+    }
+
     private void setupData()
     {
         eventProgramStageId = programActions.programStageActions.get( "", new QueryParamsBuilder().add( "filter=program.id:eq:" +

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -194,7 +194,6 @@ public class EventTrackerConverterService
     {
         ProgramStage programStage = preheat.get( ProgramStage.class, event.getProgramStage() );
         Program program = preheat.get( Program.class, event.getProgram() );
-        ;
         OrganisationUnit organisationUnit = preheat.get( OrganisationUnit.class, event.getOrgUnit() );
 
         Date now = new Date();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -193,7 +193,8 @@ public class EventTrackerConverterService
     private ProgramStageInstance from( TrackerPreheat preheat, Event event, ProgramStageInstance programStageInstance )
     {
         ProgramStage programStage = preheat.get( ProgramStage.class, event.getProgramStage() );
-        Program program = programStage.getProgram();
+        Program program = preheat.get( Program.class, event.getProgram() );
+        ;
         OrganisationUnit organisationUnit = preheat.get( OrganisationUnit.class, event.getOrgUnit() );
 
         Date now = new Date();
@@ -252,7 +253,7 @@ public class EventTrackerConverterService
             programStageInstance.setAssignedUser( assignedUser );
         }
 
-        if ( programStage.getProgram().isRegistration() && programStageInstance.getDueDate() == null &&
+        if ( program.isRegistration() && programStageInstance.getDueDate() == null &&
             programStageInstance.getExecutionDate() != null )
         {
             programStageInstance.setDueDate( programStageInstance.getExecutionDate() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.preheat.mappers;
 import java.util.Set;
 
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.user.UserAccess;
 import org.hisp.dhis.user.UserGroupAccess;
 import org.mapstruct.BeanMapping;
@@ -38,7 +39,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper( uses = { DebugMapper.class, OrganisationUnitMapper.class, UserGroupAccessMapper.class,
-    UserAccessMapper.class, TrackedEntityTypeMapper.class } )
+    UserAccessMapper.class, TrackedEntityTypeMapper.class, ProgramStageMapper.class } )
 public interface ProgramMapper extends PreheatMapper<Program>
 {
     ProgramMapper INSTANCE = Mappers.getMapper( ProgramMapper.class );
@@ -55,6 +56,7 @@ public interface ProgramMapper extends PreheatMapper<Program>
     @Mapping( target = "userAccesses" )
     @Mapping( target = "programType" )
     @Mapping( target = "programAttributes" )
+    @Mapping( target = "programStages" )
     @Mapping( target = "onlyEnrollOnce" )
     @Mapping( target = "featureType" )
     @Mapping( target = "categoryCombo" )
@@ -70,4 +72,6 @@ public interface ProgramMapper extends PreheatMapper<Program>
     Set<UserGroupAccess> userGroupAccessesProgram( Set<UserGroupAccess> userGroupAccesses );
 
     Set<UserAccess> mapUserAccessProgramInstanceProgram( Set<UserAccess> userAccesses );
+
+    Set<ProgramStage> mapProgramStages( Set<ProgramStage> programStages );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -40,7 +40,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.rules.models.RuleEffects;
@@ -183,8 +182,7 @@ public class DefaultTrackerProgramRuleService
 
     private Program getProgramFromEvent( TrackerPreheat preheat, Event event )
     {
-        ProgramStage programStage = preheat.get( ProgramStage.class, event.getProgramStage() );
-        return programStage.getProgram();
+        return preheat.get( Program.class, event.getProgram() );
     }
 
     private ProgramInstance getEnrollment( TrackerBundle bundle, String enrollmentUid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -71,7 +71,7 @@ public class EventCategoryOptValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        Program program = context.getProgramStage( event.getProgramStage() ).getProgram();
+        Program program = context.getProgram( event.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
         checkNotNull( context.getBundle().getUser(), TrackerImporterAssertErrors.USER_CANT_BE_NULL );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -64,7 +64,7 @@ public class EventDateValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        Program program = context.getProgramStage( event.getProgramStage() ).getProgram();
+        Program program = context.getProgram( event.getProgram() );
 
         if ( event.getOccurredAt() == null && occuredAtDateIsMandatory( event, program ) )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
@@ -257,19 +257,23 @@ public class PreCheckOwnershipValidationHook
         // Check acting user is allowed to change existing/write event
         if ( strategy.isUpdateOrDelete() )
         {
-            validateUpdateAndDeleteEvent( reporter, event, context.getProgramStageInstance( event.getEvent() ),
+            ProgramStageInstance programStageInstance = context.getProgramStageInstance( event.getEvent() );
+            TrackedEntityInstance entityInstance = programStageInstance.getProgramInstance().getEntityInstance();
+            validateUpdateAndDeleteEvent( reporter, event, programStageInstance,
+                programStageInstance.getAttributeOptionCombo(),
+                programStageInstance.getProgramStage(),
+                entityInstance == null ? null : entityInstance.getUid(),
+                programStageInstance.getOrganisationUnit() );
+        }
+        else
+        {
+            validateCreateEvent( reporter, user,
                 categoryOptionCombo,
                 programStage,
                 teiUid,
-                organisationUnit );
+                organisationUnit,
+                program, event.isCreatableInSearchScope() );
         }
-
-        validateCreateEvent( reporter, user,
-            categoryOptionCombo,
-            programStage,
-            teiUid,
-            organisationUnit,
-            program, event.isCreatableInSearchScope() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
@@ -260,10 +260,7 @@ public class PreCheckOwnershipValidationHook
             ProgramStageInstance programStageInstance = context.getProgramStageInstance( event.getEvent() );
             TrackedEntityInstance entityInstance = programStageInstance.getProgramInstance().getEntityInstance();
             validateUpdateAndDeleteEvent( reporter, event, programStageInstance,
-                programStageInstance.getAttributeOptionCombo(),
-                programStageInstance.getProgramStage(),
-                entityInstance == null ? null : entityInstance.getUid(),
-                programStageInstance.getOrganisationUnit() );
+                entityInstance == null ? null : entityInstance.getUid() );
         }
         else
         {
@@ -302,8 +299,7 @@ public class PreCheckOwnershipValidationHook
 
     protected void validateUpdateAndDeleteEvent( ValidationErrorReporter reporter, Event event,
         ProgramStageInstance programStageInstance,
-        CategoryOptionCombo categoryOptionCombo, ProgramStage programStage,
-        String teiUid, OrganisationUnit organisationUnit )
+        String teiUid )
     {
         TrackerImportStrategy strategy = reporter.getValidationContext().getStrategy( event );
         User user = reporter.getValidationContext().getBundle().getUser();
@@ -312,8 +308,9 @@ public class PreCheckOwnershipValidationHook
         checkNotNull( programStageInstance, PROGRAM_INSTANCE_CANT_BE_NULL );
         checkNotNull( event, EVENT_CANT_BE_NULL );
 
-        trackerImportAccessManager.checkEventWriteAccess( reporter, programStage, organisationUnit, categoryOptionCombo,
-            teiUid, programStageInstance.isCreatableInSearchScope() );
+        trackerImportAccessManager.checkEventWriteAccess( reporter, programStageInstance.getProgramStage(),
+            programStageInstance.getOrganisationUnit(), programStageInstance.getAttributeOptionCombo(), teiUid,
+            programStageInstance.isCreatableInSearchScope() );
 
         if ( strategy.isUpdate()
             && EventStatus.COMPLETED == programStageInstance.getStatus()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckOwnershipValidationHook.java
@@ -209,7 +209,7 @@ public class PreCheckOwnershipValidationHook
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( event.getOrgUnit() );
         ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
-        Program program = programStage.getProgram();
+        Program program = context.getProgram( event.getProgram() );
         ProgramInstance programInstance = context.getProgramInstance( event.getEnrollment() );
 
         String teiUid = null;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -60,6 +60,7 @@ public class RepeatedEventsValidationHook
         Map<Pair<String, String>, List<Event>> eventsByEnrollmentAndNotRepeatableProgramStage = bundle.getEvents()
             .stream()
             .filter( e -> !rootReporter.isInvalid( e ) )
+            .filter( e -> !context.getStrategy( e ).isDelete() )
             .filter( e -> {
                 ProgramStage programStage = context.getProgramStage( e.getProgramStage() );
                 return programStage.getProgram().isRegistration() && !programStage.getRepeatable();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -83,6 +83,7 @@ public class EventTrackerConverterServiceTest
         programStage.setProgram( program );
 
         when( preheat.get( ProgramStage.class, programStage.getUid() ) ).thenReturn( programStage );
+        when( preheat.get( Program.class, program.getUid() ) ).thenReturn( program );
         when( preheat.get( OrganisationUnit.class, organisationUnit.getUid() ) ).thenReturn( organisationUnit );
     }
 
@@ -91,6 +92,7 @@ public class EventTrackerConverterServiceTest
     {
         Event event = new Event();
         event.setProgramStage( PROGRAM_STAGE_UID );
+        event.setProgram( PROGRAM_UID );
         event.setOrgUnit( ORGANISATION_UNIT_UID );
 
         ProgramStageInstance programStageInstance = trackerConverterService.from( preheat, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -325,6 +325,9 @@ public class EventSecurityImportValidationTest
         user.addOrganisationUnit( organisationUnitA );
         manager.update( user );
 
+        manager.flush();
+        manager.clear();
+
         trackerBundleParams.setUserId( user.getUid() );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.UPDATE );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -68,10 +68,6 @@ import com.google.common.collect.Sets;
 public class EventDateValidationHookTest
     extends DhisConvenienceTest
 {
-    private static final String PROGRAM_STAGE_WITH_REGISTRATION_ID = "ProgramStageWithRegistration";
-
-    private static final String PROGRAM_STAGE_WITHOUT_REGISTRATION_ID = "ProgramStageWithoutRegistration";
-
     private static final String PROGRAM_WITH_REGISTRATION_ID = "ProgramWithRegistration";
 
     private static final String PROGRAM_WITHOUT_REGISTRATION_ID = "ProgramWithoutRegistration";
@@ -95,11 +91,11 @@ public class EventDateValidationHookTest
 
         when( validationContext.getBundle() ).thenReturn( bundle );
 
-        when( validationContext.getProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID ) )
-            .thenReturn( getProgramStageWithRegistration() );
+        when( validationContext.getProgram( PROGRAM_WITH_REGISTRATION_ID ) )
+            .thenReturn( getProgramWithRegistration() );
 
-        when( validationContext.getProgramStage( PROGRAM_STAGE_WITHOUT_REGISTRATION_ID ) )
-            .thenReturn( getProgramStageWithoutRegistration() );
+        when( validationContext.getProgram( PROGRAM_WITHOUT_REGISTRATION_ID ) )
+            .thenReturn( getProgramWithoutRegistration() );
     }
 
     @Test
@@ -107,7 +103,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITHOUT_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITHOUT_REGISTRATION_ID );
         event.setOccurredAt( now() );
         event.setStatus( EventStatus.ACTIVE );
 
@@ -129,7 +125,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITHOUT_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITHOUT_REGISTRATION_ID );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
 
@@ -147,7 +143,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setStatus( EventStatus.ACTIVE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
@@ -165,7 +161,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setStatus( EventStatus.COMPLETED );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
@@ -183,7 +179,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( Instant.now() );
         event.setStatus( EventStatus.SCHEDULE );
 
@@ -202,7 +198,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( now() );
         event.setStatus( EventStatus.COMPLETED );
 
@@ -221,7 +217,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( now() );
         event.setCompletedAt( sevenDaysAgo() );
         event.setStatus( EventStatus.COMPLETED );
@@ -241,7 +237,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( null );
         event.setScheduledAt( null );
         event.setStatus( EventStatus.SKIPPED );
@@ -261,7 +257,7 @@ public class EventDateValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION_ID );
+        event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( sevenDaysAgo() );
         event.setStatus( EventStatus.ACTIVE );
 
@@ -273,22 +269,6 @@ public class EventDateValidationHookTest
         // then
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1047 ) );
-    }
-
-    private ProgramStage getProgramStageWithRegistration()
-    {
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( PROGRAM_STAGE_WITH_REGISTRATION_ID );
-        programStage.setProgram( getProgramWithRegistration() );
-        return programStage;
-    }
-
-    private ProgramStage getProgramStageWithoutRegistration()
-    {
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( PROGRAM_STAGE_WITHOUT_REGISTRATION_ID );
-        programStage.setProgram( getProgramWithoutRegistration() );
-        return programStage;
     }
 
     private Program getProgramWithRegistration()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
@@ -109,6 +110,7 @@ public class RepeatedEventsValidationHookTest
     {
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ) );
         bundle.setEvents( events );
+        events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 
         ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
 
@@ -120,6 +122,7 @@ public class RepeatedEventsValidationHookTest
     {
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ), notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
+        events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 
         ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
 
@@ -139,6 +142,7 @@ public class RepeatedEventsValidationHookTest
     {
         List<Event> events = Lists.newArrayList( repeatableEvent( "A" ), repeatableEvent( "B" ) );
         bundle.setEvents( events );
+        events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 
         ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
 
@@ -152,6 +156,7 @@ public class RepeatedEventsValidationHookTest
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
         ctx.getRootReporter().getInvalidDTOs().put( TrackerType.EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
         bundle.setEvents( events );
+        events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 
         ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
 
@@ -166,6 +171,7 @@ public class RepeatedEventsValidationHookTest
         eventEnrollmentB.setEnrollment( ENROLLMENT_B );
         List<Event> events = Lists.newArrayList( eventEnrollmentA, eventEnrollmentB );
         bundle.setEvents( events );
+        events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 
         ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
 
@@ -179,6 +185,7 @@ public class RepeatedEventsValidationHookTest
         Event eventProgramB = programEvent( "B" );
         List<Event> events = Lists.newArrayList( eventProgramA, eventProgramB );
         bundle.setEvents( events );
+        events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 
         ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
 


### PR DESCRIPTION
- Fix program stage instance preheat as it was not loading the list of program stages
- Fix dependencies in DELETE strategy for events. All parameters can be loaded through preheat, there is no need to get the values from the paylaod
- Add new e2e-test to check that missing program stage is extracted from program when it is of type WITHOUT_REGISTRATION