### PR TITLE
fix: remove unused code in SpringDataValueSetStore

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
@@ -38,8 +38,6 @@ import java.io.Writer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,7 +47,6 @@ import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.datavalue.DataExportParams;
 import org.hisp.dhis.dxf2.datavalue.DataValue;
-import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.query.JpaQueryUtils;
@@ -382,20 +379,6 @@ public class SpringDataValueSetStore
      */
     private String getAttributeOptionComboClause( User user )
     {
-        List<String> groupsIds = user.getGroups().stream().map( g -> g.getUid() )
-            .collect( Collectors.toList() );
-
-        String groupAccessCheck = groupsIds.size() > 0
-            ? " or ( " + JsonbFunctions.HAS_USER_GROUP_IDS + "( co.sharing, '{" + String.join( ",", groupsIds )
-                + "}' ) = true " +
-                "and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( co.sharing, '__r%', '{"
-                + String.join( ",", groupsIds ) + "}' ) = true ) )"
-            : "";
-
-        String userAccessCheck = " or ( " + JsonbFunctions.HAS_USER_ID + "( co.sharing, '" + user.getUid()
-            + "' ) = true " +
-            " and " + JsonbFunctions.CHECK_USER_ACCESS + "( co.sharing, '__r%', '" + user.getUid() + "' ) = true ) )";
-
         return "and dv.attributeoptioncomboid not in (" +
             "select distinct(cocco.categoryoptioncomboid) " +
             "from categoryoptioncombos_categoryoptions as cocco " +


### PR DESCRIPTION
Remove unused variables `groupAccessCheck`, `userAccessCheck` 
Those are replaced by `JpaQueryUtils.generateSQlQueryForSharingCheck` method