### PR TITLE
fix: [DHIS2-11437] - [ PotentialDuplicate ] - Not null for Pair of tracked entities FIX1 [2.37]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicate.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicate.java
@@ -58,6 +58,10 @@ public class PotentialDuplicate
      */
     private DeduplicationStatus status = DeduplicationStatus.OPEN;
 
+    public PotentialDuplicate()
+    {
+    }
+
     public PotentialDuplicate( String teiA, String teiB )
     {
         this.teiA = teiA;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.*;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.List;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpStatusCodeException;
 
 import com.google.common.collect.Lists;
 
@@ -110,7 +111,8 @@ public class DeduplicationController
     @GetMapping( value = "/{id}" )
     public PotentialDuplicate getPotentialDuplicate(
         @PathVariable String id )
-        throws WebMessageException
+        throws WebMessageException,
+        HttpStatusCodeException
     {
         return getPotentialDuplicateBy( id );
     }
@@ -118,7 +120,8 @@ public class DeduplicationController
     @PostMapping
     public PotentialDuplicate postPotentialDuplicate(
         @RequestBody PotentialDuplicate potentialDuplicate )
-        throws WebMessageException
+        throws WebMessageException,
+        HttpStatusCodeException
     {
         validatePotentialDuplicate( potentialDuplicate );
         deduplicationService.addPotentialDuplicate( potentialDuplicate );
@@ -128,7 +131,8 @@ public class DeduplicationController
     @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST }, value = "/{id}/invalidation" )
     public void markPotentialDuplicateInvalid(
         @PathVariable String id )
-        throws WebMessageException
+        throws WebMessageException,
+        HttpStatusCodeException
     {
         PotentialDuplicate potentialDuplicate = getPotentialDuplicateBy( id );
 
@@ -139,7 +143,8 @@ public class DeduplicationController
     @DeleteMapping( value = "/{id}" )
     public void deletePotentialDuplicate(
         @PathVariable String id )
-        throws WebMessageException
+        throws WebMessageException,
+        HttpStatusCodeException
     {
         PotentialDuplicate potentialDuplicate = getPotentialDuplicateBy( id );
         deduplicationService.deletePotentialDuplicate( potentialDuplicate );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/exception/ConflictException.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/exception/ConflictException.java
@@ -31,26 +31,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
- * Created by sultanm. This exception could be used in all operation forbidden
- * cases
+ * @author Luca Cambi luca@dhis2.org
  */
-@ResponseStatus( HttpStatus.FORBIDDEN )
-public class OperationNotAllowedException
-    extends Exception
+@ResponseStatus( HttpStatus.CONFLICT )
+public class ConflictException extends Exception
 {
 
-    public OperationNotAllowedException( String message )
+    public ConflictException( String message )
     {
         super( message );
     }
 
-    public OperationNotAllowedException( Throwable cause )
-    {
-        super( cause );
-    }
-
-    public OperationNotAllowedException( String message, Throwable cause )
-    {
-        super( message, cause );
-    }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
@@ -38,13 +38,14 @@ import java.util.Collections;
 import org.hisp.dhis.deduplication.DeduplicationService;
 import org.hisp.dhis.deduplication.DeduplicationStatus;
 import org.hisp.dhis.deduplication.PotentialDuplicate;
-import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.controller.DeduplicationController;
+import org.hisp.dhis.webapi.controller.exception.ConflictException;
+import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.Before;
 import org.junit.Test;
@@ -119,6 +120,20 @@ public class DeduplicationControllerMvcTest
             .accept( MediaType.APPLICATION_JSON ) )
             .andExpect( status().isOk() )
             .andExpect( content().contentType( "application/json" ) );
+    }
+
+    @Test
+    public void shouldThrowPostPotentialDuplicateMissingTei()
+        throws Exception
+    {
+        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, null );
+
+        mockMvc.perform( post( ENDPOINT )
+            .content( objectMapper.writeValueAsString( potentialDuplicate ) )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isConflict() )
+            .andExpect( result -> assertTrue( result.getResolvedException() instanceof ConflictException ) );
     }
 
     @Test
@@ -217,6 +232,6 @@ public class DeduplicationControllerMvcTest
             .contentType( MediaType.APPLICATION_JSON )
             .accept( MediaType.APPLICATION_JSON ) )
             .andExpect( status().isNotFound() )
-            .andExpect( result -> assertTrue( result.getResolvedException() instanceof WebMessageException ) );
+            .andExpect( result -> assertTrue( result.getResolvedException() instanceof NotFoundException ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.MediaType;
@@ -84,6 +85,9 @@ public class DeduplicationControllerMvcTest
     @Mock
     private ContextService contextService;
 
+    @InjectMocks
+    private DeduplicationController deduplicationController;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final String teiA = "trackedentA";
@@ -93,10 +97,6 @@ public class DeduplicationControllerMvcTest
     @Before
     public void setUp()
     {
-        final DeduplicationController deduplicationController = new DeduplicationController( deduplicationService,
-            trackedEntityInstanceService, trackerAccessManager, currentUserService, fieldFilterService,
-            contextService );
-
         mockMvc = MockMvcBuilders.standaloneSetup( deduplicationController ).build();
 
         lenient().when( trackedEntityInstanceService.getTrackedEntityInstance( teiA ) )
@@ -156,7 +156,6 @@ public class DeduplicationControllerMvcTest
 
         verify( deduplicationService ).updatePotentialDuplicate( potentialDuplicate );
         verify( deduplicationService ).getPotentialDuplicateByUid( uid );
-
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.deduplication;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.hisp.dhis.deduplication.DeduplicationService;
+import org.hisp.dhis.deduplication.DeduplicationStatus;
+import org.hisp.dhis.deduplication.PotentialDuplicate;
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.fieldfilter.FieldFilterService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.webapi.controller.DeduplicationController;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+
+@RunWith( MockitoJUnitRunner.class )
+public class DeduplicationControllerMvcTest
+{
+    private final static String ENDPOINT = "/" + "potentialDuplicates";
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private DeduplicationService deduplicationService;
+
+    @Mock
+    private TrackedEntityInstanceService trackedEntityInstanceService;
+
+    @Mock
+    private TrackerAccessManager trackerAccessManager;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private FieldFilterService fieldFilterService;
+
+    @Mock
+    private ContextService contextService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String teiA = "trackedentA";
+
+    private static final String teiB = "trackedentB";
+
+    @Before
+    public void setUp()
+    {
+        final DeduplicationController deduplicationController = new DeduplicationController( deduplicationService,
+            trackedEntityInstanceService, trackerAccessManager, currentUserService, fieldFilterService,
+            contextService );
+
+        mockMvc = MockMvcBuilders.standaloneSetup( deduplicationController ).build();
+
+        lenient().when( trackedEntityInstanceService.getTrackedEntityInstance( teiA ) )
+            .thenReturn( new TrackedEntityInstance() );
+        lenient().when( trackedEntityInstanceService.getTrackedEntityInstance( teiB ) )
+            .thenReturn( new TrackedEntityInstance() );
+
+        lenient().when( trackerAccessManager.canRead( any(), any( TrackedEntityInstance.class ) ) ).thenReturn(
+            Lists.newArrayList() );
+    }
+
+    @Test
+    public void shouldPostPotentialDuplicate()
+        throws Exception
+    {
+        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, teiB );
+
+        mockMvc.perform( post( ENDPOINT )
+            .content( objectMapper.writeValueAsString( potentialDuplicate ) )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isOk() )
+            .andExpect( content().contentType( "application/json" ) );
+    }
+
+    @Test
+    public void shouldMarkPotentialDuplicateInvalid()
+        throws Exception
+    {
+        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, teiB );
+
+        String uid = "uid";
+
+        when( deduplicationService.getPotentialDuplicateByUid( uid ) ).thenReturn( potentialDuplicate );
+
+        mockMvc.perform( post( ENDPOINT + "/" + uid + "/invalidation" )
+            .content( "{}" )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isOk() );
+
+        potentialDuplicate.setStatus( DeduplicationStatus.INVALID );
+
+        verify( deduplicationService ).updatePotentialDuplicate( potentialDuplicate );
+        verify( deduplicationService ).getPotentialDuplicateByUid( uid );
+
+    }
+
+    @Test
+    public void shouldDeletePotentialDuplicate()
+        throws Exception
+    {
+        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, teiB );
+
+        String uid = "uid";
+
+        when( deduplicationService.getPotentialDuplicateByUid( uid ) ).thenReturn( potentialDuplicate );
+
+        mockMvc.perform( delete( ENDPOINT + "/" + uid )
+            .content( "{}" )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isOk() );
+
+        verify( deduplicationService ).deletePotentialDuplicate( potentialDuplicate );
+        verify( deduplicationService ).getPotentialDuplicateByUid( uid );
+    }
+
+    @Test
+    public void shouldGetAllPotentialDuplicateNoPaging()
+        throws Exception
+    {
+        when( deduplicationService.getAllPotentialDuplicatesBy( any() ) )
+            .thenReturn( Collections.singletonList( new PotentialDuplicate( teiA, teiB ) ) );
+
+        mockMvc.perform( get( ENDPOINT ).param( "teis", teiA ).param( "skipPaging", "true" )
+            .content( "{}" )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isOk() )
+            .andExpect( content().contentType( "application/json" ) )
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        verify( deduplicationService ).getAllPotentialDuplicatesBy( any() );
+    }
+
+    @Test
+    public void shouldGetPotentialDuplicateById()
+        throws Exception
+    {
+        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, teiB );
+
+        String uid = "uid";
+
+        when( deduplicationService.getPotentialDuplicateByUid( uid ) ).thenReturn( potentialDuplicate );
+
+        mockMvc.perform( get( ENDPOINT + "/" + uid )
+            .content( "{}" )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isOk() )
+            .andExpect( content().contentType( "application/json" ) );
+
+        verify( deduplicationService ).getPotentialDuplicateByUid( uid );
+    }
+
+    @Test
+    public void shouldThrowMissingPotentialDuplicate()
+        throws Exception
+    {
+        String uid = "uid";
+
+        when( deduplicationService.getPotentialDuplicateByUid( uid ) ).thenReturn( null );
+
+        mockMvc.perform( get( ENDPOINT + "/" + uid )
+            .content( "{}" )
+            .contentType( MediaType.APPLICATION_JSON )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isNotFound() )
+            .andExpect( result -> assertTrue( result.getResolvedException() instanceof WebMessageException ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.deduplication;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -37,9 +38,6 @@ import org.hisp.dhis.deduplication.DeduplicationService;
 import org.hisp.dhis.deduplication.DeduplicationStatus;
 import org.hisp.dhis.deduplication.PotentialDuplicate;
 import org.hisp.dhis.deduplication.PotentialDuplicateQuery;
-import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -47,6 +45,9 @@ import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.DeduplicationController;
+import org.hisp.dhis.webapi.controller.exception.ConflictException;
+import org.hisp.dhis.webapi.controller.exception.NotFoundException;
+import org.hisp.dhis.webapi.controller.exception.OperationNotAllowedException;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +57,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.http.HttpStatus;
 
 import com.google.common.collect.Lists;
 
@@ -126,26 +126,17 @@ public class DeduplicationControllerTest
         verify( deduplicationService ).getAllPotentialDuplicatesBy( potentialDuplicateQuery );
     }
 
-    @Test
+    @Test( expected = NotFoundException.class )
     public void getPotentialDuplicateNotFound()
+        throws NotFoundException
     {
         when( deduplicationService.getPotentialDuplicateByUid( teiA ) ).thenReturn( null );
-
-        try
-        {
-            deduplicationController.getPotentialDuplicate( teiA );
-        }
-        catch ( WebMessageException e )
-        {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.NOT_FOUND.value() );
-        }
-
-        verify( deduplicationService ).getPotentialDuplicateByUid( teiA );
+        deduplicationController.getPotentialDuplicate( teiA );
     }
 
     @Test
     public void getPotentialDuplicate()
-        throws WebMessageException
+        throws NotFoundException
     {
         when( deduplicationService.getPotentialDuplicateByUid( teiA ) )
             .thenReturn( new PotentialDuplicate( teiA, teiB ) );
@@ -158,7 +149,9 @@ public class DeduplicationControllerTest
 
     @Test
     public void postPotentialDuplicate()
-        throws WebMessageException
+        throws OperationNotAllowedException,
+        ConflictException,
+        NotFoundException
     {
         Mockito.when( deduplicationService.exists( new PotentialDuplicate( teiA, teiB ) ) ).thenReturn( false );
 
@@ -183,9 +176,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( "invalid", "invalid1" ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.CONFLICT.value() );
+            assertTrue( e instanceof ConflictException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -201,9 +194,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( teiA, "invalid" ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.CONFLICT.value() );
+            assertTrue( e instanceof ConflictException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -216,9 +209,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( null, null ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.CONFLICT.value() );
+            assertTrue( e instanceof ConflictException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -231,9 +224,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( teiA, null ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.CONFLICT.value() );
+            assertTrue( e instanceof ConflictException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -249,9 +242,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( teiA, teiB ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.NOT_FOUND.value() );
+            assertTrue( e instanceof NotFoundException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -267,9 +260,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( teiA, teiB ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.FORBIDDEN.value() );
+            assertTrue( e instanceof OperationNotAllowedException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -289,9 +282,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( new PotentialDuplicate( teiA, teiB ) );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.FORBIDDEN.value() );
+            assertTrue( e instanceof OperationNotAllowedException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -315,9 +308,9 @@ public class DeduplicationControllerTest
         {
             deduplicationController.postPotentialDuplicate( pd );
         }
-        catch ( WebMessageException e )
+        catch ( OperationNotAllowedException | ConflictException | NotFoundException e )
         {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.CONFLICT.value() );
+            assertTrue( e instanceof ConflictException );
         }
 
         verify( deduplicationService, times( 0 ) ).addPotentialDuplicate( any() );
@@ -328,7 +321,7 @@ public class DeduplicationControllerTest
 
     @Test
     public void markPotentialDuplicateInvalid()
-        throws WebMessageException
+        throws NotFoundException
     {
 
         when( deduplicationService.getPotentialDuplicateByUid( teiA ) )
@@ -345,26 +338,11 @@ public class DeduplicationControllerTest
         assertEquals( DeduplicationStatus.INVALID, pd.getValue().getStatus() );
     }
 
-    @Test
+    @Test( expected = NotFoundException.class )
     public void markPotentialDuplicateInvalidNotFound()
+        throws NotFoundException
     {
         when( deduplicationService.getPotentialDuplicateByUid( teiA ) ).thenReturn( null );
-
-        try
-        {
-            deduplicationController.markPotentialDuplicateInvalid( teiA );
-        }
-        catch ( WebMessageException e )
-        {
-            checkWebMessageException( e.getWebMessage(), HttpStatus.NOT_FOUND.value() );
-        }
-
-        verify( deduplicationService, times( 0 ) ).updatePotentialDuplicate( any() );
-    }
-
-    private void checkWebMessageException( WebMessage wm, int statusCode )
-    {
-        assertEquals( statusCode, wm.getHttpStatusCode().intValue() );
-        assertEquals( Status.ERROR, wm.getStatus() );
+        deduplicationController.markPotentialDuplicateInvalid( teiA );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.deduplication;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -46,6 +46,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.DeduplicationController;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
[DHIS2-11437](https://jira.dhis2.org/browse/DHIS2-11437)

- [x] Restore default constructor for PotentialDuplicate deleted by error in https://github.com/dhis2/dhis2-core/tree/DHIS2-11437
- [x] Add mvc tests 