### PR TITLE
feat: NV as "null" in Enrollments/Events analytics filters [DHIS2-1219]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/QueryKey.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/QueryKey.java
@@ -39,6 +39,9 @@ import org.apache.commons.lang.StringUtils;
  */
 public class QueryKey
 {
+    // Null Value
+    public static final String NV = "NV";
+
     private static final char VALUE_SEP = ':';
 
     private static final char COMPONENT_SEP = '-';
@@ -57,7 +60,7 @@ public class QueryKey
      */
     public QueryKey add( String property, Object value )
     {
-        String keyComponent = property + VALUE_SEP + String.valueOf( value );
+        String keyComponent = property + VALUE_SEP + value;
         this.keyComponents.add( keyComponent );
         return this;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
@@ -36,18 +36,33 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
+ * A specialization of {@link QueryFilter} to properly render "in" condition
+ *
  * @author Giuseppe Nespolino
  */
 public class InQueryFilter extends QueryFilter
 {
     private final String field;
 
+    /**
+     * Construct a InQueryFilter using field name and the original
+     * {@link QueryFilter}
+     *
+     * @param field the field on which to construct the InQueryFilter
+     * @param queryFilter The original {@link QueryFilter}
+     */
     public InQueryFilter( String field, QueryFilter queryFilter )
     {
         super( IN, queryFilter.getFilter() );
         this.field = field;
     }
 
+    /**
+     * Renders this InQueryFilter into SQL
+     *
+     * @param encodedFilter actual "in" parameters
+     * @return a SQL condition representing this InQueryFilter
+     */
     public String getSqlFilter( String encodedFilter )
     {
         List<String> filterItems = getFilterItems( encodedFilter );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static org.hisp.dhis.analytics.QueryKey.NV;
+import static org.hisp.dhis.common.QueryOperator.IN;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Giuseppe Nespolino
+ */
+public class InQueryFilter extends QueryFilter
+{
+    private final String field;
+
+    public InQueryFilter( String field, QueryFilter queryFilter )
+    {
+        super( IN, queryFilter.getFilter() );
+        this.field = field;
+    }
+
+    public String getSqlFilter( String encodedFilter )
+    {
+        List<String> filterItems = getFilterItems( encodedFilter );
+        String condition = "";
+        if ( hasNonMissingValue( filterItems ) )
+        {
+            condition = field + " " + operator.getValue() + streamOfNonMissingValues( filterItems )
+                .collect( Collectors.joining( ",", " (", ")" ) );
+            if ( hasMissingValue( filterItems ) )
+            {
+                condition = "(" + condition + " or " + field + " is null )";
+            }
+        }
+        else
+        {
+            if ( hasMissingValue( filterItems ) )
+            {
+                condition = field + " is null";
+            }
+        }
+
+        return condition + " ";
+    }
+
+    private boolean hasMissingValue( List<String> filterItems )
+    {
+        return anyMatch( filterItems, this::isMissingItem );
+    }
+
+    private Stream<String> streamOfNonMissingValues( List<String> filterItems )
+    {
+        return filterItems.stream()
+            .filter( this::isNotMissingItem );
+    }
+
+    private boolean hasNonMissingValue( List<String> filterItems )
+    {
+        return anyMatch( filterItems, this::isNotMissingItem );
+    }
+
+    private boolean anyMatch( List<String> filterItems, Predicate<String> predi )
+    {
+        return filterItems.stream().anyMatch( predi );
+    }
+
+    private boolean isNotMissingItem( String filterItem )
+    {
+        return !isMissingItem( filterItem );
+    }
+
+    private boolean isMissingItem( String filterItem )
+    {
+        return NV.equals( filterItem );
+    }
+
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -32,6 +32,8 @@ import static org.hisp.dhis.analytics.QueryKey.NV;
 import java.util.List;
 import java.util.function.Function;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
@@ -92,7 +94,12 @@ public class QueryFilter
             return null;
         }
 
-        return OPERATOR_MAP.get( operator ).apply( filter.contains( NV ) );
+        return safelyGetOperator();
+    }
+
+    private String safelyGetOperator()
+    {
+        return OPERATOR_MAP.get( operator ).apply( StringUtils.trimToEmpty( filter ).contains( NV ) );
     }
 
     // TODO: unused. Remove ?
@@ -108,7 +115,7 @@ public class QueryFilter
             return "==";
         }
 
-        return OPERATOR_MAP.get( operator ).apply( filter.contains( NV ) );
+        return safelyGetOperator();
     }
 
     public String getSqlFilter( String encodedFilter )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.analytics.QueryKey.NV;
+
 import java.util.List;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -39,16 +42,16 @@ public class QueryFilter
 {
     public static final String OPTION_SEP = ";";
 
-    public static final ImmutableMap<QueryOperator, String> OPERATOR_MAP = ImmutableMap
-        .<QueryOperator, String> builder()
-        .put( QueryOperator.EQ, "=" )
-        .put( QueryOperator.GT, ">" )
-        .put( QueryOperator.GE, ">=" )
-        .put( QueryOperator.LT, "<" )
-        .put( QueryOperator.LE, "<=" )
-        .put( QueryOperator.NE, "!=" )
-        .put( QueryOperator.LIKE, "like" )
-        .put( QueryOperator.IN, "in" ).build();
+    public static final ImmutableMap<QueryOperator, Function<Boolean, String>> OPERATOR_MAP = ImmutableMap
+        .<QueryOperator, Function<Boolean, String>> builder()
+        .put( QueryOperator.EQ, isValueNull -> isValueNull ? "is" : "=" )
+        .put( QueryOperator.GT, unused -> ">" )
+        .put( QueryOperator.GE, unused -> ">=" )
+        .put( QueryOperator.LT, unused -> "<" )
+        .put( QueryOperator.LE, unused -> "<=" )
+        .put( QueryOperator.NE, isValueNull -> isValueNull ? "is not" : "!=" )
+        .put( QueryOperator.LIKE, unused -> "like" )
+        .put( QueryOperator.IN, unused -> "in" ).build();
 
     protected QueryOperator operator;
 
@@ -89,9 +92,10 @@ public class QueryFilter
             return null;
         }
 
-        return OPERATOR_MAP.get( operator );
+        return OPERATOR_MAP.get( operator ).apply( filter.contains( NV ) );
     }
 
+    // TODO: unused. Remove ?
     public String getJavaOperator()
     {
         if ( operator == null || operator == QueryOperator.LIKE || operator == QueryOperator.IN )
@@ -104,7 +108,7 @@ public class QueryFilter
             return "==";
         }
 
-        return OPERATOR_MAP.get( operator );
+        return OPERATOR_MAP.get( operator ).apply( filter.contains( NV ) );
     }
 
     public String getSqlFilter( String encodedFilter )
@@ -118,20 +122,13 @@ public class QueryFilter
         {
             return "'%" + encodedFilter + "%'";
         }
-        else if ( QueryOperator.IN.equals( operator ) )
+        else if ( QueryOperator.EQ.equals( operator ) || QueryOperator.NE.equals( operator ) )
         {
-            List<String> filterItems = getFilterItems( encodedFilter );
-
-            final StringBuffer buffer = new StringBuffer( "(" );
-
-            for ( String filterItem : filterItems )
+            if ( encodedFilter.equals( NV ) )
             {
-                buffer.append( "'" ).append( filterItem ).append( "'," );
+                return "null";
             }
-
-            return buffer.deleteCharAt( buffer.length() - 1 ).append( ")" ).toString();
         }
-
         return "'" + encodedFilter + "'";
     }
 
@@ -207,17 +204,10 @@ public class QueryFilter
 
         if ( operator == null )
         {
-            if ( other.operator != null )
-            {
-                return false;
-            }
+            return other.operator == null;
         }
-        else if ( !operator.equals( other.operator ) )
-        {
-            return false;
-        }
-
-        return true;
+        else
+            return operator.equals( other.operator );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -27,25 +27,33 @@
  */
 package org.hisp.dhis.common;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /**
  * @author Lars Helge Overland
  */
+@Getter
+@RequiredArgsConstructor
 public enum QueryOperator
 {
-    EQ( "=" ),
+    EQ( "=", true ),
     GT( ">" ),
     GE( ">=" ),
     LT( "<" ),
     LE( "<=" ),
-    NE( "!=" ),
+    NE( "!=", true ),
     LIKE( "like" ),
-    IN( "in" );
+    IN( "in", true );
 
     private final String value;
+
+    private final boolean nullAllowed;
 
     QueryOperator( String value )
     {
         this.value = value;
+        this.nullAllowed = false;
     }
 
     public static QueryOperator fromString( String string )
@@ -58,8 +66,4 @@ public enum QueryOperator
         return valueOf( string.toUpperCase() );
     }
 
-    public String getValue()
-    {
-        return value;
-    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -286,6 +286,7 @@ public enum ErrorCode
     E7226( "Dimension is not a valid query item: `{0}`" ),
     E7227( "Relationship entity type not supported: `{0}`" ),
     E7228( "Fallback coordinate field is invalid: `{0}` " ),
+    E7229( "Operator '{0}' does not allow missing value" ),
 
     /* Org unit analytics */
     E7300( "At least one organisation unit must be specified" ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.analytics.QueryKey.NV;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.List;
@@ -39,6 +40,7 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.MaintenanceModeException;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
@@ -173,6 +175,14 @@ public class DefaultEventQueryValidator
             else if ( params.isAggregateData() && !item.getAggregationType().isAggregatable() )
             {
                 error = new ErrorMessage( ErrorCode.E7216, item.getItemId() );
+            }
+
+            for ( QueryFilter queryFilter : item.getFilters() )
+            {
+                if ( !queryFilter.getOperator().isNullAllowed() && queryFilter.getFilter().contains( NV ) )
+                {
+                    error = new ErrorMessage( ErrorCode.E7229, queryFilter.getOperator().getValue() );
+                }
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
+import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
@@ -51,6 +52,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.InQueryFilter;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -284,8 +286,19 @@ public class JdbcEnrollmentAnalyticsManager
             {
                 for ( QueryFilter filter : item.getFilters() )
                 {
-                    sql += "and " + getSelectSql( item, params.getEarliestStartDate(), params.getLatestEndDate() ) + " "
-                        + filter.getSqlOperator() + " " + getSqlFilter( filter, item ) + " ";
+                    String field = getSelectSql( item, params.getEarliestStartDate(), params.getLatestEndDate() );
+
+                    if ( IN.equals( filter.getOperator() ) )
+                    {
+                        QueryFilter inQueryFilter = new InQueryFilter( field, filter );
+                        sql += "and " + getSqlFilter( inQueryFilter, item );
+                    }
+                    else
+                    {
+                        sql += "and " + field + " " + filter.getSqlOperator() + " "
+                            + getSqlFilter( filter, item ) + " ";
+                    }
+
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
+import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import static org.hisp.dhis.feedback.ErrorCode.E7131;
@@ -66,6 +67,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.InQueryFilter;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -489,9 +491,18 @@ public class JdbcEventAnalyticsManager
             {
                 for ( QueryFilter filter : item.getFilters() )
                 {
-                    sql += hlp.whereAnd() + " "
-                        + getSelectSql( item, params.getEarliestStartDate(), params.getLatestEndDate() ) +
-                        " " + filter.getSqlOperator() + " " + getSqlFilter( filter, item ) + " ";
+                    String field = getSelectSql( item, params.getEarliestStartDate(), params.getLatestEndDate() );
+
+                    if ( IN.equals( filter.getOperator() ) )
+                    {
+                        QueryFilter inQueryFilter = new InQueryFilter( field, filter );
+                        sql += hlp.whereAnd() + " " + getSqlFilter( inQueryFilter, item );
+                    }
+                    else
+                    {
+                        sql += hlp.whereAnd() + " " + field + " " + filter.getSqlOperator() + " "
+                            + getSqlFilter( filter, item ) + " ";
+                    }
                 }
             }
         }
@@ -607,7 +618,7 @@ public class JdbcEventAnalyticsManager
      * rank. Only data for the last 10 years relative to the period end date is
      * included.
      *
-     * @param the {@link EventQueryParams}.
+     * @param params the {@link EventQueryParams}.
      */
     private String getFirstOrLastValueSubquerySql( EventQueryParams params )
     {
@@ -644,7 +655,7 @@ public class JdbcEventAnalyticsManager
      * query. The period dimension is replaced by the name of the single period
      * in the given query.
      *
-     * @param the {@link EventQueryParams}.
+     * @param params the {@link EventQueryParams}.
      */
     private List<String> getFirstOrLastValueSubqueryQuotedColumns( EventQueryParams params )
     {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -28,22 +28,33 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.DhisConvenienceTest.*;
+import static org.hisp.dhis.analytics.QueryKey.NV;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
+import static org.hisp.dhis.common.DimensionalObject.OPTION_SEP;
+import static org.hisp.dhis.common.QueryOperator.EQ;
+import static org.hisp.dhis.common.QueryOperator.IN;
+import static org.hisp.dhis.common.QueryOperator.NE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.function.Consumer;
 
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.programindicator.DefaultProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
@@ -65,6 +76,8 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * @author Luciano Fiandesio
@@ -199,6 +212,92 @@ public class EnrollmentAnalyticsManagerTest
             + "and ps = '" + programStage.getUid() + "' and " + subSelect + " > '10' limit 10001";
 
         assertSql( sql.getValue(), expected );
+    }
+
+    @Test
+    public void verifyGetEnrollmentsWithMissingValueEqFilter()
+    {
+        String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
+            + " where analytics_event_"
+            + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
+            + programStage.getUid() + "' order by executiondate desc limit 1 )";
+
+        String expected = subSelect + " is null";
+
+        testIt( EQ, NV, Collections.singleton(
+            ( capturedSql ) -> assertThat( capturedSql, containsString( expected ) ) ) );
+    }
+
+    @Test
+    public void verifyGetEnrollmentsWithMissingValueNeFilter()
+    {
+        String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
+            + " where analytics_event_"
+            + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
+            + programStage.getUid() + "' order by executiondate desc limit 1 )";
+
+        String expected = subSelect + " is not null";
+        testIt( NE, NV, Collections.singleton(
+            ( capturedSql ) -> assertThat( capturedSql, containsString( expected ) ) ) );
+    }
+
+    @Test
+    public void verifyGetEnrollmentsWithMissingValueAndNumericValuesInFilter()
+    {
+        String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
+            + " where analytics_event_"
+            + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
+            + programStage.getUid() + "' order by executiondate desc limit 1 )";
+
+        String numericValues = String.join( OPTION_SEP, "10", "11", "12" );
+        String expected = "(" + subSelect + " in (" + String.join( ",", numericValues.split( OPTION_SEP ) )
+            + ") or " + subSelect + " is null )";
+        testIt( IN,
+            numericValues + OPTION_SEP + NV,
+            Collections.singleton( ( capturedSql ) -> assertThat( capturedSql, containsString( expected ) ) ) );
+    }
+
+    @Test
+    public void verifyGetEnrollmentsWithoutMissingValueAndNumericValuesInFilter()
+    {
+        String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
+            + " where analytics_event_"
+            + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
+            + programStage.getUid() + "' order by executiondate desc limit 1 )";
+
+        String numericValues = String.join( OPTION_SEP, "10", "11", "12" );
+        String expected = subSelect + " in (" + String.join( ",", numericValues.split( OPTION_SEP ) ) + ")";
+        testIt( IN,
+            numericValues,
+            Collections.singleton( ( capturedSql ) -> assertThat( capturedSql, containsString( expected ) ) ) );
+    }
+
+    @Test
+    public void verifyGetEnrollmentsWithOnlyMissingValueInFilter()
+    {
+        String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
+            + " where analytics_event_"
+            + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
+            + programStage.getUid() + "' order by executiondate desc limit 1 )";
+
+        String expected = subSelect + " is null";
+        String unexpected = "(" + subSelect + " in (";
+        testIt( IN, NV,
+            ImmutableList.of(
+                ( capturedSql ) -> assertThat( capturedSql, containsString( expected ) ),
+                ( capturedSql ) -> assertThat( capturedSql, not( containsString( unexpected ) ) ) ) );
+    }
+
+    private void testIt( QueryOperator operator, String filter, Collection<Consumer<String>> assertions )
+    {
+        subject.getEnrollments(
+            createRequestParamsWithFilter( programStage, ValueType.INTEGER, operator, filter ),
+            new ListGrid(),
+            10000 );
+
+        verify( jdbcTemplate ).queryForRowSet( sql.capture() );
+
+        assertions.forEach( consumer -> consumer.accept( sql.getValue() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
@@ -83,10 +83,18 @@ public abstract class EventAnalyticsTest
     protected EventQueryParams createRequestParamsWithFilter( ProgramStage withProgramStage,
         ValueType withQueryItemValueType )
     {
+        return createRequestParamsWithFilter( withProgramStage, withQueryItemValueType, QueryOperator.GT, "10" );
+    }
+
+    protected EventQueryParams createRequestParamsWithFilter( ProgramStage withProgramStage,
+        ValueType withQueryItemValueType,
+        QueryOperator withOperator,
+        String withQueryFilter )
+    {
         EventQueryParams.Builder params = new EventQueryParams.Builder(
             createRequestParams( withProgramStage, withQueryItemValueType ) );
         QueryItem queryItem = params.build().getItems().get( 0 );
-        queryItem.addFilter( new QueryFilter( QueryOperator.GT, "10" ) );
+        queryItem.addFilter( new QueryFilter( withOperator, withQueryFilter ) );
 
         return params.build();
     }


### PR DESCRIPTION
This PR enable Enrollments and Analytics endpoints to accept "NV" as null value in dimension filters.
It only makes sense to use with EQ, NE and IN operators (there's no "not in" operator).
I'm not 100% sure this is exactly what the ticket asked, neither I have enough visibility to understand if it has side effects, so I'd ask @larshelge and @maikelarabori  to have a deep review.
TY