### PR TITLE
fix: can't get orgUnit image from FileResourceController

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
@@ -48,7 +50,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.FileResourceUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -70,14 +71,23 @@ import com.google.common.base.MoreObjects;
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class FileResourceController
 {
-    @Autowired
-    private CurrentUserService currentUserService;
+    private final CurrentUserService currentUserService;
 
-    @Autowired
-    private FileResourceService fileResourceService;
+    private final FileResourceService fileResourceService;
 
-    @Autowired
-    private FileResourceUtils fileResourceUtils;
+    private final FileResourceUtils fileResourceUtils;
+
+    public FileResourceController( CurrentUserService currentUserService,
+        FileResourceService fileResourceService, FileResourceUtils fileResourceUtils )
+    {
+        checkNotNull( currentUserService );
+        checkNotNull( fileResourceService );
+        checkNotNull( fileResourceUtils );
+
+        this.currentUserService = currentUserService;
+        this.fileResourceService = fileResourceService;
+        this.fileResourceUtils = fileResourceUtils;
+    }
 
     // -------------------------------------------------------------------------
     // Controller methods
@@ -169,17 +179,17 @@ public class FileResourceController
          * doesn't make sense So we will return false if the fileResource have
          * either of these domains.
          */
+        if ( fileResource.getDomain().equals( FileResourceDomain.DATA_VALUE )
+            || fileResource.getDomain().equals( FileResourceDomain.PUSH_ANALYSIS ) )
+        {
+            return false;
+        }
 
         if ( fileResource.getDomain().equals( FileResourceDomain.USER_AVATAR ) )
         {
             return currentUser.isAuthorized( "F_USER_VIEW" ) || currentUser.getAvatar().equals( fileResource );
         }
 
-        if ( fileResource.getDomain().equals( FileResourceDomain.DOCUMENT ) )
-        {
-            return true;
-        }
-
-        return false;
+        return true;
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceDomain;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.webapi.utils.FileResourceUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class FileResourceControllerMockTest
+{
+    private FileResourceController controller;
+
+    @Mock
+    private FileResourceService fileResourceService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private FileResourceUtils fileResourceUtils;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void testGetOrgUnitImage()
+        throws WebMessageException,
+        IOException
+    {
+        controller = new FileResourceController( currentUserService, fileResourceService, fileResourceUtils );
+        FileResource fileResource = new FileResource();
+        fileResource.setDomain( FileResourceDomain.ORG_UNIT );
+        fileResource.setUid( "id" );
+
+        when( fileResourceService.getFileResource( "id" ) ).thenReturn( fileResource );
+
+        controller.getFileResourceData( "id", new MockHttpServletResponse(), null );
+
+        verify( fileResourceService ).copyFileResourceContent( any(), any() );
+    }
+
+    @Test( expected = WebMessageException.class )
+    public void testGetDataValue()
+        throws WebMessageException,
+        IOException
+    {
+        controller = new FileResourceController( currentUserService, fileResourceService, fileResourceUtils );
+        FileResource fileResource = new FileResource();
+        fileResource.setDomain( FileResourceDomain.DATA_VALUE );
+        fileResource.setUid( "id" );
+
+        when( fileResourceService.getFileResource( "id" ) ).thenReturn( fileResource );
+
+        controller.getFileResourceData( "id", new MockHttpServletResponse(), null );
+    }
+}


### PR DESCRIPTION
Issue : 
- There is a custom sharing check in FileResourceController. 
- It will only return true for `DOCUMENT` and `USER_AVATAR` ( with `F_USER_VIEW` )
- It will always false for other domains: `DATA_VALUE` `PUSH_ANALYSIS` `ORG_UNIT` `MESSAGE_ATTACHMENT` 

Fix: 
- Only return false for `DATA_VALUE` and `PUSH_ANALYSIS`
- Added mock test for the sharing check