### PR TITLE
fix: program rule variable name check now also check UID to prevent duplicates [DHIS2-11330]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -137,7 +137,32 @@ public class ProgramRuleVariableObjectBundleHookTest
         when( programRuleVariable.getUid() ).thenReturn( "uid1" );
 
         List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
-            objectBundle );
+                objectBundle );
+
+        assertEquals( 0, errorReports.size() );
+    }
+
+    @Test
+    public void shouldNotFailUpdateExistingMoreThanOneSameUid()
+    {
+        when( programRuleVariable.getProgram() ).thenReturn( program );
+        when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
+
+        ProgramRuleVariable existingProgramRuleVariable = new ProgramRuleVariable();
+        existingProgramRuleVariable.setName( "word" );
+        existingProgramRuleVariable.setUid( "uid1" );
+
+        ProgramRuleVariable anotherExistingProgramRuleVariable = new ProgramRuleVariable();
+        anotherExistingProgramRuleVariable.setName( "word" );
+        anotherExistingProgramRuleVariable.setUid( "uid2" );
+
+        when( query.getResultList() ).thenReturn( List.of( existingProgramRuleVariable, anotherExistingProgramRuleVariable ) );
+
+        when( programRuleVariable.getName() ).thenReturn( "word" );
+        when( programRuleVariable.getUid() ).thenReturn( "uid1" );
+
+        List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
+                objectBundle );
 
         assertEquals( 0, errorReports.size() );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -137,7 +137,7 @@ public class ProgramRuleVariableObjectBundleHookTest
         when( programRuleVariable.getUid() ).thenReturn( "uid1" );
 
         List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
-                objectBundle );
+            objectBundle );
 
         assertEquals( 0, errorReports.size() );
     }
@@ -156,13 +156,14 @@ public class ProgramRuleVariableObjectBundleHookTest
         anotherExistingProgramRuleVariable.setName( "word" );
         anotherExistingProgramRuleVariable.setUid( "uid2" );
 
-        when( query.getResultList() ).thenReturn( List.of( existingProgramRuleVariable, anotherExistingProgramRuleVariable ) );
+        when( query.getResultList() )
+            .thenReturn( List.of( existingProgramRuleVariable, anotherExistingProgramRuleVariable ) );
 
         when( programRuleVariable.getName() ).thenReturn( "word" );
         when( programRuleVariable.getUid() ).thenReturn( "uid1" );
 
         List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
-                objectBundle );
+            objectBundle );
 
         assertEquals( 0, errorReports.size() );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.*;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -57,6 +56,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * @author Luca Cambi

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -108,7 +108,7 @@ public class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldFailValidationInvalidCount()
+    public void shouldFailInsertAlreadyExisting()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE );
@@ -122,16 +122,46 @@ public class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldNotFailValidationInvalidCount()
+    public void shouldNotFailUpdateExistingSameUid()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
-        when( query.getResultList() ).thenReturn( Collections.singletonList( new ProgramRuleVariable() ) );
+
+        ProgramRuleVariable existingProgramRuleVariable = new ProgramRuleVariable();
+        existingProgramRuleVariable.setName( "word" );
+        existingProgramRuleVariable.setUid( "uid1" );
+
+        when( query.getResultList() ).thenReturn( Collections.singletonList( existingProgramRuleVariable ) );
 
         when( programRuleVariable.getName() ).thenReturn( "word" );
+        when( programRuleVariable.getUid() ).thenReturn( "uid1" );
+
         List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
             objectBundle );
+
         assertEquals( 0, errorReports.size() );
+    }
+
+    @Test
+    public void shouldFailUpdateExistingDifferentUid()
+    {
+        when( programRuleVariable.getProgram() ).thenReturn( program );
+        when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
+
+        ProgramRuleVariable existingProgramRuleVariable = new ProgramRuleVariable();
+        existingProgramRuleVariable.setName( "word" );
+        existingProgramRuleVariable.setUid( "uid1" );
+
+        when( query.getResultList() ).thenReturn( Collections.singletonList( existingProgramRuleVariable ) );
+
+        when( programRuleVariable.getName() ).thenReturn( "word" );
+        when( programRuleVariable.getUid() ).thenReturn( "uid2" );
+
+        List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
+            objectBundle );
+
+        assertEquals( 1, errorReports.size() );
+        assertTrue( errorReports.stream().anyMatch( e -> e.getErrorCode().equals( E4051 ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.*;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -157,7 +158,7 @@ public class ProgramRuleVariableObjectBundleHookTest
         anotherExistingProgramRuleVariable.setUid( "uid2" );
 
         when( query.getResultList() )
-            .thenReturn( List.of( existingProgramRuleVariable, anotherExistingProgramRuleVariable ) );
+            .thenReturn( ImmutableList.of( existingProgramRuleVariable, anotherExistingProgramRuleVariable ) );
 
         when( programRuleVariable.getName() ).thenReturn( "word" );
         when( programRuleVariable.getUid() ).thenReturn( "uid1" );


### PR DESCRIPTION
The case that was not covered in the previous implementation was:

- existing PRV with same name/program
- object to update had a different UID (generated)
 
in this case, the check was failing, allowing PRV to be duplicated.

With the current implementation, in case of updates, also UIDs are checked.