### PR TITLE
chore: extract controller hooks to interface

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -103,6 +103,7 @@ import com.google.common.collect.Lists;
  */
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public abstract class AbstractCrudController<T extends IdentifiableObject> extends AbstractFullReadOnlyController<T>
+    implements ControllerHooks<T>
 {
 
     // --------------------------------------------------------------------------
@@ -904,51 +905,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         throws IOException
     {
         return renderService.fromXml( request.getInputStream(), getEntityClass() );
-    }
-
-    protected void preCreateEntity( T entity )
-        throws Exception
-    {
-    }
-
-    protected void postCreateEntity( T entity )
-    {
-    }
-
-    protected void preUpdateEntity( T entity, T newEntity )
-        throws Exception
-    {
-    }
-
-    protected void postUpdateEntity( T entity )
-    {
-    }
-
-    protected void preDeleteEntity( T entity )
-        throws Exception
-    {
-    }
-
-    protected void postDeleteEntity( String entityUid )
-    {
-    }
-
-    protected void prePatchEntity( T entity )
-        throws Exception
-    {
-    }
-
-    protected void postPatchEntity( T entity )
-    {
-    }
-
-    protected void preUpdateItems( T entity, IdentifiableObjects items )
-        throws Exception
-    {
-    }
-
-    protected void postUpdateItems( T entity, IdentifiableObjects items )
-    {
     }
 
     // --------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ControllerHooks.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ControllerHooks.java
@@ -25,48 +25,72 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.user;
+package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.commons.util.SystemUtils;
-import org.hisp.dhis.schema.descriptors.UserGroupSchemaDescriptor;
-import org.hisp.dhis.user.UserGroup;
-import org.hisp.dhis.webapi.controller.AbstractCrudController;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjects;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Pre- and post- hooks for {@link IdentifiableObject} controllers that do
+ * nothing by default.
+ *
+ * @author Jan Bernitt
+ * @param <T> type of the object the hooks apply to
  */
-@Controller
-@RequestMapping( value = UserGroupSchemaDescriptor.API_ENDPOINT )
-public class UserGroupController
-    extends AbstractCrudController<UserGroup>
+public interface ControllerHooks<T extends IdentifiableObject>
 {
-    @Autowired
-    private Environment env;
-
-    @Override
-    public void postUpdateEntity( UserGroup entity )
+    default void preCreateEntity( T entity )
+        throws Exception
     {
-        hibernateCacheManager.clearCache();
+        // by default do nothing
     }
 
-    @Override
-    public void postDeleteEntity( String entityUid )
+    default void postCreateEntity( T entity )
     {
-        /*
-         * This function will caused error in
-         * SchemaBasedControllerTest.testCreateAndDeleteSchemaObjects because of
-         * H2 database being used. The test is instead covered in
-         * IdentifiableObjectManagerTest.testRemoveUserGroupFromSharing()
-         */
-        if ( SystemUtils.isTestRun( env.getActiveProfiles() ) )
-        {
-            return;
-        }
+        // by default do nothing
+    }
 
-        manager.removeUserGroupFromSharing( entityUid );
+    default void preUpdateEntity( T entity, T newEntity )
+        throws Exception
+    {
+        // by default do nothing
+    }
+
+    default void postUpdateEntity( T entity )
+    {
+        // by default do nothing
+    }
+
+    default void preDeleteEntity( T entity )
+        throws Exception
+    {
+        // by default do nothing
+    }
+
+    default void postDeleteEntity( String entityUid )
+    {
+        // by default do nothing
+    }
+
+    default void prePatchEntity( T entity )
+        throws Exception
+    {
+        // by default do nothing
+    }
+
+    default void postPatchEntity( T entity )
+    {
+        // by default do nothing
+    }
+
+    default void preUpdateItems( T entity, IdentifiableObjects items )
+        throws Exception
+    {
+        // by default do nothing
+    }
+
+    default void postUpdateItems( T entity, IdentifiableObjects items )
+    {
+        // by default do nothing
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalLevelController.java
@@ -43,13 +43,13 @@ public class DataApprovalLevelController
     private DataApprovalLevelService dataApprovalLevelService;
 
     @Override
-    protected void preCreateEntity( DataApprovalLevel entity )
+    public void preCreateEntity( DataApprovalLevel entity )
     {
         dataApprovalLevelService.prepareAddDataApproval( entity );
     }
 
     @Override
-    protected void postDeleteEntity( String entityUID )
+    public void postDeleteEntity( String entityUID )
     {
         dataApprovalLevelService.postDeleteDataApprovalLevel();
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -152,7 +152,7 @@ public class MapController
     }
 
     @Override
-    protected void preUpdateEntity( Map map, Map newMap )
+    public void preUpdateEntity( Map map, Map newMap )
     {
         map.getMapViews().clear();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -404,19 +404,19 @@ public class OrganisationUnitController
     }
 
     @Override
-    protected void postCreateEntity( OrganisationUnit entity )
+    public void postCreateEntity( OrganisationUnit entity )
     {
         versionService.updateVersion( VersionService.ORGANISATIONUNIT_VERSION );
     }
 
     @Override
-    protected void postUpdateEntity( OrganisationUnit entity )
+    public void postUpdateEntity( OrganisationUnit entity )
     {
         versionService.updateVersion( VersionService.ORGANISATIONUNIT_VERSION );
     }
 
     @Override
-    protected void postDeleteEntity( String entityUID )
+    public void postDeleteEntity( String entityUID )
     {
         versionService.updateVersion( VersionService.ORGANISATIONUNIT_VERSION );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -109,14 +109,14 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void preCreateEntity( JobConfiguration jobConfiguration )
+    public void preCreateEntity( JobConfiguration jobConfiguration )
         throws WebMessageException
     {
         checkConfigurable( jobConfiguration, HttpStatus.BAD_REQUEST, "Job %s must be configurable but was not." );
     }
 
     @Override
-    protected void prePatchEntity( JobConfiguration jobConfiguration )
+    public void prePatchEntity( JobConfiguration jobConfiguration )
         throws WebMessageException
     {
         checkConfigurable( jobConfiguration, HttpStatus.UNPROCESSABLE_ENTITY,
@@ -124,7 +124,7 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void preUpdateEntity( JobConfiguration before, JobConfiguration after )
+    public void preUpdateEntity( JobConfiguration before, JobConfiguration after )
         throws WebMessageException
     {
         checkConfigurable( before, HttpStatus.UNPROCESSABLE_ENTITY, "Job %s is a system job that cannot be modified." );
@@ -132,7 +132,7 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void preDeleteEntity( JobConfiguration jobConfiguration )
+    public void preDeleteEntity( JobConfiguration jobConfiguration )
         throws WebMessageException
     {
         checkConfigurable( jobConfiguration, HttpStatus.UNPROCESSABLE_ENTITY,
@@ -140,7 +140,7 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void preUpdateItems( JobConfiguration jobConfiguration, IdentifiableObjects items )
+    public void preUpdateItems( JobConfiguration jobConfiguration, IdentifiableObjects items )
         throws Exception
     {
         checkConfigurable( jobConfiguration, HttpStatus.UNPROCESSABLE_ENTITY,
@@ -148,7 +148,7 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void postPatchEntity( JobConfiguration jobConfiguration )
+    public void postPatchEntity( JobConfiguration jobConfiguration )
     {
         if ( !jobConfiguration.isEnabled() )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -674,7 +674,7 @@ public class UserController
     // -------------------------------------------------------------------------
 
     @Override
-    protected void prePatchEntity( User entity )
+    public void prePatchEntity( User entity )
         throws Exception
     {
         User currentUser = currentUserService.getCurrentUser();
@@ -688,7 +688,7 @@ public class UserController
     }
 
     @Override
-    protected void postPatchEntity( User entity )
+    public void postPatchEntity( User entity )
     {
         UserCredentials credentials = entity.getUserCredentials();
 
@@ -705,7 +705,7 @@ public class UserController
     // -------------------------------------------------------------------------
 
     @Override
-    protected void preDeleteEntity( User entity )
+    public void preDeleteEntity( User entity )
         throws Exception
     {
         User currentUser = currentUserService.getCurrentUser();


### PR DESCRIPTION
PR extracts the hook methods in controllers to an interface `ControllerHooks` mostly to further de-clutter the `AbstractCrudController` class. As a result the hook methods now are `public` instead of `protected`.