### PR TITLE
feat: adds period name to followup value API [DHIS2-11446]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupValue.java
@@ -31,9 +31,12 @@ import java.util.Date;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -64,6 +67,10 @@ public final class FollowupValue
 
     @JsonProperty
     private Date peEndDate;
+
+    @Setter
+    @JsonProperty
+    private String peName;
 
     @JsonProperty
     private String ou;
@@ -113,5 +120,11 @@ public final class FollowupValue
         return peType == null
             ? null
             : PeriodType.getIsoPeriod( PeriodType.getCalendar(), peType, peStartDate );
+    }
+
+    @JsonIgnore
+    Period getPeAsPeriod()
+    {
+        return peType == null ? null : PeriodType.getPeriodFromIsoString( getPe() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/DefaultFollowupAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/DefaultFollowupAnalysisService.java
@@ -45,6 +45,8 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
+import org.hisp.dhis.i18n.I18nFormat;
+import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.user.CurrentUserService;
@@ -68,6 +70,8 @@ public class DefaultFollowupAnalysisService
     private final FollowupValueManager followupValueManager;
 
     private final CurrentUserService currentUserService;
+
+    private final I18nManager i18nManager;
 
     @Override
     @Transactional( readOnly = true )
@@ -104,6 +108,9 @@ public class DefaultFollowupAnalysisService
 
         List<FollowupValue> followupValues = followupValueManager
             .getFollowupDataValues( currentUserService.getCurrentUser(), request );
+
+        I18nFormat format = i18nManager.getI18nFormat();
+        followupValues.forEach( value -> value.setPeName( format.formatPeriod( value.getPeAsPeriod() ) ) );
         return new FollowupAnalysisResponse( new FollowupAnalysisMetadata( request ), followupValues );
     }
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/FollowupValueManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/FollowupValueManager.java
@@ -62,7 +62,7 @@ public class FollowupValueManager
     private static final String FOLLOWUP_VALUE_HQL = "select new org.hisp.dhis.dataanalysis.FollowupValue(" +
         "de.uid, de.name, " +
         "pt.class, " +
-        "pe.startDate, pe.endDate, " +
+        "pe.startDate, pe.endDate, cast(null as java.lang.String)," +
         "ou.uid, ou.name, ou.path, " +
         "coc.uid, coc.name, " +
         "aoc.uid, aoc.name, " +

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonFollowupValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonFollowupValue.java
@@ -69,6 +69,11 @@ public interface JsonFollowupValue extends JsonObject
         return getString( "pe" ).string();
     }
 
+    default String getPeName()
+    {
+        return getString( "peName" ).string();
+    }
+
     default String getPeType()
     {
         return getString( "peType" ).string();

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
@@ -87,6 +87,7 @@ public class FollowupAnalysisControllerTest extends AbstractDataValueControllerT
         assertEquals( "5", value.getValue() );
         assertEquals( "admin", value.getStoredBy() );
         assertEquals( "Needs_check", value.getComment() );
+        assertEquals( "March 2021", value.getPeName() );
         assertNotNull( value.getLastUpdated() );
         assertNotNull( value.getCreated() );
     }


### PR DESCRIPTION
Adds period display name to the followup values. 

Since this needs the i18n service the DB level prefills the field with `null` when mapping DB fields to the all args constructor. 
In the service we then loop over the values and add the display name.

I opted to call the field `peName` to be more consistent with the other fields in `FollowupValue`.

Tests have been adopted and check a simple case.