### PR TITLE
fix: error reports merge with other, set items with clear (2.36)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectReport.java
@@ -185,6 +185,7 @@ public class ObjectReport
     @JacksonXmlProperty( localName = "errorReport", namespace = DxfNamespaces.DXF_2_0 )
     public void setErrorReports( List<ErrorReport> errorReports )
     {
+        errorReportsByCode.clear();
         if ( errorReports != null )
         {
             errorReports.forEach( er -> {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/feedback/ImportReport.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/feedback/ImportReport.java
@@ -143,6 +143,7 @@ public class ImportReport
     @JacksonXmlProperty( localName = "typeReport", namespace = DxfNamespaces.DXF_2_0 )
     public void setTypeReports( List<TypeReport> typeReports )
     {
+        typeReportMap.clear();
         if ( typeReports != null )
         {
             typeReports.forEach( tr -> typeReportMap.put( tr.getKlass(), tr ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/feedback/ObjectBundleCommitReport.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/feedback/ObjectBundleCommitReport.java
@@ -98,7 +98,7 @@ public class ObjectBundleCommitReport
         }
 
         TypeReport typeReport = typeReportMap.get( report.getKlass() );
-        typeReport.merge( typeReport );
+        typeReport.merge( report );
     }
 
     // -----------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/feedback/ObjectBundleValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/feedback/ObjectBundleValidationReport.java
@@ -90,7 +90,7 @@ public class ObjectBundleValidationReport
         }
 
         TypeReport typeReport = typeReportMap.get( report.getKlass() );
-        typeReport.merge( typeReport );
+        typeReport.merge( report );
     }
 
     // -----------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes 2 issues around error reports:

* when `merge`d reports do not merge with themselves (unintentional NOOP) but with the other provided report
* when setting a list of items by transfering them to an internal data structure in a loop the internal structure is cleared first so it has the effect of a setter (not an adder)

See #8353 for more context.

Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>