### PR TITLE
perf: Avoid intermediate collections in ObjectBundle [DHIS2-2162]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -342,14 +342,10 @@ public class DefaultMetadataImportService implements MetadataImportService
             return;
         }
 
-        for ( Class<? extends IdentifiableObject> klass : bundle.getObjectMap().keySet() )
-        {
-            bundle.getObjectMap().get( klass )
-                .forEach( o -> postCreateBundleObject( (BaseIdentifiableObject) o, bundle, params ) );
-        }
+        bundle.forEach( object -> postCreateBundleObject( object, bundle, params ) );
     }
 
-    private void postCreateBundleObject( BaseIdentifiableObject object, ObjectBundle bundle, ObjectBundleParams params )
+    private void postCreateBundleObject( IdentifiableObject object, ObjectBundle bundle, ObjectBundleParams params )
     {
         IdentifiableObject userByReference = bundle.getPreheat().get( params.getPreheatIdentifier(),
             User.class, params.getPreheatIdentifier().getIdentifier( object.getCreatedBy() ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.metadata.objectbundle;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -411,17 +412,9 @@ public class DefaultObjectBundleService implements ObjectBundleService
     @SuppressWarnings( "unchecked" )
     private List<Class<? extends IdentifiableObject>> getSortedClasses( ObjectBundle bundle )
     {
-        List<Class<? extends IdentifiableObject>> klasses = new ArrayList<>();
-
-        schemaService.getMetadataSchemas().forEach( schema -> {
-            Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) schema.getKlass();
-
-            if ( bundle.getObjectMap().containsKey( klass ) )
-            {
-                klasses.add( klass );
-            }
-        } );
-
-        return klasses;
+        return schemaService.getMetadataSchemas().stream()
+            .map( schema -> (Class<? extends IdentifiableObject>) schema.getKlass() )
+            .filter( bundle::hasObjects )
+            .collect( toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle;
 
-import java.util.ArrayList;
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
 import java.util.Map;
 
@@ -135,19 +136,9 @@ public class DefaultObjectBundleValidationService
     @SuppressWarnings( "unchecked" )
     private List<Class<? extends IdentifiableObject>> getSortedClasses( ObjectBundle bundle )
     {
-        List<Class<? extends IdentifiableObject>> klasses = new ArrayList<>();
-
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = bundle.getObjectMap();
-
-        schemaService.getMetadataSchemas().forEach( schema -> {
-            Class<? extends IdentifiableObject> klass = (Class<? extends IdentifiableObject>) schema.getKlass();
-
-            if ( objectMap.containsKey( klass ) )
-            {
-                klasses.add( klass );
-            }
-        } );
-
-        return klasses;
+        return schemaService.getMetadataSchemas().stream()
+            .map( schema -> (Class<? extends IdentifiableObject>) schema.getKlass() )
+            .filter( bundle::hasObjects )
+            .collect( toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundle.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle;
 
+import static java.util.Collections.emptyList;
+
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -52,6 +53,8 @@ import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.preheat.PreheatMode;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.User;
+
+import com.google.common.collect.Iterables;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -148,7 +151,9 @@ public class ObjectBundle implements ObjectIndexProvider
     /**
      * Objects to import.
      */
-    private Map<Boolean, Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>>> objects = new HashMap<>();
+    private final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> persistedObjects = new HashMap<>();
+
+    private final Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> nonPersistedObjects = new HashMap<>();
 
     /**
      * Contains the indexes of the objects to be imported grouped by their type.
@@ -171,11 +176,6 @@ public class ObjectBundle implements ObjectIndexProvider
     public ObjectBundle( ObjectBundleParams params, Preheat preheat,
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap )
     {
-        if ( !objects.containsKey( Boolean.TRUE ) )
-            objects.put( Boolean.TRUE, new HashMap<>() );
-        if ( !objects.containsKey( Boolean.FALSE ) )
-            objects.put( Boolean.FALSE, new HashMap<>() );
-
         this.user = params.getUser();
         this.userOverrideMode = params.getUserOverrideMode();
         this.overrideUser = params.getOverrideUser();
@@ -334,24 +334,13 @@ public class ObjectBundle implements ObjectIndexProvider
 
         Class<? extends IdentifiableObject> realClass = HibernateProxyUtils.getRealClass( object );
 
-        if ( !objects.get( Boolean.TRUE ).containsKey( realClass ) )
-        {
-            objects.get( Boolean.TRUE ).put( realClass, new ArrayList<>() );
-        }
-
-        if ( !objects.get( Boolean.FALSE ).containsKey( realClass ) )
-        {
-            objects.get( Boolean.FALSE ).put( realClass, new ArrayList<>() );
-        }
-
         if ( isPersisted( object ) )
         {
-            objects.get( Boolean.TRUE ).get( realClass ).add( object );
+            persistedObjects.computeIfAbsent( realClass, key -> new ArrayList<>() ).add( object );
         }
         else
         {
-            objects.get( Boolean.FALSE ).get( realClass ).add( object );
-
+            nonPersistedObjects.computeIfAbsent( realClass, key -> new ArrayList<>() ).add( object );
         }
 
         typedIndexedObjectContainer.add( object );
@@ -364,30 +353,46 @@ public class ObjectBundle implements ObjectIndexProvider
 
     private void addObject( Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects )
     {
-        objects.keySet().forEach( klass -> addObject( objects.get( klass ) ) );
+        objects.values().forEach( this::addObject );
     }
 
-    public Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> getObjectMap()
+    public void forEach( Consumer<IdentifiableObject> objectConsumer )
     {
-        Set<Class<? extends IdentifiableObject>> klasses = new HashSet<>();
+        persistedObjects.values().forEach( list -> list.forEach( objectConsumer ) );
+        nonPersistedObjects.values().forEach( list -> list.forEach( objectConsumer ) );
+    }
 
-        klasses.addAll( objects.get( Boolean.TRUE ).keySet() );
-        klasses.addAll( objects.get( Boolean.FALSE ).keySet() );
+    public boolean hasObjects( Class<? extends IdentifiableObject> klass )
+    {
+        return persistedObjects.containsKey( klass ) || nonPersistedObjects.containsKey( klass );
+    }
 
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objectMap = new HashMap<>();
+    public int getObjectsCount( Class<? extends IdentifiableObject> klass )
+    {
+        List<IdentifiableObject> none = emptyList();
+        return persistedObjects.getOrDefault( klass, none ).size()
+            + nonPersistedObjects.getOrDefault( klass, none ).size();
+    }
 
-        klasses.forEach( klass -> {
-            objectMap.put( klass, new ArrayList<>() );
-            objectMap.get( klass ).addAll( objects.get( Boolean.TRUE ).get( klass ) );
-            objectMap.get( klass ).addAll( objects.get( Boolean.FALSE ).get( klass ) );
-        } );
-
-        return objectMap;
+    @SuppressWarnings( "unchecked" )
+    public <T extends IdentifiableObject> Iterable<T> getObjects( Class<T> klass )
+    {
+        List<IdentifiableObject> persistedObjectsOfType = persistedObjects.get( klass );
+        if ( persistedObjectsOfType == null || persistedObjectsOfType.isEmpty() )
+        {
+            return (Iterable<T>) nonPersistedObjects.getOrDefault( klass, emptyList() );
+        }
+        List<IdentifiableObject> nonPersistedObjectsOfType = nonPersistedObjects.get( klass );
+        if ( nonPersistedObjectsOfType == null || nonPersistedObjectsOfType.isEmpty() )
+        {
+            return (Iterable<T>) persistedObjectsOfType;
+        }
+        return (Iterable<T>) Iterables.concat( persistedObjectsOfType, nonPersistedObjectsOfType );
     }
 
     public Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> getObjects( boolean persisted )
     {
-        return persisted ? objects.get( Boolean.TRUE ) : objects.get( Boolean.FALSE );
+        return persisted ? persistedObjects : nonPersistedObjects;
     }
 
     public List<IdentifiableObject> getObjects( Class<? extends IdentifiableObject> klass, boolean persisted )
@@ -396,20 +401,20 @@ public class ObjectBundle implements ObjectIndexProvider
 
         if ( persisted )
         {
-            if ( objects.get( Boolean.TRUE ).containsKey( klass ) )
+            if ( persistedObjects.containsKey( klass ) )
             {
-                identifiableObjects = objects.get( Boolean.TRUE ).get( klass );
+                identifiableObjects = persistedObjects.get( klass );
             }
         }
         else
         {
-            if ( objects.get( Boolean.FALSE ).containsKey( klass ) )
+            if ( nonPersistedObjects.containsKey( klass ) )
             {
-                identifiableObjects = objects.get( Boolean.FALSE ).get( klass );
+                identifiableObjects = nonPersistedObjects.get( klass );
             }
         }
 
-        return identifiableObjects != null ? identifiableObjects : new ArrayList<>();
+        return identifiableObjects != null ? identifiableObjects : emptyList();
     }
 
     public Map<String, Map<String, Object>> getObjectReferences( Class<?> klass )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OrganisationUnitObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OrganisationUnitObjectBundleHook.java
@@ -65,17 +65,17 @@ public class OrganisationUnitObjectBundleHook extends AbstractObjectBundleHook
     @Override
     public void postCommit( ObjectBundle bundle )
     {
-        if ( !bundle.getObjectMap().containsKey( OrganisationUnit.class ) )
+        if ( !bundle.hasObjects( OrganisationUnit.class ) )
         {
             return;
         }
 
-        List<IdentifiableObject> objects = bundle.getObjectMap().get( OrganisationUnit.class );
+        Iterable<OrganisationUnit> objects = bundle.getObjects( OrganisationUnit.class );
         Map<String, Map<String, Object>> objectReferences = bundle.getObjectReferences( OrganisationUnit.class );
 
         Session session = sessionFactory.getCurrentSession();
 
-        for ( IdentifiableObject identifiableObject : objects )
+        for ( OrganisationUnit identifiableObject : objects )
         {
             identifiableObject = bundle.getPreheat().get( bundle.getPreheatIdentifier(), identifiableObject );
             Map<String, Object> objectReferenceMap = objectReferences
@@ -87,7 +87,7 @@ public class OrganisationUnitObjectBundleHook extends AbstractObjectBundleHook
                 continue;
             }
 
-            OrganisationUnit organisationUnit = (OrganisationUnit) identifiableObject;
+            OrganisationUnit organisationUnit = identifiableObject;
             OrganisationUnit parentRef = (OrganisationUnit) objectReferenceMap.get( "parent" );
             OrganisationUnit parent = bundle.getPreheat().get( bundle.getPreheatIdentifier(), parentRef );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -209,10 +208,12 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
     @SuppressWarnings( "unchecked" )
     public void postCommit( ObjectBundle bundle )
     {
-        if ( !bundle.getObjectMap().containsKey( User.class ) )
+        if ( !bundle.hasObjects( User.class ) )
+        {
             return;
+        }
 
-        List<IdentifiableObject> objects = bundle.getObjectMap().get( User.class );
+        Iterable<User> objects = bundle.getObjects( User.class );
         Map<String, Map<String, Object>> userReferences = bundle.getObjectReferences( User.class );
         Map<String, Map<String, Object>> userCredentialsReferences = bundle
             .getObjectReferences( UserCredentials.class );
@@ -223,9 +224,9 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook
             return;
         }
 
-        for ( IdentifiableObject identifiableObject : objects )
+        for ( User identifiableObject : objects )
         {
-            User user = (User) identifiableObject;
+            User user = identifiableObject;
             handleNoAccessRoles( user, bundle );
 
             user = bundle.getPreheat().get( bundle.getPreheatIdentifier(), user );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.category.Category;
@@ -154,7 +155,8 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         bundle.getPreheat().put( bundle.getPreheatIdentifier(), dataElementGroup );
 
-        assertTrue( bundle.getObjectMap().get( DataElementGroup.class ).contains( dataElementGroup ) );
+        assertTrue( StreamSupport.stream( bundle.getObjects( DataElementGroup.class ).spliterator(), false )
+            .anyMatch( dataElementGroup::equals ) );
         assertTrue( bundle.getPreheat().containsKey( PreheatIdentifier.UID, DataElementGroup.class,
             dataElementGroup.getUid() ) );
     }
@@ -347,7 +349,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         assertEquals( 1, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5001 ).size() );
         assertFalse( validate.getErrorReportsByCode( DataElement.class, ErrorCode.E4000 ).isEmpty() );
-        assertEquals( 0, bundle.getObjectMap().get( DataElement.class ).size() );
+        assertEquals( 0, bundle.getObjectsCount( DataElement.class ) );
     }
 
     @Test


### PR DESCRIPTION
This PR has nothing to do directly with DHIS2-2162 but in the issue context I looked into `ObjectBundleHook`s and 
`ObjectBundle` and noticed that `getObjectsMap()` was creating intermediate collections and itself was called in loops. 

There were some unnecessary cases of iterating a map by key just to get the values out by the iterated key. If this is "disguised" by using a `forEach` sonar does not seem to recognise this anti-pattern.

Also I felt the extra level of a `Map<Boolean, ...>` for persisted and non-persisted object list made things more complicated to read and process than simply having two individual fields. 

To satisfy the needs of the prior callers of `getObjectsMap()` new methods where introduced instead which simply just read access the existing state for a dedicated use case:
* `forEach` to iterate all `IdentifiableObject`s (of any type both persisted and non-persisted)
* `hasObjects(Class)` to check if there is any persisted or non-persisted object of a certain object type
* `getObjectsCount(Class)` to get the sum of both persisted and non-persisted object of a certain object type
* `getObjects(Class)` to get a `Iterable` list of persisted and non-persisted objects of a certain object type

This also means that the internal data structure of `ObjectBundle` is more private. 
Only `getObjects(boolean)` still allows to access the persisted or non-persisted underlying map in a way that would allow direct modification instead of using the add methods provided by `ObjectBundle`.