### PR TITLE
feat: add i18nTranslationKey to schema property

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
@@ -287,6 +287,12 @@ public class Property implements Ordered, Klass
 
     private String translationKey;
 
+    /**
+     * The translation key use for retrieving I18n translation of this
+     * property's name. The key follows snake_case naming convention.
+     */
+    private String i18nTranslationKey;
+
     private GistPreferences gistPreferences = GistPreferences.DEFAULT;
 
     public Property()
@@ -747,6 +753,18 @@ public class Property implements Ordered, Klass
     public void setTranslationKey( String translationKey )
     {
         this.translationKey = translationKey;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getI18nTranslationKey()
+    {
+        return i18nTranslationKey;
+    }
+
+    public void setI18nTranslationKey( String i18nTranslationKey )
+    {
+        this.i18nTranslationKey = i18nTranslationKey;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
@@ -33,6 +33,8 @@ import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.system.util.AnnotationUtils;
 
+import com.google.common.base.CaseFormat;
+
 /**
  * A {@link PropertyIntrospector} that adds information to existing
  * {@link Property} values if they are annotated with
@@ -60,6 +62,8 @@ public class TranslatablePropertyIntrospector implements PropertyIntrospector
             {
                 property.setTranslatable( true );
                 property.setTranslationKey( translatableFields.get( property.getFieldName() ) );
+                String i18nKey = CaseFormat.LOWER_CAMEL.to( CaseFormat.LOWER_UNDERSCORE, property.getFieldName() );
+                property.setI18nTranslationKey( i18nKey );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.schema;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -35,6 +36,7 @@ import java.util.Map;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.schema.introspection.TranslatablePropertyIntrospector;
 import org.junit.Test;
 
@@ -101,5 +103,28 @@ public class TranslatablePropertyIntrospectorTest extends DhisSpringTest
 
         assertFalse( propertyMap.get( "name" ).isTranslatable() );
         assertFalse( propertyMap.get( "code" ).isTranslatable() );
+    }
+
+    @Test
+    public void testI18nTranslationKey()
+    {
+        Property propTranslation = new Property( DataSet.class );
+        propTranslation.setName( "translations" );
+        propTranslation.setFieldName( "translations" );
+        propTranslation.setPersisted( true );
+
+        Property property = new Property( DataSet.class );
+        property.setFieldName( "formName" );
+        property.setName( "formName" );
+        property.setPersisted( true );
+
+        Map<String, Property> propertyMap = new HashMap<>();
+        propertyMap.put( "formName", property );
+        propertyMap.put( "translations", propTranslation );
+
+        TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
+        introspector.introspect( DataSet.class, propertyMap );
+        assertEquals( "form_name", propertyMap.get( "formName" ).getI18nTranslationKey() );
+
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10763

- This PR add a new property named `i18nTranslationKey` to `Schema` class
- This property will be used by `Translations` app in order to get i18n translations for all properties and display them as labels on UI.
- The app will send a `POST` request to `api/i18n` with payload is the array of `i18nTranslationKeys`.

