### PR TITLE
fix: broken periodOffset function DHIS2-11515

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -1056,7 +1056,7 @@ public class DataHandler
             if ( periodOffsetRow != null )
             {
                 result.put( key, new DimensionItemObjectValue( dimensionalItemObject,
-                    ((Number) row.get( valueIndex )).doubleValue() ) );
+                    ((Number) periodOffsetRow.get( valueIndex )).doubleValue() ) );
             }
 
             clone = SerializationUtils.clone( dimensionalItemObject );


### PR DESCRIPTION
From [DHIS2-11515](https://jira.dhis2.org/browse/DHIS2-11515):

> ### Symptom
> 
> The .periodOffset indicator expression function has been broken in trunk, 2.36, and 2.35 since June 8 commit [87968f2](https://github.com/dhis2/dhis2-core/pull/8142/commits/23811a37d08d1a1e685213a878e92aa46f7033e6).
> 
> Effectively the periodOffset is ignored. The same value is returned by analytics with or without the periodOffset function.
> 
> ### Cause
> 
> `(Double) periodOffsetRow.get( valueIndex )`
> 
> was replaced with:
> 
> `((Number) row.get( valueIndex )).doubleValue()`
> 
> It should have been replaced with:
> 
> `((Number) periodOffsetRow.get( valueIndex )).doubleValue()`