### PR TITLE
feat: complete data set registration ID schema alias for UID [DHIS2-11355]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/ImportConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/ImportConfig.java
@@ -127,18 +127,23 @@ final class ImportConfig
         String schemeName = primary.get();
         if ( schemeName != null )
         {
-            return IdScheme.from( schemeName );
+            return getIdSchemeIdAsUid( IdScheme.from( schemeName ) );
         }
         IdScheme scheme = secondary.get();
         if ( scheme != null && scheme != IdScheme.NULL )
         {
-            return scheme;
+            return getIdSchemeIdAsUid( scheme );
         }
         schemeName = primaryDefault.get();
         if ( schemeName != null )
         {
-            return IdScheme.from( schemeName );
+            return getIdSchemeIdAsUid( IdScheme.from( schemeName ) );
         }
-        return IdScheme.from( secondaryDefault.get() );
+        return getIdSchemeIdAsUid( IdScheme.from( secondaryDefault.get() ) );
+    }
+
+    private static IdScheme getIdSchemeIdAsUid( IdScheme scheme )
+    {
+        return scheme == IdScheme.ID ? IdScheme.UID : scheme;
     }
 }


### PR DESCRIPTION
As discussed on slack for the complete data set registration import we want to treat `IdScheme.ID` as an alias for `IdScheme.UID`.

This is mainly since it does not make sense to use actual numeric IDs (they should be unknown) and because documentation states `id` as possible value but means `uid` so we decided making this an alias.