### PR TITLE
fix: [DHIS2-11405] do not allow enrollments to orgunit without program access (2.37)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -643,38 +643,13 @@ public abstract class AbstractEnrollmentService
     {
         ImportSummary importSummary = new ImportSummary( enrollment.getEnrollment() );
 
-        if ( program == null )
+        String error = validateProgramForEnrollment( program, enrollment, importSummary );
+        if ( !StringUtils.isEmpty( error ) )
         {
             importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.setDescription( "Program can not be null" );
+            importSummary.setDescription( error );
             importSummary.incrementIgnored();
-
             return importSummary;
-        }
-
-        if ( !program.isRegistration() )
-        {
-            importSummary.setStatus( ImportStatus.ERROR );
-            importSummary.setDescription( "Provided program " + program.getUid() +
-                " is a program without registration. An enrollment cannot be created into program without registration." );
-            importSummary.incrementIgnored();
-
-            return importSummary;
-        }
-
-        if ( program.getOrganisationUnits() != null && program.getOrganisationUnits().size() > 0 )
-        {
-            boolean programOrgUnitAccessible = program.getOrganisationUnits().stream()
-                .anyMatch( pou -> pou.getUid().equals( enrollment.getOrgUnit() ) );
-            if ( !programOrgUnitAccessible )
-            {
-                importSummary.setStatus( ImportStatus.ERROR );
-                importSummary
-                    .setDescription( "Program is not assigned to this Organisation Unit: " + enrollment.getOrgUnit() );
-                importSummary.incrementIgnored();
-
-                return importSummary;
-            }
         }
 
         ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
@@ -740,6 +715,31 @@ public abstract class AbstractEnrollmentService
         }
 
         return importSummary;
+    }
+
+    private String validateProgramForEnrollment( Program program, Enrollment enrollment, ImportSummary importSummary )
+    {
+        if ( program == null )
+        {
+            return "Program can not be null";
+        }
+
+        if ( !program.isRegistration() )
+        {
+            return "Provided program " + program.getUid() +
+                " is a program without registration. An enrollment cannot be created into program without registration.";
+        }
+
+        if ( program.getOrganisationUnits() != null && program.getOrganisationUnits().size() > 0 )
+        {
+            boolean programOrgUnitAccessible = program.getOrganisationUnits().stream()
+                .anyMatch( pou -> pou.getUid().equals( enrollment.getOrgUnit() ) );
+            if ( !programOrgUnitAccessible )
+            {
+                return "Program is not assigned to this Organisation Unit: " + enrollment.getOrgUnit();
+            }
+        }
+        return null;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dxf2.events.enrollment;
 
-import static org.hisp.dhis.dxf2.importsummary.ImportSummary.error;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.trackedentity.TrackedEntityAttributeService.TEA_VALUE_MAX_LENGTH;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.events.enrollment;
 
+import static org.hisp.dhis.dxf2.importsummary.ImportSummary.error;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.trackedentity.TrackedEntityAttributeService.TEA_VALUE_MAX_LENGTH;
 
@@ -660,6 +661,21 @@ public abstract class AbstractEnrollmentService
             importSummary.incrementIgnored();
 
             return importSummary;
+        }
+
+        if ( program.getOrganisationUnits() != null && program.getOrganisationUnits().size() > 0 )
+        {
+            boolean programOrgUnitAccessible = program.getOrganisationUnits().stream()
+                .anyMatch( pou -> pou.getUid().equals( enrollment.getOrgUnit() ) );
+            if ( !programOrgUnitAccessible )
+            {
+                importSummary.setStatus( ImportStatus.ERROR );
+                importSummary
+                    .setDescription( "Program is not assigned to this Organisation Unit: " + enrollment.getOrgUnit() );
+                importSummary.incrementIgnored();
+
+                return importSummary;
+            }
         }
 
         ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -643,7 +643,7 @@ public abstract class AbstractEnrollmentService
     {
         ImportSummary importSummary = new ImportSummary( enrollment.getEnrollment() );
 
-        String error = validateProgramForEnrollment( program, enrollment, importSummary );
+        String error = validateProgramForEnrollment( program, enrollment );
         if ( !StringUtils.isEmpty( error ) )
         {
             importSummary.setStatus( ImportStatus.ERROR );
@@ -717,7 +717,7 @@ public abstract class AbstractEnrollmentService
         return importSummary;
     }
 
-    private String validateProgramForEnrollment( Program program, Enrollment enrollment, ImportSummary importSummary )
+    private String validateProgramForEnrollment( Program program, Enrollment enrollment )
     {
         if ( program == null )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -606,33 +606,6 @@ public class TrackedEntityInstanceAggregateTest extends TrackerTest
     }
 
     @Test
-    public void testEnrollmentWithoutOrgUnit()
-    {
-        Map<String, Object> enrollmentValues = new HashMap<>();
-        enrollmentValues.put( "orgUnit", null );
-        doInTransaction( () -> this.persistTrackedEntityInstanceWithEnrollmentAndEvents( enrollmentValues ) );
-
-        TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
-        queryParams.setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
-        queryParams.setTrackedEntityType( trackedEntityTypeA );
-        queryParams.setIncludeAllAttributes( true );
-
-        TrackedEntityInstanceParams params = new TrackedEntityInstanceParams();
-        params.setIncludeEnrollments( true );
-        params.setIncludeEvents( true );
-
-        final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
-            .getTrackedEntityInstances( queryParams, params, false, true );
-        TrackedEntityInstance tei = trackedEntityInstances.get( 0 );
-        Enrollment enrollment = tei.getEnrollments().get( 0 );
-        Event event = enrollment.getEvents().get( 0 );
-
-        assertNotNull( enrollment );
-        assertNotNull( event );
-
-    }
-
-    @Test
     public void testTrackedEntityInstanceRelationshipsTei2Tei()
     {
         final String[] teiUid = new String[2];

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -485,6 +485,30 @@ public class EnrollmentSecurityTest
         enrollmentService.getEnrollment( importSummary.getReference() );
     }
 
+    @Test
+    public void testAddEnrollmentToOrgUnitWithoutProgramAccess()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.updateNoAcl( programA );
+        Enrollment en = createEnrollment( programA.getUid(), maleA.getUid() );
+        en.setOrgUnit( organisationUnitB.getUid() );
+        ImportSummary importSummary = enrollmentService.addEnrollment(
+            en, ImportOptions.getDefaultImportOptions() );
+
+        assertEquals( ImportStatus.ERROR, importSummary.getStatus() );
+        assertEquals( "Program is not assigned to this Organisation Unit: " + organisationUnitB.getUid(),
+            importSummary.getDescription() );
+
+        programA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        programA.getOrganisationUnits().add( organisationUnitB );
+        manager.updateNoAcl( programA );
+
+        importSummary = enrollmentService.addEnrollment(
+            en, ImportOptions.getDefaultImportOptions() );
+        assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
+
+    }
+
     private Enrollment createEnrollment( String program, String person )
     {
         Enrollment enrollment = new Enrollment();


### PR DESCRIPTION
It was possible to create enrollments into organisation units for which the program has not given access to. 
Program.getOrganisationUnits() if not empty, will be the list of org units to which enrollments can be created. This validation was missing.

Added the missing validation and a corresponding test case. 