### PR TITLE
chore: extracts read-only methods from generic CRUD controller

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -27,42 +27,24 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.validateAndThrowErrors;
-import static org.springframework.http.CacheControl.noCache;
 
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
-import org.cache2k.Cache;
-import org.cache2k.Cache2kBuilder;
-import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjects;
-import org.hisp.dhis.common.NamedParams;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SubscribableObject;
-import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatch;
-import org.hisp.dhis.dxf2.common.OrderParams;
-import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.metadata.MetadataExportService;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportService;
@@ -77,68 +59,31 @@ import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.feedback.TypeReport;
-import org.hisp.dhis.fieldfilter.Defaults;
-import org.hisp.dhis.fieldfilter.FieldFilterParams;
-import org.hisp.dhis.fieldfilter.FieldFilterService;
-import org.hisp.dhis.gist.GistAutoType;
-import org.hisp.dhis.gist.GistQuery;
-import org.hisp.dhis.gist.GistQuery.Comparison;
-import org.hisp.dhis.gist.GistQuery.Filter;
-import org.hisp.dhis.gist.GistQuery.Owner;
-import org.hisp.dhis.gist.GistService;
 import org.hisp.dhis.hibernate.exception.CreateAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.DeleteAccessDeniedException;
-import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.UpdateAccessDeniedException;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.jsonpatch.JsonPatchManager;
-import org.hisp.dhis.node.Node;
-import org.hisp.dhis.node.NodeUtils;
-import org.hisp.dhis.node.Preset;
-import org.hisp.dhis.node.config.InclusionStrategy;
-import org.hisp.dhis.node.types.CollectionNode;
-import org.hisp.dhis.node.types.ComplexNode;
-import org.hisp.dhis.node.types.RootNode;
-import org.hisp.dhis.node.types.SimpleNode;
 import org.hisp.dhis.patch.Patch;
 import org.hisp.dhis.patch.PatchParams;
 import org.hisp.dhis.patch.PatchService;
-import org.hisp.dhis.query.Order;
-import org.hisp.dhis.query.Pagination;
-import org.hisp.dhis.query.Query;
-import org.hisp.dhis.query.QueryParserException;
-import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.schema.MergeService;
 import org.hisp.dhis.schema.Property;
-import org.hisp.dhis.schema.Schema;
-import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.validation.SchemaValidator;
-import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.sharing.SharingService;
 import org.hisp.dhis.translation.Translation;
-import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.user.UserSettingKey;
-import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.user.sharing.Sharing;
-import org.hisp.dhis.webapi.JsonBuilder;
-import org.hisp.dhis.webapi.controller.exception.BadRequestException;
-import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.service.ContextService;
-import org.hisp.dhis.webapi.service.LinkService;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.hisp.dhis.webapi.utils.PaginationUtils;
-import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -148,53 +93,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Enums;
-import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-public abstract class AbstractCrudController<T extends IdentifiableObject>
+public abstract class AbstractCrudController<T extends IdentifiableObject> extends AbstractReadOnlyCrudController<T>
 {
-    protected static final WebOptions NO_WEB_OPTIONS = new WebOptions( new HashMap<>() );
-
-    protected static final String DEFAULTS = "INCLUDE";
-
-    private final Cache<String, Long> paginationCountCache = new Cache2kBuilder<String, Long>()
-    {
-    }
-        .expireAfterWrite( 1, TimeUnit.MINUTES )
-        .build();
 
     // --------------------------------------------------------------------------
     // Dependencies
     // --------------------------------------------------------------------------
 
     @Autowired
-    protected IdentifiableObjectManager manager;
-
-    @Autowired
-    protected CurrentUserService currentUserService;
-
-    @Autowired
-    protected FieldFilterService fieldFilterService;
-
-    @Autowired
-    protected AclService aclService;
-
-    @Autowired
-    protected SchemaService schemaService;
-
-    @Autowired
     protected SchemaValidator schemaValidator;
-
-    @Autowired
-    protected LinkService linkService;
 
     @Autowired
     protected RenderService renderService;
@@ -206,19 +120,10 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     protected MetadataExportService exportService;
 
     @Autowired
-    protected ContextService contextService;
-
-    @Autowired
-    protected QueryService queryService;
-
-    @Autowired
     protected WebMessageService webMessageService;
 
     @Autowired
     protected HibernateCacheManager hibernateCacheManager;
-
-    @Autowired
-    protected UserSettingService userSettingService;
 
     @Autowired
     protected CollectionService collectionService;
@@ -233,12 +138,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     protected PatchService patchService;
 
     @Autowired
-    protected AttributeService attributeService;
-
-    @Autowired
-    protected ObjectMapper jsonMapper;
-
-    @Autowired
     @Qualifier( "xmlMapper" )
     protected ObjectMapper xmlMapper;
 
@@ -247,264 +146,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
     @Autowired
     protected SharingService sharingService;
-
-    @Autowired
-    private GistService gistService;
-
-    // --------------------------------------------------------------------------
-    // GET
-    // --------------------------------------------------------------------------
-
-    @RequestMapping( value = "/{uid}/gist", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
-    public @ResponseBody ResponseEntity<JsonNode> getObjectGist(
-        @PathVariable( "uid" ) String uid,
-        HttpServletRequest request, HttpServletResponse response )
-        throws NotFoundException
-    {
-        return gistToJsonObjectResponse( uid, createGistQuery( request, getEntityClass(), GistAutoType.L )
-            .withFilter( new Filter( "id", Comparison.EQ, uid ) ) );
-    }
-
-    @RequestMapping( value = "/gist", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
-    public @ResponseBody ResponseEntity<JsonNode> getObjectListGist(
-        HttpServletRequest request, HttpServletResponse response )
-    {
-        return gistToJsonArrayResponse( request, createGistQuery( request, getEntityClass(), GistAutoType.S ),
-            getSchema() );
-    }
-
-    @RequestMapping( value = "/{uid}/{property}/gist", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
-    public @ResponseBody ResponseEntity<JsonNode> getObjectPropertyGist(
-        @PathVariable( "uid" ) String uid,
-        @PathVariable( "property" ) String property,
-        HttpServletRequest request, HttpServletResponse response )
-        throws Exception
-    {
-        Property objProperty = getSchema().getProperty( property );
-
-        if ( objProperty == null )
-        {
-            throw new BadRequestException( "No such property: " + property );
-        }
-
-        if ( !objProperty.isCollection() )
-        {
-            return gistToJsonObjectResponse( uid, createGistQuery( request, getEntityClass(), GistAutoType.L )
-                .withFilter( new Filter( "id", Comparison.EQ, uid ) )
-                .withField( property ) );
-        }
-
-        GistQuery query = createGistQuery( request, (Class<IdentifiableObject>) objProperty.getItemKlass(),
-            GistAutoType.M )
-                .withOwner( Owner.builder()
-                    .id( uid )
-                    .type( getEntityClass() )
-                    .collectionProperty( property ).build() );
-
-        return gistToJsonArrayResponse( request, query,
-            schemaService.getDynamicSchema( objProperty.getItemKlass() ) );
-    }
-
-    private static GistQuery createGistQuery( HttpServletRequest request,
-        Class<? extends IdentifiableObject> elementType, GistAutoType autoDefault )
-    {
-        NamedParams params = new NamedParams( request::getParameter, request::getParameterValues );
-        Locale translationLocale = !params.getString( "locale", "" ).isEmpty()
-            ? Locale.forLanguageTag( params.getString( "locale" ) )
-            : UserContext.getUserSetting( UserSettingKey.DB_LOCALE );
-        return GistQuery.builder()
-            .elementType( elementType )
-            .autoType( params.getEnum( "auto", autoDefault ) )
-            .contextRoot( ContextUtils.getRootPath( request ) )
-            .translationLocale( translationLocale )
-            .build()
-            .with( params );
-    }
-
-    private ResponseEntity<JsonNode> gistToJsonObjectResponse( String uid, GistQuery query )
-        throws NotFoundException
-    {
-        query = gistService.plan( query );
-        List<?> elements = gistService.gist( query );
-        JsonNode body = new JsonBuilder( jsonMapper ).skipNullOrEmpty().toArray( query.getFieldNames(), elements );
-        if ( body.isEmpty() )
-        {
-            throw NotFoundException.notFoundUid( uid );
-        }
-        return ResponseEntity.ok().cacheControl( noCache().cachePrivate() ).body( body.get( 0 ) );
-    }
-
-    private ResponseEntity<JsonNode> gistToJsonArrayResponse( HttpServletRequest request,
-        GistQuery query, Schema dynamicSchema )
-    {
-        query = gistService.plan( query );
-        List<?> elements = gistService.gist( query );
-        JsonBuilder responseBuilder = new JsonBuilder( jsonMapper );
-        JsonNode body = responseBuilder.skipNullOrEmpty().toArray( query.getFieldNames(), elements );
-        if ( !query.isHeadless() )
-        {
-            body = responseBuilder.toObject( asList( "pager", dynamicSchema.getPlural() ),
-                gistService.pager( query, elements, request.getParameterMap() ), body );
-        }
-        return ResponseEntity.ok().cacheControl( noCache().cachePrivate() ).body( body );
-    }
-
-    @RequestMapping( method = RequestMethod.GET )
-    public @ResponseBody RootNode getObjectList(
-        @RequestParam Map<String, String> rpParameters, OrderParams orderParams,
-        HttpServletResponse response, User currentUser )
-        throws QueryParserException
-    {
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
-        List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<Order> orders = orderParams.getOrders( getSchema() );
-
-        if ( fields.isEmpty() )
-        {
-            fields.addAll( Preset.defaultPreset().getFields() );
-        }
-
-        WebOptions options = new WebOptions( rpParameters );
-        WebMetadata metadata = new WebMetadata();
-
-        if ( !aclService.canRead( currentUser, getEntityClass() ) )
-        {
-            throw new ReadAccessDeniedException(
-                "You don't have the proper permissions to read objects of this type." );
-        }
-
-        List<T> entities = getEntityList( metadata, options, filters, orders );
-
-        Pager pager = metadata.getPager();
-
-        if ( options.hasPaging() && pager == null )
-        {
-            long totalCount;
-
-            if ( options.getOptions().containsKey( "query" ) )
-            {
-                totalCount = entities.size();
-
-                long skip = (long) (options.getPage() - 1) * options.getPageSize();
-                entities = entities.stream()
-                    .skip( skip )
-                    .limit( options.getPageSize() )
-                    .collect( toList() );
-            }
-            else
-            {
-                String cacheKey = composePaginationCountKey( currentUser, filters, options );
-                totalCount = paginationCountCache.computeIfAbsent( cacheKey,
-                    () -> countTotal( options, filters, orders ) );
-            }
-
-            pager = new Pager( options.getPage(), totalCount, options.getPageSize() );
-        }
-
-        postProcessResponseEntities( entities, options, rpParameters );
-
-        handleLinksAndAccess( entities, fields, false );
-
-        handleAttributeValues( entities, fields );
-
-        linkService.generatePagerLinks( pager, getEntityClass() );
-
-        RootNode rootNode = NodeUtils.createMetadata();
-        rootNode.getConfig().setInclusionStrategy( getInclusionStrategy( rpParameters.get( "inclusionStrategy" ) ) );
-
-        if ( pager != null )
-        {
-            rootNode.addChild( NodeUtils.createPager( pager ) );
-        }
-
-        rootNode.addChild( fieldFilterService.toCollectionNode( getEntityClass(),
-            new FieldFilterParams( entities, fields, Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) ) ) );
-
-        cachePrivate( response );
-
-        return rootNode;
-    }
-
-    @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
-    public @ResponseBody RootNode getObject(
-        @PathVariable( "uid" ) String pvUid,
-        @RequestParam Map<String, String> rpParameters,
-        HttpServletRequest request, HttpServletResponse response )
-        throws Exception
-    {
-        User user = currentUserService.getCurrentUser();
-
-        if ( !aclService.canRead( user, getEntityClass() ) )
-        {
-            throw new ReadAccessDeniedException(
-                "You don't have the proper permissions to read objects of this type." );
-        }
-
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
-        List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-
-        if ( fields.isEmpty() )
-        {
-            fields.add( ":all" );
-        }
-
-        cachePrivate( response );
-
-        return getObjectInternal( pvUid, rpParameters, filters, fields, user );
-    }
-
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.GET )
-    public @ResponseBody RootNode getObjectProperty(
-        @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
-        @RequestParam Map<String, String> rpParameters,
-        TranslateParams translateParams,
-        HttpServletResponse response )
-        throws Exception
-    {
-        User user = currentUserService.getCurrentUser();
-
-        if ( !"translations".equals( pvProperty ) )
-        {
-            setUserContext( user, translateParams );
-        }
-        else
-        {
-            setUserContext( null, new TranslateParams( false ) );
-        }
-
-        try
-        {
-            if ( !aclService.canRead( user, getEntityClass() ) )
-            {
-                throw new ReadAccessDeniedException(
-                    "You don't have the proper permissions to read objects of this type." );
-            }
-
-            List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
-
-            if ( fields.isEmpty() )
-            {
-                fields.add( ":all" );
-            }
-
-            String fieldFilter = "[" + Joiner.on( ',' ).join( fields ) + "]";
-
-            cachePrivate( response );
-
-            return getObjectInternal( pvUid, rpParameters, Lists.newArrayList(),
-                Lists.newArrayList( pvProperty + fieldFilter ), user );
-        }
-        finally
-        {
-            UserContext.reset();
-        }
-    }
-
-    private void cachePrivate( HttpServletResponse response )
-    {
-        response.setHeader( ContextUtils.HEADER_CACHE_CONTROL,
-            noCache().cachePrivate().getHeaderValue() );
-    }
 
     @RequestMapping( value = "/{uid}/translations", method = RequestMethod.PUT )
     public void replaceTranslations(
@@ -747,67 +388,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         }
 
         webMessageService.send( webMessage, response, request );
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private RootNode getObjectInternal( String uid, Map<String, String> parameters,
-        List<String> filters, List<String> fields, User user )
-        throws Exception
-    {
-        WebOptions options = new WebOptions( parameters );
-        List<T> entities = getEntity( uid, options );
-
-        if ( entities.isEmpty() )
-        {
-            throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), uid ) );
-        }
-
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
-            getPaginationData( options ), options.getRootJunction() );
-        query.setUser( user );
-        query.setObjects( entities );
-        query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
-
-        entities = (List<T>) queryService.query( query );
-
-        handleLinksAndAccess( entities, fields, true );
-
-        handleAttributeValues( entities, fields );
-
-        for ( T entity : entities )
-        {
-            postProcessResponseEntity( entity, options, parameters );
-        }
-
-        CollectionNode collectionNode = fieldFilterService.toCollectionNode( getEntityClass(),
-            new FieldFilterParams( entities, fields, Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) )
-                .setUser( user ) );
-
-        if ( options.isTrue( "useWrapper" ) || entities.size() > 1 )
-        {
-            RootNode rootNode = NodeUtils.createMetadata( collectionNode );
-            rootNode.getConfig().setInclusionStrategy( getInclusionStrategy( parameters.get( "inclusionStrategy" ) ) );
-
-            return rootNode;
-        }
-        else
-        {
-            List<Node> children = collectionNode.getChildren();
-            RootNode rootNode;
-
-            if ( !children.isEmpty() )
-            {
-                rootNode = NodeUtils.createRootNode( children.get( 0 ) );
-            }
-            else
-            {
-                rootNode = NodeUtils.createRootNode( new ComplexNode( getSchema().getSingular() ) );
-            }
-
-            rootNode.getConfig().setInclusionStrategy( getInclusionStrategy( parameters.get( "inclusionStrategy" ) ) );
-
-            return rootNode;
-        }
     }
 
     // --------------------------------------------------------------------------
@@ -1145,57 +725,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     // Identifiable object collections add, delete
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.GET )
-    public @ResponseBody RootNode getCollectionItem(
-        @PathVariable( "uid" ) String pvUid,
-        @PathVariable( "property" ) String pvProperty,
-        @PathVariable( "itemId" ) String pvItemId,
-        @RequestParam Map<String, String> parameters,
-        TranslateParams translateParams,
-        HttpServletResponse response )
-        throws Exception
-    {
-        User user = currentUserService.getCurrentUser();
-        setUserContext( user, translateParams );
-
-        try
-        {
-            if ( !aclService.canRead( user, getEntityClass() ) )
-            {
-                throw new ReadAccessDeniedException(
-                    "You don't have the proper permissions to read objects of this type." );
-            }
-
-            RootNode rootNode = getObjectInternal( pvUid, parameters, Lists.newArrayList(),
-                Lists.newArrayList( pvProperty + "[:all]" ), user );
-
-            // TODO optimize this using field filter (collection filtering)
-            if ( !rootNode.getChildren().isEmpty() && rootNode.getChildren().get( 0 ).isCollection() )
-            {
-                rootNode.getChildren().get( 0 ).getChildren().stream().filter( Node::isComplex ).forEach( node -> {
-                    node.getChildren().stream()
-                        .filter( child -> child.isSimple() && child.getName().equals( "id" )
-                            && !((SimpleNode) child).getValue().equals( pvItemId ) )
-                        .forEach( child -> rootNode.getChildren().get( 0 ).removeChild( node ) );
-                } );
-            }
-
-            if ( rootNode.getChildren().isEmpty() || rootNode.getChildren().get( 0 ).getChildren().isEmpty() )
-            {
-                throw new WebMessageException(
-                    WebMessageUtils.notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
-            }
-
-            cachePrivate( response );
-
-            return rootNode;
-        }
-        finally
-        {
-            UserContext.reset();
-        }
-    }
-
     @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
@@ -1389,23 +918,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return renderService.fromXml( request.getInputStream(), getEntityClass() );
     }
 
-    /**
-     * Override to process entities after it has been retrieved from storage and
-     * before it is returned to the view. Entities is null-safe.
-     */
-    protected void postProcessResponseEntities( List<T> entityList, WebOptions options, Map<String, String> parameters )
-    {
-    }
-
-    /**
-     * Override to process a single entity after it has been retrieved from
-     * storage and before it is returned to the view. Entity is null-safe.
-     */
-    protected void postProcessResponseEntity( T entity, WebOptions options, Map<String, String> parameters )
-        throws Exception
-    {
-    }
-
     protected void preCreateEntity( T entity )
         throws Exception
     {
@@ -1454,157 +966,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
     // --------------------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------------------
-
-    protected void setUserContext( TranslateParams translateParams )
-    {
-        setUserContext( currentUserService.getCurrentUser(), translateParams );
-    }
-
-    protected void setUserContext( User user, TranslateParams translateParams )
-    {
-        Locale dbLocale = getLocaleWithDefault( translateParams );
-        UserContext.setUser( user );
-        UserContext.setUserSetting( UserSettingKey.DB_LOCALE, dbLocale );
-    }
-
-    protected Locale getLocaleWithDefault( TranslateParams translateParams )
-    {
-        return translateParams.isTranslate()
-            ? translateParams
-                .getLocaleWithDefault( (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE ) )
-            : null;
-    }
-
-    protected Pagination getPaginationData( WebOptions options )
-    {
-        return PaginationUtils.getPaginationData( options );
-    }
-
-    @SuppressWarnings( "unchecked" )
-    protected List<T> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters,
-        List<Order> orders )
-        throws QueryParserException
-    {
-        List<T> entityList;
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ),
-            options.getRootJunction() );
-        query.setDefaultOrder();
-        query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
-
-        if ( options.getOptions().containsKey( "query" ) )
-        {
-            entityList = Lists.newArrayList( manager.filter( getEntityClass(), options.getOptions().get( "query" ) ) );
-        }
-        else
-        {
-            entityList = (List<T>) queryService.query( query );
-        }
-
-        return entityList;
-    }
-
-    private long countTotal( WebOptions options, List<String> filters, List<Order> orders )
-    {
-        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
-            options.getRootJunction() );
-
-        return queryService.count( query );
-    }
-
-    private List<T> getEntity( String uid )
-    {
-        return getEntity( uid, NO_WEB_OPTIONS );
-    }
-
-    protected List<T> getEntity( String uid, WebOptions options )
-    {
-        ArrayList<T> list = new ArrayList<>();
-        getEntity( uid, getEntityClass() ).ifPresent( list::add );
-        return list; // TODO consider ACL
-    }
-
-    protected <E extends IdentifiableObject> java.util.Optional<E> getEntity( String uid, Class<E> entityType )
-    {
-        return java.util.Optional.ofNullable( manager.getNoAcl( entityType, uid ) );
-    }
-
-    private Schema schema;
-
-    protected Schema getSchema()
-    {
-        if ( schema == null )
-        {
-            schema = schemaService.getDynamicSchema( getEntityClass() );
-        }
-
-        return schema;
-    }
-
-    protected Schema getSchema( Class<?> klass )
-    {
-        return schemaService.getDynamicSchema( klass );
-    }
-
-    private boolean fieldsContains( String match, List<String> fields )
-    {
-        for ( String field : fields )
-        {
-            // for now assume href/access if * or preset is requested
-            if ( field.contains( match ) || field.equals( "*" ) || field.startsWith( ":" ) )
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    protected boolean hasHref( List<String> fields )
-    {
-        return fieldsContains( "href", fields );
-    }
-
-    protected boolean hasAccess( List<String> fields )
-    {
-        return fieldsContains( "access", fields );
-    }
-
-    protected void handleLinksAndAccess( List<T> entityList, List<String> fields, boolean deep )
-    {
-        boolean generateLinks = hasHref( fields );
-
-        if ( generateLinks )
-        {
-            linkService.generateLinks( entityList, deep );
-        }
-    }
-
-    protected void handleAttributeValues( List<T> entityList, List<String> fields )
-    {
-        List<String> hasAttributeValues = fields.stream().filter( field -> field.contains( "attributeValues" ) )
-            .collect( toList() );
-
-        if ( !hasAttributeValues.isEmpty() )
-        {
-            attributeService.generateAttributes( entityList );
-        }
-    }
-
-    private InclusionStrategy.Include getInclusionStrategy( String inclusionStrategy )
-    {
-        if ( inclusionStrategy != null )
-        {
-            Optional<InclusionStrategy.Include> optional = Enums.getIfPresent( InclusionStrategy.Include.class,
-                inclusionStrategy );
-
-            if ( optional.isPresent() )
-            {
-                return optional.get();
-            }
-        }
-
-        return InclusionStrategy.Include.NON_NULL;
-    }
 
     /**
      * Serializes an object, tries to guess output format using this order.
@@ -1727,52 +1088,4 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
         return false;
     }
 
-    // --------------------------------------------------------------------------
-    // Reflection helpers
-    // --------------------------------------------------------------------------
-
-    private Class<T> entityClass;
-
-    private String entityName;
-
-    private String entitySimpleName;
-
-    @SuppressWarnings( "unchecked" )
-    protected Class<T> getEntityClass()
-    {
-        if ( entityClass == null )
-        {
-            Type[] actualTypeArguments = ((ParameterizedType) getClass().getGenericSuperclass())
-                .getActualTypeArguments();
-            entityClass = (Class<T>) actualTypeArguments[0];
-        }
-
-        return entityClass;
-    }
-
-    protected String getEntityName()
-    {
-        if ( entityName == null )
-        {
-            entityName = getEntityClass().getName();
-        }
-
-        return entityName;
-    }
-
-    protected String getEntitySimpleName()
-    {
-        if ( entitySimpleName == null )
-        {
-            entitySimpleName = getEntityClass().getSimpleName();
-        }
-
-        return entitySimpleName;
-    }
-
-    private String composePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
-    {
-        return currentUser.getUsername() + "." + getEntityName() + "." + String.join( "|", filters ) + "."
-            + options.getRootJunction().name();
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -100,7 +100,7 @@ import com.google.common.collect.Lists;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-public abstract class AbstractCrudController<T extends IdentifiableObject> extends AbstractReadOnlyCrudController<T>
+public abstract class AbstractCrudController<T extends IdentifiableObject> extends AbstractFullReadOnlyController<T>
 {
 
     // --------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -102,7 +102,7 @@ import com.google.common.collect.Lists;
  * @author Jan Bernitt
  */
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-public abstract class AbstractReadOnlyCrudController<T extends IdentifiableObject>
+public abstract class AbstractFullReadOnlyController<T extends IdentifiableObject>
     extends AbstractGistReadOnlyController<T>
 {
     protected static final String DEFAULTS = "INCLUDE";

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -431,7 +431,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
     }
 
     @SuppressWarnings( "unchecked" )
-    protected final List<T> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters,
+    protected List<T> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters,
         List<Order> orders )
         throws QueryParserException
     {
@@ -546,7 +546,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
         return getEntity( uid, NO_WEB_OPTIONS );
     }
 
-    protected final List<T> getEntity( String uid, WebOptions options )
+    protected List<T> getEntity( String uid, WebOptions options )
     {
         ArrayList<T> list = new ArrayList<>();
         getEntity( uid, getEntityClass() ).ifPresent( list::add );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static java.util.Arrays.asList;
+import static org.springframework.http.CacheControl.noCache;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.NamedParams;
+import org.hisp.dhis.common.UserContext;
+import org.hisp.dhis.gist.GistAutoType;
+import org.hisp.dhis.gist.GistQuery;
+import org.hisp.dhis.gist.GistQuery.Comparison;
+import org.hisp.dhis.gist.GistQuery.Filter;
+import org.hisp.dhis.gist.GistQuery.Owner;
+import org.hisp.dhis.gist.GistService;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.user.UserSettingKey;
+import org.hisp.dhis.webapi.JsonBuilder;
+import org.hisp.dhis.webapi.controller.exception.BadRequestException;
+import org.hisp.dhis.webapi.controller.exception.NotFoundException;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Base controller for APIs that only want to offer read-only access though Gist
+ * API.
+ *
+ * @author Jan Bernitt
+ */
+@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+public abstract class AbstractGistReadOnlyController<T extends IdentifiableObject>
+{
+
+    @Autowired
+    protected ObjectMapper jsonMapper;
+
+    @Autowired
+    protected SchemaService schemaService;
+
+    @Autowired
+    private GistService gistService;
+
+    // --------------------------------------------------------------------------
+    // GET Gist
+    // --------------------------------------------------------------------------
+
+    @RequestMapping( value = "/{uid}/gist", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    public @ResponseBody ResponseEntity<JsonNode> getObjectGist(
+        @PathVariable( "uid" ) String uid,
+        HttpServletRequest request, HttpServletResponse response )
+        throws NotFoundException
+    {
+        return gistToJsonObjectResponse( uid, createGistQuery( request, getEntityClass(), GistAutoType.L )
+            .withFilter( new Filter( "id", Comparison.EQ, uid ) ) );
+    }
+
+    @RequestMapping( value = "/gist", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    public @ResponseBody ResponseEntity<JsonNode> getObjectListGist(
+        HttpServletRequest request, HttpServletResponse response )
+    {
+        return gistToJsonArrayResponse( request, createGistQuery( request, getEntityClass(), GistAutoType.S ),
+            getSchema() );
+    }
+
+    @RequestMapping( value = "/{uid}/{property}/gist", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    public @ResponseBody ResponseEntity<JsonNode> getObjectPropertyGist(
+        @PathVariable( "uid" ) String uid,
+        @PathVariable( "property" ) String property,
+        HttpServletRequest request, HttpServletResponse response )
+        throws Exception
+    {
+        Property objProperty = getSchema().getProperty( property );
+
+        if ( objProperty == null )
+        {
+            throw new BadRequestException( "No such property: " + property );
+        }
+
+        if ( !objProperty.isCollection() )
+        {
+            return gistToJsonObjectResponse( uid, createGistQuery( request, getEntityClass(), GistAutoType.L )
+                .withFilter( new Filter( "id", Comparison.EQ, uid ) )
+                .withField( property ) );
+        }
+
+        @SuppressWarnings( "unchecked" )
+        GistQuery query = createGistQuery( request, (Class<IdentifiableObject>) objProperty.getItemKlass(),
+            GistAutoType.M )
+                .withOwner( Owner.builder()
+                    .id( uid )
+                    .type( getEntityClass() )
+                    .collectionProperty( property ).build() );
+
+        return gistToJsonArrayResponse( request, query,
+            schemaService.getDynamicSchema( objProperty.getItemKlass() ) );
+    }
+
+    private static GistQuery createGistQuery( HttpServletRequest request,
+        Class<? extends IdentifiableObject> elementType, GistAutoType autoDefault )
+    {
+        NamedParams params = new NamedParams( request::getParameter, request::getParameterValues );
+        Locale translationLocale = !params.getString( "locale", "" ).isEmpty()
+            ? Locale.forLanguageTag( params.getString( "locale" ) )
+            : UserContext.getUserSetting( UserSettingKey.DB_LOCALE );
+        return GistQuery.builder()
+            .elementType( elementType )
+            .autoType( params.getEnum( "auto", autoDefault ) )
+            .contextRoot( ContextUtils.getRootPath( request ) )
+            .translationLocale( translationLocale )
+            .build()
+            .with( params );
+    }
+
+    private ResponseEntity<JsonNode> gistToJsonObjectResponse( String uid, GistQuery query )
+        throws NotFoundException
+    {
+        query = gistService.plan( query );
+        List<?> elements = gistService.gist( query );
+        JsonNode body = new JsonBuilder( jsonMapper ).skipNullOrEmpty().toArray( query.getFieldNames(), elements );
+        if ( body.isEmpty() )
+        {
+            throw NotFoundException.notFoundUid( uid );
+        }
+        return ResponseEntity.ok().cacheControl( noCache().cachePrivate() ).body( body.get( 0 ) );
+    }
+
+    private ResponseEntity<JsonNode> gistToJsonArrayResponse( HttpServletRequest request,
+        GistQuery query, Schema dynamicSchema )
+    {
+        query = gistService.plan( query );
+        List<?> elements = gistService.gist( query );
+        JsonBuilder responseBuilder = new JsonBuilder( jsonMapper );
+        JsonNode body = responseBuilder.skipNullOrEmpty().toArray( query.getFieldNames(), elements );
+        if ( !query.isHeadless() )
+        {
+            body = responseBuilder.toObject( asList( "pager", dynamicSchema.getPlural() ),
+                gistService.pager( query, elements, request.getParameterMap() ), body );
+        }
+        return ResponseEntity.ok().cacheControl( noCache().cachePrivate() ).body( body );
+    }
+
+    // --------------------------------------------------------------------------
+    // Reflection helpers
+    // --------------------------------------------------------------------------
+
+    private Class<T> entityClass;
+
+    @SuppressWarnings( "unchecked" )
+    protected final Class<T> getEntityClass()
+    {
+        if ( entityClass == null )
+        {
+            Type[] actualTypeArguments = ((ParameterizedType) getClass().getGenericSuperclass())
+                .getActualTypeArguments();
+            entityClass = (Class<T>) actualTypeArguments[0];
+        }
+
+        return entityClass;
+    }
+
+    private Schema schema;
+
+    protected final Schema getSchema()
+    {
+        if ( schema == null )
+        {
+            schema = schemaService.getDynamicSchema( getEntityClass() );
+        }
+        return schema;
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractReadOnlyCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractReadOnlyCrudController.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static java.util.stream.Collectors.toList;
+import static org.springframework.http.CacheControl.noCache;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
+import org.hisp.dhis.attribute.AttributeService;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.UserContext;
+import org.hisp.dhis.dxf2.common.OrderParams;
+import org.hisp.dhis.dxf2.common.TranslateParams;
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
+import org.hisp.dhis.fieldfilter.Defaults;
+import org.hisp.dhis.fieldfilter.FieldFilterParams;
+import org.hisp.dhis.fieldfilter.FieldFilterService;
+import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
+import org.hisp.dhis.node.Node;
+import org.hisp.dhis.node.NodeUtils;
+import org.hisp.dhis.node.Preset;
+import org.hisp.dhis.node.config.InclusionStrategy;
+import org.hisp.dhis.node.config.InclusionStrategy.Include;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.ComplexNode;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Pagination;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.QueryParserException;
+import org.hisp.dhis.query.QueryService;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserSettingKey;
+import org.hisp.dhis.user.UserSettingService;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.hisp.dhis.webapi.service.LinkService;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.hisp.dhis.webapi.utils.PaginationUtils;
+import org.hisp.dhis.webapi.webdomain.WebMetadata;
+import org.hisp.dhis.webapi.webdomain.WebOptions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+/**
+ * Base controller for APIs that only want to offer read only access through
+ * both Gist API and full API.
+ *
+ * @author Jan Bernitt
+ */
+@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+public abstract class AbstractReadOnlyCrudController<T extends IdentifiableObject>
+    extends AbstractGistReadOnlyController<T>
+{
+    protected static final String DEFAULTS = "INCLUDE";
+
+    protected static final WebOptions NO_WEB_OPTIONS = new WebOptions( new HashMap<>() );
+
+    private final Cache<String, Long> paginationCountCache = new Cache2kBuilder<String, Long>()
+    {
+    }
+        .expireAfterWrite( 1, TimeUnit.MINUTES )
+        .build();
+
+    @Autowired
+    protected IdentifiableObjectManager manager;
+
+    @Autowired
+    protected CurrentUserService currentUserService;
+
+    @Autowired
+    protected UserSettingService userSettingService;
+
+    @Autowired
+    protected ContextService contextService;
+
+    @Autowired
+    protected QueryService queryService;
+
+    @Autowired
+    protected FieldFilterService fieldFilterService;
+
+    @Autowired
+    protected LinkService linkService;
+
+    @Autowired
+    protected AclService aclService;
+
+    @Autowired
+    protected AttributeService attributeService;
+
+    // --------------------------------------------------------------------------
+    // Hooks
+    // --------------------------------------------------------------------------
+
+    /**
+     * Override to process entities after it has been retrieved from storage and
+     * before it is returned to the view. Entities is null-safe.
+     */
+    protected void postProcessResponseEntities( List<T> entityList, WebOptions options, Map<String, String> parameters )
+    {
+    }
+
+    /**
+     * Override to process a single entity after it has been retrieved from
+     * storage and before it is returned to the view. Entity is null-safe.
+     */
+    protected void postProcessResponseEntity( T entity, WebOptions options, Map<String, String> parameters )
+        throws Exception
+    {
+    }
+
+    // --------------------------------------------------------------------------
+    // GET Full
+    // --------------------------------------------------------------------------
+
+    @RequestMapping( method = RequestMethod.GET )
+    public @ResponseBody RootNode getObjectList(
+        @RequestParam Map<String, String> rpParameters, OrderParams orderParams,
+        HttpServletResponse response, User currentUser )
+        throws QueryParserException
+    {
+        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
+        List<Order> orders = orderParams.getOrders( getSchema() );
+
+        if ( fields.isEmpty() )
+        {
+            fields.addAll( Preset.defaultPreset().getFields() );
+        }
+
+        WebOptions options = new WebOptions( rpParameters );
+        WebMetadata metadata = new WebMetadata();
+
+        if ( !aclService.canRead( currentUser, getEntityClass() ) )
+        {
+            throw new ReadAccessDeniedException(
+                "You don't have the proper permissions to read objects of this type." );
+        }
+
+        List<T> entities = getEntityList( metadata, options, filters, orders );
+
+        Pager pager = metadata.getPager();
+
+        if ( options.hasPaging() && pager == null )
+        {
+            long totalCount;
+
+            if ( options.getOptions().containsKey( "query" ) )
+            {
+                totalCount = entities.size();
+
+                long skip = (long) (options.getPage() - 1) * options.getPageSize();
+                entities = entities.stream()
+                    .skip( skip )
+                    .limit( options.getPageSize() )
+                    .collect( toList() );
+            }
+            else
+            {
+                String cacheKey = composePaginationCountKey( currentUser, filters, options );
+                totalCount = paginationCountCache.computeIfAbsent( cacheKey,
+                    () -> countTotal( options, filters, orders ) );
+            }
+
+            pager = new Pager( options.getPage(), totalCount, options.getPageSize() );
+        }
+
+        postProcessResponseEntities( entities, options, rpParameters );
+
+        handleLinksAndAccess( entities, fields, false );
+
+        handleAttributeValues( entities, fields );
+
+        linkService.generatePagerLinks( pager, getEntityClass() );
+
+        RootNode rootNode = NodeUtils.createMetadata();
+        rootNode.getConfig().setInclusionStrategy( getInclusionStrategy( rpParameters.get( "inclusionStrategy" ) ) );
+
+        if ( pager != null )
+        {
+            rootNode.addChild( NodeUtils.createPager( pager ) );
+        }
+
+        rootNode.addChild( fieldFilterService.toCollectionNode( getEntityClass(),
+            new FieldFilterParams( entities, fields, Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) ) ) );
+
+        cachePrivate( response );
+
+        return rootNode;
+    }
+
+    @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
+    public @ResponseBody RootNode getObject(
+        @PathVariable( "uid" ) String pvUid,
+        @RequestParam Map<String, String> rpParameters,
+        HttpServletRequest request, HttpServletResponse response )
+        throws Exception
+    {
+        User user = currentUserService.getCurrentUser();
+
+        if ( !aclService.canRead( user, getEntityClass() ) )
+        {
+            throw new ReadAccessDeniedException(
+                "You don't have the proper permissions to read objects of this type." );
+        }
+
+        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
+
+        if ( fields.isEmpty() )
+        {
+            fields.add( ":all" );
+        }
+
+        cachePrivate( response );
+
+        return getObjectInternal( pvUid, rpParameters, filters, fields, user );
+    }
+
+    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.GET )
+    public @ResponseBody RootNode getObjectProperty(
+        @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
+        @RequestParam Map<String, String> rpParameters,
+        TranslateParams translateParams,
+        HttpServletResponse response )
+        throws Exception
+    {
+        User user = currentUserService.getCurrentUser();
+
+        if ( !"translations".equals( pvProperty ) )
+        {
+            setUserContext( user, translateParams );
+        }
+        else
+        {
+            setUserContext( null, new TranslateParams( false ) );
+        }
+
+        try
+        {
+            if ( !aclService.canRead( user, getEntityClass() ) )
+            {
+                throw new ReadAccessDeniedException(
+                    "You don't have the proper permissions to read objects of this type." );
+            }
+
+            List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+
+            if ( fields.isEmpty() )
+            {
+                fields.add( ":all" );
+            }
+
+            String fieldFilter = "[" + Joiner.on( ',' ).join( fields ) + "]";
+
+            cachePrivate( response );
+
+            return getObjectInternal( pvUid, rpParameters, Lists.newArrayList(),
+                Lists.newArrayList( pvProperty + fieldFilter ), user );
+        }
+        finally
+        {
+            UserContext.reset();
+        }
+    }
+
+    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.GET )
+    public @ResponseBody RootNode getCollectionItem(
+        @PathVariable( "uid" ) String pvUid,
+        @PathVariable( "property" ) String pvProperty,
+        @PathVariable( "itemId" ) String pvItemId,
+        @RequestParam Map<String, String> parameters,
+        TranslateParams translateParams,
+        HttpServletResponse response )
+        throws Exception
+    {
+        User user = currentUserService.getCurrentUser();
+        setUserContext( user, translateParams );
+
+        try
+        {
+            if ( !aclService.canRead( user, getEntityClass() ) )
+            {
+                throw new ReadAccessDeniedException(
+                    "You don't have the proper permissions to read objects of this type." );
+            }
+
+            RootNode rootNode = getObjectInternal( pvUid, parameters, Lists.newArrayList(),
+                Lists.newArrayList( pvProperty + "[:all]" ), user );
+
+            // TODO optimize this using field filter (collection filtering)
+            if ( !rootNode.getChildren().isEmpty() && rootNode.getChildren().get( 0 ).isCollection() )
+            {
+                rootNode.getChildren().get( 0 ).getChildren().stream().filter( Node::isComplex ).forEach( node -> {
+                    node.getChildren().stream()
+                        .filter( child -> child.isSimple() && child.getName().equals( "id" )
+                            && !((SimpleNode) child).getValue().equals( pvItemId ) )
+                        .forEach( child -> rootNode.getChildren().get( 0 ).removeChild( node ) );
+                } );
+            }
+
+            if ( rootNode.getChildren().isEmpty() || rootNode.getChildren().get( 0 ).getChildren().isEmpty() )
+            {
+                throw new WebMessageException(
+                    WebMessageUtils.notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
+            }
+
+            cachePrivate( response );
+
+            return rootNode;
+        }
+        finally
+        {
+            UserContext.reset();
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private RootNode getObjectInternal( String uid, Map<String, String> parameters,
+        List<String> filters, List<String> fields, User user )
+        throws Exception
+    {
+        WebOptions options = new WebOptions( parameters );
+        List<T> entities = getEntity( uid, options );
+
+        if ( entities.isEmpty() )
+        {
+            throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), uid ) );
+        }
+
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
+            getPaginationData( options ), options.getRootJunction() );
+        query.setUser( user );
+        query.setObjects( entities );
+        query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
+
+        entities = (List<T>) queryService.query( query );
+
+        handleLinksAndAccess( entities, fields, true );
+
+        handleAttributeValues( entities, fields );
+
+        for ( T entity : entities )
+        {
+            postProcessResponseEntity( entity, options, parameters );
+        }
+
+        CollectionNode collectionNode = fieldFilterService.toCollectionNode( getEntityClass(),
+            new FieldFilterParams( entities, fields, Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) )
+                .setUser( user ) );
+
+        if ( options.isTrue( "useWrapper" ) || entities.size() > 1 )
+        {
+            RootNode rootNode = NodeUtils.createMetadata( collectionNode );
+            rootNode.getConfig().setInclusionStrategy( getInclusionStrategy( parameters.get( "inclusionStrategy" ) ) );
+
+            return rootNode;
+        }
+        else
+        {
+            List<Node> children = collectionNode.getChildren();
+            RootNode rootNode;
+
+            if ( !children.isEmpty() )
+            {
+                rootNode = NodeUtils.createRootNode( children.get( 0 ) );
+            }
+            else
+            {
+                rootNode = NodeUtils.createRootNode( new ComplexNode( getSchema().getSingular() ) );
+            }
+
+            rootNode.getConfig().setInclusionStrategy( getInclusionStrategy( parameters.get( "inclusionStrategy" ) ) );
+
+            return rootNode;
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    protected final List<T> getEntityList( WebMetadata metadata, WebOptions options, List<String> filters,
+        List<Order> orders )
+        throws QueryParserException
+    {
+        List<T> entityList;
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, getPaginationData( options ),
+            options.getRootJunction() );
+        query.setDefaultOrder();
+        query.setDefaults( Defaults.valueOf( options.get( "defaults", DEFAULTS ) ) );
+
+        if ( options.getOptions().containsKey( "query" ) )
+        {
+            entityList = Lists.newArrayList( manager.filter( getEntityClass(), options.getOptions().get( "query" ) ) );
+        }
+        else
+        {
+            entityList = (List<T>) queryService.query( query );
+        }
+
+        return entityList;
+    }
+
+    private long countTotal( WebOptions options, List<String> filters, List<Order> orders )
+    {
+        Query query = queryService.getQueryFromUrl( getEntityClass(), filters, orders, new Pagination(),
+            options.getRootJunction() );
+
+        return queryService.count( query );
+    }
+
+    private void cachePrivate( HttpServletResponse response )
+    {
+        response.setHeader( ContextUtils.HEADER_CACHE_CONTROL,
+            noCache().cachePrivate().getHeaderValue() );
+    }
+
+    private String composePaginationCountKey( User currentUser, List<String> filters, WebOptions options )
+    {
+        return currentUser.getUsername() + "." + getEntityName() + "." + String.join( "|", filters ) + "."
+            + options.getRootJunction().name();
+    }
+
+    private boolean hasHref( List<String> fields )
+    {
+        return fieldsContains( "href", fields );
+    }
+
+    private void handleLinksAndAccess( List<T> entityList, List<String> fields, boolean deep )
+    {
+        boolean generateLinks = hasHref( fields );
+
+        if ( generateLinks )
+        {
+            linkService.generateLinks( entityList, deep );
+        }
+    }
+
+    private void handleAttributeValues( List<T> entityList, List<String> fields )
+    {
+        List<String> hasAttributeValues = fields.stream().filter( field -> field.contains( "attributeValues" ) )
+            .collect( toList() );
+
+        if ( !hasAttributeValues.isEmpty() )
+        {
+            attributeService.generateAttributes( entityList );
+        }
+    }
+
+    private boolean fieldsContains( String match, List<String> fields )
+    {
+        for ( String field : fields )
+        {
+            // for now assume href/access if * or preset is requested
+            if ( field.contains( match ) || field.equals( "*" ) || field.startsWith( ":" ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // --------------------------------------------------------------------------
+    // Reflection helpers
+    // --------------------------------------------------------------------------
+
+    private String entityName;
+
+    private String entitySimpleName;
+
+    protected final String getEntityName()
+    {
+        if ( entityName == null )
+        {
+            entityName = getEntityClass().getName();
+        }
+
+        return entityName;
+    }
+
+    protected final String getEntitySimpleName()
+    {
+        if ( entitySimpleName == null )
+        {
+            entitySimpleName = getEntityClass().getSimpleName();
+        }
+
+        return entitySimpleName;
+    }
+
+    protected final List<T> getEntity( String uid )
+    {
+        return getEntity( uid, NO_WEB_OPTIONS );
+    }
+
+    protected final List<T> getEntity( String uid, WebOptions options )
+    {
+        ArrayList<T> list = new ArrayList<>();
+        getEntity( uid, getEntityClass() ).ifPresent( list::add );
+        return list; // TODO consider ACL
+    }
+
+    protected final <E extends IdentifiableObject> java.util.Optional<E> getEntity( String uid, Class<E> entityType )
+    {
+        return java.util.Optional.ofNullable( manager.getNoAcl( entityType, uid ) );
+    }
+
+    protected final Schema getSchema( Class<?> klass )
+    {
+        return schemaService.getDynamicSchema( klass );
+    }
+
+    // --------------------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------------------
+
+    protected final void setUserContext( TranslateParams translateParams )
+    {
+        setUserContext( currentUserService.getCurrentUser(), translateParams );
+    }
+
+    protected final void setUserContext( User user, TranslateParams translateParams )
+    {
+        Locale dbLocale = getLocaleWithDefault( translateParams );
+        UserContext.setUser( user );
+        UserContext.setUserSetting( UserSettingKey.DB_LOCALE, dbLocale );
+    }
+
+    private Locale getLocaleWithDefault( TranslateParams translateParams )
+    {
+        return translateParams.isTranslate()
+            ? translateParams.getLocaleWithDefault(
+                (Locale) userSettingService.getUserSetting( UserSettingKey.DB_LOCALE ) )
+            : null;
+    }
+
+    protected final Pagination getPaginationData( WebOptions options )
+    {
+        return PaginationUtils.getPaginationData( options );
+    }
+
+    private InclusionStrategy.Include getInclusionStrategy( String inclusionStrategy )
+    {
+        if ( inclusionStrategy != null )
+        {
+            Optional<Include> optional = Enums.getIfPresent( InclusionStrategy.Include.class,
+                inclusionStrategy );
+
+            if ( optional.isPresent() )
+            {
+                return optional.get();
+            }
+        }
+
+        return InclusionStrategy.Include.NON_NULL;
+    }
+}


### PR DESCRIPTION
This PR is an attempt to break the large class `AbstractCrudController` into smaller parts in a way that is useful.

The idea is that the read access methods are extracted to superclasses so that extending controller can chose to only inherit the read-only part of CRUD by not extending the `AbstractCrudController` but the `AbstractFullReadOnlyController` or the `AbstractGistReadOnlyController` depending on if they want just Gist API or both Gist API and classic/full read access API.

PR basically moves methods to newly created superclasses. 
In some cases the visibility is changed to `private` where possible and `protected` methods are made `final` when overriding makes little sense.