### PR TITLE
chore: use long IDs for data approval [DHIS2-11370]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApproval.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApproval.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DxfNamespaces;
@@ -63,7 +64,7 @@ public class DataApproval
     /**
      * Identifies the data approval instance (required).
      */
-    private int id;
+    private long id;
 
     /**
      * The approval level for which this approval is defined.
@@ -200,12 +201,12 @@ public class DataApproval
     // Getters and setters
     // -------------------------------------------------------------------------
 
-    public int getId()
+    public long getId()
     {
         return id;
     }
 
-    public void setId( int id )
+    public void setId( long id )
     {
         this.id = id;
     }
@@ -336,74 +337,17 @@ public class DataApproval
         {
             return true;
         }
-
-        if ( object == null || !(object instanceof DataApproval) )
+        if ( !(object instanceof DataApproval) )
         {
             return false;
         }
 
-        DataApproval that = (DataApproval) object;
+        DataApproval other = (DataApproval) object;
 
-        if ( dataApprovalLevel != null )
-        {
-            if ( !dataApprovalLevel.equals( that.getDataApprovalLevel() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getDataApprovalLevel() != null )
-        {
-            return false;
-        }
-
-        if ( workflow != null )
-        {
-            if ( !workflow.equals( that.getWorkflow() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getWorkflow() != null )
-        {
-            return false;
-        }
-
-        if ( period != null )
-        {
-            if ( !period.equals( that.getPeriod() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getPeriod() != null )
-        {
-            return false;
-        }
-
-        if ( organisationUnit != null )
-        {
-            if ( !organisationUnit.equals( that.getOrganisationUnit() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getOrganisationUnit() != null )
-        {
-            return false;
-        }
-
-        if ( attributeOptionCombo != null )
-        {
-            if ( !attributeOptionCombo.equals( that.getAttributeOptionCombo() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getAttributeOptionCombo() != null )
-        {
-            return false;
-        }
-
-        return true;
+        return Objects.equals( dataApprovalLevel, other.dataApprovalLevel )
+            && Objects.equals( workflow, other.workflow )
+            && Objects.equals( period, other.period )
+            && Objects.equals( organisationUnit, other.organisationUnit )
+            && Objects.equals( attributeOptionCombo, other.attributeOptionCombo );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApproval.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApproval.java
@@ -300,17 +300,7 @@ public class DataApproval
     @Override
     public int hashCode()
     {
-        final int prime = 31;
-
-        int result = 1;
-
-        result = prime * result + ((dataApprovalLevel == null) ? 0 : dataApprovalLevel.hashCode());
-        result = prime * result + ((workflow == null) ? 0 : workflow.hashCode());
-        result = prime * result + ((period == null) ? 0 : period.hashCode());
-        result = prime * result + ((organisationUnit == null) ? 0 : organisationUnit.hashCode());
-        result = prime * result + ((attributeOptionCombo == null) ? 0 : attributeOptionCombo.hashCode());
-
-        return result;
+        return Objects.hash( dataApprovalLevel, workflow, period, organisationUnit, attributeOptionCombo );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalAudit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalAudit.java
@@ -235,22 +235,8 @@ public class DataApprovalAudit
     @Override
     public int hashCode()
     {
-
-        final int prime = 31;
-
-        int result = 1;
-
-        result = prime * result + (int) id;
-        result = prime * result + ((level == null) ? 0 : level.hashCode());
-        result = prime * result + ((workflow == null) ? 0 : workflow.hashCode());
-        result = prime * result + ((period == null) ? 0 : period.hashCode());
-        result = prime * result + ((organisationUnit == null) ? 0 : organisationUnit.hashCode());
-        result = prime * result + ((attributeOptionCombo == null) ? 0 : attributeOptionCombo.hashCode());
-        result = prime * result + ((action == null) ? 0 : action.hashCode());
-        result = prime * result + ((created == null) ? 0 : created.hashCode());
-        result = prime * result + ((creator == null) ? 0 : creator.hashCode());
-
-        return result;
+        return Objects.hash( id, level, workflow, period, organisationUnit, attributeOptionCombo, action, created,
+            creator );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalAudit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalAudit.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dataapproval;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DxfNamespaces;
@@ -54,7 +55,7 @@ public class DataApprovalAudit
     /**
      * Identifies the data approval audit record (required).
      */
-    private int id;
+    private long id;
 
     /**
      * The approval level for which this approval is defined.
@@ -121,12 +122,12 @@ public class DataApprovalAudit
     // Getters and setters
     // -------------------------------------------------------------------------
 
-    public int getId()
+    public long getId()
     {
         return id;
     }
 
-    public void setId( int id )
+    public void setId( long id )
     {
         this.id = id;
     }
@@ -234,11 +235,12 @@ public class DataApprovalAudit
     @Override
     public int hashCode()
     {
+
         final int prime = 31;
 
         int result = 1;
 
-        result = prime * result + id;
+        result = prime * result + (int) id;
         result = prime * result + ((level == null) ? 0 : level.hashCode());
         result = prime * result + ((workflow == null) ? 0 : workflow.hashCode());
         result = prime * result + ((period == null) ? 0 : period.hashCode());
@@ -275,114 +277,21 @@ public class DataApprovalAudit
         {
             return true;
         }
-
-        if ( object == null || !(object instanceof DataApprovalAudit) )
+        if ( !(object instanceof DataApprovalAudit) )
         {
             return false;
         }
 
-        DataApprovalAudit that = (DataApprovalAudit) object;
+        DataApprovalAudit other = (DataApprovalAudit) object;
 
-        if ( id != that.id )
-        {
-            return false;
-        }
-        else if ( level != null )
-        {
-            if ( !level.equals( that.getLevel() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getLevel() != null )
-        {
-            return false;
-        }
-
-        if ( workflow != null )
-        {
-            if ( !workflow.equals( that.getWorkflow() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getWorkflow() != null )
-        {
-            return false;
-        }
-
-        if ( period != null )
-        {
-            if ( !period.equals( that.getPeriod() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getPeriod() != null )
-        {
-            return false;
-        }
-
-        if ( organisationUnit != null )
-        {
-            if ( !organisationUnit.equals( that.getOrganisationUnit() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getOrganisationUnit() != null )
-        {
-            return false;
-        }
-
-        if ( attributeOptionCombo != null )
-        {
-            if ( !attributeOptionCombo.equals( that.getAttributeOptionCombo() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getAttributeOptionCombo() != null )
-        {
-            return false;
-        }
-
-        if ( action != null )
-        {
-            if ( !action.equals( that.getAction() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getAction() != null )
-        {
-            return false;
-        }
-
-        if ( created != null )
-        {
-            if ( !created.equals( that.getCreated() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getCreated() != null )
-        {
-            return false;
-        }
-
-        if ( creator != null )
-        {
-            if ( !creator.equals( that.getCreator() ) )
-            {
-                return false;
-            }
-        }
-        else if ( that.getCreator() != null )
-        {
-            return false;
-        }
-
-        return true;
+        return id == other.id
+            && action == other.action
+            && Objects.equals( level, other.level )
+            && Objects.equals( workflow, other.workflow )
+            && Objects.equals( period, other.period )
+            && Objects.equals( organisationUnit, other.organisationUnit )
+            && Objects.equals( attributeOptionCombo, other.attributeOptionCombo )
+            && Objects.equals( created, other.created )
+            && Objects.equals( creator, other.creator );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_19__Migrate_DataApproval_id_column_to_long.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_19__Migrate_DataApproval_id_column_to_long.sql
@@ -1,0 +1,2 @@
+alter table dataapproval alter column dataapprovalid type bigint;
+alter table dataapprovalaudit alter column dataapprovalauditid type bigint;


### PR DESCRIPTION
Changes PK ids from `int` to `long` for `DataApproval` and `DataApprovalAudit`.
Also cleanup of their `equals` implementation using `Objects.equals` instead of if-else construct.