### PR TITLE
fix: Data Import COC IdScheme ATTRIBUTE DHIS2-9313

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.hisp.dhis.association.IdentifiableObjectAssociations;
-import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
@@ -385,16 +385,6 @@ public interface CategoryService
         Set<CategoryOption> categoryOptions );
 
     /**
-     * Retrieves the CategoryOptionCombo with the given uid and
-     * {@link IdentifiableProperty}.
-     *
-     * @param id the id of the CategoryOptionCombo.
-     * @param property the type of id to use
-     * @return the CategoryOptionCombo.
-     */
-    CategoryOptionCombo getCategoryOptionCombo( IdentifiableProperty property, String id );
-
-    /**
      * Retrieves all CategoryOptionCombos.
      *
      * @return a list of CategoryOptionCombos.
@@ -443,11 +433,11 @@ public interface CategoryService
      * control by only returning objects which the current user has
      * {@code data write} access to.
      *
-     * @param property the property.
+     * @param idScheme the id scheme.
      * @param id the id.
      * @return a category option combo.
      */
-    CategoryOptionCombo getCategoryOptionComboAcl( IdentifiableProperty property, String id );
+    CategoryOptionCombo getCategoryOptionComboAcl( IdScheme idScheme, String id );
 
     /**
      * Updates the name property of all category option combinations.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java
@@ -52,8 +52,8 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.category.CategoryStore;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.DeleteNotAllowedException;
+import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.program.jdbc.JdbcOrgUnitAssociationsStore;
@@ -481,12 +481,6 @@ public class DefaultCategoryService
     }
 
     @Override
-    public CategoryOptionCombo getCategoryOptionCombo( IdentifiableProperty property, String id )
-    {
-        return idObjectManager.getObject( CategoryOptionCombo.class, property, id );
-    }
-
-    @Override
     @Transactional( readOnly = true )
     public List<CategoryOptionCombo> getAllCategoryOptionCombos()
     {
@@ -643,9 +637,9 @@ public class DefaultCategoryService
 
     @Override
     @Transactional( readOnly = true )
-    public CategoryOptionCombo getCategoryOptionComboAcl( IdentifiableProperty property, String id )
+    public CategoryOptionCombo getCategoryOptionComboAcl( IdScheme idScheme, String id )
     {
-        CategoryOptionCombo coc = idObjectManager.getObject( CategoryOptionCombo.class, property, id );
+        CategoryOptionCombo coc = idObjectManager.getObject( CategoryOptionCombo.class, idScheme, id );
 
         if ( coc != null )
         {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/callable/CategoryOptionComboAclCallable.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/callable/CategoryOptionComboAclCallable.java
@@ -54,7 +54,7 @@ public class CategoryOptionComboAclCallable
     public CategoryOptionCombo call()
         throws ExecutionException
     {
-        return categoryService.getCategoryOptionComboAcl( idScheme.getIdentifiableProperty(), id );
+        return categoryService.getCategoryOptionComboAcl( idScheme, id );
     }
 
     @Override


### PR DESCRIPTION
As I was writing the [DHIS2-9313](https://jira.dhis2.org/browse/DHIS2-9313) documentation for PR [fix: Standardize ADX export parameters](https://github.com/dhis2/dhis2-core/pull/8170), I realized that I should also test ADX export and import for idScheme=attribute. I did, and export worked fine, but import failed when `CategoryOptionCombo` had _idScheme=attribute_.

This is because `DefaultCategoryService.getCategoryOptionComboAcl` was fetching the COC by `IdentifiableProperty` instead of `IdScheme`, so it worked fine for URL, CODE, and NAME, but not for ATTRIBUTE. Changing it to `IdScheme` fixed everything. This was also presumably an existing problem with the other data import formats.

I also removed `CategoryService.getCategoryOptionCombo( IdentifiableProperty property, String id )` since it was no longer used anywhere.