### PR TITLE
feat: Dataset reports multiple periods DHIS2-11502

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datasetreport/DataSetReportService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datasetreport/DataSetReportService.java
@@ -45,7 +45,7 @@ public interface DataSetReportService
      * Generates HTML code for a custom data set report.
      *
      * @param dataSet the data set.
-     * @param period the period.
+     * @param periods the periods.
      * @param orgUnit the organisation unit.
      * @param dimensions mapping between dimension identifiers and dimension
      *        option identifiers.
@@ -53,14 +53,14 @@ public interface DataSetReportService
      *        data.
      * @return the HTML code for the custom data set report.
      */
-    String getCustomDataSetReport( DataSet dataSet, Period period, OrganisationUnit orgUnit, Set<String> dimensions,
-        boolean selectedUnitOnly );
+    String getCustomDataSetReport( DataSet dataSet, List<Period> periods, OrganisationUnit orgUnit,
+        Set<String> dimensions, boolean selectedUnitOnly );
 
     /**
      * Generates a list of Grids based on the data set sections or custom form.
      *
      * @param dataSet the data set.
-     * @param period the period.
+     * @param periods the periods.
      * @param orgUnit the organisation unit.
      * @param dimensions mapping between dimension identifiers and dimension
      *        option identifiers.
@@ -68,6 +68,6 @@ public interface DataSetReportService
      *        data.
      * @return a list of Grids.
      */
-    List<Grid> getDataSetReportAsGrid( DataSet dataSet, Period period, OrganisationUnit orgUnit, Set<String> dimensions,
-        boolean selectedUnitOnly );
+    List<Grid> getDataSetReportAsGrid( DataSet dataSet, List<Period> periods, OrganisationUnit orgUnit,
+        Set<String> dimensions, boolean selectedUnitOnly );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datasetreport/DataSetReportStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datasetreport/DataSetReportStore.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.datasetreport;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,13 +46,13 @@ public interface DataSetReportStore
      * Get a mapping from dimensional identifiers to aggregated values.
      *
      * @param dataSet the data set.
-     * @param period the period.
+     * @param periods the periods.
      * @param unit the organisation unit.
      * @param filters the filters on the analytics dimension format, e.g.
      *        <dim-id>:<dim-item>;<dim-item>
      * @return a mapping from dimensional identifiers to aggregated values.
      */
-    Map<String, Object> getAggregatedValues( DataSet dataSet, Period period, OrganisationUnit unit,
+    Map<String, Object> getAggregatedValues( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters );
 
     /**
@@ -59,28 +60,28 @@ public interface DataSetReportStore
      * values.
      *
      * @param dataSet the data set.
-     * @param period the period.
+     * @param periods the periods.
      * @param unit the organisation unit.
      * @param filters the filters on the analytics dimension format, e.g.
      *        <dim-id>:<dim-item>;<dim-item>
      * @return a mapping from dimensional identifiers to aggregated sub-total
      *         values.
      */
-    Map<String, Object> getAggregatedSubTotals( DataSet dataSet, Period period, OrganisationUnit unit,
+    Map<String, Object> getAggregatedSubTotals( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters );
 
     /**
      * Get a mapping from dimensional identifiers to aggregated total values.
      *
      * @param dataSet the data set.
-     * @param period the period.
+     * @param periods the periods.
      * @param unit the organisation unit.
      * @param filters the filters on the analytics dimension format, e.g.
      *        <dim-id>:<dim-item>;<dim-item>
      * @return a mapping from dimensional identifiers to aggregated total
      *         values.
      */
-    Map<String, Object> getAggregatedTotals( DataSet dataSet, Period period, OrganisationUnit unit,
+    Map<String, Object> getAggregatedTotals( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters );
 
     /**
@@ -88,13 +89,13 @@ public interface DataSetReportStore
      * values.
      *
      * @param dataSet the data set.
-     * @param period the period.
+     * @param periods the periods.
      * @param unit the organisation unit.
      * @param filters the filters on the analytics dimension format, e.g.
      *        <dim-id>:<dim-item>;<dim-item>
      * @return a mapping from dimensional identifiers to aggregated indicator
      *         values.
      */
-    Map<String, Object> getAggregatedIndicatorValues( DataSet dataSet, Period period, OrganisationUnit unit,
+    Map<String, Object> getAggregatedIndicatorValues( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters );
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/impl/DefaultDataSetReportService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/impl/DefaultDataSetReportService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.datasetreport.impl;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.dataentryform.DataEntryFormService.DATAELEMENT_TOTAL_PATTERN;
 import static org.hisp.dhis.dataentryform.DataEntryFormService.IDENTIFIER_PATTERN;
@@ -36,7 +35,6 @@ import static org.hisp.dhis.dataentryform.DataEntryFormService.INPUT_PATTERN;
 import static org.hisp.dhis.datasetreport.DataSetReportStore.SEPARATOR;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,8 +72,6 @@ import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.system.util.MathUtils;
 import org.springframework.stereotype.Component;
-
-import com.google.common.base.Joiner;
 
 /**
  * @author Abyot Asalefew
@@ -350,7 +346,7 @@ public class DefaultDataSetReportService
             .filter( Objects::nonNull )
             .collect( Collectors.toList() );
 
-        return ( values.isEmpty() )
+        return (values.isEmpty())
             ? null
             : values.stream()
                 .mapToDouble( Double::doubleValue )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/impl/DefaultDataSetReportService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/impl/DefaultDataSetReportService.java
@@ -71,6 +71,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.system.filter.AggregatableDataElementFilter;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.system.util.MathUtils;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Joiner;
@@ -355,7 +356,7 @@ public class DefaultDataSetReportService
             DataValue dataValue = dataValueService.getDataValue( dataElement, period, unit, optionCombo );
 
             Double value = (dataValue != null && dataValue.getValue() != null)
-                ? Double.parseDouble( dataValue.getValue() )
+                ? MathUtils.parseDouble( dataValue.getValue() )
                 : null;
 
             if ( value != null )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/impl/DefaultDataSetReportService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/impl/DefaultDataSetReportService.java
@@ -326,7 +326,7 @@ public class DefaultDataSetReportService
     {
         return periods.stream()
             .sorted()
-            .map( p -> format.formatPeriod( p ) )
+            .map( format::formatPeriod )
             .collect( Collectors.joining( ", " ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
@@ -78,7 +78,7 @@ public class AnalyticsDataSetReportStore
     // -------------------------------------------------------------------------
 
     @Override
-    public Map<String, Object> getAggregatedValues( DataSet dataSet, Period period, OrganisationUnit unit,
+    public Map<String, Object> getAggregatedValues( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters )
     {
         List<DataElement> dataElements = new ArrayList<>( dataSet.getDataElements() );
@@ -92,7 +92,7 @@ public class AnalyticsDataSetReportStore
 
         DataQueryParams.Builder params = DataQueryParams.newBuilder()
             .withDataElements( dataElements )
-            .withPeriod( period )
+            .withPeriods( periods )
             .withOrganisationUnit( unit )
             .withCategoryOptionCombos( Lists.newArrayList() );
 
@@ -109,14 +109,14 @@ public class AnalyticsDataSetReportStore
         for ( Entry<String, Object> entry : map.entrySet() )
         {
             String[] split = entry.getKey().split( SEPARATOR );
-            dataMap.put( split[0] + SEPARATOR + split[3], entry.getValue() );
+            addToMap( dataMap, split[0] + SEPARATOR + split[3], entry.getValue() );
         }
 
         return dataMap;
     }
 
     @Override
-    public Map<String, Object> getAggregatedSubTotals( DataSet dataSet, Period period, OrganisationUnit unit,
+    public Map<String, Object> getAggregatedSubTotals( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters )
     {
         Map<String, Object> dataMap = new HashMap<>();
@@ -154,7 +154,7 @@ public class AnalyticsDataSetReportStore
 
                 DataQueryParams.Builder params = DataQueryParams.newBuilder()
                     .withDataElements( dataElements )
-                    .withPeriod( period )
+                    .withPeriods( periods )
                     .withOrganisationUnit( unit )
                     .withCategory( category );
 
@@ -169,7 +169,7 @@ public class AnalyticsDataSetReportStore
                 for ( Entry<String, Object> entry : map.entrySet() )
                 {
                     String[] split = entry.getKey().split( SEPARATOR );
-                    dataMap.put( split[0] + SEPARATOR + split[3], entry.getValue() );
+                    addToMap( dataMap, split[0] + SEPARATOR + split[3], entry.getValue() );
                 }
             }
         }
@@ -178,7 +178,7 @@ public class AnalyticsDataSetReportStore
     }
 
     @Override
-    public Map<String, Object> getAggregatedTotals( DataSet dataSet, Period period, OrganisationUnit unit,
+    public Map<String, Object> getAggregatedTotals( DataSet dataSet, List<Period> periods, OrganisationUnit unit,
         Set<String> filters )
     {
         List<DataElement> dataElements = new ArrayList<>( dataSet.getDataElements() );
@@ -192,7 +192,7 @@ public class AnalyticsDataSetReportStore
 
         DataQueryParams.Builder params = DataQueryParams.newBuilder()
             .withDataElements( dataElements )
-            .withPeriod( period )
+            .withPeriods( periods )
             .withOrganisationUnit( unit );
 
         if ( filters != null )
@@ -208,15 +208,15 @@ public class AnalyticsDataSetReportStore
         for ( Entry<String, Object> entry : map.entrySet() )
         {
             String[] split = entry.getKey().split( SEPARATOR );
-            dataMap.put( split[0], entry.getValue() );
+            addToMap( dataMap, split[0], entry.getValue() );
         }
 
         return dataMap;
     }
 
     @Override
-    public Map<String, Object> getAggregatedIndicatorValues( DataSet dataSet, Period period, OrganisationUnit unit,
-        Set<String> filters )
+    public Map<String, Object> getAggregatedIndicatorValues( DataSet dataSet, List<Period> periods,
+        OrganisationUnit unit, Set<String> filters )
     {
         List<Indicator> indicators = new ArrayList<>( dataSet.getIndicators() );
 
@@ -227,7 +227,7 @@ public class AnalyticsDataSetReportStore
 
         DataQueryParams.Builder params = DataQueryParams.newBuilder()
             .withIndicators( indicators )
-            .withPeriod( period )
+            .withPeriods( periods )
             .withOrganisationUnit( unit );
 
         if ( filters != null )
@@ -243,9 +243,33 @@ public class AnalyticsDataSetReportStore
         for ( Entry<String, Object> entry : map.entrySet() )
         {
             String[] split = entry.getKey().split( SEPARATOR );
+            addToMap( dataMap, split[0], entry.getValue() );
             dataMap.put( split[0], entry.getValue() );
         }
 
         return dataMap;
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    private void addToMap( Map<String, Object> dataMap, String key, Object value )
+    {
+        if ( value == null )
+        {
+            return;
+        }
+
+        Object existingValue = dataMap.get( key );
+
+        if ( existingValue == null || !(existingValue instanceof Double) || !(value instanceof Double) )
+        {
+            dataMap.put( key, value );
+        }
+        else
+        {
+            dataMap.put( key, (Double) existingValue + (Double) value );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
@@ -255,17 +255,16 @@ public class AnalyticsDataSetReportStore
     // -------------------------------------------------------------------------
 
     /**
-     * If values are numeric, sum the values in the map for the same key.
-     * If values are non-numeric, add the value to the map.
-     * Ignore nulls.
+     * If values are numeric, sum the values in the map for the same key. If
+     * values are non-numeric, add the value to the map. Ignore nulls.
      */
     private void addToMap( Map<String, Object> dataMap, String key, Object value )
     {
         if ( value != null )
         {
-            dataMap.compute( key, (k, v) -> ( v == null || !( v instanceof Double ) || !( value instanceof Double )
+            dataMap.compute( key, ( k, v ) -> (v == null || !(v instanceof Double) || !(value instanceof Double)
                 ? value
-                : (Double) v + (Double) value ) );
+                : (Double) v + (Double) value) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
@@ -254,22 +254,18 @@ public class AnalyticsDataSetReportStore
     // Supportive methods
     // -------------------------------------------------------------------------
 
+    /**
+     * If values are numeric, sum the values in the map for the same key.
+     * If values are non-numeric, add the value to the map.
+     * Ignore nulls.
+     */
     private void addToMap( Map<String, Object> dataMap, String key, Object value )
     {
-        if ( value == null )
+        if ( value != null )
         {
-            return;
-        }
-
-        Object existingValue = dataMap.get( key );
-
-        if ( existingValue == null || !(existingValue instanceof Double) || !(value instanceof Double) )
-        {
-            dataMap.put( key, value );
-        }
-        else
-        {
-            dataMap.put( key, (Double) existingValue + (Double) value );
+            dataMap.compute( key, (k, v) -> ( v == null || !( v instanceof Double ) || !( value instanceof Double )
+                ? value
+                : (Double) v + (Double) value ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datasetreport/jdbc/AnalyticsDataSetReportStore.java
@@ -262,7 +262,7 @@ public class AnalyticsDataSetReportStore
     {
         if ( value != null )
         {
-            dataMap.compute( key, ( k, v ) -> (v == null || !(v instanceof Double) || !(value instanceof Double)
+            dataMap.compute( key, ( k, v ) -> (!(v instanceof Double) || !(value instanceof Double)
                 ? value
                 : (Double) v + (Double) value) );
         }

--- a/dhis-2/dhis-web/dhis-web-approval/src/main/java/org/hisp/dhis/approval/dataset/action/GenerateDataSetReportAction.java
+++ b/dhis-2/dhis-web/dhis-web-approval/src/main/java/org/hisp/dhis/approval/dataset/action/GenerateDataSetReportAction.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.approval.dataset.action;
 
+import static com.google.common.collect.Lists.newArrayList;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -251,13 +253,13 @@ public class GenerateDataSetReportAction
 
         if ( formType.isCustom() && type == null )
         {
-            customDataEntryFormCode = dataSetReportService.getCustomDataSetReport( selectedDataSet, selectedPeriod,
-                selectedOrgunit, dimension, selectedUnitOnly );
+            customDataEntryFormCode = dataSetReportService.getCustomDataSetReport( selectedDataSet,
+                newArrayList( selectedPeriod ), selectedOrgunit, dimension, selectedUnitOnly );
         }
         else
         {
-            grids = dataSetReportService.getDataSetReportAsGrid( selectedDataSet, selectedPeriod, selectedOrgunit,
-                dimension, selectedUnitOnly );
+            grids = dataSetReportService.getDataSetReportAsGrid( selectedDataSet,
+                newArrayList( selectedPeriod ), selectedOrgunit, dimension, selectedUnitOnly );
         }
 
         return type != null ? type : formType.toString();


### PR DESCRIPTION
### Requirements

For the requirements, see [DHIS2-11502](https://jira.dhis2.org/browse/DHIS2-11502): 

> ...
> This feature will allow the /dataSetReport endpoint to specify multiple periods instead of just one, such as:
> 
> /dataSetReport?pe=202101,202102,202103&ou=...
> 
> The data returned in the data set report will be the sum of all data for the periods requested.

### Code changes

Most of the changes are trivial, just replace `Period` with `List<Period>` at several places in the code. The main pieces of (small) logic are:

1. The subtitle for a report section contained the formatted period. This was changed to a comma separated list of formatted periods (in date order). See `DefaultDataSetReportService.formatPeriods`.

2. In two places, data from multiple periods needs to be summed, but set to null if data from all periods are null. See 
`DefaultDataSetReportService.getSelectedUnitValue` and `AnalyticsDataSetReportStore.addToMap`.

The code had a Double.parseDouble uncaught exception from in `DefaultDataSetReportService.getSectionDataSetReport`. I'm using MathUtils.parseDouble to fix this. See `DefaultDataSetReportService.getSectionDataSetReport.getSelectedUnitValue`.

### Testing

There are not unit tests for the reports. I didn't write them, as the changes were small and I was hoping to do a quick job of them.

I did test the changes comprehensively through the WebAPI:

- compared single-period reports with existing code to be sure they were the same
- compared multi-period reports with single-period reports to insure that period data were summed correctly
- verified that nulls in the input periods were correctly combined with each other and with non-null values from other periods
- verified all the above with "selected unit only" option on and off
- verified correct display of single and multiple periods in section subtitles, regardless of URL period order

### SonarQube message

SonarQube didn't like the complexity of `DataSetReportService.getSectionDataSetReport`. This method was complex before. I actually made it shorter by one statement, by using a private method to combine values from different periods, rather than adding this logic inline. Can someone mark this as "Won't Fix"? (I don't have the privilege to do this.)

If this block of code is refactored at some point, it might be advisable to write unit tests first, to verify the code before and after the refactoring.