### PR TITLE
feat: CategoryOptionGroups + DataElementGroups in indicators [2.37-DHIS2-9747]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Service;
 import com.google.common.base.Joiner;
 
 /**
+ * @author Luciano Fiandesio
  * @author Dusan Bernat
  */
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
@@ -120,23 +120,18 @@ public class CategoryOptionGroupResolver implements ExpressionResolver
             CategoryOptionGroup cog = categoryOptionGroupStore
                 .getByUid( cogUid );
 
-            if ( cog != null )
+            List<String> cocUids = categoryOptionComboStore.getCategoryOptionCombosByGroupUid( cog.getUid() )
+                .stream()
+                .map( BaseIdentifiableObject::getUid )
+                .collect( Collectors.toList() );
+
+            if ( cocUidIntersection == null )
             {
-                if ( cocUidIntersection == null )
-                {
-                    cocUidIntersection = categoryOptionComboStore.getCategoryOptionCombosByGroupUid( cog.getUid() )
-                        .stream()
-                        .map( BaseIdentifiableObject::getUid )
-                        .collect( Collectors.toList() );
-                }
-                else
-                {
-                    cocUidIntersection
-                        .retainAll( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( cog.getUid() )
-                            .stream()
-                            .map( BaseIdentifiableObject::getUid )
-                            .collect( Collectors.toList() ) );
-                }
+                cocUidIntersection = cocUids;
+            }
+            else
+            {
+                cocUidIntersection.retainAll( cocUids );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
@@ -129,11 +129,14 @@ public class CategoryOptionGroupResolver implements ExpressionResolver
                         .map( BaseIdentifiableObject::getUid )
                         .collect( Collectors.toList() );
                 }
-
-                cocUidIntersection.retainAll( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( cog.getUid() )
-                    .stream()
-                    .map( BaseIdentifiableObject::getUid )
-                    .collect( Collectors.toList() ) );
+                else
+                {
+                    cocUidIntersection
+                        .retainAll( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( cog.getUid() )
+                            .stream()
+                            .map( BaseIdentifiableObject::getUid )
+                            .collect( Collectors.toList() ) );
+                }
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.resolver;
+
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT_OPERAND;
+import static org.hisp.dhis.expression.Expression.*;
+import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+
+import org.hisp.dhis.category.CategoryOptionComboStore;
+import org.hisp.dhis.category.CategoryOptionGroup;
+import org.hisp.dhis.category.CategoryOptionGroupStore;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.expression.ExpressionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.base.Joiner;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Service( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupTaglessResolver" )
+@AllArgsConstructor
+public class CategoryOptionGroupTaglessResolver
+    implements
+    ExpressionResolver
+{
+    private final ExpressionService expressionService;
+
+    private final CategoryOptionGroupStore categoryOptionGroupStore;
+
+    private final CategoryOptionComboStore categoryOptionComboStore;
+
+    private Set<String> resolveCoCFromCog( String categoryOptionGroupUid )
+    {
+        return categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroupUid ).stream()
+            .map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
+    }
+
+    /**
+     * Resolves a Data Element Operand expression containing one or two Category
+     * Option Group UID to an equivalent expression where the associated
+     * Category Option Combos for the given Category Option Group are "exploded"
+     * into the expression.
+     *
+     * Resolves one of the expressions below:
+     *
+     * 1) #{DEUID.COGUID.AOCUID} 2) #{DEUID.COCUID.COGUID} 3)
+     * #{DEUID.COG1UID.COG2UID}
+     *
+     * to:
+     *
+     * 1) #{DEUID.COCUID1.AOCUID} + #{DEUID.COCUID2.AOCUID} +
+     * #{DEUID.COCUID3.AOCUID} where COCUID1,2,3... are resolved by fetching all
+     * COCUID by COGUID
+     *
+     * 2) #{DEUID.COCUID} + #{DEUID.COCUID1} + #{DEUID.COCUID2} +
+     * #{DEUID.COCUID3} + #{DEUID.COCUID4} where COCUID1,2,3... are resolved by
+     * fetching all COCUID by COGUID
+     *
+     * 3) #{DEUID.COCUID1} + #{DEUID.COCUID2} + #{DEUID.COCUID3} +
+     * #{DEUID.COCUID4} where COCUID1 and COCUID2 are resolved from COG1UID and
+     * COCUID3 and COCUID4 are resolved from COGUID2
+     *
+     * DEUID = Data Element UID COCUID = Category Option Combo UID COGUID =
+     * Category Option Group UID
+     *
+     * @param expression a Data Element Expression
+     * @return an expression containing additional CategoryOptionCombos based on
+     *         the given Category Option Group
+     */
+    @Override
+    @Transactional( readOnly = true )
+    public String resolve( String expression )
+    {
+        // Get a DimensionalItemId from the expression. The expression is parsed
+        // and
+        // each element placed in the DimensionalItemId
+        Set<DimensionalItemId> dimItemIds = expressionService.getExpressionDimensionalItemIds( expression,
+            INDICATOR_EXPRESSION );
+        List<String> resolvedOperands = new ArrayList<>();
+        if ( isDataElementOperand( dimItemIds ) )
+        {
+            DimensionalItemId dimensionalItemId = dimItemIds.stream().findFirst().get();
+            // First element is always the Data Element Id
+            String dataElementUid = dimensionalItemId.getId0();
+
+            resolvedOperands
+                .addAll( evaluate( dataElementUid, dimensionalItemId.getId1(), dimensionalItemId.getId2() ) );
+
+            resolvedOperands.addAll( evaluate( dataElementUid, dimensionalItemId.getId2(), null ) );
+        }
+        if ( resolvedOperands.isEmpty() )
+        {
+            // nothing to resolve, add the expression as it is
+            resolvedOperands.add( expression );
+        }
+        return Joiner.on( "+" ).join( resolvedOperands );
+    }
+
+    private List<String> evaluate( String dataElementUid, String uid, String uid2 )
+    {
+        List<String> resolvedExpression = new ArrayList<>();
+        Optional<String> cogUid = getCategoryOptionGroupUid( uid );
+        if ( cogUid.isPresent() )
+        {
+            Set<String> cocs = resolveCoCFromCog( cogUid.get() );
+            resolvedExpression = Arrays.asList( resolve( cocs, dataElementUid, uid2 ).split( "\\+" ) );
+        }
+        return resolvedExpression;
+    }
+
+    private String resolve( Set<String> cocs, String dataElementUid, String third )
+    {
+        boolean isAoc = isAoc( third );
+
+        return cocs.stream()
+            .map( coc -> EXP_OPEN + dataElementUid + SEPARATOR + coc + (isAoc ? SEPARATOR + third : "") + EXP_CLOSE )
+            .collect( Collectors.joining( "+" ) );
+    }
+
+    private boolean isAoc( String uid )
+    {
+        return (uid != null && categoryOptionComboStore.getByUid( uid ) != null);
+    }
+
+    private Optional<String> getCategoryOptionGroupUid( String uid )
+    {
+        CategoryOptionGroup cog = categoryOptionGroupStore.getByUid( uid );
+
+        return cog == null ? Optional.empty() : Optional.of( cog.getUid() );
+    }
+
+    private boolean isDataElementOperand( Set<DimensionalItemId> dimensionalItemIds )
+    {
+        return dimensionalItemIds.size() == 1
+            && dimensionalItemIds.iterator().next().getDimensionItemType().equals( DATA_ELEMENT_OPERAND );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
@@ -112,14 +112,19 @@ public class CategoryOptionGroupTaglessResolver
         List<String> resolvedOperands = new ArrayList<>();
         if ( isDataElementOperand( dimItemIds ) )
         {
-            DimensionalItemId dimensionalItemId = dimItemIds.stream().findFirst().get();
-            // First element is always the Data Element Id
-            String dataElementUid = dimensionalItemId.getId0();
+            Optional<DimensionalItemId> dimItemId = dimItemIds.stream().findFirst();
 
-            resolvedOperands
-                .addAll( evaluate( dataElementUid, dimensionalItemId.getId1(), dimensionalItemId.getId2() ) );
+            if ( dimItemId.isPresent() )
+            {
+                DimensionalItemId dimensionalItemId = dimItemId.get();
+                // First element is always the Data Element Id
+                String dataElementUid = dimensionalItemId.getId0();
 
-            resolvedOperands.addAll( evaluate( dataElementUid, dimensionalItemId.getId2(), null ) );
+                resolvedOperands
+                    .addAll( evaluate( dataElementUid, dimensionalItemId.getId1(), dimensionalItemId.getId2() ) );
+
+                resolvedOperands.addAll( evaluate( dataElementUid, dimensionalItemId.getId2(), null ) );
+            }
         }
         if ( resolvedOperands.isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolver.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.analytics.resolver;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionStore;
@@ -47,6 +48,7 @@ import com.google.common.base.Joiner;
  */
 
 @Service( "org.hisp.dhis.analytics.resolver.CategoryOptionResolver" )
+@AllArgsConstructor
 public class CategoryOptionResolver implements ExpressionResolver
 {
     private final ExpressionService expressionService;
@@ -61,15 +63,6 @@ public class CategoryOptionResolver implements ExpressionResolver
 
     private static final String EMPTY_STRING = "";
 
-    public CategoryOptionResolver( ExpressionService expressionService, CategoryOptionStore categoryOptionStore )
-    {
-        checkNotNull( categoryOptionStore );
-        checkNotNull( expressionService );
-
-        this.expressionService = expressionService;
-        this.categoryOptionStore = categoryOptionStore;
-    }
-
     @Override
     public String resolve( String expression )
     {
@@ -78,7 +71,7 @@ public class CategoryOptionResolver implements ExpressionResolver
 
         for ( DimensionalItemId id : dimItemIds )
         {
-            if ( id.getItem() != null && id.getId1() != null && id.getId1().contains( CATEGORY_OPTION_PREFIX ) )
+            if ( id.getItem() != null && id.getId1() != null && id.getId1().startsWith( CATEGORY_OPTION_PREFIX ) )
             {
                 CategoryOption co = categoryOptionStore
                     .getByUid( id.getId1().replace( CATEGORY_OPTION_PREFIX, EMPTY_STRING ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolver.java
@@ -78,7 +78,7 @@ public class CategoryOptionResolver implements ExpressionResolver
 
         for ( DimensionalItemId id : dimItemIds )
         {
-            if ( id.getId1() != null && id.getId1().contains( CATEGORY_OPTION_PREFIX ) )
+            if ( id.getItem() != null && id.getId1() != null && id.getId1().contains( CATEGORY_OPTION_PREFIX ) )
             {
                 CategoryOption co = categoryOptionStore
                     .getByUid( id.getId1().replace( CATEGORY_OPTION_PREFIX, EMPTY_STRING ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolver.java
@@ -78,7 +78,7 @@ public class CategoryOptionResolver implements ExpressionResolver
 
         for ( DimensionalItemId id : dimItemIds )
         {
-            if ( id.getId1().contains( CATEGORY_OPTION_PREFIX ) )
+            if ( id.getId1() != null && id.getId1().contains( CATEGORY_OPTION_PREFIX ) )
             {
                 CategoryOption co = categoryOptionStore
                     .getByUid( id.getId1().replace( CATEGORY_OPTION_PREFIX, EMPTY_STRING ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolver.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.analytics.resolver;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.dataelement.DataElementGroup;
@@ -47,6 +48,7 @@ import com.google.common.base.Joiner;
  */
 
 @Service( "org.hisp.dhis.analytics.resolver.DataElementGroupResolver" )
+@AllArgsConstructor
 public class DataElementGroupResolver implements ExpressionResolver
 {
     private final ExpressionService expressionService;
@@ -61,16 +63,6 @@ public class DataElementGroupResolver implements ExpressionResolver
 
     private static final String EMPTY_STRING = "";
 
-    public DataElementGroupResolver( ExpressionService expressionService,
-        DataElementGroupStore dataElementGroupStore )
-    {
-        checkNotNull( expressionService );
-        checkNotNull( dataElementGroupStore );
-
-        this.expressionService = expressionService;
-        this.dataElementGroupStore = dataElementGroupStore;
-    }
-
     @Override
     public String resolve( String expression )
     {
@@ -79,7 +71,7 @@ public class DataElementGroupResolver implements ExpressionResolver
 
         for ( DimensionalItemId id : dimItemIds )
         {
-            if ( id.getItem() != null && id.getId0() != null && id.getId0().contains( DATA_ELEMENT_GROUP_PREFIX ) )
+            if ( id.getItem() != null && id.getId0() != null && id.getId0().startsWith( DATA_ELEMENT_GROUP_PREFIX ) )
             {
                 DataElementGroup deGroup = dataElementGroupStore
                     .getByUid( id.getId0().replace( DATA_ELEMENT_GROUP_PREFIX, EMPTY_STRING ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
@@ -43,23 +43,31 @@ import com.google.common.collect.ImmutableList;
 @Service
 public class ExpressionResolvers implements ExpressionResolverCollection
 {
-    private final List<ExpressionResolver> resolvers;
+    private final List<ExpressionResolver> expressionResolvers;
 
     public ExpressionResolvers(
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupResolver" ) ExpressionResolver cogExpressionResolver,
-        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionResolver" ) ExpressionResolver coExpressionResolver )
+        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionResolver" ) ExpressionResolver coExpressionResolver,
+        @Qualifier( "org.hisp.dhis.analytics.resolver.DataElementGroupResolver" ) ExpressionResolver degExpressionResolver )
     {
         checkNotNull( cogExpressionResolver );
+
         checkNotNull( coExpressionResolver );
 
-        resolvers = new ArrayList<>();
-        resolvers.add( cogExpressionResolver );
-        resolvers.add( coExpressionResolver );
+        checkNotNull( degExpressionResolver );
+
+        expressionResolvers = new ArrayList<>();
+
+        expressionResolvers.add( cogExpressionResolver );
+
+        expressionResolvers.add( coExpressionResolver );
+
+        expressionResolvers.add( degExpressionResolver );
     }
 
     @Override
     public List<ExpressionResolver> getExpressionResolvers()
     {
-        return ImmutableList.copyOf( resolvers );
+        return ImmutableList.copyOf( expressionResolvers );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
@@ -46,10 +46,13 @@ public class ExpressionResolvers implements ExpressionResolverCollection
     private final List<ExpressionResolver> expressionResolvers;
 
     public ExpressionResolvers(
+        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupTaglessResolver" ) ExpressionResolver cogTaglessExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupResolver" ) ExpressionResolver cogExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionResolver" ) ExpressionResolver coExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.DataElementGroupResolver" ) ExpressionResolver degExpressionResolver )
     {
+        checkNotNull( cogTaglessExpressionResolver );
+
         checkNotNull( cogExpressionResolver );
 
         checkNotNull( coExpressionResolver );
@@ -57,6 +60,8 @@ public class ExpressionResolvers implements ExpressionResolverCollection
         checkNotNull( degExpressionResolver );
 
         expressionResolvers = new ArrayList<>();
+
+        expressionResolvers.add( cogTaglessExpressionResolver );
 
         expressionResolvers.add( cogExpressionResolver );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
@@ -55,6 +55,7 @@ import org.mockito.junit.MockitoRule;
 import com.google.common.collect.Sets;
 
 /**
+ * @author Luciano Fiandesio
  * @author Dusan Bernat
  */
 public class CategoryOptionGroupResolverTest

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
@@ -114,7 +114,6 @@ public class CategoryOptionResolverTest
     public void verifyExpressionIsResolvedProperly()
     {
         // arrange
-
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
             CATEGORY_OPTION_PREFIX + uid2, uid3, 0, createIndicatorExpression() );
 
@@ -137,7 +136,6 @@ public class CategoryOptionResolverTest
     public void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
     {
         // arrange
-
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
             CATEGORY_OPTION_PREFIX + uid2, uid3, 0 );
 
@@ -156,10 +154,9 @@ public class CategoryOptionResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenCoPrefixNotInUid1()
+    public void verifyExpressionIsNotResolvedWhenCoPrefixInUid1()
     {
         // arrange
-
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
             uid2, uid3, 0, createIndicatorExpression() );
 
@@ -181,7 +178,6 @@ public class CategoryOptionResolverTest
     public void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
     {
         // arrange
-
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
             uid2, uid3, 0, createIndicatorExpression() );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
@@ -137,7 +137,7 @@ public class CategoryOptionResolverTest
     {
         // arrange
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
-            CATEGORY_OPTION_PREFIX + uid2, uid3, 0 );
+            CATEGORY_OPTION_PREFIX + uid2, uid3, 0, createIndicatorExpression() );
 
         String expression = createIndicatorExpression();
 
@@ -150,7 +150,8 @@ public class CategoryOptionResolverTest
 
         // assert
 
-        assertEquals( expression, resolvedExpression );
+        assertEquals( expectedResolvedIndicatorExpression( coc1.getUid(), coc2.getUid(), coc3.getUid() ),
+            resolvedExpression );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
@@ -155,7 +155,7 @@ public class CategoryOptionResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenCoPrefixInUid1()
+    public void verifyExpressionIsNotResolvedWhenCoPrefixNotInUid1()
     {
         // arrange
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolverTest.java
@@ -114,7 +114,6 @@ public class DataElementGroupResolverTest
         resolver = new DataElementGroupResolver( expressionService, dataElementGroupStore );
 
         when( dataElementGroupStore.getByUid( anyString() ) ).thenReturn( dataElementGroup );
-
     }
 
     @Test


### PR DESCRIPTION
All changes in CategoryOptionGroupResolver are based on coGroup tag (#{datalement:coGroup.categoryotiongroup}) and not backward compatible. Otherwise the old CategoryOptionGroupResolver has to be added into resolver collection.