### PR TITLE
chore: error reports as ADT (avoid collections)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorReportContainer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorReportContainer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.feedback;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * An ADT interface for a collection of {@link ErrorReport}s.
+ *
+ * @author Jan Bernitt
+ */
+public interface ErrorReportContainer
+{
+    int getErrorReportsCount();
+
+    int getErrorReportsCount( ErrorCode errorCode );
+
+    boolean hasErrorReports();
+
+    boolean hasErrorReport( Predicate<ErrorReport> test );
+
+    void forEachErrorReport( Consumer<ErrorReport> reportConsumer );
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/TypeReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/TypeReport.java
@@ -32,10 +32,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.hisp.dhis.common.DxfNamespaces;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -46,7 +49,7 @@ import com.google.common.base.MoreObjects;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @JacksonXmlRootElement( localName = "typeReport", namespace = DxfNamespaces.DXF_2_0 )
-public class TypeReport
+public class TypeReport implements ErrorReportContainer
 {
     private static final Map<Class<?>, TypeReport> EMPTY_BY_TYPE = new ConcurrentHashMap<>();
 
@@ -79,38 +82,42 @@ public class TypeReport
     // Utility Methods
     // -----------------------------------------------------------------------------------
 
-    public void merge( TypeReport typeReport )
+    public void merge( TypeReport other )
     {
         if ( empty )
         {
             throw new IllegalStateException( "Empty report cannot be changed." );
         }
-        if ( typeReport.empty )
+        if ( other.empty )
         {
             return; // done: nothing to merge with
         }
-        stats.merge( typeReport.getStats() );
+        stats.merge( other.getStats() );
 
-        typeReport.getObjectReportMap().forEach( ( index, objectReport ) -> {
-            if ( !objectReportMap.containsKey( index ) )
-            {
-                objectReportMap.put( index, objectReport );
-                return;
-            }
-
-            objectReportMap.get( index ).addErrorReports( objectReport.getErrorReports() );
-        } );
+        other.objectReportMap.forEach(
+            ( index, objectReport ) -> objectReportMap.compute( index, ( key, value ) -> {
+                if ( value == null )
+                {
+                    return objectReport;
+                }
+                objectReport.forEachErrorReport( value::addErrorReport );
+                return value;
+            } ) );
     }
 
-    public void addObjectReport( ObjectReport objectReport )
+    /**
+     * Removes entries where the {@link ObjectReport} has no
+     * {@link ErrorReport}s.
+     */
+    public void clean()
     {
-        if ( !objectReportMap.containsKey( objectReport.getIndex() ) )
-        {
-            objectReportMap.put( objectReport.getIndex(), objectReport );
-            return;
-        }
+        objectReportMap.entrySet().removeIf( entry -> !entry.getValue().hasErrorReports() );
+    }
 
-        objectReportMap.get( objectReport.getIndex() ).merge( objectReport );
+    public void addObjectReport( ObjectReport report )
+    {
+        objectReportMap.compute( report.getIndex(),
+            ( key, value ) -> value == null ? report : value.merge( report ) );
     }
 
     // -----------------------------------------------------------------------------------
@@ -144,23 +151,63 @@ public class TypeReport
     @JacksonXmlProperty( localName = "objectReport", namespace = DxfNamespaces.DXF_2_0 )
     public void setObjectReports( List<ObjectReport> objectReports )
     {
+        objectReportMap.clear();
         if ( objectReports != null )
         {
             objectReports.forEach( or -> objectReportMap.put( or.getIndex(), or ) );
         }
     }
 
-    public List<ErrorReport> getErrorReports()
+    @JsonIgnore
+    public int getObjectReportsCount()
     {
-        List<ErrorReport> errorReports = new ArrayList<>();
-        objectReportMap.values().forEach( objectReport -> errorReports.addAll( objectReport.getErrorReports() ) );
-
-        return errorReports;
+        return objectReportMap.size();
     }
 
-    public Map<Integer, ObjectReport> getObjectReportMap()
+    public boolean hasObjectReports()
     {
-        return objectReportMap;
+        return !objectReportMap.isEmpty();
+    }
+
+    public ObjectReport getFirstObjectReport()
+    {
+        return objectReportMap.isEmpty() ? null : objectReportMap.values().iterator().next();
+    }
+
+    public void forEachObjectReport( Consumer<ObjectReport> reportConsumer )
+    {
+        objectReportMap.values().forEach( reportConsumer );
+    }
+
+    @JsonIgnore
+    @Override
+    public int getErrorReportsCount()
+    {
+        return objectReportMap.values().stream().mapToInt( ObjectReport::getErrorReportsCount ).sum();
+    }
+
+    @Override
+    public int getErrorReportsCount( ErrorCode errorCode )
+    {
+        return objectReportMap.values().stream().mapToInt( report -> report.getErrorReportsCount( errorCode ) ).sum();
+    }
+
+    @Override
+    public boolean hasErrorReports()
+    {
+        return objectReportMap.values().stream().anyMatch( ObjectReport::hasErrorReports );
+    }
+
+    @Override
+    public boolean hasErrorReport( Predicate<ErrorReport> test )
+    {
+        return objectReportMap.values().stream().anyMatch( report -> report.hasErrorReport( test ) );
+    }
+
+    @Override
+    public void forEachErrorReport( Consumer<ErrorReport> reportConsumer )
+    {
+        objectReportMap.values().forEach( objectReport -> objectReport.forEachErrorReport( reportConsumer ) );
     }
 
     @Override
@@ -172,4 +219,5 @@ public class TypeReport
             .add( "objectReports", getObjectReports() )
             .toString();
     }
+
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/TypeReportTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/TypeReportTest.java
@@ -57,8 +57,8 @@ public class TypeReportTest
         typeReport0.addObjectReport( objectReport1 );
         typeReport0.addObjectReport( objectReport2 );
 
-        assertEquals( 3, typeReport0.getObjectReports().size() );
-        assertEquals( 3, typeReport0.getErrorReports().size() );
+        assertEquals( 3, typeReport0.getObjectReportsCount() );
+        assertEquals( 3, typeReport0.getErrorReportsCount() );
 
         ObjectReport objectReport3 = new ObjectReport( DataElement.class, 3 );
         ObjectReport objectReport4 = new ObjectReport( DataElement.class, 4 );
@@ -76,8 +76,8 @@ public class TypeReportTest
         typeReport1.addObjectReport( objectReport1 );
         typeReport1.addObjectReport( objectReport2 );
 
-        assertEquals( 3, typeReport1.getObjectReports().size() );
-        assertEquals( 3, typeReport1.getErrorReports().size() );
+        assertEquals( 3, typeReport1.getObjectReportsCount() );
+        assertEquals( 3, typeReport1.getErrorReportsCount() );
     }
 
     @Test
@@ -99,8 +99,8 @@ public class TypeReportTest
         typeReport0.addObjectReport( objectReport1 );
         typeReport0.addObjectReport( objectReport2 );
 
-        assertEquals( 3, typeReport0.getObjectReports().size() );
-        assertEquals( 3, typeReport0.getErrorReports().size() );
+        assertEquals( 3, typeReport0.getObjectReportsCount() );
+        assertEquals( 3, typeReport0.getErrorReportsCount() );
 
         ObjectReport objectReport3 = new ObjectReport( DataElement.class, 3 );
         ObjectReport objectReport4 = new ObjectReport( DataElement.class, 4 );
@@ -118,12 +118,12 @@ public class TypeReportTest
         typeReport1.addObjectReport( objectReport4 );
         typeReport1.addObjectReport( objectReport5 );
 
-        assertEquals( 3, typeReport1.getObjectReports().size() );
-        assertEquals( 3, typeReport1.getErrorReports().size() );
+        assertEquals( 3, typeReport1.getObjectReportsCount() );
+        assertEquals( 3, typeReport1.getErrorReportsCount() );
 
         typeReport0.merge( typeReport1 );
 
-        assertEquals( 6, typeReport0.getErrorReports().size() );
-        assertEquals( 6, typeReport0.getObjectReports().size() );
+        assertEquals( 6, typeReport0.getErrorReportsCount() );
+        assertEquals( 6, typeReport0.getObjectReportsCount() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContext.java
@@ -27,13 +27,10 @@
  */
 package org.hisp.dhis.dxf2.metadata.jobs;
 
-import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.springframework.context.annotation.Scope;
@@ -93,21 +90,10 @@ public class MetadataRetryContext
     {
         Status status = importReport.getStatus();
 
-        if ( Status.ERROR.equals( status ) )
+        if ( Status.ERROR == status )
         {
             StringBuilder report = new StringBuilder();
-            List<ErrorReport> errorReports = importReport.getErrorReports();
-
-            for ( ErrorReport errorReport : errorReports )
-            {
-
-                if ( errorReport != null )
-                {
-                    report.append( errorReport.toString() + "\n" );
-                }
-
-            }
-
+            importReport.forEachErrorReport( errorReport -> report.append( errorReport.toString() + "\n" ) );
             retryContext.setAttribute( MetadataSyncJob.METADATA_SYNC_REPORT, report.toString() );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleValidationService.java
@@ -125,7 +125,7 @@ public class DefaultObjectBundleValidationService
 
         if ( AtomicMode.ALL == bundle.getAtomicMode() )
         {
-            if ( !validation.getErrorReports().isEmpty() )
+            if ( validation.hasErrorReports() )
             {
                 nonPersistedObjects.clear();
                 persistedObjects.clear();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/feedback/ObjectBundleCommitReport.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/feedback/ObjectBundleCommitReport.java
@@ -27,28 +27,29 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.feedback;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.ErrorReportContainer;
 import org.hisp.dhis.feedback.TypeReport;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class ObjectBundleCommitReport
+public class ObjectBundleCommitReport implements ErrorReportContainer, Iterable<TypeReport>
 {
-    private Map<Class<?>, TypeReport> typeReportMap = new HashMap<>();
+    private final Map<Class<?>, TypeReport> typeReportMap;
 
     public ObjectBundleCommitReport()
     {
+        this( new HashMap<>() );
     }
 
     public ObjectBundleCommitReport( Map<Class<?>, TypeReport> typeReportMap )
@@ -60,28 +61,10 @@ public class ObjectBundleCommitReport
     // Utility Methods
     // -----------------------------------------------------------------------------------
 
-    public List<ErrorReport> getErrorReportsByCode( Class<?> klass, ErrorCode errorCode )
+    public int getErrorReportsCountByCode( Class<?> klass, ErrorCode errorCode )
     {
-        List<ErrorReport> errorReports = new ArrayList<>();
-
-        if ( !typeReportMap.containsKey( klass ) )
-        {
-            return errorReports;
-        }
-
-        List<ObjectReport> objectReports = typeReportMap.get( klass ).getObjectReports();
-
-        for ( ObjectReport objectReport : objectReports )
-        {
-            List<ErrorReport> byCode = objectReport.getErrorReportsByCode().get( errorCode );
-
-            if ( byCode != null )
-            {
-                errorReports.addAll( byCode );
-            }
-        }
-
-        return errorReports;
+        TypeReport report = typeReportMap.get( klass );
+        return report == null ? 0 : report.getErrorReportsCount( errorCode );
     }
 
     public void addTypeReport( TypeReport report )
@@ -91,14 +74,14 @@ public class ObjectBundleCommitReport
             return;
         }
 
-        if ( !typeReportMap.containsKey( report.getKlass() ) )
-        {
-            typeReportMap.put( report.getKlass(), report );
-            return;
-        }
-
-        TypeReport typeReport = typeReportMap.get( report.getKlass() );
-        typeReport.merge( typeReport );
+        typeReportMap.compute( report.getKlass(), ( key, value ) -> {
+            if ( value == null )
+            {
+                return report;
+            }
+            value.merge( report );
+            return value;
+        } );
     }
 
     // -----------------------------------------------------------------------------------
@@ -110,48 +93,45 @@ public class ObjectBundleCommitReport
         return typeReportMap.isEmpty();
     }
 
-    public boolean isEmpty( Class<?> klass )
+    @Override
+    public Iterator<TypeReport> iterator()
     {
-        return typeReportMap.containsKey( klass ) && typeReportMap.get( klass ).getObjectReportMap().isEmpty();
+        return typeReportMap.values().iterator();
     }
 
-    public Map<Class<?>, TypeReport> getTypeReportMap()
-    {
-        return typeReportMap;
-    }
-
-    public TypeReport getTypeReportMap( Class<?> klass )
+    public TypeReport getTypeReport( Class<?> klass )
     {
         return typeReportMap.get( klass );
     }
 
-    public List<ObjectReport> getObjectReports( Class<?> klass )
+    @Override
+    public int getErrorReportsCount()
     {
-        if ( !typeReportMap.containsKey( klass ) )
-        {
-            return Lists.newArrayList();
-        }
-
-        return typeReportMap.get( klass ).getObjectReports();
+        return typeReportMap.values().stream().mapToInt( TypeReport::getErrorReportsCount ).sum();
     }
 
-    public List<ErrorReport> getErrorReports( Class<?> klass )
+    @Override
+    public int getErrorReportsCount( ErrorCode errorCode )
     {
-        if ( !typeReportMap.containsKey( klass ) )
-        {
-            return Lists.newArrayList();
-        }
-
-        return new ArrayList<>( typeReportMap.get( klass ).getErrorReports() );
+        return typeReportMap.values().stream().mapToInt( report -> report.getErrorReportsCount( errorCode ) ).sum();
     }
 
-    public List<ErrorReport> getErrorReports()
+    @Override
+    public boolean hasErrorReports()
     {
-        List<ErrorReport> errorReports = new ArrayList<>();
+        return typeReportMap.values().stream().anyMatch( TypeReport::hasErrorReports );
+    }
 
-        typeReportMap.values().forEach( typeReport -> errorReports.addAll( typeReport.getErrorReports() ) );
+    @Override
+    public boolean hasErrorReport( Predicate<ErrorReport> test )
+    {
+        return typeReportMap.values().stream().anyMatch( report -> report.hasErrorReport( test ) );
+    }
 
-        return errorReports;
+    @Override
+    public void forEachErrorReport( Consumer<ErrorReport> reportConsumer )
+    {
+        typeReportMap.values().forEach( report -> report.forEachErrorReport( reportConsumer ) );
     }
 
     @Override
@@ -161,4 +141,5 @@ public class ObjectBundleCommitReport
             .add( "typeReportMap", typeReportMap )
             .toString();
     }
+
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
@@ -59,9 +59,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 /**
  * @author Luciano Fiandesio
  */
-public class ReferencesCheck
-    implements
-    ValidationCheck
+public class ReferencesCheck implements ValidationCheck
 {
     @Override
     public TypeReport check( ObjectBundle bundle, Class<? extends IdentifiableObject> klass,
@@ -88,7 +86,7 @@ public class ReferencesCheck
             }
         }
 
-        if ( !typeReport.getErrorReports().isEmpty() && AtomicMode.ALL == bundle.getAtomicMode() )
+        if ( typeReport.hasErrorReports() && AtomicMode.ALL == bundle.getAtomicMode() )
         {
             typeReport.getStats().incIgnored();
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessor.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.dxf2.metadata.sync;
 
-import java.util.Map;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
@@ -38,7 +36,6 @@ import org.hisp.dhis.email.Email;
 import org.hisp.dhis.email.EmailService;
 import org.hisp.dhis.feedback.Stats;
 import org.hisp.dhis.feedback.Status;
-import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.VersionType;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,47 +113,38 @@ public class MetadataSyncPostProcessor
                 .append( "Version Name: " + metadataSyncSummary.getMetadataVersion().getName() + "\n" )
                 .append( "Version Type: " + metadataSyncSummary.getMetadataVersion().getType() + "\n" );
 
-        Map<Class<?>, TypeReport> typeReportMap = importReport.getTypeReportMap();
-
-        if ( typeReportMap != null && typeReportMap.entrySet().size() == 0 )
+        if ( importReport.getTypeReportCount() == 0 )
         {
             text.append( "New Version created. It does not have any metadata changes. \n" );
         }
-        else if ( typeReportMap != null )
+        else
         {
             text.append( "Imported Object Details: \n" );
 
-            for ( Map.Entry<Class<?>, TypeReport> typeReportEntry : typeReportMap.entrySet() )
-            {
-                if ( typeReportEntry != null )
+            importReport.forEachTypeReport( typeReport -> {
+                Stats stats = typeReport.getStats();
+
+                text.append( "Metadata Object Type: " )
+                    .append( typeReport.getKlass() )
+                    .append( "\n" )
+                    .append( "Stats: \n" )
+                    .append( "total: " + stats.getTotal() + "\n" );
+
+                if ( stats.getCreated() > 0 )
                 {
-                    Class<?> key = typeReportEntry.getKey();
-                    TypeReport value = typeReportEntry.getValue();
-                    Stats stats = value.getStats();
-
-                    text.append( "Metadata Object Type: " )
-                        .append( key )
-                        .append( "\n" )
-                        .append( "Stats: \n" )
-                        .append( "total: " + stats.getTotal() + "\n" );
-
-                    if ( stats.getCreated() > 0 )
-                    {
-                        text.append( " created: " + stats.getCreated() + "\n" );
-                    }
-
-                    if ( stats.getUpdated() > 0 )
-                    {
-                        text.append( " updated: " + stats.getUpdated() + "\n" );
-                    }
-
-                    if ( stats.getIgnored() > 0 )
-                    {
-                        text.append( " ignored: " + stats.getIgnored() + "\n" );
-                    }
+                    text.append( " created: " + stats.getCreated() + "\n" );
                 }
 
-            }
+                if ( stats.getUpdated() > 0 )
+                {
+                    text.append( " updated: " + stats.getUpdated() + "\n" );
+                }
+
+                if ( stats.getIgnored() > 0 )
+                {
+                    text.append( " ignored: " + stats.getIgnored() + "\n" );
+                }
+            } );
 
             text.append( "\n\n" );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
@@ -268,7 +268,7 @@ public final class WebMessageUtils
         WebMessage webMessage = new WebMessage();
         webMessage.setResponse( new TypeReportWebMessageResponse( typeReport ) );
 
-        if ( typeReport.getErrorReports().isEmpty() )
+        if ( !typeReport.hasErrorReports() )
         {
             webMessage.setStatus( Status.OK );
             webMessage.setHttpStatus( HttpStatus.OK );
@@ -285,19 +285,10 @@ public final class WebMessageUtils
 
     public static WebMessage objectReport( ImportReport importReport )
     {
-        WebMessage webMessage = new WebMessage( Status.OK, HttpStatus.OK );
-
-        if ( !importReport.getTypeReports().isEmpty() )
-        {
-            TypeReport typeReport = importReport.getTypeReports().get( 0 );
-
-            if ( !typeReport.getObjectReports().isEmpty() )
-            {
-                return objectReport( typeReport.getObjectReports().get( 0 ) );
-            }
-        }
-
-        return webMessage;
+        ObjectReport firstObjectReport = importReport.getFirstObjectReport();
+        return firstObjectReport == null
+            ? new WebMessage( Status.OK, HttpStatus.OK )
+            : objectReport( firstObjectReport );
     }
 
     public static WebMessage objectReport( ObjectReport objectReport )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/responses/TypeReportWebMessageResponse.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/responses/TypeReportWebMessageResponse.java
@@ -59,7 +59,7 @@ public class TypeReportWebMessageResponse
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Status getStatus()
     {
-        return typeReport.getErrorReports().isEmpty() ? Status.OK : Status.ERROR;
+        return !typeReport.hasErrorReports() ? Status.OK : Status.ERROR;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -48,10 +48,12 @@ import javax.xml.xpath.XPathExpressionException;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.collections4.*;
+import org.apache.commons.collections4.MapUtils;
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
@@ -59,7 +61,6 @@ import org.hisp.dhis.dataset.Section;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.mapping.MapView;
@@ -578,9 +579,7 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
 
         ImportReport importReport = importService.importMetadata( params );
 
-        assertTrue( importReport.getTypeReports().stream()
-            .flatMap( typeReport -> typeReport.getErrorReports().stream() )
-            .anyMatch( errorReport -> errorReport.getErrorCode().equals( ErrorCode.E5005 ) ) );
+        assertTrue( importReport.hasErrorReport( errorReport -> errorReport.getErrorCode() == ErrorCode.E5005 ) );
     }
 
     @Test
@@ -839,11 +838,7 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         dbmsManager.clearSession();
 
         report = importService.importMetadata( params );
-        final List<ErrorReport> errorReports = report.getErrorReports();
-        for ( ErrorReport errorReport : errorReports )
-        {
-            log.error( "Error report:" + errorReport );
-        }
+        report.forEachErrorReport( errorReport -> log.error( "Error report:" + errorReport ) );
         assertEquals( Status.OK, report.getStatus() );
 
         dataset = manager.get( DataSet.class, "em8Bg4LCr5k" );
@@ -894,11 +889,7 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         params.setMetadataSyncImport( true );
 
         report = importService.importMetadata( params );
-        final List<ErrorReport> errorReports = report.getErrorReports();
-        for ( ErrorReport errorReport : errorReports )
-        {
-            log.error( "Error report:" + errorReport );
-        }
+        report.forEachErrorReport( errorReport -> log.error( "Error report:" + errorReport ) );
         assertEquals( Status.OK, report.getStatus() );
 
         programStage = manager.get( ProgramStage.class, "NpsdDv6kKSO" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/feedback/ObjectBundleReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/feedback/ObjectBundleReportTest.java
@@ -58,9 +58,9 @@ public class ObjectBundleReportTest
         validationReport.addTypeReport( typeReport0 );
         validationReport.addTypeReport( typeReport1 );
 
-        assertEquals( 6, validationReport.getErrorReports().size() );
-        assertEquals( 3, validationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E3000 ).size() );
-        assertEquals( 3, validationReport.getErrorReportsByCode( Indicator.class, ErrorCode.E3000 ).size() );
+        assertEquals( 6, validationReport.getErrorReportsCount() );
+        assertEquals( 3, validationReport.getErrorReportsCountByCode( DataElement.class, ErrorCode.E3000 ) );
+        assertEquals( 3, validationReport.getErrorReportsCountByCode( Indicator.class, ErrorCode.E3000 ) );
     }
 
     @Test
@@ -73,9 +73,9 @@ public class ObjectBundleReportTest
         validationReport.addTypeReport( typeReport0 );
         validationReport.addTypeReport( typeReport1 );
 
-        assertEquals( 6, validationReport.getErrorReports().size() );
-        assertEquals( 3, validationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E3000 ).size() );
-        assertEquals( 3, validationReport.getErrorReportsByCode( Indicator.class, ErrorCode.E3000 ).size() );
+        assertEquals( 6, validationReport.getErrorReportsCount() );
+        assertEquals( 3, validationReport.getErrorReportsCountByCode( DataElement.class, ErrorCode.E3000 ) );
+        assertEquals( 3, validationReport.getErrorReportsCountByCode( Indicator.class, ErrorCode.E3000 ) );
     }
 
     @Test
@@ -90,34 +90,34 @@ public class ObjectBundleReportTest
         objectBundleValidationReport.addTypeReport( typeReport0 );
         objectBundleValidationReport.addTypeReport( typeReport1 );
 
-        assertEquals( 6, objectBundleValidationReport.getErrorReports().size() );
+        assertEquals( 6, objectBundleValidationReport.getErrorReportsCount() );
         assertEquals( 3,
-            objectBundleValidationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E3000 ).size() );
+            objectBundleValidationReport.getErrorReportsCountByCode( DataElement.class, ErrorCode.E3000 ) );
         assertEquals( 3,
-            objectBundleValidationReport.getErrorReportsByCode( Indicator.class, ErrorCode.E3000 ).size() );
+            objectBundleValidationReport.getErrorReportsCountByCode( Indicator.class, ErrorCode.E3000 ) );
 
         ObjectBundleCommitReport objectBundleCommitReport = new ObjectBundleCommitReport();
         objectBundleCommitReport.addTypeReport( typeReport2 );
         objectBundleCommitReport.addTypeReport( typeReport3 );
 
-        assertEquals( 6, objectBundleCommitReport.getErrorReports().size() );
-        assertEquals( 3, objectBundleCommitReport.getErrorReportsByCode( Indicator.class, ErrorCode.E3000 ).size() );
+        assertEquals( 6, objectBundleCommitReport.getErrorReportsCount() );
+        assertEquals( 3, objectBundleCommitReport.getErrorReportsCountByCode( Indicator.class, ErrorCode.E3000 ) );
         assertEquals( 3,
-            objectBundleCommitReport.getErrorReportsByCode( OrganisationUnit.class, ErrorCode.E3000 ).size() );
+            objectBundleCommitReport.getErrorReportsCountByCode( OrganisationUnit.class, ErrorCode.E3000 ) );
 
         ImportReport importReport = new ImportReport();
-        importReport.addTypeReports( objectBundleValidationReport.getTypeReportMap() );
-        importReport.addTypeReports( objectBundleCommitReport.getTypeReportMap() );
+        importReport.addTypeReports( objectBundleValidationReport );
+        importReport.addTypeReports( objectBundleCommitReport );
 
-        assertEquals( 3, importReport.getTypeReportMap().size() );
+        assertEquals( 3, importReport.getTypeReportKeys().size() );
 
-        assertEquals( 3, importReport.getTypeReportMap().get( DataElement.class ).getErrorReports().size() );
-        assertEquals( 3, importReport.getTypeReportMap().get( OrganisationUnit.class ).getErrorReports().size() );
-        assertEquals( 6, importReport.getTypeReportMap().get( Indicator.class ).getErrorReports().size() );
+        assertEquals( 3, importReport.getTypeReport( DataElement.class ).getErrorReportsCount() );
+        assertEquals( 3, importReport.getTypeReport( OrganisationUnit.class ).getErrorReportsCount() );
+        assertEquals( 6, importReport.getTypeReport( Indicator.class ).getErrorReportsCount() );
 
-        assertEquals( 3, importReport.getTypeReportMap().get( DataElement.class ).getObjectReports().size() );
-        assertEquals( 3, importReport.getTypeReportMap().get( Indicator.class ).getObjectReports().size() );
-        assertEquals( 3, importReport.getTypeReportMap().get( OrganisationUnit.class ).getObjectReports().size() );
+        assertEquals( 3, importReport.getTypeReport( DataElement.class ).getObjectReportsCount() );
+        assertEquals( 3, importReport.getTypeReport( Indicator.class ).getObjectReportsCount() );
+        assertEquals( 3, importReport.getTypeReport( OrganisationUnit.class ).getObjectReportsCount() );
     }
 
     private TypeReport createTypeReport( Class<?> mainKlass, Class<?> errorKlass )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceAttributesTest.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
@@ -108,7 +108,7 @@ public class ObjectBundleServiceAttributesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         transactionTemplate.execute( status -> {
             objectBundleService.commit( bundle );
@@ -193,11 +193,11 @@ public class ObjectBundleServiceAttributesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ObjectReport> objectReports = validationReport.getObjectReports( DataElement.class );
+        TypeReport typeReport = validationReport.getTypeReport( DataElement.class );
 
-        assertFalse( objectReports.isEmpty() );
-        assertEquals( 4, objectReports.size() );
-        objectReports.forEach( objectReport -> assertEquals( 2, objectReport.getErrorReports().size() ) );
+        assertNotNull( typeReport );
+        assertEquals( 4, typeReport.getObjectReportsCount() );
+        typeReport.forEachObjectReport( objectReport -> assertEquals( 2, objectReport.getErrorReportsCount() ) );
     }
 
     @Test
@@ -214,11 +214,11 @@ public class ObjectBundleServiceAttributesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ObjectReport> objectReports = validationReport.getObjectReports( DataElement.class );
+        TypeReport typeReport = validationReport.getTypeReport( DataElement.class );
 
-        assertFalse( objectReports.isEmpty() );
-        assertEquals( 4, objectReports.size() );
-        objectReports.forEach( objectReport -> assertEquals( 1, objectReport.getErrorReports().size() ) );
+        assertNotNull( typeReport );
+        assertEquals( 4, typeReport.getObjectReportsCount() );
+        typeReport.forEachObjectReport( objectReport -> assertEquals( 1, objectReport.getErrorReportsCount() ) );
     }
 
     @Test
@@ -236,10 +236,10 @@ public class ObjectBundleServiceAttributesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ObjectReport> objectReports = validationReport.getObjectReports( DataElement.class );
+        TypeReport typeReport = validationReport.getTypeReport( DataElement.class );
 
-        assertFalse( objectReports.isEmpty() );
-        assertEquals( 2, validationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E4009 ).size() );
+        assertNotNull( typeReport );
+        assertEquals( 2, validationReport.getErrorReportsCountByCode( DataElement.class, ErrorCode.E4009 ) );
     }
 
     @Test
@@ -256,10 +256,9 @@ public class ObjectBundleServiceAttributesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ObjectReport> objectReports = validationReport.getObjectReports( DataElement.class );
 
-        assertFalse( objectReports.isEmpty() );
-        assertEquals( 2, validationReport.getErrorReportsByCode( DataElement.class, ErrorCode.E4009 ).size() );
+        assertNotNull( validationReport.getTypeReport( DataElement.class ) );
+        assertEquals( 2, validationReport.getErrorReportsCountByCode( DataElement.class, ErrorCode.E4009 ) );
     }
 
     private void defaultSetupWithAttributes()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceFavoritesTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceFavoritesTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.metadata.objectbundle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -99,7 +100,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<DataSet> dataSets = manager.getAll( DataSet.class );
@@ -128,7 +129,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<DataSet> dataSets = manager.getAll( DataSet.class );
@@ -188,7 +189,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<DataSet> dataSets = manager.getAll( DataSet.class );
@@ -222,7 +223,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<DataSet> dataSets = manager.getAll( DataSet.class );
@@ -256,7 +257,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<DataSet> dataSets = manager.getAll( DataSet.class );
@@ -284,7 +285,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<LegendSet> legendSets = manager.getAll( LegendSet.class );
@@ -312,7 +313,7 @@ public class ObjectBundleServiceFavoritesTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<LegendSet> legendSets = manager.getAll( LegendSet.class );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceProgramTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceProgramTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -112,9 +111,9 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        validate.getErrorReports().forEach( System.out::println );
+        validate.forEachErrorReport( System.out::println );
 
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -156,7 +155,7 @@ public class ObjectBundleServiceProgramTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -203,9 +202,9 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        validate.getErrorReports().forEach( System.out::println );
+        validate.forEachErrorReport( System.out::println );
 
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -246,8 +245,8 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle1 = objectBundleService.create( params1 );
         ObjectBundleValidationReport validate1 = objectBundleValidationService.validate( bundle1 );
 
-        assertTrue( validate1.getErrorReports().isEmpty() );
-        assertEquals( 0, validate1.getErrorReports().size() );
+        assertFalse( validate1.hasErrorReports() );
+        assertEquals( 0, validate1.getErrorReportsCount() );
     }
 
     @Test
@@ -267,7 +266,7 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle1 = objectBundleService.create( params1 );
         ObjectBundleValidationReport validate1 = objectBundleValidationService.validate( bundle1 );
 
-        assertTrue( validate1.getErrorReports().isEmpty() );
+        assertFalse( validate1.hasErrorReports() );
     }
 
     @Test
@@ -287,14 +286,10 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        validate.getErrorReports().forEach( System.out::println );
+        validate.forEachErrorReport( System.out::println );
 
-        assertFalse( validate.getErrorReports().isEmpty() );
-
-        List<ErrorCode> codes = validate.getErrorReports().stream().map( r -> r.getErrorCode() )
-            .collect( Collectors.toList() );
-
-        assertTrue( codes.contains( ErrorCode.E4047 ) );
+        assertTrue( validate.hasErrorReports() );
+        assertTrue( validate.hasErrorReport( report -> report.getErrorCode() == ErrorCode.E4047 ) );
     }
 
     @Test
@@ -314,9 +309,9 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        validate.getErrorReports().forEach( System.out::println );
+        validate.forEachErrorReport( System.out::println );
 
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
     }
 
     @Test
@@ -334,7 +329,7 @@ public class ObjectBundleServiceProgramTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -350,8 +345,8 @@ public class ObjectBundleServiceProgramTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        validate.getErrorReports().forEach( System.out::println );
-        assertFalse( validate.getErrorReports().isEmpty() );
+        validate.forEachErrorReport( System.out::println );
+        assertTrue( validate.hasErrorReports() );
     }
 
     @Test
@@ -369,7 +364,7 @@ public class ObjectBundleServiceProgramTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -400,8 +395,8 @@ public class ObjectBundleServiceProgramTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        validate.getErrorReports().forEach( System.out::println );
-        assertFalse( validate.getErrorReports().isEmpty() );
+        validate.forEachErrorReport( System.out::println );
+        assertTrue( validate.hasErrorReports() );
     }
 
     @Test
@@ -419,8 +414,8 @@ public class ObjectBundleServiceProgramTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        validate.getErrorReports().forEach( System.out::println );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        validate.forEachErrorReport( System.out::println );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -462,8 +457,8 @@ public class ObjectBundleServiceProgramTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        validate.getErrorReports().forEach( System.out::println );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        validate.forEachErrorReport( System.out::println );
+        assertFalse( validate.hasErrorReports() );
     }
 
     private void createProgramRuleMetadata()
@@ -481,9 +476,9 @@ public class ObjectBundleServiceProgramTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        validate.getErrorReports().forEach( System.out::println );
+        validate.forEachErrorReport( System.out::println );
 
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
 import static org.hisp.dhis.dxf2.metadata.AtomicMode.NONE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -58,8 +59,6 @@ import org.hisp.dhis.dataset.Section;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.option.OptionSet;
@@ -177,38 +176,26 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
         assertFalse( validate.isEmpty() );
 
-        List<ObjectReport> objectReports = validate.getObjectReports( DataElement.class );
-        assertFalse( objectReports.isEmpty() );
+        assertTrue( validate.hasErrorReports() );
 
-        for ( ObjectReport objectReport : objectReports )
-        {
-            for ( ErrorCode errorCode : objectReport.getErrorCodes() )
+        validate.forEachErrorReport( errorReport -> {
+            assertTrue( errorReport instanceof PreheatErrorReport );
+            PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
+            assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
+
+            if ( preheatErrorReport.getValue() instanceof CategoryCombo )
             {
-                List<ErrorReport> errorReports = objectReport.getErrorReportsByCode().get( errorCode );
-
-                assertFalse( errorReports.isEmpty() );
-
-                for ( ErrorReport errorReport : errorReports )
-                {
-                    assertTrue( errorReport instanceof PreheatErrorReport );
-                    PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
-                    assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
-
-                    if ( preheatErrorReport.getValue() instanceof CategoryCombo )
-                    {
-                        assertEquals( "p0KPaWEg3cf", preheatErrorReport.getObjectReference().getUid() );
-                    }
-                    else if ( preheatErrorReport.getValue() instanceof User )
-                    {
-                        assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
-                    }
-                    else if ( preheatErrorReport.getValue() instanceof OptionSet )
-                    {
-                        assertEquals( "pQYCiuosBnZ", preheatErrorReport.getObjectReference().getUid() );
-                    }
-                }
+                assertEquals( "p0KPaWEg3cf", preheatErrorReport.getObjectReference().getUid() );
             }
-        }
+            else if ( preheatErrorReport.getValue() instanceof User )
+            {
+                assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
+            }
+            else if ( preheatErrorReport.getValue() instanceof OptionSet )
+            {
+                assertEquals( "pQYCiuosBnZ", preheatErrorReport.getObjectReference().getUid() );
+            }
+        } );
     }
 
     @Test
@@ -234,40 +221,26 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertFalse( validate.getTypeReportMap().isEmpty() );
 
-        List<ObjectReport> objectReports = validate.getObjectReports( DataElement.class );
-        assertFalse( objectReports.isEmpty() );
+        assertTrue( validate.hasErrorReports() );
+        validate.forEachErrorReport( errorReport -> {
+            assertTrue( errorReport instanceof PreheatErrorReport );
+            PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
+            assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
 
-        for ( ObjectReport objectReport : objectReports )
-        {
-            for ( ErrorCode errorCode : objectReport.getErrorCodes() )
+            if ( preheatErrorReport.getValue() instanceof CategoryCombo )
             {
-                List<ErrorReport> errorReports = objectReport.getErrorReportsByCode().get( errorCode );
-
-                assertFalse( errorReports.isEmpty() );
-
-                for ( ErrorReport errorReport : errorReports )
-                {
-                    assertTrue( errorReport instanceof PreheatErrorReport );
-                    PreheatErrorReport preheatErrorReport = (PreheatErrorReport) errorReport;
-                    assertEquals( PreheatIdentifier.UID, preheatErrorReport.getPreheatIdentifier() );
-
-                    if ( preheatErrorReport.getValue() instanceof CategoryCombo )
-                    {
-                        fail();
-                    }
-                    else if ( preheatErrorReport.getValue() instanceof User )
-                    {
-                        assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
-                    }
-                    else if ( preheatErrorReport.getValue() instanceof OptionSet )
-                    {
-                        fail();
-                    }
-                }
+                fail();
             }
-        }
+            else if ( preheatErrorReport.getValue() instanceof User )
+            {
+                assertEquals( "GOLswS44mh8", preheatErrorReport.getObjectReference().getUid() );
+            }
+            else if ( preheatErrorReport.getValue() instanceof OptionSet )
+            {
+                fail();
+            }
+        } );
     }
 
     @Test
@@ -285,10 +258,10 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertFalse( validate.getTypeReportMap().isEmpty() );
+        assertTrue( validate.hasErrorReports() );
 
-        assertEquals( 5, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5002 ).size() );
-        assertEquals( 3, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E4000 ).size() );
+        assertEquals( 5, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E5002 ) );
+        assertEquals( 3, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E4000 ) );
     }
 
     @Test
@@ -306,8 +279,8 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertFalse( validate.getTypeReportMap().isEmpty() );
-        assertEquals( 3, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5001 ).size() );
+        assertTrue( validate.hasErrorReports() );
+        assertEquals( 3, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E5001 ) );
     }
 
     @Test
@@ -326,7 +299,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertEquals( 3, validate.getTypeReportMap( DataElement.class ).getObjectReports().size() );
+        assertEquals( 3, validate.getTypeReport( DataElement.class ).getObjectReportsCount() );
     }
 
     @Test
@@ -347,8 +320,8 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertEquals( 1, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5001 ).size() );
-        assertFalse( validate.getErrorReportsByCode( DataElement.class, ErrorCode.E4000 ).isEmpty() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E5001 ) );
+        assertNotEquals( 0, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E4000 ) );
         assertEquals( 0, bundle.getObjectsCount( DataElement.class ) );
     }
 
@@ -368,8 +341,8 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertFalse( validate.getTypeReportMap( DataElement.class ).getObjectReports().isEmpty() );
-        assertEquals( 3, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5001 ).size() );
+        assertTrue( validate.getTypeReport( DataElement.class ).hasObjectReports() );
+        assertEquals( 3, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E5001 ) );
     }
 
     @Test
@@ -388,8 +361,8 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertFalse( validate.getTypeReportMap( DataElement.class ).getObjectReports().isEmpty() );
-        assertEquals( 3, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5001 ).size() );
+        assertTrue( validate.getTypeReport( DataElement.class ).hasObjectReports() );
+        assertEquals( 3, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E5001 ) );
     }
 
     @Test
@@ -408,8 +381,8 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertFalse( validate.getTypeReportMap( DataElement.class ).getObjectReports().isEmpty() );
-        assertEquals( 3, validate.getErrorReportsByCode( DataElement.class, ErrorCode.E5001 ).size() );
+        assertTrue( validate.getTypeReport( DataElement.class ).hasObjectReports() );
+        assertEquals( 3, validate.getErrorReportsCountByCode( DataElement.class, ErrorCode.E5001 ) );
     }
 
     @Test
@@ -574,7 +547,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         metadata = renderService.fromMetadata(
@@ -587,7 +560,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<OrganisationUnit> organisationUnits = manager.getAll( OrganisationUnit.class );
@@ -740,7 +713,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -788,7 +761,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -857,7 +830,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -887,8 +860,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        final List<ErrorReport> errorReports = validate.getErrorReports();
-        assertTrue( errorReports.isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -990,7 +962,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundle bundle = objectBundleService.create( params );
 
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1018,7 +990,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1045,7 +1017,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1086,7 +1058,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1100,7 +1072,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1142,9 +1114,9 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertFalse( validate.getErrorReports().isEmpty() );
-        assertEquals( "leftSide.description", validate.getErrorReports().get( 0 ).getErrorProperty() );
-        assertEquals( ErrorCode.E4001, validate.getErrorReports().get( 0 ).getErrorCode() );
+        assertEquals( 1, validate.getErrorReportsCount() );
+        assertTrue( validate.hasErrorReport( report -> "leftSide.description".equals( report.getErrorProperty() )
+            && ErrorCode.E4001 == report.getErrorCode() ) );
     }
 
     @Test
@@ -1162,9 +1134,9 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertFalse( validate.getErrorReports().isEmpty() );
-        assertEquals( "rightSide", validate.getErrorReports().get( 0 ).getErrorProperty() );
-        assertEquals( ErrorCode.E4000, validate.getErrorReports().get( 0 ).getErrorCode() );
+        assertEquals( 1, validate.getErrorReportsCount() );
+        assertTrue( validate.hasErrorReport( report -> "rightSide".equals( report.getErrorProperty() )
+            && ErrorCode.E4000 == report.getErrorCode() ) );
     }
 
     @Test
@@ -1188,7 +1160,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport objectBundleValidationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( objectBundleValidationReport.getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationReport.hasErrorReports() );
         objectBundleService.commit( bundle );
 
         DataElement dataElementA = dataElementMap.get( "deabcdefghA" );
@@ -1247,7 +1219,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
 
         DataElement dataElementA = manager.get( DataElement.class, "deabcdefghA" );
@@ -1306,7 +1278,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
 
         DataElement dataElementE = manager.get( DataElement.class, "deabcdefghE" );
@@ -1336,7 +1308,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
 
         assertFalse( validate.isEmpty() );
-        assertEquals( 1, validate.getErrorReportsByCode( UserAuthorityGroup.class, ErrorCode.E5003 ).size() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( UserAuthorityGroup.class, ErrorCode.E5003 ) );
     }
 
     @Test
@@ -1428,7 +1400,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1451,7 +1423,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1465,8 +1437,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        List<ErrorReport> errorReports = validate.getErrorReports();
-        assertTrue( validate.getErrorReports().isEmpty() );
+        assertFalse( validate.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1546,7 +1517,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1570,7 +1541,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
 
         objectBundleService.commit( bundle );
 
@@ -1597,7 +1568,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
     }
 
@@ -1617,7 +1588,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertEquals( 3, objectBundleValidationService.validate( bundle ).getErrorReports().size() );
+        assertEquals( 3, objectBundleValidationService.validate( bundle ).getErrorReportsCount() );
     }
 
     @Test
@@ -1634,7 +1605,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<OrganisationUnit> organisationUnits = manager.getAll( OrganisationUnit.class );
@@ -1655,7 +1626,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
 
         organisationUnits = manager.getAll( OrganisationUnit.class );
@@ -1679,7 +1650,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
 
         List<OrganisationUnit> organisationUnits = manager.getAll( OrganisationUnit.class );
@@ -1700,7 +1671,7 @@ public class ObjectBundleServiceTest extends TransactionalIntegrationTest
         params.setObjects( metadata );
 
         bundle = objectBundleService.create( params );
-        assertTrue( objectBundleValidationService.validate( bundle ).getErrorReports().isEmpty() );
+        assertFalse( objectBundleValidationService.validate( bundle ).hasErrorReports() );
         objectBundleService.commit( bundle );
 
         organisationUnits = manager.getAll( OrganisationUnit.class );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,7 +42,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.render.RenderFormat;
@@ -102,7 +102,7 @@ public class ObjectBundleServiceUserTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertEquals( 1, validate.getErrorReportsByCode( UserAuthorityGroup.class, ErrorCode.E5003 ).size() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( UserAuthorityGroup.class, ErrorCode.E5003 ) );
         objectBundleService.commit( bundle );
 
         List<User> users = manager.getAll( User.class );
@@ -131,7 +131,7 @@ public class ObjectBundleServiceUserTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertEquals( 1, validate.getErrorReportsByCode( UserAuthorityGroup.class, ErrorCode.E5003 ).size() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( UserAuthorityGroup.class, ErrorCode.E5003 ) );
         objectBundleService.commit( bundle );
 
         params = createBundleParams( ObjectBundleMode.COMMIT, ImportStrategy.UPDATE, AtomicMode.NONE,
@@ -139,7 +139,7 @@ public class ObjectBundleServiceUserTest
 
         bundle = objectBundleService.create( params );
         validate = objectBundleValidationService.validate( bundle );
-        assertEquals( 1, validate.getErrorReportsByCode( UserAuthorityGroup.class, ErrorCode.E5001 ).size() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( UserAuthorityGroup.class, ErrorCode.E5001 ) );
         objectBundleService.commit( bundle );
 
         List<User> users = manager.getAll( User.class );
@@ -165,7 +165,7 @@ public class ObjectBundleServiceUserTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertEquals( 1, validate.getErrorReportsByCode( UserAuthorityGroup.class, ErrorCode.E5003 ).size() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( UserAuthorityGroup.class, ErrorCode.E5003 ) );
         objectBundleService.commit( bundle );
 
         params = createBundleParams( ObjectBundleMode.COMMIT, ImportStrategy.UPDATE, AtomicMode.NONE,
@@ -173,12 +173,9 @@ public class ObjectBundleServiceUserTest
 
         bundle = objectBundleService.create( params );
         ObjectBundleValidationReport report = objectBundleValidationService.validate( bundle );
-        List<ErrorReport> userErrors = report.getErrorReportsByCode( User.class, ErrorCode.E4003 );
-        assertEquals( 1, userErrors.size() );
-        ErrorReport error = userErrors.get( 0 );
-        assertEquals( "email", error.getErrorProperty() );
-        assertEquals( "Property `email` requires a valid email address, was given `notAnEmail`.",
-            error.getMessage() );
+        assertEquals( 1, report.getErrorReportsCountByCode( User.class, ErrorCode.E4003 ) );
+        assertTrue( report.hasErrorReport( error -> "email".equals( error.getErrorProperty() ) &&
+            "Property `email` requires a valid email address, was given `notAnEmail`.".equals( error.getMessage() ) ) );
     }
 
     @Test
@@ -221,7 +218,7 @@ public class ObjectBundleServiceUserTest
             "dxf2/user_admin.json" );
 
         ObjectBundle bundle = objectBundleService.create( params );
-        assertEquals( 0, objectBundleValidationService.validate( bundle ).getErrorReports().size() );
+        assertEquals( 0, objectBundleValidationService.validate( bundle ).getErrorReportsCount() );
     }
 
     @Test
@@ -235,7 +232,7 @@ public class ObjectBundleServiceUserTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validate = objectBundleValidationService.validate( bundle );
-        assertEquals( 1, validate.getErrorReportsByCode( User.class, ErrorCode.E4005 ).size() );
+        assertEquals( 1, validate.getErrorReportsCountByCode( User.class, ErrorCode.E4005 ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactoryTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactoryTest.java
@@ -104,7 +104,7 @@ public class ValidationFactoryTest
         assertThat( typeReport.getStats().getUpdated(), is( 0 ) );
         assertThat( typeReport.getStats().getDeleted(), is( 0 ) );
         assertThat( typeReport.getStats().getIgnored(), is( 1 ) );
-        assertThat( typeReport.getObjectReports(), hasSize( 1 ) );
+        assertThat( typeReport.getObjectReportsCount(), is( 1 ) );
     }
 
     private ObjectBundle createObjectBundle()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -108,7 +109,7 @@ public abstract class TrackerTest extends TransactionalIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.bundle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -97,7 +98,7 @@ public class ReportSummaryIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerEventBundleServiceTest.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.tracker.bundle;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.List;
@@ -84,7 +84,7 @@ public class TrackerEventBundleServiceTest extends TrackerTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         objectBundleService.commit( bundle );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
@@ -31,7 +31,6 @@ import static org.awaitility.Awaitility.await;
 import static org.hisp.dhis.tracker.validation.AbstractImportValidationTest.ADMIN_USER_UID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -100,7 +99,7 @@ public class TrackerSideEffectHandlerServiceTest extends TransactionalIntegratio
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         objectBundleService.commit( bundle );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/params/AtomicModeIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/params/AtomicModeIntegrationTest.java
@@ -28,9 +28,9 @@
 package org.hisp.dhis.tracker.params;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,7 +101,7 @@ public class AtomicModeIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.tracker.programrule;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,20 +39,32 @@ import java.util.Map;
 import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dxf2.metadata.objectbundle.*;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.programrule.*;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionService;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
+import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.report.*;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.hisp.dhis.tracker.report.TrackerStatus;
+import org.hisp.dhis.tracker.report.TrackerWarningReport;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.Test;
@@ -101,7 +115,7 @@ public class ProgramRuleIntegrationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertTrue( validationReport.getErrorReports().isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         objectBundleService.commit( bundle );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -50,7 +50,6 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleCommitReport;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -67,7 +66,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.report.*;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.Test;
@@ -225,12 +226,10 @@ public class EnrollmentSecurityImportValidationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ErrorReport> errorReports = validationReport.getErrorReports();
-        assertTrue( errorReports.isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         ObjectBundleCommitReport commit = objectBundleService.commit( bundle );
-        List<ErrorReport> objectReport = commit.getErrorReports();
-        assertTrue( objectReport.isEmpty() );
+        assertFalse( commit.hasErrorReports() );
 
         TrackerImportParams trackerBundleParams = createBundleFromJson(
             "tracker/validations/enrollments_te_te-data.json" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -28,11 +28,19 @@
 package org.hisp.dhis.tracker.validation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Every.everyItem;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.UPDATE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Date;
@@ -49,7 +57,6 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleCommitReport;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
@@ -115,12 +122,10 @@ public class EventImportValidationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ErrorReport> errorReports = validationReport.getErrorReports();
-        assertTrue( errorReports.isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         ObjectBundleCommitReport commit = objectBundleService.commit( bundle );
-        List<ErrorReport> objectReport = commit.getErrorReports();
-        assertTrue( objectReport.isEmpty() );
+        assertFalse( commit.hasErrorReports() );
 
         TrackerImportParams trackerImportParams = createBundleFromJson(
             "tracker/validations/enrollments_te_te-data.json" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.List;
@@ -46,7 +46,6 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleCommitReport;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
@@ -107,12 +106,10 @@ public class TrackedEntityImportValidationTest
 
         ObjectBundle bundle = objectBundleService.create( params );
         ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        List<ErrorReport> errorReports = validationReport.getErrorReports();
-        assertTrue( errorReports.isEmpty() );
+        assertFalse( validationReport.hasErrorReports() );
 
         ObjectBundleCommitReport commit = objectBundleService.commit( bundle );
-        List<ErrorReport> errorReports1 = commit.getErrorReports();
-        assertTrue( errorReports1.isEmpty() );
+        assertFalse( commit.hasErrorReports() );
 
         manager.flush();
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -566,7 +566,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
             }
         }
 
-        if ( !typeReport.getErrorReports().isEmpty() )
+        if ( typeReport.hasErrorReports() )
         {
             WebMessage webMessage = WebMessageUtils.typeReport( typeReport );
             webMessageService.send( webMessage, response, request );
@@ -874,17 +874,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
     private ObjectReport getObjectReport( ImportReport importReport )
     {
-        if ( !importReport.getTypeReports().isEmpty() )
-        {
-            TypeReport typeReport = importReport.getTypeReports().get( 0 );
-
-            if ( !typeReport.getObjectReports().isEmpty() )
-            {
-                return typeReport.getObjectReports().get( 0 );
-            }
-        }
-
-        return null;
+        return importReport.getFirstObjectReport();
     }
 
     @RequestMapping( value = "/{uid}/favorite", method = RequestMethod.POST )
@@ -1363,7 +1353,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
         typeReport.addObjectReport( sharingService.saveSharing( getEntityClass(), entity, sharingObject ) );
 
-        if ( !typeReport.getErrorReports().isEmpty() )
+        if ( typeReport.hasErrorReports() )
         {
             WebMessage webMessage = WebMessageUtils.typeReport( typeReport );
             webMessageService.send( webMessage, response, request );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -432,7 +432,7 @@ public abstract class ChartFacadeController
             }
         }
 
-        if ( !typeReport.getErrorReports().isEmpty() )
+        if ( typeReport.hasErrorReports() )
         {
             WebMessage webMessage = WebMessageUtils.typeReport( typeReport );
             webMessageService.send( webMessage, response, request );
@@ -1226,17 +1226,7 @@ public abstract class ChartFacadeController
 
     private ObjectReport getObjectReport( ImportReport importReport )
     {
-        if ( !importReport.getTypeReports().isEmpty() )
-        {
-            TypeReport typeReport = importReport.getTypeReports().get( 0 );
-
-            if ( !typeReport.getObjectReports().isEmpty() )
-            {
-                return typeReport.getObjectReports().get( 0 );
-            }
-        }
-
-        return null;
+        return importReport.getFirstObjectReport();
     }
 
     protected List<Visualization> getEntity( String uid, WebOptions options )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -431,7 +431,7 @@ public abstract class ReportTableFacadeController
             }
         }
 
-        if ( !typeReport.getErrorReports().isEmpty() )
+        if ( typeReport.hasErrorReports() )
         {
             WebMessage webMessage = WebMessageUtils.typeReport( typeReport );
             webMessageService.send( webMessage, response, request );
@@ -1217,17 +1217,7 @@ public abstract class ReportTableFacadeController
 
     private ObjectReport getObjectReport( ImportReport importReport )
     {
-        if ( !importReport.getTypeReports().isEmpty() )
-        {
-            TypeReport typeReport = importReport.getTypeReports().get( 0 );
-
-            if ( !typeReport.getObjectReports().isEmpty() )
-            {
-                return typeReport.getObjectReports().get( 0 );
-            }
-        }
-
-        return null;
+        return importReport.getFirstObjectReport();
     }
 
     protected List<Visualization> getEntity( String uid, WebOptions options )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -57,7 +57,6 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.Status;
-import org.hisp.dhis.feedback.TypeReport;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.hibernate.exception.CreateAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.UpdateAccessDeniedException;
@@ -832,19 +831,9 @@ public class UserController
         return objectReport;
     }
 
-    private ObjectReport getObjectReport( ImportReport importReport )
+    private static ObjectReport getObjectReport( ImportReport importReport )
     {
-        if ( !importReport.getTypeReports().isEmpty() )
-        {
-            TypeReport typeReport = importReport.getTypeReports().get( 0 );
-
-            if ( !typeReport.getObjectReports().isEmpty() )
-            {
-                return typeReport.getObjectReports().get( 0 );
-            }
-        }
-
-        return null;
+        return importReport.getFirstObjectReport();
     }
 
     /**


### PR DESCRIPTION
This PR changes report classes to work more like an ADT with the goal to avoid exposing the inner data structure and/or the need to copy parts into intermediate collection. 

Instead dedicated methods are introduced to:

* check emptiness/non-emptiness
* count conditional/unconditional entries
* iterate entries

In this context I also updated the internals using stream API and more recent map API methods.
Here I found that two of the `merge` methods were incorrectly merging with themselves instead of the passed other report. See my comments for details.

Another change of behaviour is that setter which would accept a list of elements which internally is stored in a map had missed to clear the map before inserting the elements in a loop effectively doing an _add_, not a _set_ operation. I added a `Map#clear`.