### PR TITLE
fix: LazyInitializationException when search for TEI [2.35.6]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -73,13 +73,13 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -102,7 +102,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResourceService;
-import org.hisp.dhis.hibernate.HibernateUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.EventSyncService;
@@ -132,6 +131,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -214,9 +214,9 @@ public abstract class AbstractEventService
 
     private final Set<TrackedEntityInstance> trackedEntityInstancesToUpdate = new HashSet<>();
 
-    private static final Cache<DataElement> DATA_ELEM_CACHE = new SimpleCacheBuilder<DataElement>()
-        .forRegion( "dataElementCache" ).expireAfterAccess( 60, TimeUnit.MINUTES ).withInitialCapacity( 1000 )
-        .withMaximumSize( 50000 ).build();
+    private static final Cache<Boolean> DATA_ELEM_CACHE = new SimpleCacheBuilder<Boolean>()
+        .forRegion( "dataElementCache" ).expireAfterAccess( 60, TimeUnit.MINUTES ).withInitialCapacity( 10000 )
+        .withMaximumSize( 100000 ).build();
 
     // -------------------------------------------------------------------------
     // CREATE
@@ -613,18 +613,8 @@ public abstract class AbstractEventService
 
         for ( EventDataValue dataValue : dataValues )
         {
-
-            DataElement dataElement = getDataElement( IdScheme.UID, dataValue.getDataElement() );
-
-            if ( dataElement != null )
+            if ( getDataElement( user.getUid(), dataValue.getDataElement() ) )
             {
-                errors = trackerAccessManager.canRead( user, programStageInstance, dataElement, true );
-
-                if ( !errors.isEmpty() )
-                {
-                    continue;
-                }
-
                 DataValue value = new DataValue();
                 value.setCreated( DateUtils.getIso8601NoTz( dataValue.getCreated() ) );
                 value.setCreatedByUserInfo( dataValue.getCreatedByUserInfo() );
@@ -927,15 +917,21 @@ public abstract class AbstractEventService
     private OrganisationUnit getOrganisationUnit( IdSchemes idSchemes, String id )
     {
         return organisationUnitCache.get( id,
-            () -> HibernateUtils
-                .initializeProxy( manager.getObject( OrganisationUnit.class, idSchemes.getOrgUnitIdScheme(), id ) ) );
+            () -> manager.getObject( OrganisationUnit.class, idSchemes.getOrgUnitIdScheme(), id ) );
     }
 
-    private DataElement getDataElement( IdScheme idScheme, String id )
+    /**
+     * Get DataElement by given uid
+     *
+     * @return FALSE if currentUser doesn't have READ access to given
+     *         DataElement OR no DataElement with given uid exist TRUE if
+     *         DataElement exist and currentUser has READ access
+     */
+    private boolean getDataElement( String userUid, String dataElementUid )
     {
-        return DATA_ELEM_CACHE
-            .get( id, s -> HibernateUtils.initializeProxy( manager.getObject( DataElement.class, idScheme, id ) ) )
-            .orElse( null );
+        String key = userUid + "-" + dataElementUid;
+        return DATA_ELEM_CACHE.get( key, k -> manager.get( DataElement.class, dataElementUid ) != null )
+            .orElse( false );
     }
 
     @Override
@@ -1062,5 +1058,12 @@ public abstract class AbstractEventService
         }
 
         importOptions.setUser( userService.getUser( importOptions.getUser().getId() ) );
+    }
+
+    @Override
+    @EventListener
+    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
+    {
+        DATA_ELEM_CACHE.invalidateAll();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.report.EventRows;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
@@ -166,4 +167,11 @@ public interface EventService
     ImportSummaries deleteEvents( List<String> uids, boolean clearSession );
 
     void validate( EventSearchParams params );
+
+    /**
+     * Event handler for {@link ApplicationCacheClearedEvent}.
+     *
+     * @param event the {@link ApplicationCacheClearedEvent}.
+     */
+    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }


### PR DESCRIPTION
JIRA: https://jira.dhis2.org/browse/DHIS2-11055
port from the hot fix #8251

Issue:

- In AbstractEventService we have a cache for DataElement.
- The cache works fine in testing environment, no error.
- However, in a busy production instance, the cache start working incorrectly. DE retrieved from cache sometime throws lazily initialize exception for the UserGroupAccesses collection although we explicitly initialize the collection before put DE into the cache.
- I guess this happen when the cache item is expired and Cache2k try to refresh the cache without hibernate session, but this theory has not been proved yet.

Fix:

- Replace the Cache<DataElement> cache with a Cache<Boolean> which stores the result of the sharing check ( user, dataElement )
- The method manager.get(DataElement.class, uid ) already do the sharing check in database query. So we don't need to call aclService.canRead( user, dataElement).
- Added a cache invalidate function, so that the cache will be invalidated when user use Clear Application Cache function in Data Admin App.

Test:

- Sent a war file with the hot fix to Rhwanda team ( the code is branched out from patch/2.35.5 with the security fix ).
They deployed it to their production server from June 19th, and the search TEI function work correctly till now.