### PR TITLE
feat: Gist API - include fields of references without endpoint [DHIS2-11323]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -70,6 +70,8 @@ import org.hisp.dhis.period.ConfigurablePeriod;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.period.RelativePeriods;
+import org.hisp.dhis.schema.annotation.Gist;
+import org.hisp.dhis.schema.annotation.Gist.Include;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension;
 import org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension;
@@ -890,6 +892,7 @@ public abstract class BaseAnalyticalObject
         this.endDate = endDate;
     }
 
+    @Gist( included = Include.FALSE )
     @JsonProperty( value = "relativePeriods" )
     @JacksonXmlProperty( localName = "relativePeriods", namespace = DxfNamespaces.DXF_2_0 )
     public RelativePeriods getRelatives()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/report/Report.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/report/Report.java
@@ -34,6 +34,8 @@ import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.common.cache.Cacheable;
 import org.hisp.dhis.period.RelativePeriods;
+import org.hisp.dhis.schema.annotation.Gist;
+import org.hisp.dhis.schema.annotation.Gist.Include;
 import org.hisp.dhis.visualization.ReportingParams;
 import org.hisp.dhis.visualization.Visualization;
 
@@ -169,6 +171,7 @@ public class Report
         this.visualization = visualization;
     }
 
+    @Gist( included = Include.FALSE )
     @JsonProperty( "relativePeriods" )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public RelativePeriods getRelatives()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -249,10 +249,10 @@ class GistPlanner
     }
 
     @SuppressWarnings( "unchecked" )
-    private boolean canRead( Schema schema, String name )
+    private boolean canRead( Schema schema, String path )
     {
         return !schema.isIdentifiableObject()
-            || access.canRead( (Class<? extends IdentifiableObject>) schema.getKlass(), name );
+            || access.canRead( (Class<? extends IdentifiableObject>) schema.getKlass(), path );
     }
 
     private List<Field> withDisplayAsTranslatedFields( List<Field> fields )

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -105,7 +105,8 @@ public class GistFieldsControllerTest extends AbstractGistControllerTest
         switchToGuestUser();
         JsonArray users = GET( "/users/gist?headless=true" ).content();
         JsonObject user0 = users.getObject( 0 );
-        assertContainsOnly( user0.node().members().keySet(), "id", "code", "surname", "firstName" );
+        assertContainsOnly( user0.node().members().keySet(), "id", "code", "surname", "firstName", "userCredentials" );
+        assertContainsOnly( user0.getObject( "userCredentials" ).node().members().keySet(), "username" );
 
         switchToSuperuser();
         users = GET( "/users/gist?headless=true" ).content();


### PR DESCRIPTION
Small PR following up on QA feedback on Gist API where users would not include fields of user credentials by default (`*` preset).
This is particular inconvinent since user credentials have no API endpoint so that gist API would not link to a gist of the user credentials. User could manually add fields of user credentials by explicitly naming their path (such as `userCredentials.username`) in the `fields` parameter list of fields. 

The solution to this is to expand field presets to the fields of referenced entities as long as those do not have an API endpoint on their own.

For users this now means users without authority by default see users as:
```json
{
	"1": {
		"id": "DXyJmlo9rge",
		"surname": "Barnes",
		"firstName": "John",
		"userCredentials": {
			"username": "android"
		}
	}
}
```
while user with authority sees it as:
```json
{
	"1": {
		"id": "DXyJmlo9rge",
		"surname": "Barnes",
		"firstName": "John",
		"email": "test@example.com",
		"lastUpdated": "2021-02-22T17:35:50.400",
		"created": "2015-03-31T13:31:09.324",
		"userCredentials": {
			"code": "android",
			"id": "M0fCOxtkURr",
			"username": "android",
			"externalAuth": false,
			"disabled": true,
			"twoFA": false,
			"invitation": false,
			"selfRegistered": false,
			"lastLogin": "2015-03-31T13:39:21.777",
			"lastUpdated": "2016-04-06T00:05:57.493",
			"passwordLastUpdated": "2015-03-31T13:31:09.206",
			"created": "2015-03-31T13:31:09.206",
			"userInfo": "DXyJmlo9rge"
		},
		"apiEndpoints": {
			"userCredentials.userInfo": "/users/DXyJmlo9rge/gist"
		}
	}
}
``` 

Users and UserCredentials is just an example. The change here is generic and applies to all types shown as gist. 
This means more information is shown for complex objects. 
In the case of classes that have fields of type `RelativePeriods` this caused wrong join whereby objects wrongly are no longer found. Since this is a special issue (which always existed) I simply excluded those fields for now.

### Automatic Testing
`SchemaBasedControllerTest` covers controllers that have gist API available which found the issue with the `RelativePeriods` fields. As it now passes again I am quite confident the change does not break endpoints fundamentally.