### PR TITLE
chore: Cache#getAll as Stream

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.cache;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public interface Cache<V>
 {
@@ -79,7 +79,7 @@ public interface Cache<V>
      *
      * @return collection with all cached values
      */
-    Collection<V> getAll();
+    Stream<V> getAll();
 
     /**
      * Associates the {@code value} with the {@code key} in this cache. If the

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -31,10 +31,9 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.springframework.util.Assert.hasText;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.cache2k.Cache2kBuilder;
 
@@ -124,9 +123,9 @@ public class LocalCache<V> implements Cache<V>
     }
 
     @Override
-    public Collection<V> getAll()
+    public Stream<V> getAll()
     {
-        return new ArrayList<V>( cache2kInstance.asMap().values() );
+        return cache2kInstance.asMap().values().stream();
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
@@ -29,11 +29,9 @@ package org.hisp.dhis.cache;
 
 import static org.springframework.util.Assert.hasText;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
-
-import com.google.common.collect.Sets;
+import java.util.stream.Stream;
 
 /**
  * A No operation implementation of {@link Cache}. The implementation will not
@@ -84,9 +82,9 @@ public class NoOpCache<V> implements Cache<V>
     }
 
     @Override
-    public Collection<V> getAll()
+    public Stream<V> getAll()
     {
-        return Sets.newHashSet();
+        return Stream.empty();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -116,7 +116,7 @@ public class DefaultAppManager
     @Override
     public List<App> getApps( String contextPath )
     {
-        List<App> apps = appCache.getAll().stream().filter( app -> app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
+        List<App> apps = appCache.getAll().filter( app -> app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
             .collect( Collectors.toList() );
 
         apps.forEach( a -> a.init( contextPath ) );
@@ -145,15 +145,7 @@ public class DefaultAppManager
         }
 
         // If no apps are found, check for original name
-        for ( App app : appCache.getAll() )
-        {
-            if ( app.getShortName().equals( appName ) )
-            {
-                return app;
-            }
-        }
-
-        return null;
+        return appCache.getAll().filter( app -> app.getShortName().equals( appName ) ).findFirst().orElse( null );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -27,9 +27,12 @@
  */
 package org.hisp.dhis.program;
 
-import static org.junit.Assert.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -324,7 +327,7 @@ public class ProgramStageInstanceServiceTest
         dataElementMap.put( dataElementC.getUid(), dataElementC );
         dataElementMap.put( dataElementD.getUid(), dataElementD );
 
-        dataElements = new ArrayList<>( dataElementMap.getAll() );
+        dataElements = dataElementMap.getAll().collect( toList() );
     }
 
     @Test
@@ -564,7 +567,7 @@ public class ProgramStageInstanceServiceTest
 
     private Map<String, DataElement> convertToMap( Cache<DataElement> dataElementMap )
     {
-        return dataElementMap.getAll().stream()
+        return stream( dataElementMap.getAll().spliterator(), false )
             .collect( Collectors.toMap( DataElement::getUid, d -> d ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.program;
 
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -567,7 +566,7 @@ public class ProgramStageInstanceServiceTest
 
     private Map<String, DataElement> convertToMap( Cache<DataElement> dataElementMap )
     {
-        return stream( dataElementMap.getAll().spliterator(), false )
+        return dataElementMap.getAll()
             .collect( Collectors.toMap( DataElement::getUid, d -> d ) );
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
@@ -31,10 +31,8 @@ import static java.lang.Integer.parseInt;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -209,9 +208,9 @@ public class CappedLocalCache
         }
 
         @Override
-        public Collection<V> getAll()
+        public Stream<V> getAll()
         {
-            return entries.values().stream().map( CacheEntry::read ).collect( toList() );
+            return entries.values().stream().map( CacheEntry::read );
         }
 
         @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
@@ -138,10 +138,6 @@ public class RedisCache<V> implements Cache<V>
     public Stream<V> getAll()
     {
         Set<String> keySet = redisTemplate.keys( cacheRegion + "*" );
-        if ( keySet == null )
-        {
-            return Stream.empty();
-        }
         List<V> values = redisTemplate.opsForValue().multiGet( keySet );
         return values == null ? Stream.empty() : values.stream();
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
@@ -30,10 +30,11 @@ package org.hisp.dhis.cache;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.springframework.util.Assert.hasText;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -134,10 +135,15 @@ public class RedisCache<V> implements Cache<V>
     }
 
     @Override
-    public Collection<V> getAll()
+    public Stream<V> getAll()
     {
         Set<String> keySet = redisTemplate.keys( cacheRegion + "*" );
-        return redisTemplate.opsForValue().multiGet( keySet );
+        if ( keySet == null )
+        {
+            return Stream.empty();
+        }
+        List<V> values = redisTemplate.opsForValue().multiGet( keySet );
+        return values == null ? Stream.empty() : values.stream();
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/CappedLocalCacheTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/CappedLocalCacheTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.cache;
 
+import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -116,6 +117,6 @@ public class CappedLocalCacheTest
     {
         testRegion.put( "x", "y" );
         testRegion.put( "a", "b" );
-        assertContainsOnly( testRegion.getAll(), "y", "b" );
+        assertContainsOnly( testRegion.getAll().collect( toList() ), "y", "b" );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.cache;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * @author Luciano Fiandesio
@@ -66,9 +66,9 @@ public class TestCache<V> implements Cache<V>
     }
 
     @Override
-    public Collection<V> getAll()
+    public Stream<V> getAll()
     {
-        return mapCache.values();
+        return mapCache.values().stream();
     }
 
     @Override


### PR DESCRIPTION
Trying to tick some boxes on my list of chores.

In this PR I change `Cache#getAll()` from returning a `Collection` to return a `Stream`. 
Ideally such a method would not at all exist for a cache but now that we have it best we can do is not expose too much internals of the cache implementation. A `Collection` has still lots of methods to support and either requires defensive and potentially expensive copying or implementing a view into the internal data structures of the cache. This is an unnecessary burden on the cache requirements. `Stream` fits both with the existing use cases of the method and with a more healthy pattern of giving access to all values.

In this PR I really just changed the API and "repaired" the existing usage.

This now opens up the possibilities for the redis cache implementation to use redis stream operations instead which should be a better way to do this without running risk of loading large collections into memory.