### PR TITLE
fix: Refactor Relationship fetching in tracker preheater

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipKey.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipKey.java
@@ -29,9 +29,6 @@ package org.hisp.dhis.relationship;
 
 import static org.apache.commons.lang3.StringUtils.splitByWholeSeparatorPreserveAllTokens;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -101,9 +98,20 @@ public class RelationshipKey
 
         public String asString()
         {
-            return Stream.of( trackedEntity, enrollment, event )
-                .map( StringUtils::trimToEmpty )
-                .collect( Collectors.joining( RELATIONSHIP_KEY_SEPARATOR ) );
+            if ( isTrackedEntity() )
+            {
+                return trackedEntity;
+            }
+            else if ( isEnrollment() )
+            {
+                return enrollment;
+            }
+            else if ( isEvent() )
+            {
+                return enrollment;
+            }
+
+            return "ERROR";
         }
 
         public boolean isTrackedEntity()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -61,5 +61,7 @@ public interface RelationshipStore
      */
     Relationship getByRelationship( Relationship relationship );
 
-    Relationship getByRelationshipKey( String relationshipKey );
+    List<String> getUidsByRelationshipKeys( List<String> relationshipKeyList );
+
+    List<Relationship> getByUids( List<String> uids );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/RelationshipStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/classStrategy/RelationshipStrategy.java
@@ -27,28 +27,21 @@
  */
 package org.hisp.dhis.tracker.preheat.supplier.classStrategy;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.relationship.RelationshipStore;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
-import org.hisp.dhis.tracker.preheat.RelationshipPreheatKeySupport;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.mappers.RelationshipMapper;
-import org.hisp.dhis.tracker.util.Constant;
 import org.springframework.stereotype.Component;
-
-import com.google.common.collect.Lists;
 
 /**
  * @author Luciano Fiandesio
@@ -72,21 +65,15 @@ public class RelationshipStrategy implements ClassBasedSupplierStrategy
 
     private List<org.hisp.dhis.relationship.Relationship> retrieveRelationships( List<List<String>> splitList )
     {
-        return splitList.stream()
-            .flatMap( Collection::stream )
-            .collect( Collectors.partitioningBy( RelationshipPreheatKeySupport::isRelationshipPreheatKey ) )
-            .entrySet().stream()
-            .flatMap( this::getRelationships )
-            .filter( Objects::nonNull )
+        List<String> keys = splitList.stream().flatMap( List::stream )
+            .filter( identifier -> !CodeGenerator.isValidUid( identifier ) )
             .collect( Collectors.toList() );
-    }
+        List<String> uids = splitList.stream().flatMap( List::stream )
+            .filter( CodeGenerator::isValidUid )
+            .collect( Collectors.toList() );
 
-    private Stream<org.hisp.dhis.relationship.Relationship> getRelationships( Map.Entry<Boolean, List<String>> entry )
-    {
-        return entry.getKey() ? entry.getValue().stream()
-            .map( relationshipStore::getByRelationshipKey )
-            : Lists.partition( entry.getValue(), Constant.SPLIT_LIST_PARTITION_SIZE ).stream()
-                .map( relationshipStore::getByUid )
-                .flatMap( Collection::stream );
+        uids.addAll( relationshipStore.getUidsByRelationshipKeys( keys ) );
+
+        return relationshipStore.getByUids( uids );
     }
 }


### PR DESCRIPTION
The complicated query of fetcing existing relationships takes too long when it's fetcing relationships individually. This change gets all relationships uids in one go, and preheats all relationships using those and other uids.