### PR TITLE
fix: LazyInitializationException when search for TEI  [2.36.2]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.report.EventRows;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
@@ -166,4 +167,11 @@ public interface EventService
     ImportSummaries deleteEvents( List<String> uids, boolean clearSession );
 
     void validate( EventSearchParams params );
+
+    /**
+     * Event handler for {@link ApplicationCacheClearedEvent}.
+     *
+     * @param event the {@link ApplicationCacheClearedEvent}.
+     */
+    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.report.EventRows;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventService.java
@@ -167,11 +167,4 @@ public interface EventService
     ImportSummaries deleteEvents( List<String> uids, boolean clearSession );
 
     void validate( EventSearchParams params );
-
-    /**
-     * Event handler for {@link ApplicationCacheClearedEvent}.
-     *
-     * @param event the {@link ApplicationCacheClearedEvent}.
-     */
-    void handleApplicationCachesCleared( ApplicationCacheClearedEvent event );
 }


### PR DESCRIPTION
JIRA: https://jira.dhis2.org/browse/DHIS2-11055
port  from the hot fix https://github.com/dhis2/dhis2-core/pull/8251

Issue: 
- In `AbstractEventService` we have a cache for `DataElement`.
- The cache works fine in testing environment, no error.
- However, in a busy production instance, the cache start working incorrectly. DE retrieved from cache sometime throws ` lazily initialize exception` for  the `UserGroupAccesses` collection although we explicitly initialize the collection before put DE into the cache.
- I guess this happen when the cache item is expired and Cache2k try to refresh the cache without hibernate session, but this theory has not been proved yet.

Fix:
- Replace the `Cache<DataElement>` cache with a `Cache<Boolean>` which stores the result of the sharing check ( user, dataElement )
- The method `manager.get(DataElement.class, uid )` already do the sharing check in database query. So we don't need to call `aclService.canRead( user, dataElement)`. 
- Added a cache invalidate function, so that the cache will be invalidated when user use `Clear Application Cache` function in Data Admin App. 

Test:
- Sent a war file with the hot fix to Rhwanda team ( the code is branched out from patch/2.35.5 with the security fix ). 
- They deployed it to their production server from June 19th, and the search TEI function work correctly till now. 

