### PR TITLE
feat: Gist API describe parameter [DHIS2-11496]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
@@ -94,6 +94,12 @@ public class DefaultGistAccessControl implements GistAccessControl
     }
 
     @Override
+    public boolean isDescribeUser()
+    {
+        return isSuperuser() || currentUser.isAuthorized( "F_METADATA_EXPORT" );
+    }
+
+    @Override
     public boolean canRead( Class<? extends IdentifiableObject> type )
     {
         return aclService.canRead( currentUser, type );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistAccessControl.java
@@ -90,11 +90,11 @@ public class DefaultGistAccessControl implements GistAccessControl
     @Override
     public boolean isSuperuser()
     {
-        return currentUser != null && !currentUser.isSuper();
+        return currentUser != null && currentUser.isSuper();
     }
 
     @Override
-    public boolean isDescribeUser()
+    public boolean canReadHQL()
     {
         return isSuperuser() || currentUser.isAuthorized( "F_METADATA_EXPORT" );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistAccessControl.java
@@ -54,6 +54,14 @@ public interface GistAccessControl
      */
     boolean isSuperuser();
 
+    /**
+     * Whether or not the current user is allowed to use Gist API
+     * {@code describe}
+     *
+     * @return true, if the current user is allowed, otherwise false
+     */
+    boolean isDescribeUser();
+
     boolean canRead( Class<? extends IdentifiableObject> type );
 
     boolean canReadObject( Class<? extends IdentifiableObject> type, String uid );
@@ -98,4 +106,5 @@ public interface GistAccessControl
     Access asAccess( Class<? extends IdentifiableObject> type, Sharing value );
 
     String createAccessFilterHQL( String tableName );
+
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistAccessControl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistAccessControl.java
@@ -56,11 +56,11 @@ public interface GistAccessControl
 
     /**
      * Whether or not the current user is allowed to use Gist API
-     * {@code describe}
+     * {@code describe} to view the HQL query.
      *
      * @return true, if the current user is allowed, otherwise false
      */
-    boolean isDescribeUser();
+    boolean canReadHQL();
 
     boolean canRead( Class<? extends IdentifiableObject> type );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -586,7 +586,7 @@ final class GistBuilder
 
     private String getEndpointUrlParams()
     {
-        return query.isAbsolute() ? "?absoluteUrls=true" : "";
+        return query.isAbsoluteUrls() ? "?absoluteUrls=true" : "";
     }
 
     private static IdObject toIdObject( Object id )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistService.java
@@ -78,4 +78,6 @@ public interface GistService
      * @return the pager suitable for the provided situation
      */
     GistPager pager( GistQuery query, List<?> rows, Map<String, String[]> params );
+
+    Map<String, ?> describe( GistQuery query );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistService.java
@@ -79,5 +79,11 @@ public interface GistService
      */
     GistPager pager( GistQuery query, List<?> rows, Map<String, String[]> params );
 
+    /**
+     * Describes the query execution without actually running the query.
+     *
+     * @param query a not yet {@link #plan(GistQuery)}ned query
+     * @return a description of the query execution
+     */
     Map<String, ?> describe( GistQuery query );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -161,11 +161,11 @@ public abstract class AbstractGistReadOnlyController<T extends IdentifiableObjec
     private ResponseEntity<JsonNode> gistToJsonObjectResponse( String uid, GistQuery query )
         throws NotFoundException
     {
-        query = gistService.plan( query );
         if ( query.isDescribe() )
         {
             return gistDescribeToJsonObjectResponse( query );
         }
+        query = gistService.plan( query );
         List<?> elements = gistService.gist( query );
         JsonNode body = new JsonBuilder( jsonMapper ).skipNullOrEmpty().toArray( query.getFieldNames(), elements );
         if ( body.isEmpty() )
@@ -178,11 +178,11 @@ public abstract class AbstractGistReadOnlyController<T extends IdentifiableObjec
     private ResponseEntity<JsonNode> gistToJsonArrayResponse( HttpServletRequest request,
         GistQuery query, Schema schema )
     {
-        query = gistService.plan( query );
         if ( query.isDescribe() )
         {
             return gistDescribeToJsonObjectResponse( query );
         }
+        query = gistService.plan( query );
         List<?> elements = gistService.gist( query );
         JsonBuilder responseBuilder = new JsonBuilder( jsonMapper );
         JsonNode body = responseBuilder.skipNullOrEmpty().toArray( query.getFieldNames(), elements );

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistDescribeControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistDescribeControllerTest.java
@@ -118,6 +118,23 @@ public class GistDescribeControllerTest extends AbstractGistControllerTest
         assertEquals( "Jo%", parameters.getString( "f_0" ).string() );
     }
 
+    @Test
+    public void testDescribe_Authorisation_Guest()
+    {
+        switchToGuestUser();
+
+        JsonObject description = GET( "/users/{uid}/gist?describe=true", getSuperuserUid() ).content();
+        assertFalse( description.has( "hql" ) );
+    }
+
+    @Test
+    public void testDescribe_Authorisation_Admin()
+    {
+        switchToNewUser( "guest", "Test_skipSharingCheck", "F_METADATA_EXPORT" );
+
+        assertBaseDescription( GET( "/users/{uid}/gist?describe=true", getSuperuserUid() ).content() );
+    }
+
     private void assertBaseDescription( JsonObject description )
     {
         assertTrue( description.has( "status", "hql", "planned", "unplanned" ) );

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistDescribeControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistDescribeControllerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.junit.Test;
+
+/**
+ * Tests the {@code describe=true} parameter of the Gist API.
+ *
+ * @author Jan Bernitt
+ */
+public class GistDescribeControllerTest extends AbstractGistControllerTest
+{
+    @Test
+    public void testDescribe_Object()
+    {
+        JsonObject description = GET( "/users/{uid}/gist?describe=true", getSuperuserUid() ).content();
+
+        assertBaseDescription( description );
+        assertFalse( description.getObject( "hql" ).has( "count" ) );
+    }
+
+    @Test
+    public void testDescribe_ObjectList()
+    {
+        JsonObject description = GET( "/users/gist?describe=true", getSuperuserUid() ).content();
+
+        assertBaseDescription( description );
+        assertFalse( description.getObject( "hql" ).has( "count" ) );
+    }
+
+    @Test
+    public void testDescribe_ObjectCollectionList()
+    {
+        JsonObject description = GET( "/users/{uid}/userGroups/gist?describe=true", getSuperuserUid() ).content();
+
+        assertBaseDescription( description );
+        assertFalse( description.getObject( "hql" ).has( "count" ) );
+    }
+
+    @Test
+    public void testDescribe_Error_PlanningFailed()
+    {
+        JsonObject description = GET( "/users/{uid}/userGroups/gist?describe=true&filter=foo:eq:bar",
+            getSuperuserUid() ).content();
+
+        assertTrue( description.has( "error", "unplanned", "status" ) );
+        assertTrue( description.getObject( "error" ).has( "type", "message" ) );
+        assertTrue( description.getObject( "unplanned" ).has( "fields", "filters", "orders" ) );
+        assertEquals( "planning-failed", description.getString( "status" ).string() );
+    }
+
+    @Test
+    public void testDescribe_Error_ValidationFailed()
+    {
+        JsonObject description = GET( "/users/gist?describe=true&fields=userCredentials.password",
+            getSuperuserUid() ).content();
+
+        assertTrue( description.has( "error", "unplanned", "planned", "status" ) );
+        assertTrue( description.getObject( "error" ).has( "type", "message" ) );
+        assertTrue( description.getObject( "unplanned" ).has( "fields", "filters", "orders" ) );
+        assertEquals( "validation-failed", description.getString( "status" ).string() );
+        assertEquals( "Property `userCredentials.password` is not readable.",
+            description.getObject( "error" ).getString( "message" ).string() );
+    }
+
+    @Test
+    public void testDescribe_Total()
+    {
+        JsonObject description = GET( "/users/gist?describe=true&total=true", getSuperuserUid() ).content();
+
+        assertBaseDescription( description );
+        assertTrue( description.getObject( "hql" ).has( "count" ) );
+    }
+
+    @Test
+    public void testDescribe_FetchParameters()
+    {
+        JsonObject description = GET( "/users/gist?describe=true&filter=surname:startsWith:Jo", getSuperuserUid() )
+            .content();
+
+        assertBaseDescription( description );
+        JsonObject hql = description.getObject( "hql" );
+        assertTrue( hql.has( "parameters" ) );
+        JsonObject parameters = hql.getObject( "parameters" );
+        assertTrue( parameters.isObject() );
+        assertEquals( 1, parameters.size() );
+        assertEquals( "Jo%", parameters.getString( "f_0" ).string() );
+    }
+
+    private void assertBaseDescription( JsonObject description )
+    {
+        assertTrue( description.has( "status", "hql", "planned", "unplanned" ) );
+        assertTrue( description.getObject( "hql" ).has( "fetch", "parameters" ) );
+        assertTrue( description.getObject( "planned" ).has( "fields", "filters", "orders", "summary" ) );
+        assertTrue( description.getObject( "planned" ).has( "fields", "filters", "orders" ) );
+        assertEquals( "ok", description.getString( "status" ).string() );
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds a new URL parameter `describe` to Gist API.
When set `true` the gist query is not performed but instead described a bit like a SQL describe would do.

The main use case for the description is to allow insights into how the server understood the query and which HQL query it would run as a result of it. This information is otherwise only available by live debugging the server.

A description is an object with following members:
* `unplanned`: the query as received (mapped from URL => java objects)
* `planned`: the query as modified after `GistService#plan(unplanned)`. Main difference is that the planned query holds the list of actually included fields. Those are also summarised in additional listed in `planned.summary`.
* `hql`: the HQL query used to `fetch` the listed elements, when `total=true` also the `count` HQL used to count all rows as well as the `parameters` used in those queries

In case of an error during planning or validating the description contains an `error` object and might not contain the `planned` and/or the `hql` part since only valid queries move to further steps.

To see the HQL the `F_METADATA_EXPORT` authority is needed (or being superuser).

Note that there is a also a fix for access control `isSuperuser` check. This was used to determine whether or not the database query needed sharing filters applied. This means the sharing check would be wrongly skipped in Gist API. However, this code was never released.

### Automatic Testing
New parameter is tested with a new set of tests.

### Example
Some things are best explained with an example for query: http://localhost:8080/api/organisationUnits/gist?auto=L&filter=name:eq:Bo&absoluteUrls&describe (formatted and shortened in arrays using "...")

```json
{
  "unplanned":{
    "pageOffset":0,
    "pageSize":50,
    "total":false,
    "inverse":false,
    "translate":true,
    "absoluteUrls":true,
    "headless":false,
    "anyFilter":false,
    "fields":[
      
    ],
    "filters":[
      {
        "propertyPath":"name",
        "operator":"EQ",
        "value":[
          "Bo"
        ]
      }
    ],
    "orders":[
      
    ],
    "auto":"L"
  },
  "planned":{
    "summary":[
      "id",
      "code",
      "path",
      "level",
      "name",
      "shortName",
      ...
    ],
    "pageOffset":0,
    "pageSize":50,
    "total":false,
    "inverse":false,
    "translate":true,
    "absoluteUrls":true,
    "headless":false,
    "anyFilter":false,
    "fields":[
      {
        "propertyPath":"id",
        "transformation":"IDS",
        "alias":"",
        "translate":false,
        "name":"id"
      },
      {
        "propertyPath":"code",
        "transformation":"IDS",
        "alias":"",
        "translate":false,
        "name":"code"
      },
      ...
    ],
    "filters":[
      {
        "propertyPath":"name",
        "operator":"EQ",
        "value":[
          "Bo"
        ]
      }
    ],
    "orders":[
      
    ],
    "auto":"L"
  },
  "hql":{
    "fetch":"select e.uid, e.code, e.path, e.hierarchyLevel, e.name, e.shortName, e.description, e.contactPerson, e.address, e.comment, e.email, e.url, e.lastUpdated, e.created, e.openingDate, e.closedDate, e.phoneNumber, (select t_17.uid from OrganisationUnit t_17 where t_17 = e.parent), (select t_18.uid from FileResource t_18 where t_18 = e.image), (select t_19.uid from User t_19 where t_19 = e.lastUpdatedBy), e.attributeValues, (select array_agg(t_21.uid) from OrganisationUnit t_21 where t_21 in elements(e.children) and 1=1), (select array_agg(t_22.uid) from OrganisationUnitGroup t_22 where t_22 in elements(e.groups) and ( ( jsonb_extract_path_text(t_22.sharing, 'owner') is null or jsonb_extract_path_text(t_22.sharing, 'owner') = 'xE7jOejl9FI')  or jsonb_extract_path_text(t_22.sharing, 'public') like 'r%' or jsonb_extract_path_text(t_22.sharing, 'public') is null  or (jsonb_has_user_id( t_22.sharing, 'xE7jOejl9FI') = true  and jsonb_check_user_access( t_22.sharing, 'xE7jOejl9FI', 'r%' ) = true )   or ( jsonb_has_user_group_ids( t_22.sharing, '{Kk12LkEWtXp,M1Qre0247G3,NTC8GjJ7p8P,B6JNeAQ6akX,wl5cDMuUhmF,QYrzIjSfI8z,lFHP5lLkzVr,jvrEwEJ2yZn,vAvEltyXGbD,w900PX10L7O,GogLpGmkL0g,vRoAruMnNpB,z1gNAf2zUxZ,gXpmQO6eEOo,tH0GcNZZ1vW,H9XnHoWRKCg}') = true  and jsonb_check_user_groups_access( t_22.sharing, '{Kk12LkEWtXp,M1Qre0247G3,NTC8GjJ7p8P,B6JNeAQ6akX,wl5cDMuUhmF,QYrzIjSfI8z,lFHP5lLkzVr,jvrEwEJ2yZn,vAvEltyXGbD,w900PX10L7O,GogLpGmkL0g,vRoAruMnNpB,z1gNAf2zUxZ,gXpmQO6eEOo,tH0GcNZZ1vW,H9XnHoWRKCg}', 'r%') = true ))), (select array_agg(t_23.uid) from User t_23 where t_23 in elements(e.users) and 1=1), (select array_agg(t_24.uid) from DataSet t_24 where t_24 in elements(e.dataSets) and ( ( jsonb_extract_path_text(t_24.sharing, 'owner') is null or jsonb_extract_path_text(t_24.sharing, 'owner') = 'xE7jOejl9FI')  or jsonb_extract_path_text(t_24.sharing, 'public') like 'r%' or jsonb_extract_path_text(t_24.sharing, 'public') is null  or (jsonb_has_user_id( t_24.sharing, 'xE7jOejl9FI') = true  and jsonb_check_user_access( t_24.sharing, 'xE7jOejl9FI', 'r%' ) = true )   or ( jsonb_has_user_group_ids( t_24.sharing, '{Kk12LkEWtXp,M1Qre0247G3,NTC8GjJ7p8P,B6JNeAQ6akX,wl5cDMuUhmF,QYrzIjSfI8z,lFHP5lLkzVr,jvrEwEJ2yZn,vAvEltyXGbD,w900PX10L7O,GogLpGmkL0g,vRoAruMnNpB,z1gNAf2zUxZ,gXpmQO6eEOo,tH0GcNZZ1vW,H9XnHoWRKCg}') = true  and jsonb_check_user_groups_access( t_24.sharing, '{Kk12LkEWtXp,M1Qre0247G3,NTC8GjJ7p8P,B6JNeAQ6akX,wl5cDMuUhmF,QYrzIjSfI8z,lFHP5lLkzVr,jvrEwEJ2yZn,vAvEltyXGbD,w900PX10L7O,GogLpGmkL0g,vRoAruMnNpB,z1gNAf2zUxZ,gXpmQO6eEOo,tH0GcNZZ1vW,H9XnHoWRKCg}', 'r%') = true ))), (select array_agg(t_25.uid) from Program t_25 where t_25 in elements(e.programs) and ( ( jsonb_extract_path_text(t_25.sharing, 'owner') is null or jsonb_extract_path_text(t_25.sharing, 'owner') = 'xE7jOejl9FI')  or jsonb_extract_path_text(t_25.sharing, 'public') like 'r%' or jsonb_extract_path_text(t_25.sharing, 'public') is null  or (jsonb_has_user_id( t_25.sharing, 'xE7jOejl9FI') = true  and jsonb_check_user_access( t_25.sharing, 'xE7jOejl9FI', 'r%' ) = true )   or ( jsonb_has_user_group_ids( t_25.sharing, '{Kk12LkEWtXp,M1Qre0247G3,NTC8GjJ7p8P,B6JNeAQ6akX,wl5cDMuUhmF,QYrzIjSfI8z,lFHP5lLkzVr,jvrEwEJ2yZn,vAvEltyXGbD,w900PX10L7O,GogLpGmkL0g,vRoAruMnNpB,z1gNAf2zUxZ,gXpmQO6eEOo,tH0GcNZZ1vW,H9XnHoWRKCg}') = true  and jsonb_check_user_groups_access( t_25.sharing, '{Kk12LkEWtXp,M1Qre0247G3,NTC8GjJ7p8P,B6JNeAQ6akX,wl5cDMuUhmF,QYrzIjSfI8z,lFHP5lLkzVr,jvrEwEJ2yZn,vAvEltyXGbD,w900PX10L7O,GogLpGmkL0g,vRoAruMnNpB,z1gNAf2zUxZ,gXpmQO6eEOo,tH0GcNZZ1vW,H9XnHoWRKCg}', 'r%') = true ))), cast(null as char), e.translations from OrganisationUnit e where (e.name = :f_0) and (1=1) order by e.id asc",
    "parameters":{
      "f_0":"Bo"
    }
  },
  "status":"ok"
}
```