### PR TITLE
fix: ADX Exeption and ImportOptions DHIS2-9313

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
-import static org.hisp.dhis.util.DateUtils.getLongGmtDateString;
 
 import java.util.*;
 import java.util.function.Function;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
+import static org.hisp.dhis.util.DateUtils.getLongGmtDateString;
 
 import java.util.*;
 import java.util.function.Function;
@@ -220,7 +221,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
             hql += "and ao.id in (:attributeOptionCombos) ";
         }
 
-        if ( params.hasLastUpdated() )
+        if ( params.hasLastUpdated() || params.hasLastUpdatedDuration() )
         {
             hql += "and dv.lastUpdated >= :lastUpdated ";
         }
@@ -276,6 +277,10 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         if ( params.hasLastUpdated() )
         {
             query.setParameter( "lastUpdated", params.getLastUpdated() );
+        }
+        else if ( params.hasLastUpdatedDuration() )
+        {
+            query.setParameter( "lastUpdated", DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) );
         }
 
         if ( params.hasLimit() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/AdxException.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/AdxException.java
@@ -44,7 +44,7 @@ public class AdxException
 
     public AdxException( String msg )
     {
-        this( null, msg );
+        this( "ADX Error", msg );
     }
 
     public AdxException( String object, String msg )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -455,6 +455,12 @@ public class ImportOptions
         return this;
     }
 
+    public ImportOptions setCategoryIdScheme( String idScheme )
+    {
+        idSchemes.setCategoryIdScheme( idScheme );
+        return this;
+    }
+
     public ImportOptions setOrgUnitIdScheme( String idScheme )
     {
         idSchemes.setOrgUnitIdScheme( idScheme );
@@ -482,6 +488,12 @@ public class ImportOptions
     public ImportOptions setTrackedEntityAttributeIdScheme( String idScheme )
     {
         idSchemes.setTrackedEntityAttributeIdScheme( idScheme );
+        return this;
+    }
+
+    public ImportOptions setDataSetIdScheme( String idScheme )
+    {
+        idSchemes.setDataSetIdScheme( idScheme );
         return this;
     }
 


### PR DESCRIPTION
While writing testing instructions for the ADX fixes in [DHIS2-9313](https://jira.dhis2.org/browse/DHIS2-9313), I ran across three more bugs:

**1. HibernateDataValueStore** didn't support lastUpdatedDuration, so neither did ADX Export. Now it works.

**2. AdxException** had been creating an exception with a null `object`. Subsequently `DefaultAdxDataService` was catching this exception and trying to add it as a conflict to an `ImportSummary` with:

            importSummary.addConflict( ex.getObject(), ex.getMessage() );

However `ImportSummary` was throwing an exception because the object was null. This means, for example, that the return WebAPI status for not being able to find an identifiable object was:

    {"httpStatus":"Internal Server Error","httpStatusCode":500,"status":"ERROR"}

The fix is to not create an `AdxException` with a null object. With the fix, the return status for the same error includes:

    <conflict object="ADX Error" value="No data set matching uid 'DiszpKrYNg8'"/>

**3. ImportOptions** takes various `idSchemes` directly from the WebApi, but sets them within the `IdSchemes` property contained in `ImportOptions`. I had missed this, and the two new import option schemes used only by ADX imports were not getting set properly: `categoryIDScheme` and `dataSetIdScheme`. With the fix, they work.