### PR TITLE
feat: Add outputIdScheme support for Event Analytics [DHIS2-11181]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -92,6 +92,8 @@ public class EventDataQueryRequest
 
     private IdScheme dataIdScheme;
 
+    private IdScheme outputIdScheme;
+
     private DisplayProperty displayProperty;
 
     private Date relativePeriodDate;
@@ -215,6 +217,7 @@ public class EventDataQueryRequest
                 .userOrgUnit( criteria.getUserOrgUnit() )
                 .value( criteria.getValue() )
                 .dataIdScheme( criteria.getDataIdScheme() )
+                .outputIdScheme( criteria.getOutputIdScheme() )
                 .orgUnitField( criteria.getOrgUnitField() )
                 .coordinatesOnly( criteria.isCoordinatesOnly() )
                 .coordinateOuFallback( criteria.isCoordinateOuFallback() );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -266,6 +266,12 @@ public class EventsAnalyticsQueryCriteria
     private IdScheme dataIdScheme;
 
     /**
+     * Identifier scheme to use for metadata items the query response, can be
+     * identifier, code or attributes. ( options: UID | CODE | ATTRIBUTE:<ID> )
+     */
+    private IdScheme outputIdScheme;
+
+    /**
      * The page number. Default page is 1.
      */
     private Integer page;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -74,7 +74,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class SchemaIdResponseMapper
 {
-
     /**
      * This method will map the respective element UID's with their respective
      * id schema set. The 'outputIdScheme' is considered the most general id
@@ -91,7 +90,7 @@ public class SchemaIdResponseMapper
      *        outputDataElementIdScheme and outputOrgUnitIdScheme.
      * @return a Map of <uid, mapping value>
      */
-    Map<String, String> getSchemeIdResponseMap( final DataQueryParams params )
+    public Map<String, String> getSchemeIdResponseMap( final DataQueryParams params )
     {
         final Map<String, String> responseMap = getDimensionItemIdSchemeMap( params.getAllDimensionItems(),
             params.getOutputIdScheme() );
@@ -131,6 +130,17 @@ public class SchemaIdResponseMapper
     {
         map.putAll( getDataElementOperandIdSchemeMap(
             asTypedList( params.getDataElementOperands() ), params.getOutputIdScheme() ) );
+
+        if ( params.getProgramStage() != null )
+        {
+            map.put( params.getProgramStage().getUid(),
+                params.getProgramStage().getPropertyValue( params.getOutputIdScheme() ) );
+        }
+
+        if ( params.getProgram() != null )
+        {
+            map.put( params.getProgram().getUid(), params.getProgram().getPropertyValue( params.getOutputIdScheme() ) );
+        }
     }
 
     private void applyDataElementOperandsIdSchemaMapping( final DataQueryParams params, final Map<String, String> map )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -1369,6 +1369,12 @@ public class EventQueryParams
             return this;
         }
 
+        public Builder withOutputIdScheme( IdScheme outputIdScheme )
+        {
+            this.params.outputIdScheme = outputIdScheme;
+            return this;
+        }
+
         public EventQueryParams build()
         {
             return params;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -584,12 +584,13 @@ public class DefaultEventAnalyticsService
 
     /**
      * Substitutes the meta data of the grid with the identifier scheme meta
-     * data property indicated in the query.
+     * data property indicated in the query. This happens only when a custom ID
+     * Schema is set.
      *
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void applyIdScheme( DataQueryParams params, Grid grid )
+    private void maybeApplyIdScheme( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipMeta() )
         {
@@ -610,7 +611,7 @@ public class DefaultEventAnalyticsService
     {
         final Grid grid = getGrid( params );
 
-        applyIdScheme( params, grid );
+        maybeApplyIdScheme( params, grid );
 
         return grid;
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -66,6 +66,7 @@ import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.EventAnalyticsDimensionalItem;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.analytics.cache.AnalyticsCache;
+import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventAnalyticsService;
@@ -158,11 +159,14 @@ public class DefaultEventAnalyticsService
 
     private final AnalyticsCache analyticsCache;
 
+    final SchemaIdResponseMapper schemaIdResponseMapper;
+
     public DefaultEventAnalyticsService( DataElementService dataElementService,
         TrackedEntityAttributeService trackedEntityAttributeService, EventAnalyticsManager eventAnalyticsManager,
         EventDataQueryService eventDataQueryService, AnalyticsSecurityManager securityManager,
         EventQueryPlanner queryPlanner, EventQueryValidator queryValidator, DatabaseInfo databaseInfo,
-        AnalyticsCache analyticsCache, EnrollmentAnalyticsManager enrollmentAnalyticsManager )
+        AnalyticsCache analyticsCache, EnrollmentAnalyticsManager enrollmentAnalyticsManager,
+        SchemaIdResponseMapper schemaIdResponseMapper )
     {
         super( securityManager, queryValidator );
 
@@ -173,6 +177,7 @@ public class DefaultEventAnalyticsService
         checkNotNull( queryPlanner );
         checkNotNull( databaseInfo );
         checkNotNull( analyticsCache );
+        checkNotNull( schemaIdResponseMapper );
 
         this.dataElementService = dataElementService;
         this.trackedEntityAttributeService = trackedEntityAttributeService;
@@ -182,6 +187,7 @@ public class DefaultEventAnalyticsService
         this.databaseInfo = databaseInfo;
         this.analyticsCache = analyticsCache;
         this.enrollmentAnalyticsManager = enrollmentAnalyticsManager;
+        this.schemaIdResponseMapper = schemaIdResponseMapper;
     }
 
     // -------------------------------------------------------------------------
@@ -576,6 +582,25 @@ public class DefaultEventAnalyticsService
         return grid;
     }
 
+    /**
+     * Substitutes the meta data of the grid with the identifier scheme meta
+     * data property indicated in the query.
+     *
+     * @param params the {@link DataQueryParams}.
+     * @param grid the grid.
+     */
+    void applyIdScheme( DataQueryParams params, Grid grid )
+    {
+        if ( !params.isSkipMeta() )
+        {
+            if ( params.hasCustomIdSchemaSet() )
+            {
+                // Apply all schemas set/mapped to the grid.
+                grid.substituteMetaData( schemaIdResponseMapper.getSchemeIdResponseMap( params ) );
+            }
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Query
     // -------------------------------------------------------------------------
@@ -583,7 +608,11 @@ public class DefaultEventAnalyticsService
     @Override
     public Grid getEvents( EventQueryParams params )
     {
-        return getGrid( params );
+        final Grid grid = getGrid( params );
+
+        applyIdScheme( params, grid );
+
+        return grid;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -244,6 +244,7 @@ public class DefaultEventDataQueryService
             .withCoordinateOuFallback( request.isCoordinateOuFallback() )
             .withIncludeMetadataDetails( request.isIncludeMetadataDetails() )
             .withDataIdScheme( request.getDataIdScheme() )
+            .withOutputIdScheme( request.getOutputIdScheme() )
             .withEventStatus( request.getEventStatus() )
             .withDisplayProperty( request.getDisplayProperty() )
             .withTimeField( request.getTimeField() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.event.data;
+
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.hisp.dhis.DhisConvenienceTest.createPeriod;
+import static org.hisp.dhis.DhisConvenienceTest.createProgram;
+import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.analytics.AnalyticsSecurityManager;
+import org.hisp.dhis.analytics.Partitions;
+import org.hisp.dhis.analytics.cache.AnalyticsCache;
+import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
+import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
+import org.hisp.dhis.analytics.event.EventAnalyticsManager;
+import org.hisp.dhis.analytics.event.EventDataQueryService;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.analytics.event.EventQueryPlanner;
+import org.hisp.dhis.analytics.event.EventQueryValidator;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.system.database.DatabaseInfo;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Unit tests for DefaultEventAnalyticsService.
+ *
+ * @author maikel arabori
+ */
+public class DefaultEventAnalyticsServiceTest
+{
+    private DefaultEventAnalyticsService defaultEventAnalyticsService;
+
+    @Mock
+    private AnalyticsSecurityManager securityManager;
+
+    @Mock
+    private EventQueryValidator eventQueryValidator;
+
+    @Mock
+    private DataElementService dataElementService;
+
+    @Mock
+    private TrackedEntityAttributeService trackedEntityAttributeService;
+
+    @Mock
+    private EventAnalyticsManager eventAnalyticsManager;
+
+    @Mock
+    private EnrollmentAnalyticsManager enrollmentAnalyticsManager;
+
+    @Mock
+    private EventDataQueryService eventDataQueryService;
+
+    @Mock
+    private EventQueryPlanner queryPlanner;
+
+    @Mock
+    private DatabaseInfo databaseInfo;
+
+    @Mock
+    private AnalyticsCache analyticsCache;
+
+    @Mock
+    private SchemaIdResponseMapper schemaIdResponseMapper;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp()
+    {
+        defaultEventAnalyticsService = new DefaultEventAnalyticsService( dataElementService,
+            trackedEntityAttributeService, eventAnalyticsManager, eventDataQueryService, securityManager, queryPlanner,
+            eventQueryValidator, databaseInfo, analyticsCache, enrollmentAnalyticsManager, schemaIdResponseMapper );
+    }
+
+    @Test
+    public void testOutputSchemeInvocation()
+    {
+        // Given mock variables
+        final OrganisationUnit mockOrgUnit = createOrganisationUnit( 'A' );
+        final Program mockProgram = createProgram( 'A', null, null, Sets.newHashSet( mockOrgUnit ), null );
+        final EventQueryParams mockParams = new EventQueryParams.Builder()
+            .withPeriods( getList( createPeriod( "2000Q1" ) ), "monthly" )
+            .withPartitions( new Partitions() )
+            .withOrganisationUnits( getList( mockOrgUnit ) )
+            .withProgram( mockProgram )
+            .withOutputIdScheme( IdScheme.CODE )
+            .build();
+
+        // Given mock calls
+        doNothing().when( securityManager ).decideAccessEventQuery( mockParams );
+        when( securityManager.withUserConstraints( mockParams ) ).thenReturn( mockParams );
+        doNothing().when( eventQueryValidator ).validate( mockParams );
+        when( queryPlanner.planEventQuery( any( EventQueryParams.class ) ) ).thenReturn( mockParams );
+
+        // When
+        defaultEventAnalyticsService.getEvents( mockParams );
+
+        // Then
+        verify( schemaIdResponseMapper, atMost( 1 ) ).getSchemeIdResponseMap( mockParams );
+    }
+}


### PR DESCRIPTION
This feature will be enabled when the client sets the "outputIdScheme=NAME|CODE|UUID" in the GET request/URL.

ie.:
`http://localhost:8080/dhis/api/29/analytics/events/query/eBAyeGv0exc.json?dimension=pe:LAST_4_QUARTERS&dimension=ou:jUb8gELQApl;TEQlaapDQoK;eIQbndfxQMb;Vth0fbpFcsO;PMa2VCrupOd;O6uvpzGd5pu;bL4ooGhyHRQ;kJq2mPyFEHo;fdc6uOvgoji;at6UHUQatSo;lc3eMKXaEfw;qhqAxPSTUXp;jmIPBj66vD6&dimension=Bpx0589u8y0:MAs88nJc9nL;oRVt7g429ZO&dimension=uIuxlbV1vRT:J40PpdN4Wkk;b0EsAxm8Nge&stage=Zj7UnCAulEk&displayProperty=NAME&tableLayout=true&dataIdScheme=NAME&columns=pe;ou;Bpx0589u8y0;uIuxlbV1vRT&rows=pe;ou;Bpx0589u8y0;uIuxlbV1vRT&paging=true&outputIdScheme=NAME`

In the case above, the data elements present in the "rows" element (in the JSON response object) will render the data elements "name" instead of the default ("uid").

