### PR TITLE
feat: Add IndicatorType in analystics meta-data resp [DHIS2-7420]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IndicatorTypeSerializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IndicatorTypeSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import java.io.IOException;
+
+import org.hisp.dhis.indicator.IndicatorType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Specific serializer to output only the minimum scope of attributes related to
+ * IndicatorType.
+ *
+ * @author maikel arabori
+ */
+public class IndicatorTypeSerializer extends JsonSerializer<IndicatorType>
+{
+    @Override
+    public void serialize( final IndicatorType indicatorType, final JsonGenerator jsonGenerator,
+        final SerializerProvider provider )
+        throws IOException
+    {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField( "name", indicatorType.getName() );
+        jsonGenerator.writeStringField( "displayName", indicatorType.getDisplayName() );
+        jsonGenerator.writeNumberField( "factor", indicatorType.getFactor() );
+        jsonGenerator.writeBooleanField( "number", indicatorType.isNumber() );
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -32,12 +32,15 @@ import java.util.Date;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Item part of meta data analytics response.
@@ -66,6 +69,8 @@ public class MetadataItem
     private AggregationType aggregationType;
 
     private TotalAggregationType totalAggregationType;
+
+    private IndicatorType indicatorType;
 
     private Date startDate;
 
@@ -172,6 +177,16 @@ public class MetadataItem
             Period period = (Period) dimensionalItemObject;
             this.startDate = period.getStartDate();
             this.endDate = period.getEndDate();
+        }
+
+        if ( dimensionalItemObject instanceof Indicator )
+        {
+            Indicator indicator = (Indicator) dimensionalItemObject;
+
+            if ( indicator.getIndicatorType() != null )
+            {
+                this.indicatorType = indicator.getIndicatorType();
+            }
         }
     }
 
@@ -290,6 +305,18 @@ public class MetadataItem
     public void setAggregationType( AggregationType itemSpecificType )
     {
         this.aggregationType = itemSpecificType;
+    }
+
+    @JsonProperty
+    @JsonSerialize( using = IndicatorTypeSerializer.class )
+    public IndicatorType getIndicatorType()
+    {
+        return indicatorType;
+    }
+
+    public void setIndicatorType( IndicatorType indicatorType )
+    {
+        this.indicatorType = indicatorType;
     }
 
     @JsonProperty


### PR DESCRIPTION
When an Indicator is present in the meta-data object (in the JSON response), the IndicatorType will be now available in the following format (see **indicatorType**):

```{
  "headers": [],
  "metaData": {
    "items": {
      ...,
      "ReUHfIn0pTQ": {
        "uid": "ReUHfIn0pTQ",
        "code": "IN_52462",
        "name": "ANC 1-3 Dropout Rate",
        "description": "Indicates the percentage of clients dropping out between the 1st and the 3rd ANC visit. Calculated as the difference between ANC1 and ANC3 by the ANC 1 visits.",
        "dimensionItemType": "INDICATOR",
        "valueType": "NUMBER",
        "totalAggregationType": "AVERAGE",
        "indicatorType": {
          "name": "Per cent",
          "displayName": "Per cent",
          "factor": 100,
          "number": false
        },
        ...
      }
    }```