### PR TITLE
chore: replace @RequestMapping with dedicated annotations

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -73,8 +73,9 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -132,7 +133,7 @@ public class AccountController
         this.jsonMapper = jsonMapper;
     }
 
-    @RequestMapping( value = "/recovery", method = RequestMethod.POST )
+    @PostMapping( "/recovery" )
     public void recoverAccount(
         @RequestParam String username,
         HttpServletRequest request,
@@ -188,7 +189,7 @@ public class AccountController
         }
     }
 
-    @RequestMapping( value = "/restore", method = RequestMethod.POST )
+    @PostMapping( "/restore" )
     public void restoreAccount(
         @RequestParam String token,
         @RequestParam String password,
@@ -259,7 +260,7 @@ public class AccountController
         webMessageService.send( WebMessageUtils.ok( "Account restored" ), response, request );
     }
 
-    @RequestMapping( method = RequestMethod.POST )
+    @PostMapping
     public void createAccount(
         @RequestParam String username,
         @RequestParam String firstName,
@@ -487,7 +488,7 @@ public class AccountController
         webMessageService.send( WebMessageUtils.ok( "Account created" ), response, request );
     }
 
-    @RequestMapping( value = "/password", method = RequestMethod.POST )
+    @PostMapping( "/password" )
     public void updatePassword(
         @RequestParam String oldPassword,
         @RequestParam String password,
@@ -561,7 +562,7 @@ public class AccountController
         ContextUtils.okResponse( response, jsonMapper.writeValueAsString( result ) );
     }
 
-    @RequestMapping( value = "/username", method = RequestMethod.GET )
+    @GetMapping( "/username" )
     public void validateUserNameGet( @RequestParam String username, HttpServletResponse response )
         throws IOException
     {
@@ -570,7 +571,7 @@ public class AccountController
         ContextUtils.okResponse( response, jsonMapper.writeValueAsString( result ) );
     }
 
-    @RequestMapping( value = "/validateUsername", method = RequestMethod.POST )
+    @PostMapping( "/validateUsername" )
     public void validateUserNameGetPost( @RequestParam String username, HttpServletResponse response )
         throws IOException
     {
@@ -579,7 +580,7 @@ public class AccountController
         ContextUtils.okResponse( response, jsonMapper.writeValueAsString( result ) );
     }
 
-    @RequestMapping( value = "/password", method = RequestMethod.GET )
+    @GetMapping( "/password" )
     public void validatePasswordGet( @RequestParam String password, HttpServletResponse response )
         throws IOException
     {
@@ -588,7 +589,7 @@ public class AccountController
         ContextUtils.okResponse( response, jsonMapper.writeValueAsString( result ) );
     }
 
-    @RequestMapping( value = "/validatePassword", method = RequestMethod.POST )
+    @PostMapping( "/validatePassword" )
     public void validatePasswordPost( @RequestParam String password, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -60,9 +60,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -103,7 +106,7 @@ public class AppController
     // Resources
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( produces = ContextUtils.CONTENT_TYPE_JSON )
     public void getApps( @RequestParam( required = false ) String key,
         HttpServletRequest request, HttpServletResponse response )
         throws IOException
@@ -138,7 +141,7 @@ public class AppController
         renderService.toJson( response.getOutputStream(), apps );
     }
 
-    @RequestMapping( method = RequestMethod.POST )
+    @PostMapping
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void installApp( @RequestParam( "file" ) MultipartFile file )
@@ -158,7 +161,7 @@ public class AppController
         }
     }
 
-    @RequestMapping( method = RequestMethod.PUT )
+    @PutMapping
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void reloadApps()
@@ -166,7 +169,7 @@ public class AppController
         appManager.reloadApps();
     }
 
-    @RequestMapping( value = "/{app}/**", method = RequestMethod.GET )
+    @GetMapping( "/{app}/**" )
     public void renderApp( @PathVariable( "app" ) String app,
         HttpServletRequest request, HttpServletResponse response )
         throws IOException,
@@ -257,7 +260,7 @@ public class AppController
         }
     }
 
-    @RequestMapping( value = "/{app}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{app}" )
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteApp( @PathVariable( "app" ) String app, @RequestParam( required = false ) boolean deleteAppData )
@@ -279,7 +282,7 @@ public class AppController
     }
 
     @SuppressWarnings( "unchecked" )
-    @RequestMapping( value = "/config", method = RequestMethod.POST, consumes = ContextUtils.CONTENT_TYPE_JSON )
+    @PostMapping( value = "/config", consumes = ContextUtils.CONTENT_TYPE_JSON )
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setConfig( HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
@@ -84,9 +84,9 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -96,7 +96,7 @@ import com.google.common.collect.Lists;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Controller
-@RequestMapping( value = "/audits", method = RequestMethod.GET )
+@RequestMapping( "/audits" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class AuditController
 {
@@ -156,7 +156,7 @@ public class AuditController
      *
      * @param uid the unique id of the file resource
      */
-    @RequestMapping( value = "/files/{uid}", method = RequestMethod.GET )
+    @GetMapping( "/files/{uid}" )
     public void getFileAudit( @PathVariable String uid, HttpServletResponse response )
         throws WebMessageException
     {
@@ -195,7 +195,7 @@ public class AuditController
         }
     }
 
-    @RequestMapping( value = "dataValue", method = RequestMethod.GET )
+    @GetMapping( "dataValue" )
     public @ResponseBody RootNode getAggregateDataValueAudit(
         @RequestParam( required = false, defaultValue = "" ) List<String> ds,
         @RequestParam( required = false, defaultValue = "" ) List<String> de,
@@ -262,7 +262,7 @@ public class AuditController
         return rootNode;
     }
 
-    @RequestMapping( value = "trackedEntityDataValue", method = RequestMethod.GET )
+    @GetMapping( "trackedEntityDataValue" )
     public @ResponseBody RootNode getTrackedEntityDataValueAudit(
         @RequestParam( required = false, defaultValue = "" ) List<String> de,
         @RequestParam( required = false, defaultValue = "" ) List<String> psi,
@@ -318,7 +318,7 @@ public class AuditController
         return rootNode;
     }
 
-    @RequestMapping( value = "trackedEntityAttributeValue", method = RequestMethod.GET )
+    @GetMapping( "trackedEntityAttributeValue" )
     public @ResponseBody RootNode getTrackedEntityAttributeValueAudit(
         @RequestParam( required = false, defaultValue = "" ) List<String> tea,
         @RequestParam( required = false, defaultValue = "" ) List<String> tei,
@@ -370,7 +370,7 @@ public class AuditController
         return rootNode;
     }
 
-    @RequestMapping( value = "dataApproval", method = RequestMethod.GET )
+    @GetMapping( "dataApproval" )
     public @ResponseBody RootNode getDataApprovalAudit(
         @RequestParam( required = false, defaultValue = "" ) List<String> dal,
         @RequestParam( required = false, defaultValue = "" ) List<String> wf,
@@ -421,7 +421,7 @@ public class AuditController
         return rootNode;
     }
 
-    @RequestMapping( value = "trackedEntityInstance", method = RequestMethod.GET )
+    @GetMapping( "trackedEntityInstance" )
     public @ResponseBody RootNode getTrackedEnityInstanceAudit(
         @RequestParam( required = false, defaultValue = "" ) List<String> tei,
         @RequestParam( required = false, defaultValue = "" ) List<String> user,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
@@ -41,9 +41,11 @@ import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -63,7 +65,7 @@ public class CacheController
 
     private final CappedLocalCache cache;
 
-    @RequestMapping( method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( produces = "application/json" )
     public @ResponseBody CacheInfo getInfo( @RequestParam( value = "condensed", required = false ) Boolean condensed )
     {
         CacheInfo info = getCacheInfo();
@@ -78,14 +80,14 @@ public class CacheController
                 .collect( Collectors.toList() ) );
     }
 
-    @RequestMapping( value = "/regions", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/regions", produces = "application/json" )
     public @ResponseBody Set<String> getRegions()
     {
         // sort alphabetically
         return new TreeSet<>( cache.getRegions() );
     }
 
-    @RequestMapping( value = "/regions/{region}", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/regions/{region}", produces = "application/json" )
     public @ResponseBody CacheGroupInfo getRegionInfo( @PathVariable( "region" ) String region )
         throws NotFoundException
     {
@@ -100,13 +102,13 @@ public class CacheController
         throw new NotFoundException( region );
     }
 
-    @RequestMapping( value = "/cap", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/cap", produces = "application/json" )
     public @ResponseBody CacheCapInfo getCapInfo()
     {
         return getCacheInfo().getCap();
     }
 
-    @RequestMapping( value = "/cap", method = RequestMethod.PUT )
+    @PutMapping( "/cap" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCap( @RequestParam( value = "heap", required = false ) Integer heap,
         @RequestParam( value = "hard", required = false ) Integer hard,
@@ -126,14 +128,14 @@ public class CacheController
         }
     }
 
-    @RequestMapping( value = "/invalidate", method = RequestMethod.POST )
+    @PostMapping( "/invalidate" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void invalidate()
     {
         cache.invalidate();
     }
 
-    @RequestMapping( value = "/regions/{region}/invalidate", method = RequestMethod.POST )
+    @PostMapping( "/regions/{region}/invalidate" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void invalidateRegion( @PathVariable( "region" ) String region )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartController.java
@@ -73,9 +73,9 @@ import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -138,7 +138,7 @@ public class ChartController
     // Get data
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = { "/{uid}/data", "/{uid}/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/{uid}/data", "/{uid}/data.png" } )
     public void getChart(
         @PathVariable( "uid" ) String uid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -170,7 +170,7 @@ public class ChartController
         ChartUtils.writeChartAsPNG( response.getOutputStream(), jFreeChart, width, height );
     }
 
-    @RequestMapping( value = { "/data", "/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/data", "/data.png" } )
     public void getChart(
         @RequestParam( value = "in" ) String indicatorUid,
         @RequestParam( value = "ou" ) String organisationUnitUid,
@@ -203,7 +203,7 @@ public class ChartController
         ChartUtils.writeChartAsPNG( response.getOutputStream(), chart, width, height );
     }
 
-    @RequestMapping( value = { "/history/data", "/history/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/history/data", "/history/data.png" } )
     public void getHistoryChart(
         @RequestParam String de,
         @RequestParam String co,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -128,6 +128,8 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -489,8 +491,7 @@ public abstract class ChartFacadeController
         manager.update( persistedObject );
     }
 
-    @PutMapping( "/{uid}/{property}" )
-    @PatchMapping( "/{uid}/{property}" )
+    @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void updateObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -122,9 +122,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -225,7 +228,7 @@ public abstract class ChartFacadeController
     // GET
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody RootNode getObjectList(
         @RequestParam Map<String, String> rpParameters, OrderParams orderParams,
         HttpServletResponse response, HttpServletRequest request, User currentUser )
@@ -294,7 +297,7 @@ public abstract class ChartFacadeController
         return rootNode;
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}" )
     public @ResponseBody RootNode getObject(
         @PathVariable( "uid" ) String pvUid,
         @RequestParam Map<String, String> rpParameters,
@@ -322,7 +325,7 @@ public abstract class ChartFacadeController
         return getObjectInternal( pvUid, rpParameters, filters, fields, user );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/{property}" )
     public @ResponseBody RootNode getObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
         @RequestParam Map<String, String> rpParameters,
@@ -370,7 +373,7 @@ public abstract class ChartFacadeController
         }
     }
 
-    @RequestMapping( value = "/{uid}/translations", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}/translations" )
     public void replaceTranslations(
         @PathVariable( "uid" ) String pvUid, @RequestParam Map<String, String> rpParameters,
         HttpServletRequest request, HttpServletResponse response )
@@ -445,7 +448,7 @@ public abstract class ChartFacadeController
         response.setStatus( HttpServletResponse.SC_NO_CONTENT );
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PATCH )
+    @PatchMapping( "/{uid}" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void partialUpdateObject(
         @PathVariable( "uid" ) String pvUid, @RequestParam Map<String, String> rpParameters,
@@ -486,7 +489,8 @@ public abstract class ChartFacadeController
         manager.update( persistedObject );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )
+    @PutMapping( "/{uid}/{property}" )
+    @PatchMapping( "/{uid}/{property}" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void updateObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
@@ -608,7 +612,7 @@ public abstract class ChartFacadeController
     // POST
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     public void postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -650,7 +654,7 @@ public abstract class ChartFacadeController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { "application/xml", "text/xml" } )
     public void postXmlObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -692,7 +696,7 @@ public abstract class ChartFacadeController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( value = "/{uid}/favorite", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/favorite" )
     @ResponseStatus( HttpStatus.OK )
     public void setAsFavorite( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -721,7 +725,7 @@ public abstract class ChartFacadeController
         webMessageService.send( WebMessageUtils.ok( message ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/subscriber", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/subscriber" )
     @ResponseStatus( HttpStatus.OK )
     public void subscribe( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -754,7 +758,7 @@ public abstract class ChartFacadeController
     // PUT
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}", consumes = MediaType.APPLICATION_JSON_VALUE )
     public void putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
         throws Exception
@@ -795,8 +799,7 @@ public abstract class ChartFacadeController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = { MediaType.APPLICATION_XML_VALUE,
-        MediaType.TEXT_XML_VALUE } )
+    @PutMapping( value = "/{uid}", consumes = { MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE } )
     public void putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
         throws Exception
@@ -841,7 +844,7 @@ public abstract class ChartFacadeController
     // DELETE
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}" )
     @ResponseStatus( HttpStatus.OK )
     public void deleteObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -872,7 +875,7 @@ public abstract class ChartFacadeController
         webMessageService.send( WebMessageUtils.objectReport( importReport ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/favorite", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/favorite" )
     @ResponseStatus( HttpStatus.OK )
     public void removeAsFavorite( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -901,7 +904,7 @@ public abstract class ChartFacadeController
         webMessageService.send( WebMessageUtils.ok( message ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/subscriber", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/subscriber" )
     @ResponseStatus( HttpStatus.OK )
     public void unsubscribe( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -934,7 +937,7 @@ public abstract class ChartFacadeController
     // Identifiable object collections add, delete
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/{property}/{itemId}" )
     public @ResponseBody RootNode getCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -986,7 +989,7 @@ public abstract class ChartFacadeController
         }
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1004,7 +1007,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1022,7 +1025,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1038,7 +1041,7 @@ public abstract class ChartFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1054,7 +1057,7 @@ public abstract class ChartFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/{property}/{itemId}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItem(
         @PathVariable( "uid" ) String pvUid,
@@ -1075,7 +1078,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
     public void deleteCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1090,7 +1093,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_XML_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
     public void deleteCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1105,7 +1108,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/{property}/{itemId}" )
     public void deleteCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -84,8 +84,10 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -137,7 +139,7 @@ public class CompleteDataSetRegistrationController
     // GET
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET, produces = CONTENT_TYPE_XML )
+    @GetMapping( produces = CONTENT_TYPE_XML )
     public void getCompleteRegistrationsXml(
         @RequestParam Set<String> dataSet,
         @RequestParam( required = false ) Set<String> period,
@@ -163,7 +165,7 @@ public class CompleteDataSetRegistrationController
         registrationExchangeService.writeCompleteDataSetRegistrationsXml( params, response.getOutputStream() );
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = CONTENT_TYPE_JSON )
+    @GetMapping( produces = CONTENT_TYPE_JSON )
     public void getCompleteRegistrationsJson(
         @RequestParam Set<String> dataSet,
         @RequestParam( required = false ) Set<String> period,
@@ -193,7 +195,7 @@ public class CompleteDataSetRegistrationController
     // POST
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, consumes = CONTENT_TYPE_XML )
+    @PostMapping( consumes = CONTENT_TYPE_XML )
     public void postCompleteRegistrationsXml(
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
@@ -212,7 +214,7 @@ public class CompleteDataSetRegistrationController
         }
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = CONTENT_TYPE_JSON )
+    @PostMapping( consumes = CONTENT_TYPE_JSON )
     public void postCompleteRegistrationsJson(
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
@@ -235,7 +237,7 @@ public class CompleteDataSetRegistrationController
     // DELETE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.DELETE )
+    @DeleteMapping
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCompleteDataSetRegistration(
         @RequestParam Set<String> ds,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -60,9 +60,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -99,21 +101,21 @@ public class ConfigurationController
     // Resources
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody Configuration getConfiguration( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration();
     }
 
     @ResponseStatus( value = HttpStatus.OK )
-    @RequestMapping( value = "/systemId", method = RequestMethod.GET )
+    @GetMapping( "/systemId" )
     public @ResponseBody String getSystemId( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getSystemId();
     }
 
     @PreAuthorize( "hasRole('ALL')" )
-    @RequestMapping( value = "/systemId", method = RequestMethod.POST )
+    @PostMapping( "/systemId" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void setSystemId( @RequestBody( required = false ) String systemId )
     {
@@ -124,14 +126,14 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/feedbackRecipients", method = RequestMethod.GET )
+    @GetMapping( "/feedbackRecipients" )
     public @ResponseBody UserGroup getFeedbackRecipients( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getFeedbackRecipients();
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/feedbackRecipients", method = RequestMethod.POST )
+    @PostMapping( "/feedbackRecipients" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setFeedbackRecipients( @RequestBody String uid )
         throws NotFoundException
@@ -152,7 +154,7 @@ public class ConfigurationController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/feedbackRecipients", method = RequestMethod.DELETE )
+    @DeleteMapping( "/feedbackRecipients" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeFeedbackRecipients()
     {
@@ -163,7 +165,7 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/offlineOrganisationUnitLevel", method = RequestMethod.GET )
+    @GetMapping( "/offlineOrganisationUnitLevel" )
     public @ResponseBody OrganisationUnitLevel getOfflineOrganisationUnitLevel( Model model,
         HttpServletRequest request )
     {
@@ -171,7 +173,7 @@ public class ConfigurationController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/offlineOrganisationUnitLevel", method = RequestMethod.POST )
+    @PostMapping( "/offlineOrganisationUnitLevel" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setOfflineOrganisationUnitLevel( @RequestBody String uid )
         throws NotFoundException
@@ -192,7 +194,7 @@ public class ConfigurationController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/offlineOrganisationUnitLevel", method = RequestMethod.DELETE )
+    @DeleteMapping( "/offlineOrganisationUnitLevel" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeOfflineOrganisationUnitLevel()
     {
@@ -203,14 +205,14 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/infrastructuralIndicators", method = RequestMethod.GET )
+    @GetMapping( "/infrastructuralIndicators" )
     public @ResponseBody IndicatorGroup getInfrastructuralIndicators( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getInfrastructuralIndicators();
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/infrastructuralIndicators", method = RequestMethod.POST )
+    @PostMapping( "/infrastructuralIndicators" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setInfrastructuralIndicators( @RequestBody String uid )
         throws NotFoundException
@@ -230,14 +232,14 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/infrastructuralDataElements", method = RequestMethod.GET )
+    @GetMapping( "/infrastructuralDataElements" )
     public @ResponseBody DataElementGroup getInfrastructuralDataElements( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getInfrastructuralDataElements();
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/infrastructuralDataElements", method = RequestMethod.POST )
+    @PostMapping( "/infrastructuralDataElements" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setInfrastructuralDataElements( @RequestBody String uid )
         throws NotFoundException
@@ -257,7 +259,7 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/infrastructuralPeriodType", method = RequestMethod.GET )
+    @GetMapping( "/infrastructuralPeriodType" )
     public @ResponseBody BaseIdentifiableObject getInfrastructuralPeriodType( Model model, HttpServletRequest request )
     {
         String name = configurationService.getConfiguration().getInfrastructuralPeriodTypeDefaultIfNull().getName();
@@ -265,7 +267,7 @@ public class ConfigurationController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/infrastructuralPeriodType", method = RequestMethod.POST )
+    @PostMapping( "/infrastructuralPeriodType" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setInfrastructuralPeriodType( @RequestBody String name )
         throws NotFoundException
@@ -287,14 +289,14 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/selfRegistrationRole", method = RequestMethod.GET )
+    @GetMapping( "/selfRegistrationRole" )
     public @ResponseBody UserAuthorityGroup getSelfRegistrationRole( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getSelfRegistrationRole();
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/selfRegistrationRole", method = RequestMethod.POST )
+    @PostMapping( "/selfRegistrationRole" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setSelfRegistrationRole( @RequestBody String uid )
         throws NotFoundException
@@ -315,7 +317,7 @@ public class ConfigurationController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/selfRegistrationRole", method = RequestMethod.DELETE )
+    @DeleteMapping( "/selfRegistrationRole" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeSelfRegistrationRole()
     {
@@ -326,14 +328,14 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/selfRegistrationOrgUnit", method = RequestMethod.GET )
+    @GetMapping( "/selfRegistrationOrgUnit" )
     public @ResponseBody OrganisationUnit getSelfRegistrationOrgUnit( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getSelfRegistrationOrgUnit();
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/selfRegistrationOrgUnit", method = RequestMethod.POST )
+    @PostMapping( "/selfRegistrationOrgUnit" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setSelfRegistrationOrgUnit( @RequestBody String uid )
         throws NotFoundException
@@ -354,7 +356,7 @@ public class ConfigurationController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/selfRegistrationOrgUnit", method = RequestMethod.DELETE )
+    @DeleteMapping( "/selfRegistrationOrgUnit" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeSelfRegistrationOrgUnit()
     {
@@ -365,19 +367,19 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/remoteServerUrl", method = RequestMethod.GET )
+    @GetMapping( "/remoteServerUrl" )
     public @ResponseBody String getRemoteServerUrl( Model model, HttpServletRequest request )
     {
         return (String) systemSettingManager.getSystemSetting( SettingKey.REMOTE_INSTANCE_URL );
     }
 
-    @RequestMapping( value = "/remoteServerUsername", method = RequestMethod.GET )
+    @GetMapping( "/remoteServerUsername" )
     public @ResponseBody String getRemoteServerUsername( Model model, HttpServletRequest request )
     {
         return (String) systemSettingManager.getSystemSetting( SettingKey.REMOTE_INSTANCE_USERNAME );
     }
 
-    @RequestMapping( value = "/corsWhitelist", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/corsWhitelist", produces = "application/json" )
     public @ResponseBody Set<String> getCorsWhitelist( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getCorsWhitelist();
@@ -385,7 +387,7 @@ public class ConfigurationController
 
     @SuppressWarnings( "unchecked" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @RequestMapping( value = "/corsWhitelist", method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( value = "/corsWhitelist", consumes = "application/json" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setCorsWhitelist( @RequestBody String input )
         throws IOException
@@ -399,13 +401,13 @@ public class ConfigurationController
         configurationService.setConfiguration( config );
     }
 
-    @RequestMapping( value = "/systemReadOnlyMode", method = RequestMethod.GET )
+    @GetMapping( "/systemReadOnlyMode" )
     public @ResponseBody boolean getSystemReadOnlyMode( Model model, HttpServletRequest request )
     {
         return config.isReadOnlyMode();
     }
 
-    @RequestMapping( value = "/appHubUrl", method = RequestMethod.GET )
+    @GetMapping( "/appHubUrl" )
     public @ResponseBody String getAppHubUrl( Model model, HttpServletRequest request )
     {
         return appManager.getAppHubUrl();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -54,9 +54,9 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -75,7 +75,7 @@ public class DashboardController
     // Search
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/q/{query}", method = RequestMethod.GET )
+    @GetMapping( "/q/{query}" )
     public @ResponseBody DashboardSearchResult search( @PathVariable String query,
         @RequestParam( required = false ) Set<DashboardItemType> max,
         @RequestParam( required = false ) Integer count,
@@ -84,7 +84,7 @@ public class DashboardController
         return dashboardService.search( query, max, count, maxCount );
     }
 
-    @RequestMapping( value = "/q", method = RequestMethod.GET )
+    @GetMapping( "/q" )
     public @ResponseBody DashboardSearchResult searchNoFilter(
         @RequestParam( required = false ) Set<DashboardItemType> max, @RequestParam( required = false ) Integer count,
         @RequestParam( required = false ) Integer maxCount )
@@ -96,7 +96,7 @@ public class DashboardController
     // Metadata with dependencies
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String dashboardId,
         @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardItemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardItemController.java
@@ -42,8 +42,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
@@ -60,7 +60,7 @@ public class DashboardItemController
     @Autowired
     private DashboardService dashboardService;
 
-    @RequestMapping( value = "/{uid}/shape/{shape}", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}/shape/{shape}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void putDashboardItemShape( @PathVariable String uid, @PathVariable DashboardItemShape shape,
         HttpServletRequest request, HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -94,9 +94,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -161,7 +162,7 @@ public class DataAnalysisController
     @Autowired
     private FollowupAnalysisService followupAnalysisService;
 
-    @RequestMapping( value = "/validationRules", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/validationRules", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<ValidationResultView> performValidationRulesAnalysis(
         @RequestBody ValidationRulesAnalysisParams validationRulesAnalysisParams,
@@ -203,7 +204,7 @@ public class DataAnalysisController
         return validationResultsListToResponse( validationResults );
     }
 
-    @RequestMapping( value = "validationRulesExpression", method = RequestMethod.GET )
+    @GetMapping( "validationRulesExpression" )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody ValidationRuleExpressionDetails getValidationRuleExpressionDetials(
         @RequestParam String validationRuleId,
@@ -255,7 +256,7 @@ public class DataAnalysisController
         return validationService.getValidationRuleExpressionDetails( params );
     }
 
-    @RequestMapping( value = "/stdDevOutlier", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/stdDevOutlier", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<DeflatedDataValue> performStdDevOutlierAnalysis(
         @RequestBody DataAnalysisParams stdDevOutlierAnalysisParams,
@@ -302,7 +303,7 @@ public class DataAnalysisController
         return deflatedValuesListToResponse( dataValues );
     }
 
-    @RequestMapping( value = "/minMaxOutlier", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/minMaxOutlier", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<DeflatedDataValue> performMinMaxOutlierAnalysis(
         @RequestBody DataAnalysisParams params,
@@ -350,7 +351,7 @@ public class DataAnalysisController
         return deflatedValuesListToResponse( dataValues );
     }
 
-    @RequestMapping( value = "/followup", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/followup", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<DeflatedDataValue> performFollowupAnalysis( @RequestBody DataAnalysisParams params,
         HttpSession session )
@@ -390,14 +391,14 @@ public class DataAnalysisController
         return deflatedValuesListToResponse( dataValues );
     }
 
-    @RequestMapping( value = "/followup", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/followup", produces = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody FollowupAnalysisResponse performFollowupAnalysis( FollowupAnalysisRequest request )
     {
         return followupAnalysisService.getFollowupDataValues( request );
     }
 
-    @RequestMapping( value = "/followup/mark", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/followup/mark", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public @ResponseBody void markDataValues( @RequestBody UpdateFollowUpForDataValuesRequest params )
     {
@@ -430,7 +431,7 @@ public class DataAnalysisController
         }
     }
 
-    @RequestMapping( value = "/report.pdf", method = RequestMethod.GET )
+    @GetMapping( "/report.pdf" )
     public void getPdfReport( HttpSession session, HttpServletResponse response )
         throws Exception
     {
@@ -447,7 +448,7 @@ public class DataAnalysisController
         GridUtils.toPdf( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/report.xls", method = RequestMethod.GET )
+    @GetMapping( "/report.xls" )
     public void getXlsReport( HttpSession session, HttpServletResponse response )
         throws Exception
     {
@@ -463,7 +464,7 @@ public class DataAnalysisController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/report.csv", method = RequestMethod.GET )
+    @GetMapping( "/report.csv" )
     public void getCSVReport( HttpSession session, HttpServletResponse response )
         throws Exception
     {
@@ -480,7 +481,7 @@ public class DataAnalysisController
         GridUtils.toCsv( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "validationRules/report.pdf", method = RequestMethod.GET )
+    @GetMapping( "validationRules/report.pdf" )
     public void getValidationRulesPdfReport( HttpSession session, HttpServletResponse response )
         throws Exception
     {
@@ -497,7 +498,7 @@ public class DataAnalysisController
         GridUtils.toPdf( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "validationRules/report.xls", method = RequestMethod.GET )
+    @GetMapping( "validationRules/report.xls" )
     public void getValidationRulesXlsReport( HttpSession session, HttpServletResponse response )
         throws Exception
     {
@@ -513,7 +514,7 @@ public class DataAnalysisController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "validationRules/report.csv", method = RequestMethod.GET )
+    @GetMapping( "validationRules/report.csv" )
     public void getValidationRulesCSVReport( HttpSession session, HttpServletResponse response )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -83,9 +83,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -145,7 +147,7 @@ public class DataApprovalController
     // Get
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = APPROVALS_PATH, method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = APPROVALS_PATH, produces = ContextUtils.CONTENT_TYPE_JSON )
     public void getApprovalPermissions(
         @RequestParam( required = false ) String ds,
         @RequestParam( required = false ) String wf,
@@ -171,8 +173,8 @@ public class DataApprovalController
         renderService.toJson( response.getOutputStream(), status.getPermissions() );
     }
 
-    @RequestMapping( value = { MULTIPLE_APPROVALS_PATH,
-        APPROVALS_PATH + "/approvals" }, method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = { MULTIPLE_APPROVALS_PATH,
+        APPROVALS_PATH + "/approvals" }, produces = ContextUtils.CONTENT_TYPE_JSON )
     public void getMultipleApprovalPermissions(
         @RequestParam Set<String> wf,
         @RequestParam( required = false ) Set<String> pe,
@@ -288,7 +290,7 @@ public class DataApprovalController
         renderService.toJson( response.getOutputStream(), approvalStatuses );
     }
 
-    @RequestMapping( value = STATUS_PATH, method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = STATUS_PATH, produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody RootNode getApproval(
         @RequestParam Set<String> ds,
         @RequestParam( required = false ) String pe,
@@ -378,8 +380,8 @@ public class DataApprovalController
             createdDate, createdByUsername, status.getPermissions() );
     }
 
-    @RequestMapping( value = APPROVALS_PATH
-        + "/categoryOptionCombos", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = APPROVALS_PATH
+        + "/categoryOptionCombos", produces = ContextUtils.CONTENT_TYPE_JSON )
     public void getApprovalByCategoryOptionCombos(
         @RequestParam( required = false ) Set<String> ds,
         @RequestParam( required = false ) Set<String> wf,
@@ -449,7 +451,7 @@ public class DataApprovalController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_APPROVE_DATA') or hasRole('F_APPROVE_DATA_LOWER_LEVELS')" )
-    @RequestMapping( value = APPROVALS_PATH, method = RequestMethod.POST )
+    @PostMapping( value = APPROVALS_PATH )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void saveApproval(
         @RequestParam( required = false ) String ds,
@@ -473,7 +475,7 @@ public class DataApprovalController
         dataApprovalService.approveData( dataApprovalList );
     }
 
-    @RequestMapping( value = APPROVALS_PATH + "/approvals", method = RequestMethod.POST )
+    @PostMapping( APPROVALS_PATH + "/approvals" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void saveApprovalBatch( @RequestBody ApprovalsDto approvals )
         throws WebMessageException
@@ -481,7 +483,7 @@ public class DataApprovalController
         dataApprovalService.approveData( getDataApprovalList( approvals ) );
     }
 
-    @RequestMapping( value = APPROVALS_PATH + "/unapprovals", method = RequestMethod.POST )
+    @PostMapping( APPROVALS_PATH + "/unapprovals" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeApprovalBatch( @RequestBody ApprovalsDto approvals )
         throws WebMessageException
@@ -494,7 +496,7 @@ public class DataApprovalController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_ACCEPT_DATA_LOWER_LEVELS')" )
-    @RequestMapping( value = ACCEPTANCES_PATH, method = RequestMethod.POST )
+    @PostMapping( ACCEPTANCES_PATH )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void acceptApproval(
         @RequestParam( required = false ) String ds,
@@ -518,7 +520,7 @@ public class DataApprovalController
         dataApprovalService.acceptData( dataApprovalList );
     }
 
-    @RequestMapping( value = ACCEPTANCES_PATH + "/acceptances", method = RequestMethod.POST )
+    @PostMapping( ACCEPTANCES_PATH + "/acceptances" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void saveAcceptanceBatch( @RequestBody ApprovalsDto approvals )
         throws WebMessageException
@@ -526,7 +528,7 @@ public class DataApprovalController
         dataApprovalService.acceptData( getDataApprovalList( approvals ) );
     }
 
-    @RequestMapping( value = ACCEPTANCES_PATH + "/unacceptances", method = RequestMethod.POST )
+    @PostMapping( ACCEPTANCES_PATH + "/unacceptances" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeAcceptancesBatch( @RequestBody ApprovalsDto approvals )
         throws WebMessageException
@@ -539,7 +541,7 @@ public class DataApprovalController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_APPROVE_DATA') or hasRole('F_APPROVE_DATA_LOWER_LEVELS')" )
-    @RequestMapping( value = APPROVALS_PATH, method = RequestMethod.DELETE )
+    @DeleteMapping( APPROVALS_PATH )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeApproval(
         @RequestParam( required = false ) Set<String> ds,
@@ -570,7 +572,7 @@ public class DataApprovalController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_ACCEPT_DATA_LOWER_LEVELS')" )
-    @RequestMapping( value = ACCEPTANCES_PATH, method = RequestMethod.DELETE )
+    @DeleteMapping( ACCEPTANCES_PATH )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void unacceptApproval(
         @RequestParam( required = false ) String ds,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -42,14 +42,14 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
 @Controller
-@RequestMapping( method = RequestMethod.GET )
+@RequestMapping
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class DataIntegrityController
 {
@@ -69,7 +69,7 @@ public class DataIntegrityController
     // --------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
-    @RequestMapping( value = DataIntegrityController.RESOURCE_PATH, method = RequestMethod.POST )
+    @PostMapping( DataIntegrityController.RESOURCE_PATH )
     public void runAsyncDataIntegrity( HttpServletResponse response, HttpServletRequest request )
     {
         JobConfiguration jobConfiguration = new JobConfiguration( "runAsyncDataIntegrity", JobType.DATA_INTEGRITY, null,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -90,10 +90,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -143,7 +145,7 @@ public class DataSetController
     // -------------------------------------------------------------------------
 
     @SuppressWarnings( "unchecked" )
-    @RequestMapping( produces = "application/dsd+xml" )
+    @GetMapping( produces = "application/dsd+xml" )
     public void getStructureDefinition( @RequestParam Map<String, String> parameters, HttpServletResponse response )
         throws IOException,
         TransformerException
@@ -169,7 +171,7 @@ public class DataSetController
         transformer.transform( new StreamSource( input ), new StreamResult( response.getOutputStream() ) );
     }
 
-    @RequestMapping( value = "/{uid}/version", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/version" )
     public void getVersion( @PathVariable( "uid" ) String uid, @RequestParam Map<String, String> parameters,
         HttpServletResponse response )
         throws Exception
@@ -187,7 +189,7 @@ public class DataSetController
         renderService.toJson( response.getOutputStream(), versionMap );
     }
 
-    @RequestMapping( value = "/{uid}/version", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/version" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void bumpVersion( @PathVariable( "uid" ) String uid )
         throws Exception
@@ -204,7 +206,7 @@ public class DataSetController
         dataSetService.updateDataSet( dataSet );
     }
 
-    @RequestMapping( value = "/{uid}/categoryCombos", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/categoryCombos" )
     public @ResponseBody RootNode getCategoryCombinations( @PathVariable( "uid" ) String uid,
         HttpServletRequest request,
         TranslateParams translateParams, HttpServletResponse response )
@@ -232,7 +234,7 @@ public class DataSetController
         return rootNode;
     }
 
-    @RequestMapping( value = "/{uid}/dataValueSet", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/dataValueSet" )
     public @ResponseBody RootNode getDvs( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "orgUnitIdScheme", defaultValue = "ID", required = false ) String orgUnitIdScheme,
         @RequestParam( value = "dataElementIdScheme", defaultValue = "ID", required = false ) String dataElementIdScheme,
@@ -257,7 +259,7 @@ public class DataSetController
             dataElementIdScheme );
     }
 
-    @RequestMapping( value = "/{uid}/form", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{uid}/form", produces = "application/json" )
     public void getFormJson(
         @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnit,
@@ -290,7 +292,7 @@ public class DataSetController
         renderService.toJson( response.getOutputStream(), form );
     }
 
-    @RequestMapping( value = "/{uid}/form", method = RequestMethod.GET, produces = { "application/xml", "text/xml" } )
+    @GetMapping( value = "/{uid}/form", produces = { "application/xml", "text/xml" } )
     public void getFormXml(
         @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnit,
@@ -360,8 +362,8 @@ public class DataSetController
         return form;
     }
 
-    @RequestMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, method = { RequestMethod.PUT,
-        RequestMethod.POST }, consumes = "text/html" )
+    @PutMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, consumes = "text/html" )
+    @PostMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, consumes = "text/html" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCustomDataEntryFormHtml( @PathVariable( "uid" ) String uid,
         @RequestBody String formContent,
@@ -393,7 +395,7 @@ public class DataSetController
         dataSetService.updateDataSet( dataSet );
     }
 
-    @RequestMapping( value = "/{uid}/form", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/form", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ApiVersion( value = DhisApiVersion.ALL )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCustomDataEntryFormJson( @PathVariable( "uid" ) String uid, HttpServletRequest request )
@@ -448,7 +450,7 @@ public class DataSetController
         dataSetService.updateDataSet( dataSet );
     }
 
-    @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid,
         @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -93,9 +93,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -362,8 +362,8 @@ public class DataSetController
         return form;
     }
 
-    @PutMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, consumes = "text/html" )
-    @PostMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, consumes = "text/html" )
+    @RequestMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, method = { RequestMethod.PUT,
+        RequestMethod.POST }, consumes = "text/html" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCustomDataEntryFormHtml( @PathVariable( "uid" ) String uid,
         @RequestBody String formContent,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
@@ -27,24 +27,33 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import java.util.*;
+import java.util.List;
+import java.util.Set;
 
-import javax.servlet.http.*;
+import javax.servlet.http.HttpServletResponse;
 
-import org.hisp.dhis.common.*;
-import org.hisp.dhis.common.cache.*;
-import org.hisp.dhis.dataset.*;
-import org.hisp.dhis.datasetreport.*;
-import org.hisp.dhis.dxf2.webmessage.*;
-import org.hisp.dhis.organisationunit.*;
-import org.hisp.dhis.period.*;
-import org.hisp.dhis.system.grid.*;
-import org.hisp.dhis.webapi.mvc.annotation.*;
-import org.hisp.dhis.webapi.service.*;
-import org.hisp.dhis.webapi.utils.*;
-import org.springframework.beans.factory.annotation.*;
-import org.springframework.stereotype.*;
-import org.springframework.web.bind.annotation.*;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.datasetreport.DataSetReportService;
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.system.grid.GridUtils;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.service.WebMessageService;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * @author Stian Sandvold
@@ -77,8 +86,7 @@ public class DataSetReportController
     @Autowired
     IdentifiableObjectManager idObjectManager;
 
-    @RequestMapping( value = RESOURCE_PATH
-        + "/custom", method = RequestMethod.GET, produces = "text/html;charset=UTF-8" )
+    @GetMapping( value = RESOURCE_PATH + "/custom", produces = "text/html;charset=UTF-8" )
     public @ResponseBody String getCustomDataSetReport( HttpServletResponse response,
         @RequestParam String ds,
         @RequestParam String pe,
@@ -103,7 +111,7 @@ public class DataSetReportController
         return dataSetReportService.getCustomDataSetReport( dataSet, period, orgUnit, filter, selectedUnitOnly );
     }
 
-    @RequestMapping( value = RESOURCE_PATH, method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = RESOURCE_PATH, produces = "application/json" )
     public @ResponseBody List<Grid> getDataSetReportAsJson( HttpServletResponse response,
         @RequestParam String ds,
         @RequestParam String pe,
@@ -121,7 +129,7 @@ public class DataSetReportController
         return dataSetReportService.getDataSetReportAsGrid( dataSet, period, orgUnit, filter, selectedUnitOnly );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".xls", method = RequestMethod.GET )
+    @GetMapping( RESOURCE_PATH + ".xls" )
     public void getDataSetReportAsExcel( HttpServletResponse response,
         @RequestParam String ds,
         @RequestParam String pe,
@@ -141,7 +149,7 @@ public class DataSetReportController
         GridUtils.toXls( grids, response.getOutputStream() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".pdf", method = RequestMethod.GET )
+    @GetMapping( RESOURCE_PATH + ".pdf" )
     public void getDataSetReportAsPdf( HttpServletResponse response,
         @RequestParam String ds,
         @RequestParam String pe,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -29,9 +29,21 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
-import static org.hisp.dhis.webapi.utils.ContextUtils.*;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_PDF;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_XML;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_XML_ADX;
+import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.util.Date;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
@@ -67,8 +79,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -107,7 +120,7 @@ public class DataValueSetController
     // Get
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET, produces = CONTENT_TYPE_XML )
+    @GetMapping( produces = CONTENT_TYPE_XML )
     public void getDataValueSetXml(
         @RequestParam( required = false ) Set<String> dataSet,
         @RequestParam( required = false ) Set<String> dataElementGroup,
@@ -139,7 +152,7 @@ public class DataValueSetController
         dataValueSetService.writeDataValueSetXml( params, outputStream );
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = CONTENT_TYPE_XML_ADX )
+    @GetMapping( produces = CONTENT_TYPE_XML_ADX )
     public void getDataValueSetXmlAdx(
         @RequestParam Set<String> dataSet,
         @RequestParam( required = false ) Set<String> period,
@@ -171,7 +184,7 @@ public class DataValueSetController
         adxDataService.writeDataValueSet( params, outputStream );
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = CONTENT_TYPE_JSON )
+    @GetMapping( produces = CONTENT_TYPE_JSON )
     public void getDataValueSetJson(
         @RequestParam( required = false ) Set<String> dataSet,
         @RequestParam( required = false ) Set<String> dataElementGroup,
@@ -203,7 +216,7 @@ public class DataValueSetController
         dataValueSetService.writeDataValueSetJson( params, outputStream );
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = CONTENT_TYPE_CSV )
+    @GetMapping( produces = CONTENT_TYPE_CSV )
     public void getDataValueSetCsv(
         @RequestParam( required = false ) Set<String> dataSet,
         @RequestParam( required = false ) Set<String> dataElementGroup,
@@ -242,7 +255,7 @@ public class DataValueSetController
     // Post
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/xml" )
+    @PostMapping( consumes = "application/xml" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     public void postDxf2DataValueSet( ImportOptions importOptions,
         HttpServletRequest request, HttpServletResponse response )
@@ -262,7 +275,7 @@ public class DataValueSetController
         }
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = CONTENT_TYPE_XML_ADX )
+    @PostMapping( consumes = CONTENT_TYPE_XML_ADX )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     public void postAdxDataValueSet( ImportOptions importOptions,
         HttpServletRequest request, HttpServletResponse response )
@@ -293,7 +306,7 @@ public class DataValueSetController
         }
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     public void postJsonDataValueSet( ImportOptions importOptions,
         HttpServletRequest request, HttpServletResponse response )
@@ -313,7 +326,7 @@ public class DataValueSetController
         }
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/csv" )
+    @PostMapping( consumes = "application/csv" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     public void postCsvDataValueSet( ImportOptions importOptions,
         HttpServletRequest request, HttpServletResponse response )
@@ -333,7 +346,7 @@ public class DataValueSetController
         }
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = CONTENT_TYPE_PDF )
+    @PostMapping( consumes = CONTENT_TYPE_PDF )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     public void postPdfDataValueSet( ImportOptions importOptions,
         HttpServletRequest request, HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.*;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.forbidden;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.List;
@@ -56,7 +58,14 @@ import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.google.common.collect.Lists;
 
@@ -125,7 +134,8 @@ public class DeduplicationController
         return potentialDuplicate;
     }
 
-    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST }, value = "/{id}/invalidation" )
+    @PutMapping( "/{id}/invalidation" )
+    @PostMapping( "/{id}/invalidation" )
     public void markPotentialDuplicateInvalid(
         @PathVariable String id )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
@@ -62,9 +62,9 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.google.common.collect.Lists;
@@ -134,8 +134,7 @@ public class DeduplicationController
         return potentialDuplicate;
     }
 
-    @PutMapping( "/{id}/invalidation" )
-    @PostMapping( "/{id}/invalidation" )
+    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST }, value = "/{id}/invalidation" )
     public void markPotentialDuplicateInvalid(
         @PathVariable String id )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DocumentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DocumentController.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -75,7 +75,7 @@ public class DocumentController
     @Autowired
     private ContextUtils contextUtils;
 
-    @RequestMapping( value = "/{uid}/data", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data" )
     public void getDocumentContent( @PathVariable( "uid" ) String uid, HttpServletResponse response )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
@@ -47,9 +47,9 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -80,7 +80,7 @@ public class EmailController
     @Autowired
     private WebMessageService webMessageService;
 
-    @RequestMapping( value = "/test", method = RequestMethod.POST )
+    @PostMapping( "/test" )
     public void sendTestEmail( HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
     {
@@ -97,7 +97,7 @@ public class EmailController
         emailResponseHandler( emailResponse, request, response );
     }
 
-    @RequestMapping( value = "/notification", method = RequestMethod.POST )
+    @PostMapping( "/notification" )
     public void sendSystemNotificationEmail( @RequestBody Email email,
         HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
@@ -118,7 +118,7 @@ public class EmailController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SEND_EMAIL')" )
-    @RequestMapping( value = "/notification", method = RequestMethod.POST, produces = "application/json" )
+    @PostMapping( value = "/notification", produces = "application/json" )
     public void sendEmailNotification( @RequestParam Set<String> recipients, @RequestParam String message,
         @RequestParam( defaultValue = "DHIS 2" ) String subject,
         HttpServletResponse response, HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -43,9 +43,9 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
@@ -65,8 +65,7 @@ public class EnrollmentAnalyticsController
     @Autowired
     private ContextUtils contextUtils;
 
-    @RequestMapping( value = "/query/{program}", method = RequestMethod.GET, produces = {
-        "application/json", "application/javascript" } )
+    @GetMapping( value = "/query/{program}", produces = { "application/json", "application/javascript" } )
     public @ResponseBody Grid getQueryJson( // JSON, JSONP
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
@@ -80,7 +79,7 @@ public class EnrollmentAnalyticsController
         return analyticsService.getEnrollments( params );
     }
 
-    @RequestMapping( value = "/query/{program}.xml", method = RequestMethod.GET )
+    @GetMapping( "/query/{program}.xml" )
     public void getQueryXml(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
@@ -97,7 +96,7 @@ public class EnrollmentAnalyticsController
         GridUtils.toXml( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/query/{program}.xls", method = RequestMethod.GET )
+    @GetMapping( "/query/{program}.xls" )
     public void getQueryXls(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
@@ -114,7 +113,7 @@ public class EnrollmentAnalyticsController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/query/{program}.csv", method = RequestMethod.GET )
+    @GetMapping( "/query/{program}.csv" )
     public void getQueryCsv(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
@@ -131,7 +130,7 @@ public class EnrollmentAnalyticsController
         GridUtils.toCsv( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/query/{program}.html", method = RequestMethod.GET )
+    @GetMapping( "/query/{program}.html" )
     public void getQueryHtml(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
@@ -148,7 +147,7 @@ public class EnrollmentAnalyticsController
         GridUtils.toHtml( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/query/{program}.html+css", method = RequestMethod.GET )
+    @GetMapping( "/query/{program}.html+css" )
     public void getQueryHtmlCss(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -66,7 +66,7 @@ public class ExpressionController
     @Autowired
     private I18nManager i18nManager;
 
-    @RequestMapping( value = "/description", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getExpressionDescription( @RequestParam String expression, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExternalFileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExternalFileResourceController.java
@@ -48,9 +48,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * @author Stian Sandvold
@@ -79,7 +79,7 @@ public class ExternalFileResourceController
      * @param response
      * @throws WebMessageException
      */
-    @RequestMapping( value = "/{accessToken}", method = RequestMethod.GET )
+    @GetMapping( "/{accessToken}" )
     public void getExternalFileResource( @PathVariable String accessToken,
         HttpServletResponse response )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileController.java
@@ -46,9 +46,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
@@ -74,7 +76,7 @@ public class FileController
     // Custom script
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/script", method = RequestMethod.GET )
+    @GetMapping( "/script" )
     public void getCustomScript( HttpServletResponse response, Writer writer )
         throws IOException
     {
@@ -88,7 +90,7 @@ public class FileController
         }
     }
 
-    @RequestMapping( value = "/script", method = RequestMethod.POST, consumes = "application/javascript" )
+    @PostMapping( value = "/script", consumes = "application/javascript" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_INSERT_CUSTOM_JS_CSS')" )
     public void postCustomScript( @RequestBody String content, HttpServletResponse response,
         HttpServletRequest request )
@@ -100,7 +102,7 @@ public class FileController
         }
     }
 
-    @RequestMapping( value = "/script", method = RequestMethod.DELETE )
+    @DeleteMapping( "/script" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_INSERT_CUSTOM_JS_CSS')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeCustomScript( HttpServletResponse response )
@@ -116,7 +118,7 @@ public class FileController
      * The style/external mapping enables style to be reached from login page /
      * before authentication.
      */
-    @RequestMapping( value = { "/style", "/style/external" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/style", "/style/external" } )
     public void getCustomStyle( HttpServletResponse response, Writer writer )
         throws IOException
     {
@@ -130,7 +132,7 @@ public class FileController
         }
     }
 
-    @RequestMapping( value = "/style", method = RequestMethod.POST, consumes = "text/css" )
+    @PostMapping( value = "/style", consumes = "text/css" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_INSERT_CUSTOM_JS_CSS')" )
     public void postCustomStyle( @RequestBody String content, HttpServletResponse response, HttpServletRequest request )
     {
@@ -141,7 +143,7 @@ public class FileController
         }
     }
 
-    @RequestMapping( value = "/style", method = RequestMethod.DELETE )
+    @DeleteMapping( "/style" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_INSERT_CUSTOM_JS_CSS')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeCustomStyle( HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/I18nController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/I18nController.java
@@ -40,8 +40,8 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -67,7 +67,7 @@ public class I18nController
         this.jsonMapper = jsonMapper;
     }
 
-    @RequestMapping( method = RequestMethod.POST )
+    @PostMapping
     public void postI18n(
         @RequestParam( value = "package", required = false, defaultValue = "org.hisp.dhis" ) String searchPackage,
         HttpServletResponse response, InputStream inputStream )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IconController.java
@@ -50,7 +50,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.google.common.net.MediaType;
 
@@ -70,7 +74,7 @@ public class IconController
     @Autowired
     private ContextService contextService;
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody List<IconData> getIcons( HttpServletResponse response,
         @RequestParam( required = false ) Collection<String> keywords )
     {
@@ -91,13 +95,13 @@ public class IconController
             .collect( Collectors.toList() );
     }
 
-    @RequestMapping( value = "/keywords", method = RequestMethod.GET )
+    @GetMapping( "/keywords" )
     public @ResponseBody Collection<String> getKeywords( HttpServletResponse response )
     {
         return iconService.getKeywords();
     }
 
-    @RequestMapping( value = "/{iconKey}", method = RequestMethod.GET )
+    @GetMapping( "/{iconKey}" )
     public @ResponseBody IconData getIcon( HttpServletResponse response, @PathVariable String iconKey )
         throws WebMessageException
     {
@@ -115,7 +119,7 @@ public class IconController
         return icon.get();
     }
 
-    @RequestMapping( value = "/{iconKey}/icon.svg", method = RequestMethod.GET )
+    @GetMapping( "/{iconKey}/icon.svg" )
     public void getIconData( HttpServletResponse response, @PathVariable String iconKey )
         throws WebMessageException,
         IOException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -44,8 +44,7 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
@@ -64,7 +63,7 @@ public class IndexController
     // GET
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/api", method = RequestMethod.GET )
+    @GetMapping( "/api" )
     public void getIndex( HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -72,7 +71,7 @@ public class IndexController
         response.sendRedirect( ContextUtils.getRootPath( request ) + location );
     }
 
-    @RequestMapping( value = "/", method = RequestMethod.GET )
+    @GetMapping( "/" )
     public void getIndexWithSlash( HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -80,7 +79,7 @@ public class IndexController
         response.sendRedirect( ContextUtils.getRootPath( request ) + location );
     }
 
-    @RequestMapping( value = "/resources", method = RequestMethod.GET )
+    @GetMapping( "/resources" )
     public @ResponseBody RootNode getResources()
     {
         return createRootNode();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -71,10 +71,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -131,8 +133,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     // Interpretation create
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/reportTable/{uid}", method = RequestMethod.POST, consumes = { "text/html",
-        "text/plain" } )
+    @PostMapping( value = "/reportTable/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeReportTableInterpretation( @PathVariable( "uid" ) String visualizationUid,
         @RequestParam( value = "pe", required = false ) String isoPeriod,
         @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
@@ -156,7 +157,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
             request, response );
     }
 
-    @RequestMapping( value = "/chart/{uid}", method = RequestMethod.POST, consumes = { "text/html", "text/plain" } )
+    @PostMapping( value = "/chart/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeChartInterpretation( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
         HttpServletResponse response, HttpServletRequest request )
@@ -176,8 +177,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         createIntepretation( new Interpretation( visualization, orgUnit, text ), request, response );
     }
 
-    @RequestMapping( value = "/visualization/{uid}", method = RequestMethod.POST, consumes = { "text/html",
-        "text/plain" } )
+    @PostMapping( value = "/visualization/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeVisualizationInterpretation( @PathVariable( "uid" )
     final String uid, @RequestParam( value = "ou", required = false )
     final String orgUnitUid, @RequestBody
@@ -198,7 +198,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         createIntepretation( new Interpretation( visualization, orgUnit, text ), request, response );
     }
 
-    @RequestMapping( value = "/map/{uid}", method = RequestMethod.POST, consumes = { "text/html", "text/plain" } )
+    @PostMapping( value = "/map/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeMapInterpretation( @PathVariable( "uid" ) String uid, @RequestBody String text,
         HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
@@ -214,8 +214,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         createIntepretation( new Interpretation( map, text ), request, response );
     }
 
-    @RequestMapping( value = "/eventReport/{uid}", method = RequestMethod.POST, consumes = { "text/html",
-        "text/plain" } )
+    @PostMapping( value = "/eventReport/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeEventReportInterpretation( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
         HttpServletResponse response, HttpServletRequest request )
@@ -235,8 +234,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         createIntepretation( new Interpretation( eventReport, orgUnit, text ), request, response );
     }
 
-    @RequestMapping( value = "/eventChart/{uid}", method = RequestMethod.POST, consumes = { "text/html",
-        "text/plain" } )
+    @PostMapping( value = "/eventChart/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeEventChartInterpretation( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
         HttpServletResponse response, HttpServletRequest request )
@@ -256,8 +254,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         createIntepretation( new Interpretation( eventChart, orgUnit, text ), request, response );
     }
 
-    @RequestMapping( value = "/dataSetReport/{uid}", method = RequestMethod.POST, consumes = { "text/html",
-        "text/plain" } )
+    @PostMapping( value = "/dataSetReport/{uid}", consumes = { "text/html", "text/plain" } )
     public void writeDataSetReportInterpretation( @PathVariable( "uid" ) String dataSetUid,
         @RequestParam( "pe" ) String isoPeriod, @RequestParam( "ou" ) String orgUnitUid, @RequestBody String text,
         HttpServletResponse response, HttpServletRequest request )
@@ -337,7 +334,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     // Interpretation update
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateInterpretation( @PathVariable( "uid" ) String uid, @RequestBody String text,
         HttpServletResponse response )
@@ -383,7 +380,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     // Comment
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/comments", method = RequestMethod.POST, consumes = { "text/html", "text/plain" } )
+    @PostMapping( value = "/{uid}/comments", consumes = { "text/html", "text/plain" } )
     public void postComment( @PathVariable( "uid" ) String uid, @RequestBody String text, HttpServletResponse response,
         HttpServletRequest request )
         throws WebMessageException
@@ -403,7 +400,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         webMessageService.send( WebMessageUtils.created( "Commented created" ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/comments/{cuid}", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}/comments/{cuid}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateComment( @PathVariable( "uid" ) String uid, @PathVariable( "cuid" ) String cuid,
         HttpServletResponse response, @RequestBody String content )
@@ -433,7 +430,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         }
     }
 
-    @RequestMapping( value = "/{uid}/comments/{cuid}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/comments/{cuid}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteComment( @PathVariable( "uid" ) String uid, @PathVariable( "cuid" ) String cuid,
         HttpServletResponse response )
@@ -471,7 +468,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     // Likes
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/like", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/like" )
     public void like( @PathVariable( "uid" ) String uid, HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
     {
@@ -496,7 +493,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         }
     }
 
-    @RequestMapping( value = "/{uid}/like", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/like" )
     public void unlike( @PathVariable( "uid" ) String uid, HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/KeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/KeyJsonValueController.java
@@ -45,10 +45,13 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -70,7 +73,7 @@ public class KeyJsonValueController
      * Returns a JSON array of strings representing the different namespaces
      * used. If no namespaces exist, an empty array is returned.
      */
-    @RequestMapping( value = "", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "", produces = "application/json" )
     public @ResponseBody List<String> getNamespaces( HttpServletResponse response )
     {
         setNoStore( response );
@@ -81,7 +84,7 @@ public class KeyJsonValueController
     /**
      * Returns a list of strings representing keys in the given namespace.
      */
-    @RequestMapping( value = "/{namespace}", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{namespace}", produces = "application/json" )
     public @ResponseBody List<String> getKeysInNamespace( @RequestParam( required = false ) Date lastUpdated,
         @PathVariable String namespace,
         HttpServletResponse response )
@@ -100,7 +103,7 @@ public class KeyJsonValueController
     /**
      * Deletes all keys with the given namespace.
      */
-    @RequestMapping( value = "/{namespace}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{namespace}" )
     public void deleteNamespace( @PathVariable String namespace, HttpServletResponse response )
         throws Exception
     {
@@ -118,7 +121,7 @@ public class KeyJsonValueController
      * Retrieves the value of the KeyJsonValue represented by the given key from
      * the given namespace.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{namespace}/{key}", produces = "application/json" )
     public @ResponseBody String getKeyJsonValue( @PathVariable String namespace, @PathVariable String key,
         HttpServletResponse response )
         throws Exception
@@ -130,7 +133,7 @@ public class KeyJsonValueController
      * Retrieves the KeyJsonValue represented by the given key from the given
      * namespace.
      */
-    @RequestMapping( value = "/{namespace}/{key}/metaData", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{namespace}/{key}/metaData", produces = "application/json" )
     public @ResponseBody KeyJsonValue getKeyJsonValueMetaData( @PathVariable String namespace, @PathVariable String key,
         HttpServletResponse response )
         throws Exception
@@ -149,7 +152,7 @@ public class KeyJsonValueController
      * Creates a new KeyJsonValue Object on the given namespace with the key and
      * value supplied.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.POST, produces = "application/json", consumes = "application/json" )
+    @PostMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
     public void addKeyJsonValue( @PathVariable String namespace, @PathVariable String key, @RequestBody String body,
         @RequestParam( defaultValue = "false" ) boolean encrypt, HttpServletResponse response )
         throws Exception
@@ -168,7 +171,7 @@ public class KeyJsonValueController
     /**
      * Update a key in the given namespace.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.PUT, produces = "application/json", consumes = "application/json" )
+    @PutMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
     public void updateKeyJsonValue( @PathVariable String namespace, @PathVariable String key, @RequestBody String body,
         HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -184,7 +187,7 @@ public class KeyJsonValueController
     /**
      * Delete a key from the given namespace.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.DELETE, produces = "application/json" )
+    @DeleteMapping( value = "/{namespace}/{key}", produces = "application/json" )
     public void deleteKeyJsonValue( @PathVariable String namespace, @PathVariable String key,
         HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
@@ -72,8 +72,10 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -121,7 +123,7 @@ public class LockExceptionController
     // Resources
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody RootNode getLockExceptions( @RequestParam( required = false ) String key,
         @RequestParam Map<String, String> rpParameters, HttpServletRequest request, HttpServletResponse response )
         throws IOException,
@@ -189,7 +191,7 @@ public class LockExceptionController
         return rootNode;
     }
 
-    @RequestMapping( value = "/combinations", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = "/combinations", produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody RootNode getLockExceptionCombinations()
         throws IOException,
         WebMessageException
@@ -219,7 +221,7 @@ public class LockExceptionController
         return rootNode;
     }
 
-    @RequestMapping( method = RequestMethod.POST )
+    @PostMapping
     public void addLockException( @RequestParam( "ou" ) String organisationUnitId,
         @RequestParam( "pe" ) String periodId,
         @RequestParam( "ds" ) String dataSetId, HttpServletRequest request, HttpServletResponse response )
@@ -289,7 +291,7 @@ public class LockExceptionController
         }
     }
 
-    @RequestMapping( method = RequestMethod.DELETE )
+    @DeleteMapping
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteLockException( @RequestParam( name = "ou", required = false ) String organisationUnitId,
         @RequestParam( "pe" ) String periodId,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -57,9 +57,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -109,7 +111,8 @@ public class MaintenanceController
     @Autowired
     private CategoryService categoryService;
 
-    @RequestMapping( value = "/analyticsTablesClear", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/analyticsTablesClear" )
+    @PostMapping( "/analyticsTablesClear" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void clearAnalyticsTables()
@@ -117,7 +120,8 @@ public class MaintenanceController
         analyticsTableService.forEach( AnalyticsTableService::dropTables );
     }
 
-    @RequestMapping( value = "/analyticsTablesAnalyze", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/analyticsTablesAnalyze" )
+    @PostMapping( "/analyticsTablesAnalyze" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void analyzeAnalyticsTables()
@@ -125,7 +129,8 @@ public class MaintenanceController
         analyticsTableService.forEach( AnalyticsTableService::analyzeAnalyticsTables );
     }
 
-    @RequestMapping( value = "/expiredInvitationsClear", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/expiredInvitationsClear" )
+    @PostMapping( "/expiredInvitationsClear" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void clearExpiredInvitations()
@@ -133,7 +138,8 @@ public class MaintenanceController
         maintenanceService.removeExpiredInvitations();
     }
 
-    @RequestMapping( value = "/ouPathsUpdate", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/ouPathsUpdate" )
+    @PostMapping( "/ouPathsUpdate" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void forceUpdatePaths()
@@ -141,7 +147,8 @@ public class MaintenanceController
         organisationUnitService.forceUpdatePaths();
     }
 
-    @RequestMapping( value = "/periodPruning", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/periodPruning" )
+    @PostMapping( "/periodPruning" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void prunePeriods()
@@ -149,7 +156,8 @@ public class MaintenanceController
         maintenanceService.prunePeriods();
     }
 
-    @RequestMapping( value = "/zeroDataValueRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/zeroDataValueRemoval" )
+    @PostMapping( "/zeroDataValueRemoval" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteZeroDataValues()
@@ -157,7 +165,8 @@ public class MaintenanceController
         maintenanceService.deleteZeroDataValues();
     }
 
-    @RequestMapping( value = "/softDeletedDataValueRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/softDeletedDataValueRemoval" )
+    @PostMapping( "/softDeletedDataValueRemoval" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedDataValues()
@@ -165,8 +174,8 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedDataValues();
     }
 
-    @RequestMapping( value = "/softDeletedProgramStageInstanceRemoval", method = { RequestMethod.PUT,
-        RequestMethod.POST } )
+    @PutMapping( "/softDeletedProgramStageInstanceRemoval" )
+    @PostMapping( "/softDeletedProgramStageInstanceRemoval" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedProgramStageInstances()
@@ -174,7 +183,8 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedProgramStageInstances();
     }
 
-    @RequestMapping( value = "/softDeletedProgramInstanceRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/softDeletedProgramInstanceRemoval" )
+    @PostMapping( "/softDeletedProgramInstanceRemoval" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedProgramInstances()
@@ -182,8 +192,8 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedProgramInstances();
     }
 
-    @RequestMapping( value = "/softDeletedTrackedEntityInstanceRemoval", method = { RequestMethod.PUT,
-        RequestMethod.POST } )
+    @PutMapping( "/softDeletedTrackedEntityInstanceRemoval" )
+    @PostMapping( "/softDeletedTrackedEntityInstanceRemoval" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedTrackedEntityInstances()
@@ -191,7 +201,8 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedTrackedEntityInstances();
     }
 
-    @RequestMapping( value = "/sqlViewsCreate", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/sqlViewsCreate" )
+    @PostMapping( "/sqlViewsCreate" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void createSqlViews()
@@ -199,7 +210,8 @@ public class MaintenanceController
         resourceTableService.createAllSqlViews();
     }
 
-    @RequestMapping( value = "/sqlViewsDrop", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/sqlViewsDrop" )
+    @PostMapping( "/sqlViewsDrop" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void dropSqlViews()
@@ -207,7 +219,8 @@ public class MaintenanceController
         resourceTableService.dropAllSqlViews();
     }
 
-    @RequestMapping( value = "/categoryOptionComboUpdate", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/categoryOptionComboUpdate" )
+    @PostMapping( "/categoryOptionComboUpdate" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCategoryOptionCombos()
@@ -215,8 +228,8 @@ public class MaintenanceController
         categoryManager.addAndPruneAllOptionCombos();
     }
 
-    @RequestMapping( value = "/categoryOptionComboUpdate/categoryCombo/{uid}", method = { RequestMethod.PUT,
-        RequestMethod.POST } )
+    @PutMapping( "/categoryOptionComboUpdate/categoryCombo/{uid}" )
+    @PostMapping( "/categoryOptionComboUpdate/categoryCombo/{uid}" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void updateCategoryOptionCombos( @PathVariable String uid, HttpServletRequest request,
         HttpServletResponse response )
@@ -234,7 +247,8 @@ public class MaintenanceController
         webMessageService.send( WebMessageUtils.importSummaries( importSummaries ), response, request );
     }
 
-    @RequestMapping( value = { "/cacheClear", "/cache" }, method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( value = { "/cacheClear", "/cache" } )
+    @PostMapping( value = { "/cacheClear", "/cache" } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void clearCache()
@@ -242,8 +256,8 @@ public class MaintenanceController
         maintenanceService.clearApplicationCaches();
     }
 
-    @RequestMapping( value = "/dataPruning/organisationUnits/{uid}", method = { RequestMethod.PUT,
-        RequestMethod.POST } )
+    @PutMapping( "/dataPruning/organisationUnits/{uid}" )
+    @PostMapping( "/dataPruning/organisationUnits/{uid}" )
     @PreAuthorize( "hasRole('ALL')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void pruneDataByOrganisationUnit( @PathVariable String uid, HttpServletResponse response )
@@ -266,7 +280,8 @@ public class MaintenanceController
         webMessageService.sendJson( message, response );
     }
 
-    @RequestMapping( value = "/dataPruning/dataElements/{uid}", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/dataPruning/dataElements/{uid}" )
+    @PostMapping( "/dataPruning/dataElements/{uid}" )
     @PreAuthorize( "hasRole('ALL')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void pruneDataByDataElement( @PathVariable String uid, HttpServletResponse response )
@@ -289,7 +304,7 @@ public class MaintenanceController
         webMessageService.sendJson( message, response );
     }
 
-    @RequestMapping( value = "/appReload", method = RequestMethod.GET )
+    @GetMapping( "/appReload" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void appReload( HttpServletResponse response )
         throws IOException
@@ -298,7 +313,8 @@ public class MaintenanceController
         renderService.toJson( response.getOutputStream(), WebMessageUtils.ok( "Apps reloaded" ) );
     }
 
-    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping
+    @PostMapping
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void performMaintenance(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -59,9 +59,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -111,8 +110,7 @@ public class MaintenanceController
     @Autowired
     private CategoryService categoryService;
 
-    @PutMapping( "/analyticsTablesClear" )
-    @PostMapping( "/analyticsTablesClear" )
+    @RequestMapping( value = "/analyticsTablesClear", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void clearAnalyticsTables()
@@ -120,8 +118,7 @@ public class MaintenanceController
         analyticsTableService.forEach( AnalyticsTableService::dropTables );
     }
 
-    @PutMapping( "/analyticsTablesAnalyze" )
-    @PostMapping( "/analyticsTablesAnalyze" )
+    @RequestMapping( value = "/analyticsTablesAnalyze", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void analyzeAnalyticsTables()
@@ -129,8 +126,7 @@ public class MaintenanceController
         analyticsTableService.forEach( AnalyticsTableService::analyzeAnalyticsTables );
     }
 
-    @PutMapping( "/expiredInvitationsClear" )
-    @PostMapping( "/expiredInvitationsClear" )
+    @RequestMapping( value = "/expiredInvitationsClear", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void clearExpiredInvitations()
@@ -138,8 +134,7 @@ public class MaintenanceController
         maintenanceService.removeExpiredInvitations();
     }
 
-    @PutMapping( "/ouPathsUpdate" )
-    @PostMapping( "/ouPathsUpdate" )
+    @RequestMapping( value = "/ouPathsUpdate", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void forceUpdatePaths()
@@ -147,8 +142,7 @@ public class MaintenanceController
         organisationUnitService.forceUpdatePaths();
     }
 
-    @PutMapping( "/periodPruning" )
-    @PostMapping( "/periodPruning" )
+    @RequestMapping( value = "/periodPruning", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void prunePeriods()
@@ -156,8 +150,7 @@ public class MaintenanceController
         maintenanceService.prunePeriods();
     }
 
-    @PutMapping( "/zeroDataValueRemoval" )
-    @PostMapping( "/zeroDataValueRemoval" )
+    @RequestMapping( value = "/zeroDataValueRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteZeroDataValues()
@@ -165,8 +158,7 @@ public class MaintenanceController
         maintenanceService.deleteZeroDataValues();
     }
 
-    @PutMapping( "/softDeletedDataValueRemoval" )
-    @PostMapping( "/softDeletedDataValueRemoval" )
+    @RequestMapping( value = "/softDeletedDataValueRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedDataValues()
@@ -174,8 +166,8 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedDataValues();
     }
 
-    @PutMapping( "/softDeletedProgramStageInstanceRemoval" )
-    @PostMapping( "/softDeletedProgramStageInstanceRemoval" )
+    @RequestMapping( value = "/softDeletedProgramStageInstanceRemoval", method = { RequestMethod.PUT,
+        RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedProgramStageInstances()
@@ -183,8 +175,7 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedProgramStageInstances();
     }
 
-    @PutMapping( "/softDeletedProgramInstanceRemoval" )
-    @PostMapping( "/softDeletedProgramInstanceRemoval" )
+    @RequestMapping( value = "/softDeletedProgramInstanceRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedProgramInstances()
@@ -192,8 +183,8 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedProgramInstances();
     }
 
-    @PutMapping( "/softDeletedTrackedEntityInstanceRemoval" )
-    @PostMapping( "/softDeletedTrackedEntityInstanceRemoval" )
+    @RequestMapping( value = "/softDeletedTrackedEntityInstanceRemoval", method = { RequestMethod.PUT,
+        RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteSoftDeletedTrackedEntityInstances()
@@ -201,8 +192,7 @@ public class MaintenanceController
         maintenanceService.deleteSoftDeletedTrackedEntityInstances();
     }
 
-    @PutMapping( "/sqlViewsCreate" )
-    @PostMapping( "/sqlViewsCreate" )
+    @RequestMapping( value = "/sqlViewsCreate", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void createSqlViews()
@@ -210,8 +200,7 @@ public class MaintenanceController
         resourceTableService.createAllSqlViews();
     }
 
-    @PutMapping( "/sqlViewsDrop" )
-    @PostMapping( "/sqlViewsDrop" )
+    @RequestMapping( value = "/sqlViewsDrop", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void dropSqlViews()
@@ -219,8 +208,7 @@ public class MaintenanceController
         resourceTableService.dropAllSqlViews();
     }
 
-    @PutMapping( "/categoryOptionComboUpdate" )
-    @PostMapping( "/categoryOptionComboUpdate" )
+    @RequestMapping( value = "/categoryOptionComboUpdate", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCategoryOptionCombos()
@@ -228,8 +216,8 @@ public class MaintenanceController
         categoryManager.addAndPruneAllOptionCombos();
     }
 
-    @PutMapping( "/categoryOptionComboUpdate/categoryCombo/{uid}" )
-    @PostMapping( "/categoryOptionComboUpdate/categoryCombo/{uid}" )
+    @RequestMapping( value = "/categoryOptionComboUpdate/categoryCombo/{uid}", method = { RequestMethod.PUT,
+        RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void updateCategoryOptionCombos( @PathVariable String uid, HttpServletRequest request,
         HttpServletResponse response )
@@ -247,8 +235,7 @@ public class MaintenanceController
         webMessageService.send( WebMessageUtils.importSummaries( importSummaries ), response, request );
     }
 
-    @PutMapping( value = { "/cacheClear", "/cache" } )
-    @PostMapping( value = { "/cacheClear", "/cache" } )
+    @RequestMapping( value = { "/cacheClear", "/cache" }, method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void clearCache()
@@ -256,8 +243,8 @@ public class MaintenanceController
         maintenanceService.clearApplicationCaches();
     }
 
-    @PutMapping( "/dataPruning/organisationUnits/{uid}" )
-    @PostMapping( "/dataPruning/organisationUnits/{uid}" )
+    @RequestMapping( value = "/dataPruning/organisationUnits/{uid}", method = { RequestMethod.PUT,
+        RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void pruneDataByOrganisationUnit( @PathVariable String uid, HttpServletResponse response )
@@ -280,8 +267,7 @@ public class MaintenanceController
         webMessageService.sendJson( message, response );
     }
 
-    @PutMapping( "/dataPruning/dataElements/{uid}" )
-    @PostMapping( "/dataPruning/dataElements/{uid}" )
+    @RequestMapping( value = "/dataPruning/dataElements/{uid}", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void pruneDataByDataElement( @PathVariable String uid, HttpServletResponse response )
@@ -313,8 +299,7 @@ public class MaintenanceController
         renderService.toJson( response.getOutputStream(), WebMessageUtils.ok( "Apps reloaded" ) );
     }
 
-    @PutMapping
-    @PostMapping
+    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void performMaintenance(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MenuController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MenuController.java
@@ -39,8 +39,8 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
@@ -61,7 +61,7 @@ public class MenuController
 
     @ResponseStatus( HttpStatus.NO_CONTENT )
     @SuppressWarnings( "unchecked" )
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     public void saveMenuOrder( InputStream input )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -82,10 +82,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -347,7 +349,7 @@ public class MessageConversationController
     // POST for reply on existing MessageConversation
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.POST )
+    @PostMapping( "/{uid}" )
     public void postMessageConversationReply(
         @PathVariable( "uid" ) String uid,
         @RequestBody String message,
@@ -407,7 +409,7 @@ public class MessageConversationController
         webMessageService.send( WebMessageUtils.created( "Message conversation created" ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/recipients", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/recipients" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addRecipientsToMessageConversation( @PathVariable( "uid" ) String uid,
         @RequestBody MessageConversation messageConversation )
@@ -437,7 +439,7 @@ public class MessageConversationController
     // POST for feedback
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/feedback", method = RequestMethod.POST )
+    @PostMapping( "/feedback" )
     public void postMessageConversationFeedback( @RequestParam( "subject" ) String subject, @RequestBody String body,
         HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -453,8 +455,8 @@ public class MessageConversationController
     // Assign priority
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/priority", method = RequestMethod.POST, produces = {
-        MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
+    @PostMapping( value = "/{uid}/priority", produces = { MediaType.APPLICATION_JSON_VALUE,
+        MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode setMessagePriority(
         @PathVariable String uid, @RequestParam MessageConversationPriority messageConversationPriority,
         HttpServletResponse response )
@@ -495,7 +497,7 @@ public class MessageConversationController
     // Assign status
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/status", method = RequestMethod.POST, produces = {
+    @PostMapping( value = "/{uid}/status", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode setMessageStatus(
         @PathVariable String uid,
@@ -538,7 +540,7 @@ public class MessageConversationController
     // Assign user
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/assign", method = RequestMethod.POST, produces = {
+    @PostMapping( value = "/{uid}/assign", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode setUserAssigned(
         @PathVariable String uid,
@@ -595,7 +597,7 @@ public class MessageConversationController
     // Remove assigned user
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/assign", method = RequestMethod.DELETE, produces = {
+    @DeleteMapping( value = "/{uid}/assign", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode removeUserAssigned(
         @PathVariable String uid,
@@ -633,7 +635,7 @@ public class MessageConversationController
     // Mark conversations read
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/read", method = RequestMethod.POST, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping( value = "/{uid}/read", produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode markMessageConversationRead(
         @PathVariable String uid, @RequestParam( required = false ) String userUid, HttpServletResponse response )
@@ -641,7 +643,7 @@ public class MessageConversationController
         return modifyMessageConversationRead( userUid, Lists.newArrayList( uid ), response, true );
     }
 
-    @RequestMapping( value = "/read", method = RequestMethod.POST, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping( value = "/read", produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode markMessageConversationsRead(
         @RequestParam( value = "user", required = false ) String userUid, @RequestBody List<String> uids,
@@ -654,7 +656,7 @@ public class MessageConversationController
     // Mark conversations unread
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/unread", method = RequestMethod.POST, produces = {
+    @PostMapping( value = "/{uid}/unread", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode markMessageConversationUnread(
         @PathVariable String uid, @RequestParam( required = false ) String userUid, HttpServletResponse response )
@@ -662,7 +664,7 @@ public class MessageConversationController
         return modifyMessageConversationRead( userUid, Lists.newArrayList( uid ), response, false );
     }
 
-    @RequestMapping( value = "/unread", method = RequestMethod.POST, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping( value = "/unread", produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode markMessageConversationsUnread(
         @RequestParam( value = "user", required = false ) String userUid, @RequestBody List<String> uids,
@@ -675,7 +677,7 @@ public class MessageConversationController
     // Mark conversations for follow up
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "followup", method = RequestMethod.POST, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping( value = "followup", produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode markMessageConversationFollowup(
         @RequestParam( value = "user", required = false ) String userUid, @RequestBody List<String> uids,
@@ -730,7 +732,7 @@ public class MessageConversationController
     // Clear follow up
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "unfollowup", method = RequestMethod.POST, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping( value = "unfollowup", produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode unmarkMessageConversationFollowup(
         @RequestParam( value = "user", required = false ) String userUid, @RequestBody List<String> uids,
@@ -805,7 +807,7 @@ public class MessageConversationController
     // In practice a DELETE on MessageConversation <-> User relationship
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{mc-uid}/{user-uid}", method = RequestMethod.DELETE, produces = {
+    @DeleteMapping( value = "/{mc-uid}/{user-uid}", produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode removeUserFromMessageConversation(
         @PathVariable( value = "mc-uid" ) String mcUid, @PathVariable( value = "user-uid" ) String userUid,
@@ -855,7 +857,7 @@ public class MessageConversationController
     // Remove a user from one or more MessageConversations (batch operation)
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.DELETE, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @DeleteMapping( produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode removeUserFromMessageConversations(
         @RequestParam( "mc" ) List<String> mcUids, @RequestParam( value = "user", required = false ) String userUid,
@@ -906,7 +908,7 @@ public class MessageConversationController
         return responseNode;
     }
 
-    @RequestMapping( value = "/{mcUid}/{msgUid}/attachments/{fileUid}", method = RequestMethod.GET )
+    @GetMapping( "/{mcUid}/{msgUid}/attachments/{fileUid}" )
     public void getAttachment(
         @PathVariable( value = "mcUid" ) String mcUid,
         @PathVariable( value = "msgUid" ) String msgUid,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -60,9 +60,10 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.google.common.collect.Lists;
@@ -136,7 +137,7 @@ public class MinMaxDataElementController
     // POST
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_ADD')" )
     public void postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -171,7 +172,7 @@ public class MinMaxDataElementController
     // DELETE
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.DELETE, consumes = "application/json" )
+    @DeleteMapping( consumes = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_DELETE')" )
     public void deleteObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
@@ -50,10 +50,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -84,7 +85,7 @@ public class MinMaxValueController
     @Autowired
     private SystemSettingManager systemSettingManager;
 
-    @RequestMapping( method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_GENERATE_MIN_MAX_VALUES')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void generateMinMaxValue( @RequestBody MinMaxValueParams minMaxValueParams )
@@ -118,7 +119,7 @@ public class MinMaxValueController
 
     }
 
-    @RequestMapping( value = "/{ou}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{ou}" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_GENERATE_MIN_MAX_VALUES')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeMinMaxValue( @PathVariable( "ou" ) String organisationUnitId,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OrgUnitAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OrgUnitAnalyticsController.java
@@ -39,8 +39,7 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -59,7 +58,7 @@ public class OrgUnitAnalyticsController
     @Autowired
     private ContextUtils contextUtils;
 
-    @RequestMapping( value = RESOURCE_PATH, method = RequestMethod.GET, produces = { "application/json" } )
+    @GetMapping( value = RESOURCE_PATH, produces = { "application/json" } )
     public @ResponseBody Grid getJson(
         @RequestParam String ou,
         @RequestParam String ougs,
@@ -74,7 +73,7 @@ public class OrgUnitAnalyticsController
         return analyticsService.getOrgUnitData( params );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".xls", method = RequestMethod.GET )
+    @GetMapping( RESOURCE_PATH + ".xls" )
     public void getXls(
         @RequestParam String ou,
         @RequestParam String ougs,
@@ -90,7 +89,7 @@ public class OrgUnitAnalyticsController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".csv", method = RequestMethod.GET )
+    @GetMapping( RESOURCE_PATH + ".csv" )
     public void getCsv(
         @RequestParam String ou,
         @RequestParam String ougs,
@@ -105,7 +104,7 @@ public class OrgUnitAnalyticsController
         GridUtils.toCsv( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = RESOURCE_PATH + ".pdf", method = RequestMethod.GET )
+    @GetMapping( RESOURCE_PATH + ".pdf" )
     public void getPdf(
         @RequestParam String ou,
         @RequestParam String ougs,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PdfFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PdfFormController.java
@@ -56,9 +56,10 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.pdf.PdfWriter;
@@ -103,7 +104,7 @@ public class PdfFormController
     // DataSet
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/dataSet/{dataSetUid}", method = RequestMethod.GET )
+    @GetMapping( "/dataSet/{dataSetUid}" )
     public void getFormPdfDataSet( @PathVariable String dataSetUid, HttpServletRequest request,
         HttpServletResponse response, OutputStream out )
         throws Exception
@@ -133,7 +134,7 @@ public class PdfFormController
         baos.writeTo( out );
     }
 
-    @RequestMapping( value = "/dataSet", method = RequestMethod.POST )
+    @PostMapping( "/dataSet" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     public void sendFormPdfDataSet( HttpServletRequest request, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PeriodTypeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PeriodTypeController.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.webdomain.PeriodTypeDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -91,8 +90,7 @@ public class PeriodTypeController
         return rootNode;
     }
 
-    @RequestMapping( value = "/relativePeriodTypes", method = RequestMethod.GET, produces = { "application/json",
-        "application/javascript" } )
+    @GetMapping( value = "/relativePeriodTypes", produces = { "application/json", "application/javascript" } )
     public @ResponseBody RelativePeriodEnum[] getRelativePeriodTypes()
     {
         return RelativePeriodEnum.values();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
@@ -50,8 +50,9 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -80,7 +81,8 @@ public class PredictionController
     @Autowired
     private RenderService renderService;
 
-    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping
+    @PostMapping
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PREDICTOR_RUN')" )
     public void runPredictors(
         @RequestParam Date startDate,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static org.hisp.dhis.expression.ParseType.*;
+import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
+import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
 
 import java.io.IOException;
 import java.util.Date;
@@ -56,7 +57,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * @author Ken Haase (ken@dhis2.org)
@@ -82,7 +88,8 @@ public class PredictorController
     @Autowired
     private I18nManager i18nManager;
 
-    @RequestMapping( value = "/{uid}/run", method = { RequestMethod.POST, RequestMethod.PUT } )
+    @PutMapping( "/{uid}/run" )
+    @PostMapping( "/{uid}/run" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PREDICTOR_RUN')" )
     public void runPredictor(
         @PathVariable( "uid" ) String uid,
@@ -114,7 +121,8 @@ public class PredictorController
         }
     }
 
-    @RequestMapping( value = "/run", method = { RequestMethod.POST, RequestMethod.PUT } )
+    @PutMapping( "/run" )
+    @PostMapping( "/run" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PREDICTOR_RUN')" )
     public void runPredictors(
         @RequestParam Date startDate,
@@ -152,7 +160,7 @@ public class PredictorController
         webMessageService.send( WebMessageUtils.ok( "Generated " + count + " predictions" ), response, request );
     }
 
-    @RequestMapping( value = "/expression/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getExpressionDescription( @RequestBody String expression, HttpServletResponse response )
         throws IOException
     {
@@ -172,7 +180,7 @@ public class PredictorController
         webMessageService.sendJson( message, response );
     }
 
-    @RequestMapping( value = "/skipTest/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/skipTest/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getSkipTestDescription( @RequestBody String expression, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
@@ -59,9 +59,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -88,8 +88,7 @@ public class PredictorController
     @Autowired
     private I18nManager i18nManager;
 
-    @PutMapping( "/{uid}/run" )
-    @PostMapping( "/{uid}/run" )
+    @RequestMapping( value = "/{uid}/run", method = { RequestMethod.POST, RequestMethod.PUT } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PREDICTOR_RUN')" )
     public void runPredictor(
         @PathVariable( "uid" ) String uid,
@@ -121,8 +120,7 @@ public class PredictorController
         }
     }
 
-    @PutMapping( "/run" )
-    @PostMapping( "/run" )
+    @RequestMapping( value = "/run", method = { RequestMethod.POST, RequestMethod.PUT } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PREDICTOR_RUN')" )
     public void runPredictors(
         @RequestParam Date startDate,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PrometheusScrapeEndpointController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PrometheusScrapeEndpointController.java
@@ -36,8 +36,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import io.prometheus.client.CollectorRegistry;
@@ -58,7 +57,7 @@ public class PrometheusScrapeEndpointController
         this.collectorRegistry = collectorRegistry;
     }
 
-    @RequestMapping( value = "/metrics", method = RequestMethod.GET, produces = TextFormat.CONTENT_TYPE_004 )
+    @GetMapping( value = "/metrics", produces = TextFormat.CONTENT_TYPE_004 )
     @ResponseBody
     public String scrape()
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
@@ -50,9 +50,10 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
@@ -77,7 +78,7 @@ public class PushAnalysisController
     @Autowired
     private SchedulingManager schedulingManager;
 
-    @RequestMapping( value = "/{uid}/render", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/render" )
     public void renderPushAnalytics( @PathVariable( ) String uid, HttpServletResponse response )
         throws WebMessageException,
         IOException
@@ -102,7 +103,7 @@ public class PushAnalysisController
     }
 
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    @RequestMapping( value = "/{uid}/run", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/run" )
     public void sendPushAnalysis( @PathVariable( ) String uid )
         throws WebMessageException,
         IOException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportController.java
@@ -58,10 +58,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -87,7 +88,7 @@ public class ReportController
     // CRUD
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/design", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}/design" )
     @PreAuthorize( "hasRole('ALL')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateReportDesign( @PathVariable( "uid" ) String uid,
@@ -106,7 +107,7 @@ public class ReportController
         reportService.saveReport( report );
     }
 
-    @RequestMapping( value = "/{uid}/design", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/design" )
     public void getReportDesign( @PathVariable( "uid" ) String uid, HttpServletResponse response )
         throws Exception
     {
@@ -140,7 +141,7 @@ public class ReportController
     // Get data
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = { "/{uid}/data", "/{uid}/data.pdf" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/{uid}/data", "/{uid}/data.pdf" } )
     public void getReportAsPdf( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "pe", required = false ) String period,
@@ -152,7 +153,7 @@ public class ReportController
             false );
     }
 
-    @RequestMapping( value = "/{uid}/data.xls", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.xls" )
     public void getReportAsXls( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "pe", required = false ) String period,
@@ -164,7 +165,7 @@ public class ReportController
             true );
     }
 
-    @RequestMapping( value = "/{uid}/data.html", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.html" )
     public void getReportAsHtml( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "pe", required = false ) String period,
@@ -185,7 +186,7 @@ public class ReportController
      * servlet mapping around. Note that the path to images are relative to the
      * reports path in this controller.
      */
-    @RequestMapping( value = "/jasperReports/img", method = RequestMethod.GET )
+    @GetMapping( "/jasperReports/img" )
     public void getJasperImage( @RequestParam String image,
         HttpServletRequest request, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableController.java
@@ -59,9 +59,9 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -120,7 +120,7 @@ public class ReportTableController
     // GET - Report table data
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/data", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data" )
     public @ResponseBody Grid getReportTableData( @PathVariable( "uid" ) String uid, Model model,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -130,7 +130,7 @@ public class ReportTableController
         return getReportTableGrid( uid, organisationUnitUid, date );
     }
 
-    @RequestMapping( value = "/{uid}/data.html", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.html" )
     public void getReportTableHtml( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -146,7 +146,7 @@ public class ReportTableController
         GridUtils.toHtml( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/{uid}/data.html+css", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.html+css" )
     public void getReportTableHtmlCss( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -162,7 +162,7 @@ public class ReportTableController
         GridUtils.toHtmlCss( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/{uid}/data.xml", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.xml" )
     public void getReportTableXml( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -178,7 +178,7 @@ public class ReportTableController
         GridUtils.toXml( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/{uid}/data.pdf", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.pdf" )
     public void getReportTablePdf( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -194,7 +194,7 @@ public class ReportTableController
         GridUtils.toPdf( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/{uid}/data.xls", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.xls" )
     public void getReportTableXls( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,
@@ -210,7 +210,7 @@ public class ReportTableController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/{uid}/data.csv", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.csv" )
     public void getReportTableCsv( @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String organisationUnitUid,
         @RequestParam( value = "date", required = false ) Date date,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -122,9 +122,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -226,7 +229,7 @@ public abstract class ReportTableFacadeController
     // GET
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody RootNode getObjectList(
         @RequestParam Map<String, String> rpParameters, OrderParams orderParams,
         HttpServletResponse response, HttpServletRequest request, User currentUser )
@@ -293,7 +296,7 @@ public abstract class ReportTableFacadeController
         return rootNode;
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}" )
     public @ResponseBody RootNode getObject(
         @PathVariable( "uid" ) String pvUid,
         @RequestParam Map<String, String> rpParameters,
@@ -321,7 +324,7 @@ public abstract class ReportTableFacadeController
         return getObjectInternal( pvUid, rpParameters, filters, fields, user );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/{property}" )
     public @ResponseBody RootNode getObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
         @RequestParam Map<String, String> rpParameters,
@@ -369,7 +372,7 @@ public abstract class ReportTableFacadeController
         }
     }
 
-    @RequestMapping( value = "/{uid}/translations", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}/translations" )
     public void replaceTranslations(
         @PathVariable( "uid" ) String pvUid, @RequestParam Map<String, String> rpParameters,
         HttpServletRequest request, HttpServletResponse response )
@@ -444,7 +447,7 @@ public abstract class ReportTableFacadeController
         response.setStatus( HttpServletResponse.SC_NO_CONTENT );
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PATCH )
+    @PatchMapping( "/{uid}" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void partialUpdateObject(
         @PathVariable( "uid" ) String pvUid, @RequestParam Map<String, String> rpParameters,
@@ -485,7 +488,8 @@ public abstract class ReportTableFacadeController
         manager.update( persistedObject );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )
+    @PutMapping( "/{uid}/{property}" )
+    @PatchMapping( "/{uid}/{property}" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void updateObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
@@ -607,7 +611,7 @@ public abstract class ReportTableFacadeController
     // POST
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     public void postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -649,7 +653,7 @@ public abstract class ReportTableFacadeController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { "application/xml", "text/xml" } )
     public void postXmlObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -691,7 +695,7 @@ public abstract class ReportTableFacadeController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( value = "/{uid}/favorite", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/favorite" )
     @ResponseStatus( HttpStatus.OK )
     public void setAsFavorite( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -720,7 +724,7 @@ public abstract class ReportTableFacadeController
         webMessageService.send( WebMessageUtils.ok( message ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/subscriber", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/subscriber" )
     @ResponseStatus( HttpStatus.OK )
     public void subscribe( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -753,7 +757,7 @@ public abstract class ReportTableFacadeController
     // PUT
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}", consumes = MediaType.APPLICATION_JSON_VALUE )
     public void putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
         throws Exception
@@ -794,7 +798,7 @@ public abstract class ReportTableFacadeController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = { MediaType.APPLICATION_XML_VALUE,
+    @PutMapping( value = "/{uid}", consumes = { MediaType.APPLICATION_XML_VALUE,
         MediaType.TEXT_XML_VALUE } )
     public void putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -840,7 +844,7 @@ public abstract class ReportTableFacadeController
     // DELETE
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}" )
     @ResponseStatus( HttpStatus.OK )
     public void deleteObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -871,7 +875,7 @@ public abstract class ReportTableFacadeController
         webMessageService.send( WebMessageUtils.objectReport( importReport ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/favorite", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/favorite" )
     @ResponseStatus( HttpStatus.OK )
     public void removeAsFavorite( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -900,7 +904,7 @@ public abstract class ReportTableFacadeController
         webMessageService.send( WebMessageUtils.ok( message ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/subscriber", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/subscriber" )
     @ResponseStatus( HttpStatus.OK )
     public void unsubscribe( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -933,7 +937,7 @@ public abstract class ReportTableFacadeController
     // Identifiable object collections add, delete
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/{property}/{itemId}" )
     public @ResponseBody RootNode getCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -985,7 +989,7 @@ public abstract class ReportTableFacadeController
         }
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1003,7 +1007,7 @@ public abstract class ReportTableFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1021,7 +1025,7 @@ public abstract class ReportTableFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1037,7 +1041,7 @@ public abstract class ReportTableFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1053,7 +1057,7 @@ public abstract class ReportTableFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/{property}/{itemId}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItem(
         @PathVariable( "uid" ) String pvUid,
@@ -1072,7 +1076,7 @@ public abstract class ReportTableFacadeController
             Lists.newArrayList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1088,7 +1092,7 @@ public abstract class ReportTableFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_XML_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1104,7 +1108,7 @@ public abstract class ReportTableFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @RequestMapping( value = "/{uid}/{property}/{itemId}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}/{property}/{itemId}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItem(
         @PathVariable( "uid" ) String pvUid,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -128,6 +128,8 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -488,8 +490,7 @@ public abstract class ReportTableFacadeController
         manager.update( persistedObject );
     }
 
-    @PutMapping( "/{uid}/{property}" )
-    @PatchMapping( "/{uid}/{property}" )
+    @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void updateObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTemplateController.java
@@ -40,8 +40,7 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 /**
  * @author Lars Helge Overland
@@ -53,14 +52,14 @@ public class ReportTemplateController
     @Autowired
     private ContextUtils contextUtils;
 
-    @RequestMapping( value = "/reportTemplate.xml", method = RequestMethod.GET, produces = "application/xml" )
+    @GetMapping( value = "/reportTemplate.xml", produces = "application/xml" )
     public void getReportDesignJrxml( HttpServletResponse response )
         throws Exception
     {
         serveTemplate( response, ContextUtils.CONTENT_TYPE_XML, "jasper-report-template.jrxml" );
     }
 
-    @RequestMapping( value = "/reportTemplate.html", method = RequestMethod.GET, produces = "application/xml" )
+    @GetMapping( value = "/reportTemplate.html", produces = "application/xml" )
     public void getReportDesignHtml( HttpServletResponse response )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
@@ -48,8 +48,9 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -71,7 +72,8 @@ public class ResourceTableController
     @Autowired
     private WebMessageService webMessageService;
 
-    @RequestMapping( value = "/analytics", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/analytics" )
+    @PostMapping( "/analytics" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void analytics(
         @RequestParam( required = false ) boolean skipResourceTables,
@@ -114,7 +116,8 @@ public class ResourceTableController
         webMessageService.send( jobConfigurationReport( analyticsTableJob ), response, request );
     }
 
-    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping
+    @PostMapping
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void resourceTables( HttpServletResponse response, HttpServletRequest request )
     {
@@ -126,7 +129,8 @@ public class ResourceTableController
         webMessageService.send( jobConfigurationReport( resourceTableJob ), response, request );
     }
 
-    @RequestMapping( value = "/monitoring", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/monitoring" )
+    @PostMapping( "/monitoring" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void monitoring( HttpServletResponse response, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
@@ -48,9 +48,8 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -72,8 +71,7 @@ public class ResourceTableController
     @Autowired
     private WebMessageService webMessageService;
 
-    @PutMapping( "/analytics" )
-    @PostMapping( "/analytics" )
+    @RequestMapping( value = "/analytics", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void analytics(
         @RequestParam( required = false ) boolean skipResourceTables,
@@ -116,8 +114,7 @@ public class ResourceTableController
         webMessageService.send( jobConfigurationReport( analyticsTableJob ), response, request );
     }
 
-    @PutMapping
-    @PostMapping
+    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void resourceTables( HttpServletResponse response, HttpServletRequest request )
     {
@@ -129,8 +126,7 @@ public class ResourceTableController
         webMessageService.send( jobConfigurationReport( resourceTableJob ), response, request );
     }
 
-    @PutMapping( "/monitoring" )
-    @PostMapping( "/monitoring" )
+    @RequestMapping( value = "/monitoring", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     public void monitoring( HttpServletResponse response, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
@@ -59,9 +59,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -142,8 +141,8 @@ public class SchemaController
         throw new HttpClientErrorException( HttpStatus.NOT_FOUND, "Type " + type + " does not exist." );
     }
 
-    @PutMapping( value = "/{type}", consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
-    @PostMapping( value = "/{type}", consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
+    @RequestMapping( value = "/{type}", method = { RequestMethod.POST, RequestMethod.PUT }, consumes = {
+        MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public void validateSchema( @PathVariable String type, HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
@@ -57,9 +57,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -69,7 +71,7 @@ import com.google.common.collect.Lists;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Controller
-@RequestMapping( value = "/schemas", method = RequestMethod.GET )
+@RequestMapping( "/schemas" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class SchemaController
 {
@@ -94,7 +96,7 @@ public class SchemaController
     @Autowired
     private WebMessageService webMessageService;
 
-    @RequestMapping
+    @GetMapping
     public @ResponseBody RootNode getSchemas()
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
@@ -116,7 +118,7 @@ public class SchemaController
         return rootNode;
     }
 
-    @RequestMapping( value = "/{type}", method = RequestMethod.GET )
+    @GetMapping( "/{type}" )
     public @ResponseBody RootNode getSchema( @PathVariable String type )
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
@@ -140,8 +142,8 @@ public class SchemaController
         throw new HttpClientErrorException( HttpStatus.NOT_FOUND, "Type " + type + " does not exist." );
     }
 
-    @RequestMapping( value = "/{type}", method = { RequestMethod.POST, RequestMethod.PUT }, consumes = {
-        MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
+    @PutMapping( value = "/{type}", consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
+    @PostMapping( value = "/{type}", consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public void validateSchema( @PathVariable String type, HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -159,7 +161,7 @@ public class SchemaController
         webMessageService.send( webMessage, response, request );
     }
 
-    @RequestMapping( value = "/{type}/{property}", method = RequestMethod.GET )
+    @GetMapping( "/{type}/{property}" )
     public @ResponseBody Property getSchemaProperty( @PathVariable String type, @PathVariable String property )
     {
         Schema schema = getSchemaFromType( type );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -74,6 +74,9 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -117,7 +120,7 @@ public class SharingController
     // Resources
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE )
     public void getSharing( @RequestParam String type, @RequestParam String id, HttpServletResponse response )
         throws IOException,
         WebMessageException
@@ -225,7 +228,8 @@ public class SharingController
         renderService.toJson( response.getOutputStream(), sharing );
     }
 
-    @RequestMapping( method = { RequestMethod.POST, RequestMethod.PUT }, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
     public void setSharing( @RequestParam String type, @RequestParam String id, HttpServletResponse response,
         HttpServletRequest request )
         throws IOException,
@@ -379,7 +383,7 @@ public class SharingController
         webMessageService.send( WebMessageUtils.ok( "Access control set" ), response, request );
     }
 
-    @RequestMapping( value = "/search", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/search", produces = MediaType.APPLICATION_JSON_VALUE )
     public void searchUserGroups( @RequestParam String key, @RequestParam( required = false ) Integer pageSize,
         HttpServletResponse response )
         throws IOException,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -78,14 +78,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Controller
-@RequestMapping( value = SharingController.RESOURCE_PATH, method = RequestMethod.GET )
+@RequestMapping( value = SharingController.RESOURCE_PATH )
 @Slf4j
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class SharingController
@@ -229,11 +228,17 @@ public class SharingController
     }
 
     @PutMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
-    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
-    public void setSharing( @RequestParam String type, @RequestParam String id, HttpServletResponse response,
+    public void putSharing( @RequestParam String type, @RequestParam String id, HttpServletResponse response,
         HttpServletRequest request )
-        throws IOException,
-        WebMessageException
+        throws Exception
+    {
+        postSharing( type, id, response, request );
+    }
+
+    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
+    public void postSharing( @RequestParam String type, @RequestParam String id, HttpServletResponse response,
+        HttpServletRequest request )
+        throws Exception
     {
         type = getSharingType( type );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SmsConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SmsConfigurationController.java
@@ -44,9 +44,10 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
@@ -60,7 +61,7 @@ public class SmsConfigurationController
     @Autowired
     private SmsConfigurationManager smsConfigurationManager;
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody SmsConfiguration getSmsConfiguration()
     {
         SmsConfiguration smsConfiguration = smsConfigurationManager.getSmsConfiguration();
@@ -73,7 +74,7 @@ public class SmsConfigurationController
         return smsConfiguration;
     }
 
-    @RequestMapping( value = "test", method = RequestMethod.GET )
+    @GetMapping( "test" )
     public @ResponseBody SmsConfiguration getTest()
     {
         SmsConfiguration smsConfiguration = new SmsConfiguration();
@@ -89,7 +90,7 @@ public class SmsConfigurationController
     // POST
     // --------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.PUT )
+    @PutMapping
     public @ResponseBody SmsConfiguration putSmsConfig( @RequestBody SmsConfiguration smsConfiguration )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -48,9 +48,10 @@ import org.hisp.dhis.system.util.CodecUtils;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -77,7 +78,7 @@ public class SqlViewController
     // Get
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/data", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = "/{uid}/data", produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody RootNode getViewJson( @PathVariable( "uid" ) String uid,
         SqlViewQuery query, HttpServletResponse response )
         throws WebMessageException
@@ -89,7 +90,7 @@ public class SqlViewController
         return buildResponse( sqlView, query );
     }
 
-    @RequestMapping( value = "/{uid}/data.xml", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.xml" )
     public @ResponseBody RootNode getViewXml( @PathVariable( "uid" ) String uid,
         SqlViewQuery query, HttpServletResponse response )
         throws WebMessageException
@@ -101,7 +102,7 @@ public class SqlViewController
         return buildResponse( sqlView, query );
     }
 
-    @RequestMapping( value = "/{uid}/data.csv", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.csv" )
     public void getViewCsv( @PathVariable( "uid" ) String uid,
         @RequestParam( required = false ) Set<String> criteria, @RequestParam( required = false ) Set<String> var,
         HttpServletResponse response )
@@ -123,7 +124,7 @@ public class SqlViewController
         GridUtils.toCsv( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/{uid}/data.xls", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.xls" )
     public void getViewXls( @PathVariable( "uid" ) String uid,
         @RequestParam( required = false ) Set<String> criteria, @RequestParam( required = false ) Set<String> var,
         HttpServletResponse response )
@@ -145,7 +146,7 @@ public class SqlViewController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/{uid}/data.html", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.html" )
     public void getViewHtml( @PathVariable( "uid" ) String uid,
         @RequestParam( required = false ) Set<String> criteria, @RequestParam( required = false ) Set<String> var,
         HttpServletResponse response )
@@ -164,7 +165,7 @@ public class SqlViewController
         GridUtils.toHtml( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/{uid}/data.html+css", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.html+css" )
     public void getViewHtmlCss( @PathVariable( "uid" ) String uid,
         @RequestParam( required = false ) Set<String> criteria, @RequestParam( required = false ) Set<String> var,
         HttpServletResponse response )
@@ -183,7 +184,7 @@ public class SqlViewController
         GridUtils.toHtmlCss( grid, response.getWriter() );
     }
 
-    @RequestMapping( value = "/{uid}/data.pdf", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/data.pdf" )
     public void getViewPdf( @PathVariable( "uid" ) String uid,
         @RequestParam( required = false ) Set<String> criteria, @RequestParam( required = false ) Set<String> var,
         HttpServletResponse response )
@@ -206,7 +207,7 @@ public class SqlViewController
     // Post
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}/execute", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/execute" )
     public void executeView( @PathVariable( "uid" ) String uid, @RequestParam( required = false ) Set<String> var,
         HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
@@ -236,7 +237,7 @@ public class SqlViewController
         }
     }
 
-    @RequestMapping( value = "/{uid}/refresh", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/refresh" )
     public void refreshMaterializedView( @PathVariable( "uid" ) String uid,
         HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticContentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticContentController.java
@@ -49,8 +49,6 @@ import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 import static org.springframework.util.MimeTypeUtils.IMAGE_PNG;
 import static org.springframework.util.MimeTypeUtils.parseMimeType;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 import java.io.IOException;
 import java.util.Map;
@@ -78,6 +76,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MimeType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -180,7 +179,7 @@ public class StaticContentController
      *
      * @param key key associated with the file.
      */
-    @RequestMapping( value = "/{key}", method = GET )
+    @GetMapping( "/{key}" )
     public void getStaticContent(
         @PathVariable( "key" ) String key, HttpServletRequest request,
         HttpServletResponse response )
@@ -233,7 +232,7 @@ public class StaticContentController
      */
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
     @ResponseStatus( NO_CONTENT )
-    @RequestMapping( value = "/{key}", method = POST )
+    @PostMapping( "/{key}" )
     public void updateStaticContent( @PathVariable( "key" ) String key,
         @RequestParam( value = "file" ) MultipartFile file )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SvgConversionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SvgConversionController.java
@@ -48,8 +48,8 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -60,7 +60,7 @@ public class SvgConversionController
     @Autowired
     private ContextUtils contextUtils;
 
-    @RequestMapping( value = "/svg.png", method = RequestMethod.POST, consumes = ContextUtils.CONTENT_TYPE_FORM_ENCODED )
+    @PostMapping( value = "/svg.png", consumes = ContextUtils.CONTENT_TYPE_FORM_ENCODED )
     public void toPng( @RequestParam String svg, @RequestParam( required = false ) String filename,
         HttpServletResponse response )
         throws Exception
@@ -72,7 +72,7 @@ public class SvgConversionController
         convertToPng( svg, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/svg.pdf", method = RequestMethod.POST, consumes = ContextUtils.CONTENT_TYPE_FORM_ENCODED )
+    @PostMapping( value = "/svg.pdf", consumes = ContextUtils.CONTENT_TYPE_FORM_ENCODED )
     public void toPdf( @RequestParam String svg, @RequestParam( required = false ) String filename,
         HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SynchronizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SynchronizationController.java
@@ -44,9 +44,10 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.RestTemplate;
 
@@ -70,7 +71,7 @@ public class SynchronizationController
     private RenderService renderService;
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_EXPORT_DATA')" )
-    @RequestMapping( value = "/dataPush", method = RequestMethod.POST )
+    @PostMapping( "/dataPush" )
     public void execute( HttpServletResponse response )
         throws IOException
     {
@@ -81,7 +82,7 @@ public class SynchronizationController
     }
 
     @PreAuthorize( "hasRole('ALL')" )
-    @RequestMapping( value = "/metadataPull", method = RequestMethod.POST )
+    @PostMapping( "/metadataPull" )
     public void importMetaData( @RequestBody String url, HttpServletResponse response )
         throws IOException
     {
@@ -91,13 +92,13 @@ public class SynchronizationController
         renderService.toJson( response.getOutputStream(), importReport );
     }
 
-    @RequestMapping( value = "/availability", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/availability", produces = "application/json" )
     public @ResponseBody AvailabilityStatus remoteServerAvailable()
     {
         return synchronizationManager.isRemoteServerAvailable();
     }
 
-    @RequestMapping( value = "/metadataRepo", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/metadataRepo", produces = "application/json" )
     public @ResponseBody String getMetadataRepoIndex()
     {
         return restTemplate.getForObject( SettingKey.METADATA_REPO_URL.getDefaultValue().toString(), String.class );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
@@ -72,9 +72,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -124,7 +124,7 @@ public class SystemController
     // UID Generator
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = { "/uid", "/id" }, method = RequestMethod.GET, produces = {
+    @GetMapping( value = { "/uid", "/id" }, produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode getUid( @RequestParam( required = false, defaultValue = "1" ) Integer limit,
         HttpServletResponse response )
@@ -147,7 +147,7 @@ public class SystemController
         return rootNode;
     }
 
-    @RequestMapping( value = { "/uid", "/id" }, method = RequestMethod.GET, produces = { "application/csv" } )
+    @GetMapping( value = { "/uid", "/id" }, produces = { "application/csv" } )
     public void getUidCsv( @RequestParam( required = false, defaultValue = "1" ) Integer limit,
         HttpServletResponse response )
         throws IOException,
@@ -173,7 +173,7 @@ public class SystemController
         csvGenerator.flush();
     }
 
-    @RequestMapping( value = "/uuid", method = RequestMethod.GET, produces = { MediaType.APPLICATION_JSON_VALUE,
+    @GetMapping( value = "/uuid", produces = { MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode getUuid( @RequestParam( required = false, defaultValue = "1" ) Integer limit,
         HttpServletResponse response )
@@ -200,7 +200,7 @@ public class SystemController
     // Tasks
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/tasks", method = RequestMethod.GET, produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/tasks", produces = { "*/*", "application/json" } )
     public void getTasksJson( HttpServletResponse response )
         throws IOException
     {
@@ -210,7 +210,7 @@ public class SystemController
         renderService.toJson( response.getOutputStream(), notifier.getNotifications() );
     }
 
-    @RequestMapping( value = "/tasks/{jobType}", method = RequestMethod.GET, produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/tasks/{jobType}", produces = { "*/*", "application/json" } )
     public void getTasksExtendedJson( @PathVariable( "jobType" ) String jobType, HttpServletResponse response )
         throws IOException
     {
@@ -224,8 +224,7 @@ public class SystemController
         renderService.toJson( response.getOutputStream(), notifications );
     }
 
-    @RequestMapping( value = "/tasks/{jobType}/{jobId}", method = RequestMethod.GET, produces = { "*/*",
-        "application/json" } )
+    @GetMapping( value = "/tasks/{jobType}/{jobId}", produces = { "*/*", "application/json" } )
     public void getTaskJsonByUid( @PathVariable( "jobType" ) String jobType, @PathVariable( "jobId" ) String jobId,
         HttpServletResponse response )
         throws IOException
@@ -244,8 +243,7 @@ public class SystemController
     // Tasks summary
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/taskSummaries/{jobType}", method = RequestMethod.GET, produces = { "*/*",
-        "application/json" } )
+    @GetMapping( value = "/taskSummaries/{jobType}", produces = { "*/*", "application/json" } )
     public void getTaskSummaryExtendedJson( @PathVariable( "jobType" ) String jobType, HttpServletResponse response )
         throws IOException
     {
@@ -261,8 +259,7 @@ public class SystemController
         response.setContentType( CONTENT_TYPE_JSON );
     }
 
-    @RequestMapping( value = "/taskSummaries/{jobType}/{jobId}", method = RequestMethod.GET, produces = { "*/*",
-        "application/json" } )
+    @GetMapping( value = "/taskSummaries/{jobType}/{jobId}", produces = { "*/*", "application/json" } )
     public void getTaskSummaryJson( @PathVariable( "jobType" ) String jobType, @PathVariable( "jobId" ) String jobId,
         HttpServletResponse response )
         throws IOException
@@ -298,8 +295,7 @@ public class SystemController
     // Various
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/info", method = RequestMethod.GET, produces = { "application/json",
-        "application/javascript" } )
+    @GetMapping( value = "/info", produces = { "application/json", "application/javascript" } )
     public @ResponseBody SystemInfo getSystemInfo( Model model, HttpServletRequest request,
         HttpServletResponse response )
     {
@@ -318,7 +314,7 @@ public class SystemController
         return info;
     }
 
-    @RequestMapping( value = "/objectCounts", method = RequestMethod.GET )
+    @GetMapping( "/objectCounts" )
     public @ResponseBody RootNode getObjectCounts()
     {
         Map<Objects, Long> objectCounts = statisticsProvider.getObjectCounts();
@@ -332,7 +328,7 @@ public class SystemController
         return rootNode;
     }
 
-    @RequestMapping( value = "/ping", method = RequestMethod.GET )
+    @GetMapping( "/ping" )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody String ping( HttpServletResponse response )
     {
@@ -341,13 +337,13 @@ public class SystemController
         return "pong";
     }
 
-    @RequestMapping( value = "/flags", method = RequestMethod.GET, produces = { "application/json" } )
+    @GetMapping( value = "/flags", produces = { "application/json" } )
     public @ResponseBody List<StyleObject> getFlags()
     {
         return getFlagObjects();
     }
 
-    @RequestMapping( value = "/styles", method = RequestMethod.GET, produces = { "application/json" } )
+    @GetMapping( value = "/styles", produces = { "application/json" } )
     public @ResponseBody List<StyleObject> getStyles()
     {
         return styleManager.getStyles();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -64,10 +64,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -112,7 +114,7 @@ public class SystemSettingController
     // Create
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{key}", method = RequestMethod.POST, consumes = { ContextUtils.CONTENT_TYPE_JSON,
+    @PostMapping( value = "/{key}", consumes = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_TEXT, ContextUtils.CONTENT_TYPE_HTML } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
     public void setSystemSettingOrTranslation( @PathVariable( value = "key" ) String key,
@@ -186,7 +188,7 @@ public class SystemSettingController
         }
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = { ContextUtils.CONTENT_TYPE_JSON } )
+    @PostMapping( consumes = { ContextUtils.CONTENT_TYPE_JSON } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
     public void setSystemSettingV29( @RequestBody Map<String, Object> settings, HttpServletResponse response,
         HttpServletRequest request )
@@ -214,7 +216,7 @@ public class SystemSettingController
     // Read
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{key}", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_TEXT )
+    @GetMapping( value = "/{key}", produces = ContextUtils.CONTENT_TYPE_TEXT )
     public @ResponseBody Serializable getSystemSettingOrTranslationAsPlainText( @PathVariable( "key" ) String key,
         @RequestParam( value = "locale", required = false ) String locale, HttpServletResponse response )
     {
@@ -223,7 +225,7 @@ public class SystemSettingController
         return String.valueOf( getSystemSettingOrTranslation( key, locale ) );
     }
 
-    @RequestMapping( value = "/{key}", method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
+    @GetMapping( value = "/{key}", produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_HTML } )
     public @ResponseBody void getSystemSettingOrTranslationAsJson( @PathVariable( "key" ) String key,
         @RequestParam( value = "locale", required = false ) String locale, HttpServletResponse response )
@@ -296,7 +298,7 @@ public class SystemSettingController
         return Optional.empty();
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
+    @GetMapping( produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_HTML } )
     public void getSystemSettingsJson( @RequestParam( value = "key", required = false ) Set<String> keys,
         HttpServletResponse response )
@@ -309,7 +311,7 @@ public class SystemSettingController
         renderService.toJson( response.getOutputStream(), systemSettingManager.getSystemSettings( settingKeys ) );
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = "application/javascript" )
+    @GetMapping( produces = "application/javascript" )
     public void getSystemSettingsJsonP( @RequestParam( value = "key", required = false ) Set<String> keys,
         @RequestParam( defaultValue = "callback" ) String callback, HttpServletResponse response )
         throws IOException
@@ -348,7 +350,7 @@ public class SystemSettingController
     // Remove
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{key}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{key}" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void removeSystemSetting( @PathVariable( "key" ) String key,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.external.conf.GoogleAccessToken;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
@@ -71,7 +71,7 @@ public class TokenController
         this.tokenCache = cacheProvider.createGoogleAccessTokenCache();
     }
 
-    @RequestMapping( value = "/google", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/google", produces = "application/json" )
     public @ResponseBody GoogleAccessToken getEarthEngineToken( HttpServletResponse response )
         throws WebMessageException,
         ExecutionException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
@@ -45,10 +45,13 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -76,7 +79,7 @@ public class UserKeyJsonValueController
      * Returns a JSON array of strings representing the different namespaces
      * used. If no namespaces exist, an empty array is returned.
      */
-    @RequestMapping( value = "", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "", produces = "application/json" )
     public @ResponseBody List<String> getNamespaces( HttpServletResponse response )
         throws IOException
     {
@@ -89,7 +92,7 @@ public class UserKeyJsonValueController
      * Returns a JSON array of strings representing the different keys used in a
      * given namespace. If no namespaces exist, an empty array is returned.
      */
-    @RequestMapping( value = "/{namespace}", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{namespace}", produces = "application/json" )
     public @ResponseBody List<String> getKeys( @PathVariable String namespace, HttpServletResponse response )
         throws IOException,
         WebMessageException
@@ -108,7 +111,7 @@ public class UserKeyJsonValueController
     /**
      * Deletes all keys with the given user and namespace.
      */
-    @RequestMapping( value = "/{namespace}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{namespace}" )
     public void deleteKeys(
         @PathVariable String namespace,
         HttpServletResponse response )
@@ -124,7 +127,7 @@ public class UserKeyJsonValueController
      * Retrieves the value of the KeyJsonValue represented by the given key and
      * namespace from the current user.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{namespace}/{key}", produces = "application/json" )
     public @ResponseBody String getUserKeyJsonValue(
         @PathVariable String namespace,
         @PathVariable String key, HttpServletResponse response )
@@ -149,7 +152,7 @@ public class UserKeyJsonValueController
      * Creates a new KeyJsonValue Object on the current user with the key,
      * namespace and value supplied.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.POST, produces = "application/json", consumes = "application/json" )
+    @PostMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
     public void addUserKeyJsonValue(
         @PathVariable String namespace,
         @PathVariable String key,
@@ -190,7 +193,7 @@ public class UserKeyJsonValueController
     /**
      * Update a key.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.PUT, produces = "application/json", consumes = "application/json" )
+    @PutMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
     public void updateUserKeyJsonValue(
         @PathVariable String namespace,
         @PathVariable String key,
@@ -226,7 +229,7 @@ public class UserKeyJsonValueController
     /**
      * Delete a key.
      */
-    @RequestMapping( value = "/{namespace}/{key}", method = RequestMethod.DELETE, produces = "application/json" )
+    @DeleteMapping( value = "/{namespace}/{key}", produces = "application/json" )
     public void deleteUserKeyJsonValue(
         @PathVariable String namespace,
         @PathVariable String key,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -40,9 +40,9 @@ import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -56,7 +56,7 @@ public class CategoryComboController
     @Autowired
     private CategoryService categoryService;
 
-    @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<RootNode> getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid,
         @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
@@ -55,9 +55,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.google.common.collect.Lists;
@@ -76,7 +76,7 @@ public class DataElementGroupController
     @Autowired
     private DataElementService dataElementService;
 
-    @RequestMapping( value = "/{uid}/operands", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/operands" )
     public String getOperands( @PathVariable( "uid" ) String uid, @RequestParam Map<String, String> parameters,
         Model model,
         TranslateParams translateParams, HttpServletRequest request, HttpServletResponse response )
@@ -114,7 +114,7 @@ public class DataElementGroupController
         return StringUtils.uncapitalize( getEntitySimpleName() );
     }
 
-    @RequestMapping( value = "/{uid}/operands/query/{q}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/operands/query/{q}" )
     public String getOperandsByQuery( @PathVariable( "uid" ) String uid,
         @PathVariable( "q" ) String q, @RequestParam Map<String, String> parameters, TranslateParams translateParams,
         Model model,
@@ -160,7 +160,7 @@ public class DataElementGroupController
         return StringUtils.uncapitalize( getEntitySimpleName() );
     }
 
-    @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<RootNode> getDataElementGroupWithDependencies(
         @PathVariable( "uid" ) String dataElementGroupId,
         @RequestParam( required = false, defaultValue = "false" ) boolean download )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -75,10 +75,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -141,7 +143,7 @@ public class DataValueController
     // ---------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
-    @RequestMapping( method = RequestMethod.POST )
+    @PostMapping
     @ResponseStatus( HttpStatus.CREATED )
     public void saveDataValue(
         @RequestParam String de,
@@ -161,7 +163,7 @@ public class DataValueController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
-    @RequestMapping( value = FILE_PATH, method = RequestMethod.POST )
+    @PostMapping( FILE_PATH )
     public @ResponseBody WebMessage saveFileDataValue(
         @RequestParam String de,
         @RequestParam( required = false ) String co,
@@ -387,7 +389,7 @@ public class DataValueController
     // ---------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_DELETE')" )
-    @RequestMapping( method = RequestMethod.DELETE )
+    @DeleteMapping
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteDataValue(
         @RequestParam String de,
@@ -462,7 +464,7 @@ public class DataValueController
     // GET
     // ---------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody List<String> getDataValue(
         @RequestParam String de,
         @RequestParam( required = false ) String co,
@@ -555,7 +557,7 @@ public class DataValueController
     // GET file
     // ---------------------------------------------------------------------
 
-    @RequestMapping( value = "/files", method = RequestMethod.GET )
+    @GetMapping( "/files" )
     public void getDataValueFile(
         @RequestParam String de,
         @RequestParam( required = false ) String co,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -68,9 +68,9 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -133,7 +133,7 @@ public class DimensionController
     }
 
     @SuppressWarnings( "unchecked" )
-    @RequestMapping( value = "/{uid}/items", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/items" )
     public @ResponseBody RootNode getItems( @PathVariable String uid, @RequestParam Map<String, String> parameters,
         OrderParams orderParams )
         throws QueryParserException
@@ -187,7 +187,7 @@ public class DimensionController
         return rootNode;
     }
 
-    @RequestMapping( value = "/constraints", method = RequestMethod.GET )
+    @GetMapping( "/constraints" )
     public @ResponseBody RootNode getDimensionConstraints(
         @RequestParam( value = "links", defaultValue = "true", required = false ) Boolean links )
     {
@@ -206,7 +206,7 @@ public class DimensionController
         return rootNode;
     }
 
-    @RequestMapping( value = "/recommendations", method = RequestMethod.GET )
+    @GetMapping( "/recommendations" )
     public @ResponseBody RootNode getRecommendedDimensions( @RequestParam Set<String> dimension )
     {
         List<String> fields = newArrayList( contextService.getParameterValues( "fields" ) );
@@ -226,7 +226,7 @@ public class DimensionController
         return rootNode;
     }
 
-    @RequestMapping( value = "/dataSet/{uid}", method = RequestMethod.GET )
+    @GetMapping( "/dataSet/{uid}" )
     public @ResponseBody RootNode getDimensionsForDataSet( @PathVariable String uid,
         @RequestParam( value = "links", defaultValue = "true", required = false ) Boolean links,
         Model model, HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -76,9 +76,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -123,7 +126,7 @@ public class EnrollmentController
     // READ
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "", method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody RootNode getEnrollments(
         EnrollmentCriteria enrollmentCriteria )
     {
@@ -184,7 +187,7 @@ public class EnrollmentController
         return rootNode;
     }
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.GET )
+    @GetMapping( "/{id}" )
     public @ResponseBody Enrollment getEnrollment( @PathVariable String id,
         @RequestParam Map<String, String> parameters, Model model )
         throws NotFoundException
@@ -196,7 +199,7 @@ public class EnrollmentController
     // CREATE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
     public void postEnrollmentJson( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
@@ -241,7 +244,7 @@ public class EnrollmentController
         }
     }
 
-    @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
     public void postEnrollmentXml( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
@@ -290,7 +293,7 @@ public class EnrollmentController
     // UPDATE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{id}/note", method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( value = "/{id}/note", consumes = "application/json" )
     public void updateEnrollmentForNoteJson( @PathVariable String id, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
@@ -300,7 +303,7 @@ public class EnrollmentController
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );
     }
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
     public void updateEnrollmentXml( @PathVariable String id, ImportOptions importOptions, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
@@ -312,7 +315,7 @@ public class EnrollmentController
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );
     }
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
     public void updateEnrollmentJson( @PathVariable String id, ImportOptions importOptions, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
@@ -324,7 +327,7 @@ public class EnrollmentController
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );
     }
 
-    @RequestMapping( value = "/{id}/cancelled", method = RequestMethod.PUT )
+    @PutMapping( "/{id}/cancelled" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void cancelEnrollment( @PathVariable String id )
         throws WebMessageException
@@ -337,7 +340,7 @@ public class EnrollmentController
         enrollmentService.cancelEnrollment( id );
     }
 
-    @RequestMapping( value = "/{id}/completed", method = RequestMethod.PUT )
+    @PutMapping( "/{id}/completed" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void completeEnrollment( @PathVariable String id )
         throws WebMessageException
@@ -350,7 +353,7 @@ public class EnrollmentController
         enrollmentService.completeEnrollment( id );
     }
 
-    @RequestMapping( value = "/{id}/incompleted", method = RequestMethod.PUT )
+    @PutMapping( "/{id}/incompleted" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void incompleteEnrollment( @PathVariable String id )
         throws WebMessageException
@@ -367,7 +370,7 @@ public class EnrollmentController
     // DELETE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{id}" )
     public void deleteEnrollment( @PathVariable String id, HttpServletRequest request, HttpServletResponse response )
     {
         ImportSummary importSummary = enrollmentService.deleteEnrollment( id );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
@@ -59,9 +59,9 @@ import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -108,7 +108,7 @@ public class EventChartController
     // Get data
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = { "/{uid}/data", "/{uid}/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/{uid}/data", "/{uid}/data.png" } )
     public void getChart(
         @PathVariable( "uid" ) String uid,
         @RequestParam( value = "date", required = false ) Date date,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -118,9 +118,12 @@ import org.locationtech.jts.io.ParseException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -224,7 +227,7 @@ public class EventController
     // Query Read
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
+    @GetMapping( value = "/query", produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_JAVASCRIPT } )
     public @ResponseBody Grid queryEventsJson(
         @RequestParam( required = false ) String program,
@@ -299,7 +302,7 @@ public class EventController
 
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_XML )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_XML )
     public void queryEventsXml(
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) String programStage,
@@ -372,7 +375,7 @@ public class EventController
         GridUtils.toXml( grid, response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_EXCEL )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_EXCEL )
     public void queryEventsXls(
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) String programStage,
@@ -446,7 +449,7 @@ public class EventController
 
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_CSV )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_CSV )
     public void queryEventsCsv(
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) String programStage,
@@ -524,7 +527,7 @@ public class EventController
     // Object Read
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public @ResponseBody RootNode getEvents(
         EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
         HttpServletResponse response,
@@ -577,7 +580,7 @@ public class EventController
         return rootNode;
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = { "application/xml", "application/xml+gzip", "text/xml" } )
+    @GetMapping( produces = { "application/xml", "application/xml+gzip", "text/xml" } )
     public @ResponseBody RootNode getXmlEvents(
         EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
         HttpServletResponse response,
@@ -631,7 +634,7 @@ public class EventController
         return rootNode;
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = { "application/csv", "application/csv+gzip", "text/csv" } )
+    @GetMapping( produces = { "application/csv", "application/csv+gzip", "text/csv" } )
     public void getCsvEvents(
         EventCriteria eventCriteria,
         @RequestParam( required = false, defaultValue = "false" ) boolean skipHeader,
@@ -665,7 +668,7 @@ public class EventController
     // Rows Read
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/eventRows", method = RequestMethod.GET )
+    @GetMapping( "/eventRows" )
     public @ResponseBody EventRows getEventRows(
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) String orgUnit,
@@ -702,7 +705,7 @@ public class EventController
         return eventRowService.getEventRows( params );
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}" )
     public @ResponseBody Event getEvent( @PathVariable( "uid" ) String uid,
         @RequestParam Map<String, String> parameters,
         Model model, HttpServletRequest request )
@@ -720,7 +723,7 @@ public class EventController
         return event;
     }
 
-    @RequestMapping( value = "/files", method = RequestMethod.GET )
+    @GetMapping( "/files" )
     public void getEventDataValueFile( @RequestParam String eventUid, @RequestParam String dataElementUid,
         @RequestParam( required = false ) ImageFileDimension dimension,
         HttpServletResponse response, HttpServletRequest request )
@@ -812,7 +815,7 @@ public class EventController
     // Create
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/xml" )
+    @PostMapping( consumes = "application/xml" )
     public void postXmlEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
     {
@@ -831,7 +834,7 @@ public class EventController
         return eventService.addEventsXml( inputStream, importOptions );
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     public void postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
     {
@@ -900,7 +903,7 @@ public class EventController
         }
     }
 
-    @RequestMapping( value = "/{uid}/note", method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( value = "/{uid}/note", consumes = "application/json" )
     public void postJsonEventForNote( @PathVariable( "uid" ) String uid,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
         throws IOException,
@@ -919,7 +922,7 @@ public class EventController
         webMessageService.send( WebMessageUtils.ok( "Event updated: " + uid ), response, request );
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/csv", "text/csv" } )
+    @PostMapping( consumes = { "application/csv", "text/csv" } )
     public void postCsvEvents( @RequestParam( required = false, defaultValue = "false" ) boolean skipFirst,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
         throws IOException,
@@ -945,7 +948,7 @@ public class EventController
     // Update
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = { "application/xml", "text/xml" } )
+    @PutMapping( value = "/{uid}", consumes = { "application/xml", "text/xml" } )
     public void putXmlEvent( HttpServletResponse response, HttpServletRequest request,
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException
@@ -957,7 +960,7 @@ public class EventController
         updateEvent( updatedEvent, false, importOptions, request, response );
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = "application/json" )
+    @PutMapping( value = "/{uid}", consumes = "application/json" )
     public void putJsonEvent( HttpServletResponse response, HttpServletRequest request,
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException
@@ -977,7 +980,7 @@ public class EventController
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/{dataElementUid}", method = RequestMethod.PUT, consumes = "application/json" )
+    @PutMapping( value = "/{uid}/{dataElementUid}", consumes = "application/json" )
     public void putJsonEventSingleValue( HttpServletResponse response, HttpServletRequest request,
         @PathVariable( "uid" ) String uid, @PathVariable( "dataElementUid" ) String dataElementUid )
         throws IOException,
@@ -998,7 +1001,7 @@ public class EventController
         updateEvent( updatedEvent, true, null, request, response );
     }
 
-    @RequestMapping( value = "/{uid}/eventDate", method = RequestMethod.PUT, consumes = "application/json" )
+    @PutMapping( value = "/{uid}/eventDate", consumes = "application/json" )
     public void putJsonEventForEventDate( HttpServletResponse response, HttpServletRequest request,
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException,
@@ -1021,7 +1024,7 @@ public class EventController
     // Delete
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}" )
     public void deleteEvent( HttpServletResponse response, HttpServletRequest request,
         @PathVariable( "uid" ) String uid )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -53,7 +53,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -103,7 +102,7 @@ public class ProgramController
         return entityList;
     }
 
-    @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<RootNode> getProgramWithDependencies( @PathVariable( "uid" ) String pvUid,
         @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
@@ -42,9 +42,9 @@ import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * @author Lars Helge Overland
@@ -60,7 +60,7 @@ public class ProgramIndicatorController
     @Autowired
     private I18nManager i18nManager;
 
-    @RequestMapping( value = "/expression/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getExpressionDescription( @RequestBody String expression, HttpServletResponse response )
         throws IOException
     {
@@ -88,7 +88,7 @@ public class ProgramIndicatorController
         webMessageService.sendJson( message, response );
     }
 
-    @RequestMapping( value = "/filter/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/filter/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void validateFilter( @RequestBody String expression, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
@@ -55,8 +55,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -88,7 +89,7 @@ public class ProgramMessageController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( method = RequestMethod.GET, produces = { "application/json" } )
+    @GetMapping( produces = { "application/json" } )
     public void getProgramMessages( @RequestParam( required = false ) Set<String> ou,
         @RequestParam( required = false ) String programInstance,
         @RequestParam( required = false ) String programStageInstance,
@@ -114,7 +115,7 @@ public class ProgramMessageController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( value = "/scheduled", method = RequestMethod.GET )
+    @GetMapping( "/scheduled" )
     public void getScheduledMessage( @RequestParam( required = false ) Date scheduledAt, HttpServletResponse response )
         throws IOException
     {
@@ -131,7 +132,7 @@ public class ProgramMessageController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( value = "/scheduled/sent", method = RequestMethod.GET )
+    @GetMapping( "/scheduled/sent" )
     public void getScheduledSentMessage(
         @RequestParam( required = false ) String programInstance,
         @RequestParam( required = false ) String programStageInstance,
@@ -154,7 +155,7 @@ public class ProgramMessageController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/json" }, produces = { "application/json" } )
+    @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
     public void saveMessages( HttpServletRequest request, HttpServletResponse response )
         throws IOException,
         WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
@@ -42,9 +42,9 @@ import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -66,7 +66,7 @@ public class ProgramRuleActionController
         this.programRuleEngineService = programRuleEngineService;
     }
 
-    @RequestMapping( value = "/data/expression/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/data/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getDataExpressionDescription( @RequestBody String condition, @RequestParam String programId,
         HttpServletResponse response )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
@@ -42,9 +42,9 @@ import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -66,7 +66,7 @@ public class ProgramRuleController
         this.programRuleEngineService = programRuleEngineService;
     }
 
-    @RequestMapping( value = "/condition/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/condition/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void validateCondition( @RequestBody String condition, @RequestParam String programId,
         HttpServletResponse response )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -51,9 +51,9 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -78,7 +78,7 @@ public class TrackedEntityAttributeController
     @Autowired
     private ContextService context;
 
-    @RequestMapping( value = "/{id}/generateAndReserve", method = RequestMethod.GET, produces = {
+    @GetMapping( value = "/{id}/generateAndReserve", produces = {
         ContextUtils.CONTENT_TYPE_JSON, ContextUtils.CONTENT_TYPE_JAVASCRIPT } )
     @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
     public @ResponseBody List<ReservedValue> generateAndReserveValues(
@@ -109,7 +109,7 @@ public class TrackedEntityAttributeController
      * @return The id generated
      * @throws WebMessageException
      */
-    @RequestMapping( value = "/{id}/generate", method = RequestMethod.GET )
+    @GetMapping( "/{id}/generate" )
     @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
     public @ResponseBody ReservedValue legacyQueryTrackedEntityInstancesJson(
         @PathVariable String id,
@@ -126,7 +126,7 @@ public class TrackedEntityAttributeController
         return reserve( id, 1, expiration ).get( 0 );
     }
 
-    @RequestMapping( value = "/{id}/requiredValues", method = RequestMethod.GET )
+    @GetMapping( "/{id}/requiredValues" )
     @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
     public @ResponseBody Map<String, List<String>> getRequiredValues( @PathVariable String id )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -94,10 +94,12 @@ import org.hisp.dhis.webapi.utils.FileResourceUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -197,7 +199,7 @@ public class TrackedEntityInstanceController
         return rootNode;
     }
 
-    @RequestMapping( value = "/{teiId}/{attributeId}/image", method = RequestMethod.GET )
+    @GetMapping( "/{teiId}/{attributeId}/image" )
     public void getAttributeImage(
         @PathVariable( "teiId" ) String teiId,
         @PathVariable( "attributeId" ) String attributeId,
@@ -295,7 +297,7 @@ public class TrackedEntityInstanceController
         }
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
+    @GetMapping( value = "/query", produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_JAVASCRIPT } )
     public @ResponseBody Grid queryTrackedEntityInstancesJson( TrackedEntityInstanceCriteria criteria,
         HttpServletResponse response )
@@ -304,7 +306,7 @@ public class TrackedEntityInstanceController
         return getGridByCriteria( criteria );
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_XML )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_XML )
     public void queryTrackedEntityInstancesXml( TrackedEntityInstanceCriteria criteria,
         HttpServletResponse response )
         throws Exception
@@ -313,7 +315,7 @@ public class TrackedEntityInstanceController
         GridUtils.toXml( getGridByCriteria( criteria ), response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_EXCEL )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_EXCEL )
     public void queryTrackedEntityInstancesXls( TrackedEntityInstanceCriteria criteria,
         HttpServletResponse response )
         throws Exception
@@ -322,7 +324,7 @@ public class TrackedEntityInstanceController
         GridUtils.toXls( getGridByCriteria( criteria ), response.getOutputStream() );
     }
 
-    @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_CSV )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_CSV )
     public void queryTrackedEntityInstancesCsv( TrackedEntityInstanceCriteria criteria,
         HttpServletResponse response )
         throws Exception
@@ -331,7 +333,7 @@ public class TrackedEntityInstanceController
         GridUtils.toCsv( getGridByCriteria( criteria ), response.getWriter() );
     }
 
-    @RequestMapping( value = "/count", method = RequestMethod.GET )
+    @GetMapping( "/count" )
     public @ResponseBody int getTrackedEntityInstanceCount( TrackedEntityInstanceCriteria criteria )
     {
         criteria.setSkipMeta( true );
@@ -368,7 +370,7 @@ public class TrackedEntityInstanceController
     // CREATE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE )
     public void postTrackedEntityInstanceJson(
         @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
@@ -378,7 +380,7 @@ public class TrackedEntityInstanceController
         postTrackedEntityInstance( strategy, importOptions, request, response, MediaType.APPLICATION_JSON_VALUE );
     }
 
-    @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE )
     public void postTrackedEntityInstanceXml(
         @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
@@ -457,7 +459,7 @@ public class TrackedEntityInstanceController
     // UPDATE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE )
     public void updateTrackedEntityInstanceXml(
         @PathVariable String id,
         @RequestParam( required = false ) String program,
@@ -472,7 +474,7 @@ public class TrackedEntityInstanceController
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );
     }
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE )
     public void updateTrackedEntityInstanceJson(
         @PathVariable String id,
         @RequestParam( required = false ) String program,
@@ -491,7 +493,7 @@ public class TrackedEntityInstanceController
     // DELETE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{id}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{id}" )
     public void deleteTrackedEntityInstance( @PathVariable String id, HttpServletRequest request,
         HttpServletResponse response )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -44,8 +44,9 @@ import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -87,7 +88,7 @@ public class TrackerOwnershipController
     // 2. Break the glass and override ownership.
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/transfer", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/transfer", produces = MediaType.APPLICATION_JSON_VALUE )
     public void updateTrackerProgramOwner( @RequestParam String trackedEntityInstance, @RequestParam String program,
         @RequestParam String ou, HttpServletRequest request, HttpServletResponse response )
     {
@@ -98,7 +99,7 @@ public class TrackerOwnershipController
         webMessageService.send( WebMessageUtils.ok( "Ownership transferred" ), response, request );
     }
 
-    @RequestMapping( value = "/override", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/override", produces = MediaType.APPLICATION_JSON_VALUE )
     public void overrideOwnershipAccess( @RequestParam String trackedEntityInstance, @RequestParam String reason,
         @RequestParam String program, HttpServletRequest request, HttpServletResponse response )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorController.java
@@ -46,9 +46,9 @@ import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -67,7 +67,7 @@ public class IndicatorController
     @Autowired
     private I18nManager i18nManager;
 
-    @RequestMapping( value = "/expression/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getExpressionDescription( @RequestBody String expression, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
@@ -67,10 +67,11 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.webdomain.GeoFeature;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
-import org.springframework.http.*;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -114,7 +115,7 @@ public class GeoFeatureController
     // Resources
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
+    @GetMapping( produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_HTML } )
     @ResponseBody
     public ResponseEntity<List<GeoFeature>> getGeoFeaturesJson(
@@ -139,7 +140,7 @@ public class GeoFeatureController
             .body( features );
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = { "application/javascript" } )
+    @GetMapping( produces = { "application/javascript" } )
     public void getGeoFeaturesJsonP(
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) String oug,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
@@ -71,6 +71,7 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -115,8 +116,7 @@ public class GeoFeatureController
     // Resources
     // -------------------------------------------------------------------------
 
-    @GetMapping( produces = { ContextUtils.CONTENT_TYPE_JSON,
-        ContextUtils.CONTENT_TYPE_HTML } )
+    @GetMapping( produces = { ContextUtils.CONTENT_TYPE_JSON, ContextUtils.CONTENT_TYPE_HTML } )
     @ResponseBody
     public ResponseEntity<List<GeoFeature>> getGeoFeaturesJson(
         @RequestParam( required = false ) String ou,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -67,9 +67,10 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -121,7 +122,7 @@ public class MapController
     // --------------------------------------------------------------------------
 
     @Override
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = "application/json" )
+    @PutMapping( value = "/{uid}", consumes = "application/json" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void putJsonObject( @PathVariable String uid, HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -170,7 +171,7 @@ public class MapController
     // Get data
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = { "/{uid}/data", "/{uid}/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/{uid}/data", "/{uid}/data.png" } )
     public void getMapData( @PathVariable String uid,
         @RequestParam( value = "date", required = false ) Date date,
         @RequestParam( value = "ou", required = false ) String ou,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -53,9 +53,9 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.google.common.collect.Lists;
@@ -84,7 +84,7 @@ public class MapViewController
     // Get data
     // --------------------------------------------------------------------------
 
-    @RequestMapping( value = { "/{uid}/data", "/{uid}/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/{uid}/data", "/{uid}/data.png" } )
     public void getMapViewData( @PathVariable String uid, HttpServletResponse response )
         throws Exception
     {
@@ -98,7 +98,7 @@ public class MapViewController
         renderMapViewPng( mapView, response );
     }
 
-    @RequestMapping( value = { "/data", "/data.png" }, method = RequestMethod.GET )
+    @GetMapping( value = { "/data", "/data.png" } )
     public void getMapView( Model model,
         @RequestParam( value = "in" ) String indicatorUid,
         @RequestParam( value = "ou" ) String organisationUnitUid,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -60,9 +60,9 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -86,7 +86,7 @@ public class MetadataVersionController
     private ContextUtils contextUtils;
 
     // Gets the version by versionName or latest system version
-    @RequestMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT, method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT, produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody MetadataVersion getMetaDataVersion(
         @RequestParam( value = "versionName", required = false ) String versionName )
         throws MetadataVersionException,
@@ -136,8 +136,8 @@ public class MetadataVersionController
 
     // Gets the list of all versions in between the passed version name and
     // latest system version
-    @RequestMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
-        + "/history", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
+        + "/history", produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody RootNode getMetaDataVersionHistory(
         @RequestParam( value = "baseline", required = false ) String versionName )
         throws MetadataVersionException,
@@ -211,7 +211,7 @@ public class MetadataVersionController
     }
 
     // Gets the list of all versions
-    @RequestMapping( value = "/metadata/versions", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @GetMapping( value = "/metadata/versions", produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody RootNode getAllVersion()
         throws MetadataVersionException,
         BadRequestException
@@ -239,8 +239,8 @@ public class MetadataVersionController
     // Creates version in versioning table, exports the metadata and saves the
     // snapshot in datastore
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
-    @RequestMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
-        + "/create", method = RequestMethod.POST, produces = ContextUtils.CONTENT_TYPE_JSON )
+    @PostMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
+        + "/create", produces = ContextUtils.CONTENT_TYPE_JSON )
     public @ResponseBody MetadataVersion createSystemVersion( @RequestParam( value = "type" ) VersionType versionType )
         throws MetadataVersionException,
         BadRequestException
@@ -271,8 +271,8 @@ public class MetadataVersionController
 
     // endpoint to download metadata
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
-    @RequestMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
-        + "/{versionName}/data", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
+        + "/{versionName}/data", produces = "application/json" )
     public @ResponseBody String downloadVersion( @PathVariable( "versionName" ) String versionName )
         throws MetadataVersionException,
         BadRequestException
@@ -304,8 +304,8 @@ public class MetadataVersionController
 
     // endpoint to download metadata in gzip format
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
-    @RequestMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
-        + "/{versionName}/data.gz", method = RequestMethod.GET, produces = "*/*" )
+    @GetMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
+        + "/{versionName}/data.gz", produces = "*/*" )
     public void downloadGZipVersion( @PathVariable( "versionName" ) String versionName, HttpServletResponse response )
         throws MetadataVersionException,
         IOException,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
@@ -42,7 +42,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -56,7 +55,7 @@ public class OptionSetController
     @Autowired
     private OptionService optionService;
 
-    @RequestMapping( value = "/{uid}/metadata", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<RootNode> getOptionSetWithDependencies( @PathVariable( "uid" ) String pvUid,
         HttpServletResponse response, @RequestParam( required = false, defaultValue = "false" ) boolean download )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
@@ -43,8 +43,9 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -70,13 +71,13 @@ public class FilledOrganisationUnitLevelController
         this.organisationUnitService = organisationUnitService;
     }
 
-    @RequestMapping( method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE )
     public @ResponseBody List<OrganisationUnitLevel> getList()
     {
         return organisationUnitService.getFilledOrganisationUnitLevels();
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.CREATED )
     public void setList( HttpServletRequest request, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -69,11 +69,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -275,7 +275,7 @@ public class OrganisationUnitController
         return organisationUnits;
     }
 
-    @RequestMapping( value = "/{uid}/parents", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/parents" )
     public @ResponseBody List<OrganisationUnit> getEntityList( @PathVariable( "uid" ) String uid,
         @RequestParam Map<String, String> parameters, Model model, TranslateParams translateParams,
         HttpServletRequest request, HttpServletResponse response )
@@ -302,7 +302,7 @@ public class OrganisationUnitController
         return organisationUnits;
     }
 
-    @RequestMapping( value = "", method = RequestMethod.GET, produces = { "application/json+geo",
+    @GetMapping( value = "", produces = { "application/json+geo",
         "application/json+geojson" } )
     public void getGeoJson(
         @RequestParam( value = "level", required = false ) List<Integer> rpLevels,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLocationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLocationController.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.system.filter.OrganisationUnitPolygonCoveringCoordinateFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -69,7 +69,7 @@ public class OrganisationUnitLocationController
     /**
      * Get Organisation Units within a distance from a location
      */
-    @RequestMapping( value = "/withinRange", method = RequestMethod.GET, produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/withinRange", produces = { "*/*", "application/json" } )
     public void getEntitiesWithinRange(
         @RequestParam Double longitude,
         @RequestParam Double latitude,
@@ -120,8 +120,7 @@ public class OrganisationUnitLocationController
      * Get lowest level Org Units that includes the location in their polygon
      * shape.
      */
-    @RequestMapping( value = "/orgUnitByLocation", method = RequestMethod.GET, produces = { "*/*",
-        "application/json" } )
+    @GetMapping( value = "/orgUnitByLocation", produces = { "*/*", "application/json" } )
     public void getParentByLocation(
         @RequestParam Double longitude,
         @RequestParam Double latitude,
@@ -149,8 +148,7 @@ public class OrganisationUnitLocationController
     /**
      * Check if the location lies within the organisation unit boundary
      */
-    @RequestMapping( value = "/locationWithinOrgUnitBoundary", method = RequestMethod.GET, produces = { "*/*",
-        "application/json" } )
+    @GetMapping( value = "/locationWithinOrgUnitBoundary", produces = { "*/*", "application/json" } )
     public void checkLocationWithinOrgUnit( @RequestParam String orgUnitUid,
         @RequestParam Double longitude, @RequestParam Double latitude, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -50,7 +50,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -75,7 +74,7 @@ public class JobConfigurationController
         this.schedulingManager = schedulingManager;
     }
 
-    @RequestMapping( value = "/jobTypesExtended", method = RequestMethod.GET, produces = { "application/json",
+    @GetMapping( value = "/jobTypesExtended", produces = { "application/json",
         "application/javascript" } )
     public @ResponseBody Map<String, Map<String, Property>> getJobTypesExtended()
     {
@@ -88,8 +87,7 @@ public class JobConfigurationController
         return new JobTypes( jobConfigurationService.getJobTypeInfo() );
     }
 
-    @RequestMapping( value = "{uid}/execute", method = RequestMethod.GET, produces = { "application/json",
-        "application/javascript" } )
+    @GetMapping( value = "{uid}/execute", produces = { "application/json", "application/javascript" } )
     public ObjectReport executeJobConfiguration( @PathVariable( "uid" ) String uid )
         throws WebMessageException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
@@ -50,7 +50,6 @@ import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -75,7 +74,7 @@ public class AuthoritiesController
     @Autowired
     private SystemAuthoritiesProvider authoritiesProvider;
 
-    @RequestMapping( method = RequestMethod.GET )
+    @GetMapping
     public Map<String, List<Map<String, String>>> getAuthorities( HttpServletResponse response )
     {
         I18n i18n = i18nManager.getI18n();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -72,7 +72,7 @@ public class SecurityController
     @Autowired
     private ObjectMapper jsonMapper;
 
-    @RequestMapping( value = "/qr", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/qr", produces = "application/json" )
     public void getQrCode( HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -95,7 +95,7 @@ public class SecurityController
         jsonMapper.writeValue( response.getOutputStream(), map );
     }
 
-    @RequestMapping( value = "/authenticate", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/authenticate", produces = "application/json" )
     public void authenticate2FA( @RequestParam String code, HttpServletRequest request, HttpServletResponse response )
     {
         User currentUser = currentUserService.getCurrentUser();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -44,9 +44,12 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -82,7 +85,7 @@ public class SmsGatewayController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( method = RequestMethod.GET, produces = { "application/json" } )
+    @GetMapping( produces = { "application/json" } )
     public void getGateways( HttpServletResponse response )
         throws IOException
     {
@@ -90,7 +93,7 @@ public class SmsGatewayController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( value = "/{uid}", method = RequestMethod.GET, produces = "application/json" )
+    @GetMapping( value = "/{uid}", produces = "application/json" )
     public void getGatewayConfiguration( @PathVariable String uid, HttpServletResponse response )
         throws WebMessageException,
         IOException
@@ -110,7 +113,7 @@ public class SmsGatewayController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( value = "/default/{uid}", method = RequestMethod.PUT )
+    @PutMapping( "/default/{uid}" )
     public void setDefault( @PathVariable String uid, HttpServletRequest request, HttpServletResponse response )
         throws WebMessageException
     {
@@ -127,7 +130,7 @@ public class SmsGatewayController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT )
+    @PutMapping( "/{uid}" )
     public void updateGateway( @PathVariable String uid, HttpServletRequest request, HttpServletResponse response )
         throws WebMessageException,
         IOException
@@ -153,7 +156,7 @@ public class SmsGatewayController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( method = RequestMethod.POST )
+    @PostMapping
     public void addGateway( HttpServletRequest request, HttpServletResponse response )
         throws IOException,
         WebMessageException
@@ -174,7 +177,7 @@ public class SmsGatewayController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{uid}" )
     public void removeGateway( @PathVariable String uid, HttpServletRequest request, HttpServletResponse response )
         throws WebMessageException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
@@ -53,9 +53,10 @@ import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -99,7 +100,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
     // POST
     // -------------------------------------------------------------------------
 
-    @RequestMapping( method = RequestMethod.POST, produces = { "application/json" } )
+    @PostMapping( produces = { "application/json" } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void receiveSMSMessage( @RequestParam String originator, @RequestParam( required = false ) Date receivedTime,
         @RequestParam String message, @RequestParam( defaultValue = "Unknown", required = false ) String gateway,
@@ -122,7 +123,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         webMessageService.send( WebMessageUtils.ok( "Received SMS: " + smsId ), response, request );
     }
 
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/json" }, produces = { "application/json" } )
+    @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void receiveSMSMessage( HttpServletRequest request, HttpServletResponse response )
         throws WebMessageException,
@@ -136,7 +137,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         webMessageService.send( WebMessageUtils.ok( "Received SMS: " + smsId ), response, request );
     }
 
-    @RequestMapping( value = "/import", method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( value = "/import", consumes = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void importUnparsedSMSMessages( HttpServletRequest request, HttpServletResponse response )
     {
@@ -154,7 +155,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
     // DELETE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE, produces = "application/json" )
+    @DeleteMapping( value = "/{uid}", produces = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void deleteInboundMessage( @PathVariable String uid, HttpServletRequest request,
         HttpServletResponse response )
@@ -172,7 +173,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         webMessageService.send( WebMessageUtils.ok( "IncomingSms with " + uid + " deleted" ), response, request );
     }
 
-    @RequestMapping( method = RequestMethod.DELETE, produces = "application/json" )
+    @DeleteMapping( produces = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void deleteInboundMessages( @RequestParam List<String> ids, HttpServletRequest request,
         HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
@@ -49,9 +49,10 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.WebMessageService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -91,7 +92,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( method = RequestMethod.POST, produces = { "application/json" } )
+    @PostMapping( produces = { "application/json" } )
     public void sendSMSMessage( @RequestParam String recipient, @RequestParam String message,
         HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
@@ -119,7 +120,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/json" }, produces = { "application/json" } )
+    @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
     public void sendSMSMessage( HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException,
         IOException
@@ -142,7 +143,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     // DELETE
     // -------------------------------------------------------------------------
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE, produces = "application/json" )
+    @DeleteMapping( value = "/{uid}", produces = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void deleteOutboundMessage( @PathVariable String uid, HttpServletRequest request,
         HttpServletResponse response )
@@ -160,7 +161,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
         webMessageService.send( WebMessageUtils.ok( "OutboundSms with " + uid + " deleted" ), response, request );
     }
 
-    @RequestMapping( method = RequestMethod.DELETE, produces = "application/json" )
+    @DeleteMapping( produces = "application/json" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     public void deleteOutboundMessages( @RequestParam List<String> ids, HttpServletRequest request,
         HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -57,7 +57,6 @@ import org.mapstruct.factory.Mappers;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -145,7 +144,7 @@ public class TrackerEventsExportController
         return false;
     }
 
-    @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}" )
     public org.hisp.dhis.tracker.domain.Event getEvent(
         @PathVariable( "uid" ) String uid,
         @RequestParam Map<String, String> parameters,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -83,11 +83,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -99,7 +100,7 @@ import com.google.common.collect.Sets;
  */
 @Controller
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-@RequestMapping( value = "/me", method = RequestMethod.GET )
+@RequestMapping( "/me" )
 public class MeController
 {
     @Autowired
@@ -153,7 +154,7 @@ public class MeController
     private static final Set<UserSettingKey> USER_SETTING_KEYS = new HashSet<>(
         Sets.newHashSet( UserSettingKey.values() ) );
 
-    @RequestMapping( value = "", method = RequestMethod.GET )
+    @GetMapping
     public void getCurrentUser( HttpServletResponse response )
         throws Exception
     {
@@ -224,7 +225,7 @@ public class MeController
         return false;
     }
 
-    @RequestMapping( value = "/dataApprovalWorkflows", method = RequestMethod.GET )
+    @GetMapping( "/dataApprovalWorkflows" )
     public void getCurrentUserDataApprovalWorkflows( HttpServletResponse response )
         throws Exception
     {
@@ -240,7 +241,7 @@ public class MeController
         nodeService.serialize( rootNode, "application/json", response.getOutputStream() );
     }
 
-    @RequestMapping( value = "", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE )
     public void updateCurrentUser( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -277,7 +278,7 @@ public class MeController
             response.getOutputStream() );
     }
 
-    @RequestMapping( value = { "/authorization", "/authorities" } )
+    @GetMapping( value = { "/authorization", "/authorities" } )
     public void getAuthorities( HttpServletResponse response )
         throws IOException,
         NotAuthenticatedException
@@ -294,7 +295,7 @@ public class MeController
         renderService.toJson( response.getOutputStream(), currentUser.getUserCredentials().getAllAuthorities() );
     }
 
-    @RequestMapping( value = { "/authorization/{authority}", "/authorities/{authority}" } )
+    @GetMapping( value = { "/authorization/{authority}", "/authorities/{authority}" } )
     public void hasAuthority( HttpServletResponse response, @PathVariable String authority )
         throws IOException,
         NotAuthenticatedException
@@ -313,7 +314,7 @@ public class MeController
         renderService.toJson( response.getOutputStream(), hasAuthority );
     }
 
-    @RequestMapping( value = "/settings" )
+    @GetMapping( "/settings" )
     public void getSettings( HttpServletResponse response )
         throws IOException,
         NotAuthenticatedException
@@ -333,7 +334,7 @@ public class MeController
         renderService.toJson( response.getOutputStream(), userSettings );
     }
 
-    @RequestMapping( value = "/settings/{key}" )
+    @GetMapping( "/settings/{key}" )
     public void getSetting( HttpServletResponse response, @PathVariable String key )
         throws IOException,
         WebMessageException,
@@ -365,7 +366,7 @@ public class MeController
         renderService.toJson( response.getOutputStream(), value );
     }
 
-    @RequestMapping( value = "/changePassword", method = RequestMethod.PUT, consumes = { "text/*", "application/*" } )
+    @PutMapping( value = "/changePassword", consumes = { "text/*", "application/*" } )
     @ResponseStatus( HttpStatus.ACCEPTED )
     public void changePassword( @RequestBody Map<String, String> body, HttpServletResponse response )
         throws WebMessageException,
@@ -400,21 +401,21 @@ public class MeController
         userService.expireActiveSessions( currentUser.getUserCredentials() );
     }
 
-    @RequestMapping( value = "/verifyPassword", method = RequestMethod.POST, consumes = "text/*" )
+    @PostMapping( value = "/verifyPassword", consumes = "text/*" )
     public @ResponseBody RootNode verifyPasswordText( @RequestBody String password, HttpServletResponse response )
         throws WebMessageException
     {
         return verifyPasswordInternal( password, getCurrentUserOrThrow() );
     }
 
-    @RequestMapping( value = "/validatePassword", method = RequestMethod.POST, consumes = "text/*" )
+    @PostMapping( value = "/validatePassword", consumes = "text/*" )
     public @ResponseBody RootNode validatePasswordText( @RequestBody String password, HttpServletResponse response )
         throws WebMessageException
     {
         return validatePasswordInternal( password, getCurrentUserOrThrow() );
     }
 
-    @RequestMapping( value = "/verifyPassword", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/verifyPassword", consumes = MediaType.APPLICATION_JSON_VALUE )
     public @ResponseBody RootNode verifyPasswordJson( @RequestBody Map<String, String> body,
         HttpServletResponse response )
         throws WebMessageException
@@ -422,7 +423,7 @@ public class MeController
         return verifyPasswordInternal( body.get( "password" ), getCurrentUserOrThrow() );
     }
 
-    @RequestMapping( value = "/dashboard" )
+    @GetMapping( "/dashboard" )
     public @ResponseBody Dashboard getDashboard( HttpServletResponse response )
         throws Exception
     {
@@ -449,7 +450,7 @@ public class MeController
         interpretationService.updateCurrentUserLastChecked();
     }
 
-    @RequestMapping( value = "/dataApprovalLevels", produces = { "application/json", "text/*" } )
+    @GetMapping( value = "/dataApprovalLevels", produces = { "application/json", "text/*" } )
     public void getApprovalLevels( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -91,9 +91,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -243,7 +245,7 @@ public class UserController
     }
 
     @Override
-    @RequestMapping( value = "/{uid}/{property}", method = RequestMethod.GET )
+    @GetMapping( "/{uid}/{property}" )
     public @ResponseBody RootNode getObjectProperty(
         @PathVariable( "uid" ) String pvUid, @PathVariable( "property" ) String pvProperty,
         @RequestParam Map<String, String> rpParameters,
@@ -278,7 +280,7 @@ public class UserController
     // -------------------------------------------------------------------------
 
     @Override
-    @RequestMapping( method = RequestMethod.POST, consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { "application/xml", "text/xml" } )
     public void postXmlObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -286,7 +288,7 @@ public class UserController
     }
 
     @Override
-    @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( consumes = "application/json" )
     public void postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -303,14 +305,14 @@ public class UserController
         postObject( request, response, getObjectReport( createUser( user, currentUser ) ) );
     }
 
-    @RequestMapping( value = INVITE_PATH, method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( value = INVITE_PATH, consumes = "application/json" )
     public void postJsonInvite( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
         postInvite( request, response, renderService.fromJson( request.getInputStream(), getEntityClass() ) );
     }
 
-    @RequestMapping( value = INVITE_PATH, method = RequestMethod.POST, consumes = { "application/xml", "text/xml" } )
+    @PostMapping( value = INVITE_PATH, consumes = { "application/xml", "text/xml" } )
     public void postXmlInvite( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -327,7 +329,7 @@ public class UserController
         postObject( request, response, inviteUser( user, currentUser, request ) );
     }
 
-    @RequestMapping( value = BULK_INVITE_PATH, method = RequestMethod.POST, consumes = "application/json" )
+    @PostMapping( value = BULK_INVITE_PATH, consumes = "application/json" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void postJsonInvites( HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -335,7 +337,7 @@ public class UserController
         postInvites( request, renderService.fromJson( request.getInputStream(), Users.class ) );
     }
 
-    @RequestMapping( value = BULK_INVITE_PATH, method = RequestMethod.POST, consumes = { "application/xml",
+    @PostMapping( value = BULK_INVITE_PATH, consumes = { "application/xml",
         "text/xml" } )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void postXmlInvites( HttpServletRequest request, HttpServletResponse response )
@@ -360,7 +362,7 @@ public class UserController
         }
     }
 
-    @RequestMapping( value = "/{id}" + INVITE_PATH, method = RequestMethod.POST )
+    @PostMapping( value = "/{id}" + INVITE_PATH )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void resendInvite( @PathVariable String id, HttpServletRequest request )
         throws Exception
@@ -397,7 +399,7 @@ public class UserController
         }
     }
 
-    @RequestMapping( value = "/{id}/reset", method = RequestMethod.POST )
+    @PostMapping( "/{id}/reset" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void resetToInvite( @PathVariable String id, HttpServletRequest request )
         throws Exception
@@ -430,7 +432,7 @@ public class UserController
 
     @SuppressWarnings( "unchecked" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_REPLICATE_USER')" )
-    @RequestMapping( value = "/{uid}/replica", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/replica" )
     public void replicateUser( @PathVariable String uid,
         HttpServletRequest request, HttpServletResponse response )
         throws IOException,
@@ -518,7 +520,7 @@ public class UserController
         webMessageService.send( WebMessageUtils.created( "User replica created" ), response, request );
     }
 
-    @RequestMapping( value = "/{uid}/enabled", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/enabled" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void enableUser( @PathVariable( "uid" ) String uid )
         throws Exception
@@ -526,7 +528,7 @@ public class UserController
         setDisabled( uid, false );
     }
 
-    @RequestMapping( value = "/{uid}/disabled", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/disabled" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void disableUser( @PathVariable( "uid" ) String uid )
         throws Exception
@@ -534,7 +536,7 @@ public class UserController
         setDisabled( uid, true );
     }
 
-    @RequestMapping( value = "/{uid}/expired", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/expired" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void expireUser( @PathVariable( "uid" ) String uid, @RequestParam( "date" ) Date accountExpiry )
         throws Exception
@@ -542,7 +544,7 @@ public class UserController
         setExpires( uid, accountExpiry );
     }
 
-    @RequestMapping( value = "/{uid}/unexpired", method = RequestMethod.POST )
+    @PostMapping( "/{uid}/unexpired" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void unexpireUser( @PathVariable( "uid" ) String uid )
         throws Exception
@@ -555,7 +557,7 @@ public class UserController
     // -------------------------------------------------------------------------
 
     @Override
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = { "application/xml", "text/xml" } )
+    @PutMapping( value = "/{uid}", consumes = { "application/xml", "text/xml" } )
     public void putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
         throws Exception
@@ -569,7 +571,7 @@ public class UserController
     }
 
     @Override
-    @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = "application/json" )
+    @PutMapping( value = "/{uid}", consumes = "application/json" )
     public void putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
@@ -49,9 +49,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
@@ -81,8 +80,7 @@ public class UserRoleController
         return entityList;
     }
 
-    @PutMapping( "/{id}/users/{userId}" )
-    @PostMapping( "/{id}/users/{userId}" )
+    @RequestMapping( value = "/{id}/users/{userId}", method = { RequestMethod.POST, RequestMethod.PUT } )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addUserToRole( @PathVariable( value = "id" ) String pvId, @PathVariable( "userId" ) String pvUserId,
         HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
@@ -47,9 +47,11 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
@@ -79,7 +81,8 @@ public class UserRoleController
         return entityList;
     }
 
-    @RequestMapping( value = "/{id}/users/{userId}", method = { RequestMethod.POST, RequestMethod.PUT } )
+    @PutMapping( "/{id}/users/{userId}" )
+    @PostMapping( "/{id}/users/{userId}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addUserToRole( @PathVariable( value = "id" ) String pvId, @PathVariable( "userId" ) String pvUserId,
         HttpServletResponse response )
@@ -111,7 +114,7 @@ public class UserRoleController
         }
     }
 
-    @RequestMapping( value = "/{id}/users/{userId}", method = RequestMethod.DELETE )
+    @DeleteMapping( "/{id}/users/{userId}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void removeUserFromRole( @PathVariable( value = "id" ) String pvId,
         @PathVariable( "userId" ) String pvUserId, HttpServletResponse response )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -55,7 +55,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * @author Lars Helge Overland
@@ -83,7 +89,7 @@ public class ValidationController
     @Autowired
     private WebMessageService webMessageService;
 
-    @RequestMapping( value = "/dataSet/{ds}", method = RequestMethod.GET )
+    @GetMapping( "/dataSet/{ds}" )
     public @ResponseBody ValidationSummary validate( @PathVariable String ds, @RequestParam String pe,
         @RequestParam String ou, @RequestParam( required = false ) String aoc,
         HttpServletResponse response, Model model )
@@ -130,7 +136,8 @@ public class ValidationController
         return summary;
     }
 
-    @RequestMapping( value = "/sendNotifications", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @PutMapping( "/sendNotifications" )
+    @PostMapping( "/sendNotifications" )
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     public void runValidationNotificationsTask( HttpServletResponse response, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -57,9 +57,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -136,8 +135,7 @@ public class ValidationController
         return summary;
     }
 
-    @PutMapping( "/sendNotifications" )
-    @PostMapping( "/sendNotifications" )
+    @RequestMapping( value = "/sendNotifications", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('M_dhis-web-app-management')" )
     public void runValidationNotificationsTask( HttpServletResponse response, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
@@ -53,9 +53,9 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.google.common.collect.Lists;
 
@@ -99,7 +99,7 @@ public class ValidationRuleController
         return super.getEntityList( metadata, options, filters, orders );
     }
 
-    @RequestMapping( value = "/expression/description", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public void getExpressionDescription( @RequestBody String expression, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
@@ -39,7 +39,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
@@ -53,7 +53,7 @@ public class OAuth2ConfirmAccessController
     @Qualifier( "org.hisp.dhis.system.velocity.VelocityManager" )
     VelocityManager velocityManager;
 
-    @RequestMapping( "/oauth/confirm_access" )
+    @GetMapping( "/oauth/confirm_access" )
     public ModelAndView getAccessConfirmationB( Map<String, Object> model, HttpServletRequest request )
         throws Exception
     {
@@ -93,7 +93,7 @@ public class OAuth2ConfirmAccessController
         return new ModelAndView( approvalView, model );
     }
 
-    @RequestMapping( "/oauth/error" )
+    @GetMapping( "/oauth/error" )
     public ModelAndView handleError( HttpServletRequest request )
     {
         String errorSummary;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -85,7 +85,7 @@ public class SharingControllerTest
         when( aclService.isClassShareable( eq( OrganisationUnit.class ) ) ).thenReturn( true );
         doReturn( organisationUnit ).when( manager ).get( eq( OrganisationUnit.class ), eq( "kkSjhdhks" ) );
 
-        sharingController.setSharing( "organisationUnit", "kkSjhdhks", response, request );
+        sharingController.postSharing( "organisationUnit", "kkSjhdhks", response, request );
     }
 
     @Test( expected = AccessDeniedException.class )
@@ -99,7 +99,7 @@ public class SharingControllerTest
         when( aclService.isClassShareable( eq( Category.class ) ) ).thenReturn( true );
         when( manager.get( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
 
-        sharingController.setSharing( "category", "kkSjhdhks", response, request );
+        sharingController.postSharing( "category", "kkSjhdhks", response, request );
     }
 
     @Test( expected = WebMessageException.class )
@@ -115,7 +115,7 @@ public class SharingControllerTest
 
         try
         {
-            sharingController.setSharing( "category", "kkSjhdhks", response, request );
+            sharingController.postSharing( "category", "kkSjhdhks", response, request );
         }
         catch ( WebMessageException e )
         {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodAllController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodAllController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -43,7 +44,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping( "/method/testAll" )
 public class ApiMethodAllController
 {
-    @RequestMapping( "a" )
+    @GetMapping( "a" )
     @ApiVersion( DhisApiVersion.ALL )
     public void testAllA( HttpServletResponse response )
         throws IOException
@@ -51,7 +52,7 @@ public class ApiMethodAllController
         response.getWriter().println( "TEST" );
     }
 
-    @RequestMapping( "b" )
+    @GetMapping( "b" )
     @ApiVersion( DhisApiVersion.ALL )
     public void testAllB( HttpServletResponse response )
         throws IOException

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodAllExcludeV32Controller.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodAllExcludeV32Controller.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -43,7 +44,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping( "/method/testAllExcludeV32" )
 public class ApiMethodAllExcludeV32Controller
 {
-    @RequestMapping( "a" )
+    @GetMapping( "a" )
     @ApiVersion( value = DhisApiVersion.ALL, exclude = DhisApiVersion.V32 )
     public void testAllA( HttpServletResponse response )
         throws IOException
@@ -51,7 +52,7 @@ public class ApiMethodAllExcludeV32Controller
         response.getWriter().println( "TEST" );
     }
 
-    @RequestMapping( "b" )
+    @GetMapping( "b" )
     @ApiVersion( value = DhisApiVersion.ALL, exclude = DhisApiVersion.V32 )
     public void testAllB( HttpServletResponse response )
         throws IOException

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodDefaultController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodDefaultController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -43,7 +44,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping( "/method/testDefault" )
 public class ApiMethodDefaultController
 {
-    @RequestMapping( "a" )
+    @GetMapping( "a" )
     @ApiVersion( DhisApiVersion.DEFAULT )
     public void testVDefaultA( HttpServletResponse response )
         throws IOException
@@ -51,7 +52,7 @@ public class ApiMethodDefaultController
         response.getWriter().println( "TEST" );
     }
 
-    @RequestMapping( "b" )
+    @GetMapping( "b" )
     @ApiVersion( DhisApiVersion.DEFAULT )
     public void testDefaultB( HttpServletResponse response )
         throws IOException

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodV31V32Controller.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/method/ApiMethodV31V32Controller.java
@@ -34,8 +34,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -44,7 +46,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @RequestMapping( "/method/testV31V32" )
 public class ApiMethodV31V32Controller
 {
-    @RequestMapping( "a" )
+    @GetMapping( "a" )
     @ApiVersion( DhisApiVersion.V31 )
     public void testV31( HttpServletResponse response )
         throws IOException
@@ -52,7 +54,7 @@ public class ApiMethodV31V32Controller
         response.getWriter().println( "TEST" );
     }
 
-    @RequestMapping( value = "a", method = RequestMethod.POST )
+    @PostMapping( value = "a" )
     @ApiVersion( DhisApiVersion.V31 )
     public void testPostV31( HttpServletResponse response )
         throws IOException
@@ -68,7 +70,7 @@ public class ApiMethodV31V32Controller
         response.getWriter().println( "TEST" );
     }
 
-    @RequestMapping( value = "b", method = RequestMethod.PUT )
+    @PutMapping( value = "b" )
     @ApiVersion( DhisApiVersion.V32 )
     public void testPutV32( HttpServletResponse response )
         throws IOException

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( DhisApiVersion.ALL )
 public class ApiTypeAllController
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllExcludeV32Controller.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllExcludeV32Controller.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( value = DhisApiVersion.ALL, exclude = DhisApiVersion.V32 )
 public class ApiTypeAllExcludeV32Controller
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultAllController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultAllController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class ApiTypeDefaultAllController
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( DhisApiVersion.DEFAULT )
 public class ApiTypeDefaultController
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultV31Controller.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultV31Controller.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.V31 } )
 public class ApiTypeDefaultV31Controller
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeV31V32Controller.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeV31V32Controller.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( { DhisApiVersion.V31, DhisApiVersion.V32 } )
 public class ApiTypeV31V32Controller
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/BaseWithVersionController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/BaseWithVersionController.java
@@ -34,8 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -43,7 +42,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @ApiVersion( DhisApiVersion.V31 )
 public abstract class BaseWithVersionController
 {
-    @RequestMapping( value = "/{id}", method = RequestMethod.POST )
+    @PostMapping( "/{id}" )
     public void testWithId( @PathVariable String id, HttpServletResponse response )
         throws IOException
     {

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/InheritedFromBaseVersionController.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/type/InheritedFromBaseVersionController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @ApiVersion( DhisApiVersion.V32 )
 public class InheritedFromBaseVersionController extends BaseWithVersionController
 {
-    @RequestMapping
+    @GetMapping
     public void test( HttpServletResponse response )
         throws IOException
     {


### PR DESCRIPTION
Replaces use of `@RequestMapping` with one of the other dedicated annotations.

Sadly this was only a semi-automatic refactoring so this does need proper review of every changed line mainly to check that the correct annotation was used for the `method` property.

This PR contains all controllers but CRUD which are done in #8382

Oddly enough when mapping multiple HTTP methods to the same method using e.g. both `@PutMapping` and `@PostMapping` does not have the same effect as `@RequestMapping( methods = { PUT, POST } )`. Therefore those keep using `@RequestMapping`.

Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>