### PR TITLE
fix: skip sharing validation when skipSharing=true

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/SecurityCheck.java
@@ -128,12 +128,16 @@ public class SecurityCheck implements ObjectValidationCheck
                 }
             }
 
-            List<ErrorReport> sharingErrorReports = ctx.getAclService().verifySharing( object, bundle.getUser() );
-            if ( !sharingErrorReports.isEmpty() )
+            if ( !bundle.isSkipSharing() )
             {
-                addReports.accept( createObjectReport( sharingErrorReports, object, bundle ) );
-                ctx.markForRemoval( object );
+                List<ErrorReport> sharingErrorReports = ctx.getAclService().verifySharing( object, bundle.getUser() );
+                if ( !sharingErrorReports.isEmpty() )
+                {
+                    addReports.accept( createObjectReport( sharingErrorReports, object, bundle ) );
+                    ctx.markForRemoval( object );
+                }
             }
+
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -37,6 +37,8 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +52,7 @@ import org.apache.commons.collections4.*;
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.*;
+import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dataset.Section;
@@ -73,9 +76,13 @@ import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.render.type.SectionRenderingObject;
 import org.hisp.dhis.render.type.SectionRenderingType;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.sharing.Sharing;
+import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.visualization.Visualization;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,6 +123,9 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
 
     @Autowired
     private NodeService nodeService;
+
+    @Autowired
+    private AclService aclService;
 
     @Override
     protected void setUpTest()
@@ -221,6 +231,94 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
             new ClassPathResource( "dxf2/dataset_with_accesses_update.json" ).getInputStream(), RenderFormat.JSON );
 
         params = createParams( ImportStrategy.UPDATE, metadata );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+    }
+
+    /**
+     * User only have READ access to Dashboard object User try to update
+     * Dashboard with: skipSharing=true, and payload doesn't include sharing
+     * data. Expected: import error
+     */
+    @Test
+    public void testImportWithSkipSharingIsTrueAndNoPermission()
+    {
+        User userA = createUser( "A" );
+        userService.addUser( userA );
+
+        Dashboard dashboard = new Dashboard();
+        dashboard.setName( "DashboardA" );
+
+        Sharing sharing = new Sharing();
+        sharing.addUserAccess( new UserAccess( userA, AccessStringHelper.READ ) );
+        dashboard.setSharing( sharing );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = new HashMap<>();
+        metadata.put( Dashboard.class, Collections.singletonList( dashboard ) );
+        MetadataImportParams params = createParams( ImportStrategy.CREATE, metadata );
+        params.setSkipSharing( false );
+
+        // Create Dashboard
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        // Check sharing data
+        IdentifiableObject savedDashboard = manager.get( Dashboard.class, dashboard.getUid() );
+        assertFalse( aclService.canWrite( userA, savedDashboard ) );
+        assertTrue( aclService.canRead( userA, savedDashboard ) );
+
+        // Update dashboard with skipSharing=true and no sharing data in payload
+        dashboard.setSharing( null );
+        metadata.put( Dashboard.class, Collections.singletonList( dashboard ) );
+        params = createParams( ImportStrategy.UPDATE, metadata );
+        params.setSkipSharing( true );
+        params.setUser( userA );
+
+        report = importService.importMetadata( params );
+        assertEquals( Status.ERROR, report.getStatus() );
+    }
+
+    /**
+     * User have READ-WRITE access to Dashboard object User try to update
+     * Dashboard with: skipSharing=true, and payload doesn't include sharing
+     * data. Expected: import successfully
+     */
+    @Test
+    public void testImportWithSkipSharingIsTrueAndWritePermission()
+    {
+        User userA = createUser( 'A' );
+        userService.addUser( userA );
+
+        Dashboard dashboard = new Dashboard();
+        dashboard.setName( "DashboardA" );
+
+        Sharing sharing = new Sharing();
+        sharing.setPublicAccess( AccessStringHelper.DEFAULT );
+        sharing.addUserAccess( new UserAccess( userA, AccessStringHelper.READ_WRITE ) );
+        dashboard.setSharing( sharing );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = new HashMap<>();
+        metadata.put( Dashboard.class, Collections.singletonList( dashboard ) );
+        MetadataImportParams params = createParams( ImportStrategy.CREATE, metadata );
+        params.setSkipSharing( false );
+
+        // Create Dashboard
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        // Check all sharing data
+        IdentifiableObject savedDashboard = manager.get( Dashboard.class, dashboard.getUid() );
+        assertTrue( aclService.canWrite( userA, savedDashboard ) );
+        assertTrue( aclService.canRead( userA, savedDashboard ) );
+
+        // Update Dashboard with skipSharing=true and no sharing data in payload
+        dashboard.setSharing( null );
+        metadata.put( Dashboard.class, Collections.singletonList( dashboard ) );
+
+        params = createParams( ImportStrategy.UPDATE, metadata );
+        params.setSkipSharing( true );
+        params.setUser( userA );
 
         report = importService.importMetadata( params );
         assertEquals( Status.OK, report.getStatus() );


### PR DESCRIPTION
Issue: 
- Import with `skipSharing=true` and no sharing data in payload will return error even though user has write permission.
- There are two sharing checks in importService: 
  1)  sharing check for persistedObject ( `SecurityCheck` line 96 )
  2) sharing check  for the importing payload's sharing data
- The issue caused by (ii) even if `skipSharing=true`, so if payload doesn't include sharing data, the check will return false.

Fix: 
- Skip sharing check (ii) if `skipSharing=true` , only check for `persistedObject`
- Added integration tests for the fix.

