### PR TITLE
feat: Make assignedUserDisplayName accessible from events toString

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/Event.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/Event.java
@@ -576,6 +576,8 @@ public class Event
             ", relationships=" + relationships +
             ", eventDate='" + eventDate + '\'' +
             ", dueDate='" + dueDate + '\'' +
+            ", assignedUser=''" + assignedUser + '\'' +
+            ", assignedUserUsername=''" + assignedUserUsername + '\'' +
             ", assignedUserDisplayName=''" + assignedUserDisplayName + '\'' +
             ", dataValues=" + dataValues +
             ", notes=" + notes +

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/Event.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/Event.java
@@ -576,6 +576,7 @@ public class Event
             ", relationships=" + relationships +
             ", eventDate='" + eventDate + '\'' +
             ", dueDate='" + dueDate + '\'' +
+            ", assignedUserDisplayName=''" + assignedUserDisplayName + '\'' +
             ", dataValues=" + dataValues +
             ", notes=" + notes +
             ", deleted=" + deleted +


### PR DESCRIPTION
In order to show assigned user in tracked entity instance filtered list (arbeidsliste) in Tracker Capture  (as requested in [SMITTE-168](https://ksfiks.atlassian.net/browse/SMITTE-168)), the assignedUserDisplayName needs to be accessed through calling `trackedEntityInstances.json` endpoint. 

I believe that his PR will make this possible (not tested, but have a hunch it might be correct).