### PR TITLE
fix: TEI ID missing in event creation ownership check [DHIS2-11377] (2.37)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -173,6 +173,8 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
             {
                 trackedEntityProgramOwnerService.createTrackedEntityProgramOwner( entityInstance, program, orgUnit );
             }
+
+            ownerCache.invalidate( getOwnershipCacheKey( () -> entityInstance.getId(), program ) );
         }
         else
         {
@@ -216,6 +218,8 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
                 trackedEntityProgramOwnerService.createTrackedEntityProgramOwner( entityInstance, program,
                     organisationUnit );
             }
+
+            ownerCache.invalidate( getOwnershipCacheKey( () -> entityInstance.getId(), program ) );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramInstanceSupplier.java
@@ -178,7 +178,8 @@ public class ProgramInstanceSupplier extends AbstractSupplier<Map<String, Progra
 
     private ProgramInstance getByTeiAndProgram( ImportOptions importOptions, Long teiId, Long programId, Event event )
     {
-        final String sql = "select pi.programinstanceid, pi.programid, pi.uid , t.uid as tei_uid, " +
+        final String sql = "select pi.programinstanceid, pi.programid, pi.uid , t.trackedentityinstanceid as tei_id, t.uid as tei_uid, "
+            +
             "ou.uid as tei_ou_uid, ou.path as tei_ou_path from programinstance pi " +
             "join trackedentityinstance t on t.trackedentityinstanceid = pi.trackedentityinstanceid " +
             "join organisationunit ou on t.organisationunitid = ou.organisationunitid " +
@@ -219,7 +220,7 @@ public class ProgramInstanceSupplier extends AbstractSupplier<Map<String, Progra
             return new HashMap<>();
         }
 
-        final String sql = "select psi.uid as psi_uid, pi.programinstanceid, pi.programid, pi.uid , t.uid as tei_uid, "
+        final String sql = "select psi.uid as psi_uid, pi.programinstanceid, pi.programid, pi.uid , t.trackedentityinstanceid as tei_id, t.uid as tei_uid, "
             + "ou.uid as tei_ou_uid, ou.path as tei_ou_path from programinstance pi "
             + "left outer join trackedentityinstance t on pi.trackedentityinstanceid = t.trackedentityinstanceid "
             + "left join organisationunit ou on t.organisationunitid = ou.organisationunitid "
@@ -244,7 +245,7 @@ public class ProgramInstanceSupplier extends AbstractSupplier<Map<String, Progra
         Multimap<String, String> programInstanceToEvent, Set<String> uids )
     {
 
-        final String sql = "select pi.programinstanceid, pi.programid, pi.uid, t.uid as tei_uid, "
+        final String sql = "select pi.programinstanceid, pi.programid, pi.uid, t.trackedentityinstanceid as tei_id, t.uid as tei_uid, "
             + "ou.uid as tei_ou_uid, ou.path as tei_ou_path "
             + "from programinstance pi join trackedentityinstance t on pi.trackedentityinstanceid = t.trackedentityinstanceid "
             + "join organisationunit ou on t.organisationunitid = ou.organisationunitid where pi.uid in (:ids)";
@@ -283,6 +284,7 @@ public class ProgramInstanceSupplier extends AbstractSupplier<Map<String, Progra
         if ( teiUid != null )
         {
             TrackedEntityInstance trackedEntityInstance = new TrackedEntityInstance();
+            trackedEntityInstance.setId( rs.getLong( "tei_id" ) );
             String teiOuUid = rs.getString( "tei_ou_uid" );
             if ( teiOuUid != null )
             {


### PR DESCRIPTION
The refactored bulk event importer from 2.35, uses a `workContext` to perform validations. The `ProgramInstance` objects populated into the workContext has associated trackedEntityInstance objects with empty ids (primary key). 

Here is a representation of the bug: 

1. When populating the workContext. something like this happens.
```
ProgramInstance pi = new ProgramInstance();
TrackedEntityInstance tei = new TrackedEntityInstance();
tei.setUid("a123459"); //Note that id is not explicitly set here, which means id=0 by default.
pi.setEntityInstance(tei);
```

2. When checking for ownership, this programInstance is passed onto the trackerOwnershipManager. The Manager caches, ownerOrgUnit entries into a temporary cache for 5 minutes. The key to retrieve the ownerOrgUnit from the cache is a combination of teiID_programUid. Since the teiID is **always** 0, the key **always collides** for every tei in the same program. ( Example: `0_uYjxkTbwRNf` ). This means the cache becomes incorrect and the ownership validation fails. 


This PR fixes this by populating the `long id` in `TrackedEntityInstance` entity at the time of workContext creation in EventImporter.