### PR TITLE
fix: Gist API pluck without argument

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -117,11 +117,10 @@ final class GistValidator
                     "Property `%s` computes to many values and therefore cannot be used as a field." );
             }
         }
-        if ( f.getTransformation() == Transform.PLUCK )
+        if ( f.getTransformation() == Transform.PLUCK && f.getTransformationArgument() != null )
         {
             String pluckedField = f.getTransformationArgument();
-            Property plucked = context.switchedTo( getBaseType( field ) )
-                .resolveMandatory( pluckedField );
+            Property plucked = context.switchedTo( getBaseType( field ) ).resolveMandatory( pluckedField );
             if ( !plucked.isPersisted() )
             {
                 throw createIllegalProperty( plucked,

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistTransformControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistTransformControllerTest.java
@@ -77,6 +77,16 @@ public class GistTransformControllerTest extends AbstractGistControllerTest
     }
 
     @Test
+    public void testTransform_Pluck_NoArgument()
+    {
+        JsonObject gist = GET( "/users/{uid}/userGroups/gist?fields=name,users::pluck", getSuperuserUid() ).content();
+
+        assertHasPager( gist, 1, 50 );
+        assertEquals( getSuperuserUid(),
+            gist.getArray( "userGroups" ).getObject( 0 ).getArray( "users" ).getString( 0 ).string() );
+    }
+
+    @Test
     public void testTransform_Member()
     {
         String url = "/users/{uid}/userGroups/gist?fields=name,users::member({uid})";


### PR DESCRIPTION
Just a small fix for a small issue I noticed during testing. The latest improvements to the validator had introduced a bug causing an NPE when using the `pluck` transformation without an argument (which should pluck the ID).
This PR takes care of it and adds a test to make sure this does not break again.