### PR TITLE
fix: More common export options for ADX DHIS2-9313

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/AdxDataService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/AdxDataService.java
@@ -82,8 +82,9 @@ public interface AdxDataService
     // --------------------------------------------------------------------------
 
     DataExportParams getFromUrl( Set<String> dataSets, Set<String> periods, Date startDate, Date endDate,
-        Set<String> organisationUnits, boolean includeChildren, boolean includeDeleted, Date lastUpdated, Integer limit,
-        IdSchemes outputIdSchemes );
+        Set<String> organisationUnits, boolean includeChildren, Set<String> organisationUnitGroups,
+        Set<String> attributeOptionCombos, boolean includeDeleted, Date lastUpdated, String lastUpdatedDuration,
+        Integer limit, IdSchemes outputIdSchemes );
 
     /**
      * Post data. Takes ADX Data from input stream and saves a series of DXF2
@@ -101,9 +102,8 @@ public interface AdxDataService
     /**
      * Get data. Writes adx export data to output stream.
      *
-     * @param in the InputStream.
-     * @param importOptions the importOptions.
-     * @param id the task id, can be null.
+     * @param params the data export params.
+     * @param out the output stream to write to.
      *
      * @return an ImportSummaries collection of ImportSummary for each
      *         DataValueSet.
@@ -111,5 +111,4 @@ public interface AdxDataService
      */
     void writeDataValueSet( DataExportParams params, OutputStream out )
         throws AdxException;
-
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.DhisTest;
@@ -57,6 +58,8 @@ import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
 import org.hisp.dhis.mock.MockCurrentUserService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
@@ -94,6 +97,9 @@ public class AdxDataServiceIntegrationTest
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
+
+    @Autowired
+    private OrganisationUnitGroupService organisationUnitGroupService;
 
     @Autowired
     private UserService _userService;
@@ -151,6 +157,8 @@ public class AdxDataServiceIntegrationTest
     private OrganisationUnit ouA;
 
     private OrganisationUnit ouB;
+
+    private OrganisationUnitGroup ougA;
 
     private User user;
 
@@ -353,6 +361,15 @@ public class AdxDataServiceIntegrationTest
         idObjectManager.save( ouA );
         idObjectManager.save( ouB );
 
+        // Organisation Unit Group
+
+        ougA = createOrganisationUnitGroup( 'A' );
+
+        ougA.addOrganisationUnit( ouA );
+        ougA.addOrganisationUnit( ouB );
+
+        organisationUnitGroupService.addOrganisationUnitGroup( ougA );
+
         // User & Current User Service
 
         user = createAndInjectAdminUser();
@@ -390,8 +407,11 @@ public class AdxDataServiceIntegrationTest
             null,
             Sets.newHashSet( ouA.getUid() ),
             true,
+            null,
+            null,
             false,
             now,
+            null,
             999,
             new IdSchemes() );
 
@@ -408,7 +428,10 @@ public class AdxDataServiceIntegrationTest
             .setDataSets( Sets.newHashSet( dsB ) )
             .setStartDate( then )
             .setEndDate( now )
+            .setLastUpdatedDuration( "10d" )
             .setOrganisationUnits( Sets.newHashSet( ouB ) )
+            .setOrganisationUnitGroups( Sets.newHashSet( ougA ) )
+            .setAttributeOptionCombos( Sets.newHashSet( cocMcDonalds ) )
             .setIncludeChildren( false )
             .setIncludeDeleted( true )
             .setLastUpdated( now )
@@ -421,8 +444,11 @@ public class AdxDataServiceIntegrationTest
             now,
             Sets.newHashSet( ouB.getCode() ),
             false,
+            Sets.newHashSet( ougA.getCode() ),
+            Sets.newHashSet( cocMcDonalds.getUid() ),
             true,
             now,
+            "10d",
             null,
             new IdSchemes().setIdScheme( "UID" ) );
 
@@ -457,7 +483,8 @@ public class AdxDataServiceIntegrationTest
                 .setDataSetIdScheme( "NAME" )
                 .setOrgUnitIdScheme( "UID" )
                 .setDataElementIdScheme( "UID" )
-                .setCategoryOptionComboIdScheme( "NAME" ) ) );
+                .setCategoryOptionComboIdScheme( "NAME" ) )
+            .setOrganisationUnitGroups( Sets.newHashSet( ougA ) ) );
     }
 
     @Test
@@ -473,6 +500,22 @@ public class AdxDataServiceIntegrationTest
                 .setCategoryIdScheme( "UID" )
                 .setCategoryOptionIdScheme( "NAME" ) )
             .setIncludeChildren( true ) );
+    }
+
+    @Test
+    public void testWriteDataValueSetD()
+        throws AdxException,
+        IOException
+    {
+        testExport( "adx/exportD.adx.xml", getCommonExportParams()
+            .setOutputIdSchemes( new IdSchemes()
+                .setDefaultIdScheme( CODE )
+                .setDataSetIdScheme( "UID" )
+                .setOrgUnitIdScheme( "NAME" )
+                .setCategoryIdScheme( "UID" )
+                .setCategoryOptionIdScheme( "NAME" ) )
+            .setIncludeChildren( true )
+            .setAttributeOptionCombos( Sets.newHashSet( cocMcDonalds ) ) );
     }
 
     // --------------------------------------------------------------------------
@@ -524,7 +567,7 @@ public class AdxDataServiceIntegrationTest
         return new DataExportParams()
             .setOrganisationUnits( Sets.newHashSet( ouA ) )
             .setPeriods( Sets.newHashSet( pe202001, pe202002 ) )
-            .setDataSets( Sets.newHashSet( dsA ) );
+            .setDataSets( Sets.newHashSet( dsA, dsB ) );
     }
 
     private void testExport( String filePath, DataExportParams params )
@@ -533,7 +576,8 @@ public class AdxDataServiceIntegrationTest
     {
         dataValueService.addDataValue( new DataValue( deA, pe202001, ouA, cocFUnder5, cocDefault, "1" ) );
         dataValueService.addDataValue( new DataValue( deB, pe202002, ouA, cocDefault, cocDefault, "Some text" ) );
-        dataValueService.addDataValue( new DataValue( deA, pe202001, ouB, cocFUnder5, cocDefault, "2" ) );
+        dataValueService.addDataValue( new DataValue( deA, pe202001, ouB, cocMOver5, cocMcDonalds, "2" ) );
+        dataValueService.addDataValue( new DataValue( deA, pe202001, ouB, cocFOver5, cocPepfar, "3" ) );
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -546,7 +590,13 @@ public class AdxDataServiceIntegrationTest
         String expected = new BufferedReader( new InputStreamReader( expectedStream ) )
             .lines().map( String::trim ).collect( Collectors.joining() );
 
-        assertEquals( expected, result );
+        assertEquals( adxGroups( expected ), adxGroups( result ) );
+    }
+
+    // The adx groups could be in any order, but each contains only one value
+    private Set<String> adxGroups( String adx )
+    {
+        return Sets.newHashSet( adx.split( "</*group" ) );
     }
 
     private void testImport( String filePath, IdSchemes idSchemes )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/adx/exportB.adx.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/adx/exportB.adx.xml
@@ -7,4 +7,10 @@
             <annotation>Some text</annotation>
         </dataValue>
     </group>
+    <group dataSet="Malaria Mechanism DS" period="2020-01-01/P1M" orgUnit="D4566666666" mechanism="McDonalds">
+        <dataValue dataElement="MalNummmmmm" sex="M" age="over5" value="2"/>
+    </group>
+    <group dataSet="Malaria Mechanism DS" period="2020-01-01/P1M" orgUnit="D4566666666" mechanism="PEPFAR">
+        <dataValue dataElement="MalNummmmmm" sex="F" age="over5" value="3"/>
+    </group>
 </adx>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/adx/exportC.adx.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/adx/exportC.adx.xml
@@ -7,7 +7,10 @@
             <annotation>Some text</annotation>
         </dataValue>
     </group>
-    <group dataSet="MalariaDSSS" period="2020-01-01/P1M" orgUnit="District Hospital">
-        <dataValue dataElement="Mal_num" ageeeeeeeee="Under 5" sexxxxxxxxx="Female" value="2"/>
+    <group dataSet="MalariaMech" period="2020-01-01/P1M" orgUnit="District Hospital" mechanismmm="McDonalds mechanism">
+        <dataValue dataElement="Mal_num" ageeeeeeeee="Over 5" sexxxxxxxxx="Male" value="2"/>
+    </group>
+    <group dataSet="MalariaMech" period="2020-01-01/P1M" orgUnit="District Hospital" mechanismmm="PEPFAR mechanism">
+        <dataValue dataElement="Mal_num" ageeeeeeeee="Over 5" sexxxxxxxxx="Female" value="3"/>
     </group>
 </adx>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/adx/exportD.adx.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/adx/exportD.adx.xml
@@ -1,0 +1,5 @@
+<adx xmlns="urn:ihe:qrph:adx:2015">
+    <group dataSet="MalariaMech" period="2020-01-01/P1M" orgUnit="District Hospital" mechanismmm="McDonalds mechanism">
+        <dataValue dataElement="Mal_num" ageeeeeeeee="Over 5" sexxxxxxxxx="Male" value="2"/>
+    </group>
+</adx>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -145,10 +145,13 @@ public class DataValueSetController
         @RequestParam( required = false ) Set<String> period,
         @RequestParam( required = false ) Date startDate,
         @RequestParam( required = false ) Date endDate,
-        @RequestParam Set<String> orgUnit,
+        @RequestParam( required = false ) Set<String> orgUnit,
         @RequestParam( required = false ) boolean children,
+        @RequestParam( required = false ) Set<String> orgUnitGroup,
+        @RequestParam( required = false ) Set<String> attributeOptionCombo,
         @RequestParam( required = false ) boolean includeDeleted,
         @RequestParam( required = false ) Date lastUpdated,
+        @RequestParam( required = false ) String lastUpdatedDuration,
         @RequestParam( required = false ) Integer limit,
         @RequestParam( required = false ) String attachment,
         @RequestParam( required = false ) String compression,
@@ -159,8 +162,9 @@ public class DataValueSetController
         response.setContentType( CONTENT_TYPE_XML_ADX );
         setNoStore( response );
 
-        DataExportParams params = adxDataService.getFromUrl( dataSet, period,
-            startDate, endDate, orgUnit, children, includeDeleted, lastUpdated, limit, idSchemes );
+        DataExportParams params = adxDataService.getFromUrl( dataSet,
+            period, startDate, endDate, orgUnit, children, orgUnitGroup, attributeOptionCombo,
+            includeDeleted, lastUpdated, lastUpdatedDuration, limit, idSchemes );
 
         OutputStream outputStream = compress( response, attachment, Compression.fromValue( compression ), "xml" );
 


### PR DESCRIPTION
While documenting [DHIS2-9313](https://jira.dhis2.org/browse/DHIS2-9313) for PR [fix: Standardize ADX export parameters](https://github.com/dhis2/dhis2-core/pull/8170), I realized that I could very easily support three more options for ADX data export that are already supported for the other export formats XML, JSON, and CSV:

- organisationUnitGroups
- attributeOptionCombos
- lastUpdatedDuration

It seemed better to add the small amount of code to support these options for ADX export than to write in the documentation that ADX does not support each of these options. :)

In fact, the only remaining export option that is supported by the other formats but not ADX is dataElementGroups, as an alternative to dataSets for selecting data elements. Since the ADX export format is based on dataSets unlike the others, this would not be practical to support. (A data element could belong to multiple data sets, and there is no single way to resolve that.)