### PR TITLE
fix: ignore user back-reference in user credentials in gist API [DHIS2-11323]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -46,6 +46,8 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.annotation.Gist;
+import org.hisp.dhis.schema.annotation.Gist.Include;
 import org.hisp.dhis.schema.annotation.Property;
 import org.hisp.dhis.schema.annotation.Property.Access;
 import org.hisp.dhis.schema.annotation.PropertyRange;
@@ -558,6 +560,7 @@ public class UserCredentials
     /**
      * Refers to the user associated with this user credentials.
      */
+    @Gist( included = Include.FALSE )
     @JsonProperty
     @JsonSerialize( as = BaseIdentifiableObject.class )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )


### PR DESCRIPTION
Just noticed while testing myself that `userCredentials` unnecessarily has the `userInfo` back-reference to the user included in the gist. This adds the annotation to have it ignored.