### PR TITLE
fix: do not attempt to load in-memory job configuration from DB [TECH-592]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
@@ -121,8 +121,10 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
         String jobId = configuration.getUid();
         JobType type = configuration.getJobType();
         CompletableFuture<Future<?>> cancellation = new CompletableFuture<>();
-        Runnable task = runIfPossible( configuration, cancellation, () -> execute( jobId ) );
-        Future<?> cancelable = scheduler.apply( task );
+        Runnable task = configuration.isInMemoryJob()
+            ? () -> execute( configuration )
+            : () -> execute( jobId );
+        Future<?> cancelable = scheduler.apply( runIfPossible( configuration, cancellation, task ) );
         Future<?> scheduledBefore = scheduled.put( type, cancelable );
         if ( scheduledBefore != null && !scheduledBefore.cancel( true ) )
         {


### PR DESCRIPTION
QA/Ops did observe a NPE when jon tried to run. From the stacktrace I deduced that the cause must be that an in-memory job was run using `exectute(String)` which tries to load the job configuration by ID from database which would result in a `null` reference for `execute(JobConfiguration)`. This fix check when scheduling the job if it is a in-memory one and if so it is scheduled using `execute(JobConfiguration)` directly. 

This is most likely a corner case that was overlooked in #8375.