### PR TITLE
fix: added more importModes to program rule variable names validator …

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHook.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.dxf2.Constants.PROGRAM_RULE_VARIABLE_NAME_INVALID_KE
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -49,6 +50,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Zubair Asghar.
@@ -64,6 +66,12 @@ public class ProgramRuleVariableObjectBundleHook extends AbstractObjectBundleHoo
         .put( ProgramRuleVariableSourceType.DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE, this::processDataElementWithStage )
         .put( ProgramRuleVariableSourceType.TEI_ATTRIBUTE, this::processTEA )
         .build();
+
+    private static final Set<ImportStrategy> UPDATE_STRATEGIES = ImmutableSet.of(
+        ImportStrategy.UPDATE,
+        ImportStrategy.CREATE_AND_UPDATE,
+        ImportStrategy.NEW_AND_UPDATES,
+        ImportStrategy.UPDATES );
 
     private static final String FROM_PROGRAM_RULE_VARIABLE = " from ProgramRuleVariable prv where prv.name = :name and prv.program.uid = :programUid";
 
@@ -103,7 +111,7 @@ public class ProgramRuleVariableObjectBundleHook extends AbstractObjectBundleHoo
     {
         Query<ProgramRuleVariable> query = getProgramRuleVariableQuery( programRuleVariable );
 
-        int allowedCount = bundle.getImportMode() == ImportStrategy.UPDATE ? 1 : 0;
+        int allowedCount = UPDATE_STRATEGIES.contains( bundle.getImportMode() ) ? 1 : 0;
 
         if ( query.getResultList().size() > allowedCount )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -122,6 +122,19 @@ public class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
+    public void shouldNotFailValidationInvalidCount()
+    {
+        when( programRuleVariable.getProgram() ).thenReturn( program );
+        when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
+        when( query.getResultList() ).thenReturn( Collections.singletonList( new ProgramRuleVariable() ) );
+
+        when( programRuleVariable.getName() ).thenReturn( "word" );
+        List<ErrorReport> errorReports = programRuleVariableObjectBundleHook.validate( programRuleVariable,
+            objectBundle );
+        assertEquals( 0, errorReports.size() );
+    }
+
+    @Test
     public void shouldFailValidationInvalidCountAndInvalidName()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );


### PR DESCRIPTION
…[DHIS2-11273] (#8155) (#8176)

* fix: added more importModes to program rule variable names validator

* tests: added a specific test case

* style: fix sonarcloud warning

* style: changed List for Set for better performances

(cherry picked from commit a752e320d157c9741892d30b70918700d9f5b3fa)

Co-authored-by: Lars Helge Øverland <lars@dhis2.org>
(cherry picked from commit d4d2242a57490d3bb7c1f4472d4dbfe709e10763)