### PR TITLE
feat: Some improvments for REST API test utility

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/JsonResponse.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/JsonResponse.java
@@ -95,11 +95,16 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
         try
         {
             JsonNode node = content.get( path );
-            if ( node.getType() != expected )
+            JsonNodeType actualType = node.getType();
+            if ( actualType == JsonNodeType.NULL )
+            {
+                return null;
+            }
+            if ( actualType != expected )
             {
                 throw new UnsupportedOperationException(
                     String.format( "Path `%s` does not contain a %s but a(n) %s: %s",
-                        path, expected, node.getType(), node ) );
+                        path, expected, actualType, node ) );
             }
             return get.apply( node );
         }

--- a/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
@@ -111,6 +111,21 @@ public class JsonResponseTest
     }
 
     @Test
+    public void testNull()
+    {
+        JsonObject response = createJSON( "{'value': null}" );
+
+        assertNull( response.getBoolean( "value" ).bool() );
+        assertNull( response.getString( "value" ).string() );
+        assertNull( response.getNumber( "value" ).number() );
+        assertTrue( response.getObject( "value" ).exists() );
+        assertTrue( response.getArray( "value" ).exists() );
+        assertTrue( response.get( "value" ).isNull() );
+        assertFalse( response.get( "value" ).isObject() );
+        assertFalse( response.get( "value" ).isArray() );
+    }
+
+    @Test
     public void testBooleanValue()
     {
         JsonObject response = createJSON( "{'flag': true}" );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonError.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonError.java
@@ -97,7 +97,9 @@ public interface JsonError extends JsonObject
             }
         };
         String message = getMessage();
-        str.append( message != null ? message : "(no error message in response)" );
+        str.append( message != null
+            ? message
+            : String.format( "(no error message in %d %s response)", getHttpStatusCode(), getHttpStatus() ) );
         if ( getTypeReport().exists() )
         {
             printer.accept( getTypeReport().getErrorReports() );


### PR DESCRIPTION
Some improvements I made while working on #8414 

* JSON `null` value can become any other type when resolved (should have been that way but check was too strict)
* include HTTP status in empty message responses
* allow to access raw HTTP response content as `String` in case it not `application/json` media type
* compose a synthetic `JsonError` response from Mvc response properties for responses that do not have a body (allows easier, more uniform testing)

Note that this PR does not change any production code.