### PR TITLE
feat: Group legend objects and add new SeriesKey object [DHIS2-11347]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/CompatibilityGuard.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/CompatibilityGuard.java
@@ -44,14 +44,14 @@ public class CompatibilityGuard
 
     static void keepLegendReadingCompatibility( final Visualization visualization )
     {
-        if ( visualization.getLegend() != null && visualization.getLegend().getLabel() != null )
+        if ( visualization.getSeriesKey() != null && visualization.getSeriesKey().getLabel() != null )
         {
             if ( visualization.getFontStyle() == null )
             {
                 visualization.setFontStyle( new VisualizationFontStyle() );
             }
 
-            visualization.getFontStyle().setLegend( visualization.getLegend().getLabel().getFontStyle() );
+            visualization.getFontStyle().setLegend( visualization.getSeriesKey().getLabel().getFontStyle() );
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/LegendDefinitions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/LegendDefinitions.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.visualization;
 
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 
+import java.io.Serializable;
+
 import lombok.Data;
 
 import org.hisp.dhis.legend.LegendDisplayStrategy;
@@ -46,7 +48,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  */
 @Data
 @JacksonXmlRootElement( localName = "legend", namespace = DXF_2_0 )
-public class LegendDefinitions
+public class LegendDefinitions implements Serializable
 {
     @JsonProperty( "style" )
     @JacksonXmlProperty( namespace = DXF_2_0 )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/SeriesKey.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/SeriesKey.java
@@ -29,38 +29,28 @@ package org.hisp.dhis.visualization;
 
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 
-import lombok.Data;
+import java.io.Serializable;
 
-import org.hisp.dhis.legend.LegendDisplayStrategy;
-import org.hisp.dhis.legend.LegendDisplayStyle;
-import org.hisp.dhis.legend.LegendSet;
+import lombok.Data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * This class holds the legend definitions and related attributes.
+ * This class holds the legend definitions and settings for each Visualization.
  *
  * @author maikel arabori
  */
 @Data
-@JacksonXmlRootElement( localName = "legend", namespace = DXF_2_0 )
-public class LegendDefinitions
+@JacksonXmlRootElement( localName = "seriesKey", namespace = DXF_2_0 )
+public class SeriesKey implements Serializable
 {
-    @JsonProperty( "style" )
+    @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    private LegendDisplayStyle legendDisplayStyle;
-
-    @JsonProperty( "series" )
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    private LegendSet legendSet;
-
-    @JsonProperty( "strategy" )
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    private LegendDisplayStrategy legendDisplayStrategy;
+    private StyledObject label;
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    private boolean hideKey;
+    private boolean hidden;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -79,9 +79,6 @@ import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.RegressionType;
 import org.hisp.dhis.i18n.I18nFormat;
-import org.hisp.dhis.legend.LegendDisplayStrategy;
-import org.hisp.dhis.legend.LegendDisplayStyle;
-import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.schema.annotation.PropertyRange;
@@ -220,11 +217,7 @@ public class Visualization
      */
     private List<Axis> optionalAxes = new ArrayList<>();
 
-    private LegendDisplayStyle legendDisplayStyle;
-
-    private LegendSet legendSet;
-
-    private LegendDisplayStrategy legendDisplayStrategy;
+    private LegendDefinitions legendDefinitions;
 
     /**
      * The font style for various components of the visualization.
@@ -261,7 +254,7 @@ public class Visualization
 
     private transient String rangeAxisLabel;
 
-    private LegendDefinitions legend;
+    private SeriesKey seriesKey;
 
     private List<AxisV2> axes = new ArrayList<>();
 
@@ -509,30 +502,6 @@ public class Visualization
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    public LegendSet getLegendSet()
-    {
-        return legendSet;
-    }
-
-    public void setLegendSet( LegendSet legendSet )
-    {
-        this.legendSet = legendSet;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public LegendDisplayStrategy getLegendDisplayStrategy()
-    {
-        return legendDisplayStrategy;
-    }
-
-    public void setLegendDisplayStrategy( LegendDisplayStrategy legendDisplayStrategy )
-    {
-        this.legendDisplayStrategy = legendDisplayStrategy;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
     public String getMeasureCriteria()
     {
         return measureCriteria;
@@ -676,16 +645,16 @@ public class Visualization
         this.optionalAxes = optionalAxes;
     }
 
-    @JsonProperty
+    @JsonProperty( "legend" )
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    public LegendDisplayStyle getLegendDisplayStyle()
+    public LegendDefinitions getLegendDefinitions()
     {
-        return legendDisplayStyle;
+        return legendDefinitions;
     }
 
-    public void setLegendDisplayStyle( LegendDisplayStyle legendDisplayStyle )
+    public void setLegendDefinitions( LegendDefinitions legendDefinitions )
     {
-        this.legendDisplayStyle = legendDisplayStyle;
+        this.legendDefinitions = legendDefinitions;
     }
 
     @JsonProperty
@@ -1152,16 +1121,16 @@ public class Visualization
         this.outlierAnalysis = outlierAnalysis;
     }
 
-    @JsonProperty( value = "legend" )
-    @JacksonXmlProperty( localName = "legend", namespace = DXF_2_0 )
-    public LegendDefinitions getLegend()
+    @JsonProperty( value = "seriesKey" )
+    @JacksonXmlProperty( localName = "seriesKey", namespace = DXF_2_0 )
+    public SeriesKey getSeriesKey()
     {
-        return legend;
+        return seriesKey;
     }
 
-    public void setLegend( LegendDefinitions legend )
+    public void setSeriesKey( SeriesKey seriesKey )
     {
-        this.legend = legend;
+        this.seriesKey = seriesKey;
 
         keepLegendReadingCompatibility( this );
     }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/CompatibilityGuardTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/CompatibilityGuardTest.java
@@ -59,9 +59,9 @@ public class CompatibilityGuardTest
 
         // Then
         assertThat( visualization.getFontStyle().getLegend(),
-            is( equalTo( visualization.getLegend().getLabel().getFontStyle() ) ) );
+            is( equalTo( visualization.getSeriesKey().getLabel().getFontStyle() ) ) );
         assertThat( visualization.getFontStyle().getLegend().getFont(),
-            is( equalTo( visualization.getLegend().getLabel().getFontStyle().getFont() ) ) );
+            is( equalTo( visualization.getSeriesKey().getLabel().getFontStyle().getFont() ) ) );
     }
 
     @Test
@@ -116,7 +116,7 @@ public class CompatibilityGuardTest
 
     private Visualization mockVisualizationWithLegend()
     {
-        final LegendDefinitions legend = new LegendDefinitions();
+        final SeriesKey legend = new SeriesKey();
         final StyledObject label = new StyledObject();
         final FontStyle fontStyle = new FontStyle();
         fontStyle.setFont( Font.ARIAL );
@@ -124,7 +124,7 @@ public class CompatibilityGuardTest
         legend.setLabel( label );
 
         final Visualization visualization = new Visualization();
-        visualization.setLegend( legend );
+        visualization.setSeriesKey( legend );
 
         return visualization;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.visualization.Visualization;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -158,7 +159,14 @@ public class HibernateAnalyticalObjectStore<T extends BaseAnalyticalObject>
     @Override
     public List<T> getAnalyticalObjects( LegendSet legendSet )
     {
-        String hql = "from " + clazz.getName() + " c where c.legendSet = :legendSet";
+        String embeddedObject = "";
+
+        if ( clazz == Visualization.class )
+        {
+            embeddedObject = "legendDefinitions.";
+        }
+
+        String hql = "from " + clazz.getName() + " c where c." + embeddedObject + "legendSet = :legendSet";
         return getQuery( hql ).setParameter( "legendSet", legendSet ).list();
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
@@ -218,9 +218,34 @@
 
     <property name="outlierAnalysis" type="jbOutlierAnalysis"/>
 
-    <property name="legend" type="jbLegendDefinitions"/>
+    <property name="seriesKey" type="jbSeriesKey"/>
 
     <property name="axes" type="jbAxes"/>
+
+    <component name="legendDefinitions" class="org.hisp.dhis.visualization.LegendDefinitions">
+      <property name="legendDisplayStyle" length="40">
+        <type name="org.hibernate.type.EnumType">
+          <param name="enumClass">org.hisp.dhis.legend.LegendDisplayStyle</param>
+          <param name="useNamed">true</param>
+          <param name="type">12</param>
+        </type>
+      </property>
+
+      <property name="legendDisplayStrategy" length="40">
+        <type name="org.hibernate.type.EnumType">
+          <param name="enumClass">org.hisp.dhis.legend.LegendDisplayStrategy</param>
+          <param name="useNamed">true</param>
+          <param name="type">12</param>
+        </type>
+      </property>
+
+      <property name="hideKey">
+        <column name="legendhidekey" default="false"/>
+      </property>
+
+      <many-to-one name="legendSet" class="org.hisp.dhis.legend.LegendSet" column="legendsetid"
+                   foreign-key="fk_visualization_legendsetid"/>
+    </component>
 
     <property name="colorSet"/>
 
@@ -245,9 +270,6 @@
     <property name="hideLegend"/>
 
     <property name="noSpaceBetweenColumns"/>
-
-    <many-to-one name="legendSet" class="org.hisp.dhis.legend.LegendSet" column="legendsetid"
-      foreign-key="fk_visualization_legendsetid"/>
 
     <property name="showHierarchy"/>
 
@@ -286,22 +308,6 @@
     <property name="fontSize" length="40">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.common.FontSize</param>
-        <param name="useNamed">true</param>
-        <param name="type">12</param>
-      </type>
-    </property>
-
-    <property name="legendDisplayStyle" length="40">
-      <type name="org.hibernate.type.EnumType">
-        <param name="enumClass">org.hisp.dhis.legend.LegendDisplayStyle</param>
-        <param name="useNamed">true</param>
-        <param name="type">12</param>
-      </type>
-    </property>
-
-    <property name="legendDisplayStrategy" length="40">
-      <type name="org.hibernate.type.EnumType">
-        <param name="enumClass">org.hisp.dhis.legend.LegendDisplayStrategy</param>
         <param name="useNamed">true</param>
         <param name="type">12</param>
       </type>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceFavoritesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceFavoritesTest.java
@@ -150,9 +150,9 @@ public class ObjectBundleServiceFavoritesTest
         assertNotNull( visualizations.get( 0 ).getAxes() );
         assertNotNull( visualizations.get( 1 ).getAxes() );
         assertNotNull( visualizations.get( 2 ).getAxes() );
-        assertNotNull( visualizations.get( 0 ).getLegend() );
-        assertNotNull( visualizations.get( 1 ).getLegend() );
-        assertNotNull( visualizations.get( 2 ).getLegend() );
+        assertNotNull( visualizations.get( 0 ).getSeriesKey() );
+        assertNotNull( visualizations.get( 1 ).getSeriesKey() );
+        assertNotNull( visualizations.get( 2 ).getSeriesKey() );
         assertEquals( 2, visualizations.get( 0 ).getSeries().size() );
         assertEquals( 2, visualizations.get( 1 ).getSeries().size() );
         assertEquals( 2, visualizations.get( 2 ).getSeries().size() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_visualization_with_accesses.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_visualization_with_accesses.json
@@ -255,6 +255,9 @@
       "filterDimensions": [
         "ou"
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "series": [
         {
           "dimensionItem": "JXWenbITNIR",
@@ -359,6 +362,9 @@
           }
         }
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "series": [
         {
           "dimensionItem": "JrpFZgTcp5m",
@@ -474,6 +480,9 @@
       "filterDimensions": [
         "ou"
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "series": [
         {
           "dimensionItem": "JrpFZgTcp5m",

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_visualization_with_accesses_update.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_visualization_with_accesses_update.json
@@ -245,6 +245,9 @@
       "user": {
         "id": "M5zQapPyTZI"
       },
+      "seriesKey": {
+        "hidden": true
+      },
       "userOrganisationUnitChildren": false,
       "hideEmptyRows": false,
       "organisationUnitGroups": [ ],
@@ -309,6 +312,9 @@
       "filterDimensions": [
         "ou"
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "dataDimensionItems": [
         {
           "dataElementOperand": {
@@ -437,6 +443,9 @@
       "filterDimensions": [
         "ou"
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "showData": true,
       "organisationUnits": [
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization.json
@@ -359,6 +359,9 @@
         },
         "hidden": false
       },
+      "seriesKey": {
+        "hidden": true
+      },
       "axes": [
         {
           "index": 0,
@@ -571,6 +574,9 @@
         },
         "hidden": false
       },
+      "seriesKey": {
+        "hidden": true
+      },
       "axes": [
         {
           "index": 0,
@@ -739,6 +745,9 @@
           }
         },
         "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
       },
       "axes": [
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization_periods.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/favorites/metadata_with_visualization_periods.json
@@ -180,6 +180,9 @@
       "filterDimensions": [
         "ou"
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "hideSubtitle": false,
       "dataElementGroups": [ ],
       "sortOrder": 0,
@@ -212,6 +215,9 @@
       "filterDimensions": [
         "ou"
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "id": "qD72aBqsHvt",
       "user": {
         "id": "M5zQapPyTZI"
@@ -297,6 +303,9 @@
       "periods": [ ],
       "user": {
         "id": "M5zQapPyTZI"
+      },
+      "seriesKey": {
+        "hidden": true
       },
       "id": "z3zvnIJYQ4J",
       "sortOrder": 0,
@@ -401,6 +410,9 @@
           "id": "uyHni0GvBpD"
         }
       ],
+      "seriesKey": {
+        "hidden": true
+      },
       "categoryDimensions": [ ],
       "completedOnly": false,
       "category": "pe",

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/visualization/VisualizationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/visualization/VisualizationDeletionHandler.java
@@ -78,7 +78,11 @@ public class VisualizationDeletionHandler
 
         for ( final Visualization visualization : visualizations )
         {
-            visualization.setLegendSet( null );
+            if ( visualization.getLegendDefinitions() != null )
+            {
+                visualization.getLegendDefinitions().setLegendSet( null );
+            }
+
             service.update( visualization );
         }
     }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_18__New_Columns_in_Visualization.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_18__New_Columns_in_Visualization.sql
@@ -1,0 +1,7 @@
+-- This script relates to the task https://jira.dhis2.org/browse/DHIS2-11347
+
+-- Rename column: "legend" to "serieskey".
+ALTER TABLE visualization RENAME COLUMN legend TO serieskey;
+
+-- Add new boolean flag related to legend.
+ALTER TABLE visualization ADD COLUMN IF NOT EXISTS legendhidekey BOOLEAN DEFAULT FALSE;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_18__New_Columns_in_Visualization.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_18__New_Columns_in_Visualization.sql
@@ -4,4 +4,5 @@
 ALTER TABLE visualization RENAME COLUMN legend TO serieskey;
 
 -- Add new boolean flag related to legend.
-ALTER TABLE visualization ADD COLUMN IF NOT EXISTS legendhidekey BOOLEAN DEFAULT FALSE;
+ALTER TABLE visualization ADD COLUMN IF NOT EXISTS legendhidekey BOOLEAN;
+UPDATE visualization SET legendhidekey = FALSE;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
@@ -33,8 +33,8 @@
     <param name="clazz">org.hisp.dhis.visualization.AxisV2</param>
   </typedef>
 
-  <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jbLegendDefinitions">
-    <param name="clazz">org.hisp.dhis.visualization.LegendDefinitions</param>
+  <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jbSeriesKey">
+    <param name="clazz">org.hisp.dhis.visualization.SeriesKey</param>
   </typedef>
 
   <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jbLine">

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -95,9 +95,11 @@ public class VisualizationController
             visualization.getRowDimensions().addAll( getDimensions( visualization.getRows() ) );
             visualization.getFilterDimensions().addAll( getDimensions( visualization.getFilters() ) );
 
-            if ( visualization.getLegendSet() != null )
+            if ( visualization.getLegendDefinitions() != null
+                && visualization.getLegendDefinitions().getLegendSet() != null )
             {
-                visualization.setLegendSet( legendSetService.getLegendSet( visualization.getLegendSet().getUid() ) );
+                visualization.getLegendDefinitions().setLegendSet(
+                    legendSetService.getLegendSet( visualization.getLegendDefinitions().getLegendSet().getUid() ) );
             }
         }
     }


### PR DESCRIPTION
This change is just a regrouping of objects into a parent one (LegendDefinitions) along with the creation of a new one SeriesKey. They are used by the front-end team in order to keep the state of the respective objects in the Visualization object.

See the JIRA DHIS2-11347 for more details.
