### PR TITLE
chore: creation of WebMessages [TECH-649]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.metadata.collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.validateAndThrowErrors;
 
 import java.util.Collection;
@@ -268,7 +269,7 @@ public class DefaultCollectionService
 
         if ( !property.isCollection() || !property.isIdentifiableObject() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( message ) );
+            throw new WebMessageException( conflict( message ) );
         }
         return property;
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/DescriptiveWebMessage.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/DescriptiveWebMessage.java
@@ -27,6 +27,12 @@
  */
 package org.hisp.dhis.dxf2.webmessage;
 
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import org.hisp.dhis.feedback.Status;
+import org.springframework.http.HttpStatus;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -37,9 +43,17 @@ public class DescriptiveWebMessage
 {
     private String description;
 
+    /**
+     * Only for deserialisation
+     */
     public DescriptiveWebMessage()
     {
         super();
+    }
+
+    public DescriptiveWebMessage( Status status, HttpStatus httpStatus )
+    {
+        super( status, httpStatus );
     }
 
     @JsonProperty
@@ -48,8 +62,14 @@ public class DescriptiveWebMessage
         return description;
     }
 
-    public void setDescription( String description )
+    public DescriptiveWebMessage setDescription( String description )
     {
         this.description = description;
+        return this;
+    }
+
+    public DescriptiveWebMessage setDescription( BooleanSupplier when, Supplier<String> thenValue )
+    {
+        return when.getAsBoolean() ? setDescription( thenValue.get() ) : this;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessage.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessage.java
@@ -99,6 +99,8 @@ public class WebMessage implements WebMessageResponse
 
     private DhisApiVersion plainResponseBefore;
 
+    private String location;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -235,6 +237,17 @@ public class WebMessage implements WebMessageResponse
     public WebMessage setResponse( WebMessageResponse response )
     {
         this.response = response;
+        return this;
+    }
+
+    public String getLocation()
+    {
+        return location;
+    }
+
+    public WebMessage setLocation( String location )
+    {
+        this.location = location;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessage.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessage.java
@@ -103,13 +103,11 @@ public class WebMessage implements WebMessageResponse
     // Constructors
     // -------------------------------------------------------------------------
 
+    /**
+     * Only for deserialisation
+     */
     public WebMessage()
     {
-    }
-
-    public WebMessage( Status status )
-    {
-        this.status = status;
     }
 
     public WebMessage( Status status, HttpStatus httpStatus )
@@ -195,9 +193,10 @@ public class WebMessage implements WebMessageResponse
         return errorCode;
     }
 
-    public void setErrorCode( ErrorCode errorCode )
+    public WebMessage setErrorCode( ErrorCode errorCode )
     {
         this.errorCode = errorCode;
+        return this;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
@@ -54,29 +54,28 @@ public final class WebMessageUtils
 {
     public static WebMessage createWebMessage( String message, Status status, HttpStatus httpStatus )
     {
-        WebMessage webMessage = new WebMessage( status, httpStatus );
-        webMessage.setMessage( message );
-
-        return webMessage;
+        return new WebMessage( status, httpStatus )
+            .setMessage( message );
     }
 
     public static WebMessage createWebMessage( String message, Status status, HttpStatus httpStatus,
         ErrorCode errorCode )
     {
-        WebMessage webMessage = new WebMessage( status, httpStatus );
-        webMessage.setErrorCode( errorCode );
-        webMessage.setMessage( message );
-
-        return webMessage;
+        return new WebMessage( status, httpStatus )
+            .setErrorCode( errorCode )
+            .setMessage( message );
     }
 
     public static WebMessage createWebMessage( String message, String devMessage, Status status, HttpStatus httpStatus )
     {
-        WebMessage webMessage = new WebMessage( status, httpStatus );
-        webMessage.setMessage( message );
-        webMessage.setDevMessage( devMessage );
+        return new WebMessage( status, httpStatus )
+            .setMessage( message )
+            .setDevMessage( devMessage );
+    }
 
-        return webMessage;
+    public static WebMessage ok()
+    {
+        return ok( null );
     }
 
     public static WebMessage ok( String message )
@@ -87,6 +86,11 @@ public final class WebMessageUtils
     public static WebMessage ok( String message, String devMessage )
     {
         return createWebMessage( message, devMessage, Status.OK, HttpStatus.OK );
+    }
+
+    public static WebMessage created()
+    {
+        return created( null );
     }
 
     public static WebMessage created( String message )
@@ -165,172 +169,103 @@ public final class WebMessageUtils
         return createWebMessage( message, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE );
     }
 
-    public static WebMessage serviceUnavailable( String message, String devMessage )
-    {
-        return createWebMessage( message, devMessage, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE );
-    }
-
-    public static WebMessage unprocessableEntity( String message )
-    {
-        return createWebMessage( message, Status.ERROR, HttpStatus.UNPROCESSABLE_ENTITY );
-    }
-
-    public static WebMessage unprocessableEntity( String message, String devMessage )
-    {
-        return createWebMessage( message, devMessage, Status.ERROR, HttpStatus.UNPROCESSABLE_ENTITY );
-    }
-
-    public static WebMessage unathorized( String message )
+    public static WebMessage unauthorized( String message )
     {
         return createWebMessage( message, Status.ERROR, HttpStatus.UNAUTHORIZED );
     }
 
-    public static WebMessage unathorized( String message, String devMessage )
-    {
-        return createWebMessage( message, devMessage, Status.ERROR, HttpStatus.UNAUTHORIZED );
-    }
-
     public static WebMessage importSummary( ImportSummary importSummary )
     {
-        WebMessage webMessage = new WebMessage();
-
         if ( importSummary.isStatus( ImportStatus.ERROR ) )
         {
-            webMessage.setMessage( "An error occurred, please check import summary." );
-            webMessage.setStatus( Status.ERROR );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
+            return conflict( "An error occurred, please check import summary." )
+                .setResponse( importSummary );
         }
-        else if ( importSummary.isStatus( ImportStatus.WARNING ) )
+        if ( importSummary.isStatus( ImportStatus.WARNING ) )
         {
-            webMessage.setMessage( "One more conflicts encountered, please check import summary." );
-            webMessage.setStatus( Status.WARNING );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
+            return new WebMessage( Status.WARNING, HttpStatus.CONFLICT )
+                .setMessage( "One more conflicts encountered, please check import summary." )
+                .setResponse( importSummary );
         }
-        else
-        {
-            webMessage.setMessage( "Import was successful." );
-            webMessage.setStatus( Status.OK );
-            webMessage.setHttpStatus( HttpStatus.OK );
-        }
-
-        webMessage.setResponse( importSummary );
-
-        return webMessage;
+        return ok( "Import was successful." )
+            .setResponse( importSummary );
     }
 
     public static WebMessage importSummaries( ImportSummaries importSummaries )
     {
-        WebMessage webMessage = new WebMessage();
-
         if ( importSummaries.isStatus( ImportStatus.ERROR ) )
         {
-            webMessage.setMessage( "An error occurred, please check import summary." );
-            webMessage.setStatus( Status.ERROR );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
+            return conflict( "An error occurred, please check import summary." )
+                .setResponse( importSummaries );
         }
-        else if ( importSummaries.isStatus( ImportStatus.WARNING ) )
+        if ( importSummaries.isStatus( ImportStatus.WARNING ) )
         {
-            webMessage.setMessage( "One or more conflicts encountered, please check import summary." );
-            webMessage.setStatus( Status.WARNING );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
+            return new WebMessage( Status.WARNING, HttpStatus.CONFLICT )
+                .setMessage( "One or more conflicts encountered, please check import summary." )
+                .setResponse( importSummaries );
         }
-        else
-        {
-            webMessage.setMessage( "Import was successful." );
-            webMessage.setStatus( Status.OK );
-            webMessage.setHttpStatus( HttpStatus.OK );
-        }
-
-        webMessage.setResponse( importSummaries );
-
-        return webMessage;
+        return ok( "Import was successful." )
+            .setResponse( importSummaries );
     }
 
     public static WebMessage importReport( ImportReport importReport )
     {
-        WebMessage webMessage = new WebMessage();
-        webMessage.setResponse( new ImportReportWebMessageResponse( importReport ) );
-
-        webMessage.setStatus( importReport.getStatus() );
-
-        if ( webMessage.getStatus() != Status.OK )
+        if ( importReport.getStatus() != Status.OK )
         {
-            webMessage.setMessage( "One more more errors occurred, please see full details in import report." );
-            webMessage.setStatus( Status.WARNING );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
+            return new WebMessage( Status.WARNING, HttpStatus.CONFLICT )
+                .setMessage( "One more more errors occurred, please see full details in import report." )
+                .setResponse( new ImportReportWebMessageResponse( importReport ) );
         }
-
-        return webMessage;
+        return ok()
+            .setResponse( new ImportReportWebMessageResponse( importReport ) );
     }
 
     public static WebMessage typeReport( TypeReport typeReport )
     {
-        WebMessage webMessage = new WebMessage();
-        webMessage.setResponse( new TypeReportWebMessageResponse( typeReport ) );
-
         if ( !typeReport.hasErrorReports() )
         {
-            webMessage.setStatus( Status.OK );
-            webMessage.setHttpStatus( HttpStatus.OK );
+            return ok()
+                .setResponse( new TypeReportWebMessageResponse( typeReport ) );
         }
-        else
-        {
-            webMessage.setMessage( "One more more errors occurred, please see full details in import report." );
-            webMessage.setStatus( Status.ERROR );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
-        }
-
-        return webMessage;
+        return conflict( "One more more errors occurred, please see full details in import report." )
+            .setResponse( new TypeReportWebMessageResponse( typeReport ) );
     }
 
     public static WebMessage objectReport( ImportReport importReport )
     {
         ObjectReport firstObjectReport = importReport.getFirstObjectReport();
         return firstObjectReport == null
-            ? new WebMessage( Status.OK, HttpStatus.OK )
+            ? ok()
             : objectReport( firstObjectReport );
     }
 
     public static WebMessage objectReport( ObjectReport objectReport )
     {
-        WebMessage webMessage = new WebMessage();
-        webMessage.setResponse( new ObjectReportWebMessageResponse( objectReport ) );
-
         if ( objectReport.isEmpty() )
         {
-            webMessage.setStatus( Status.OK );
-            webMessage.setHttpStatus( HttpStatus.OK );
+            return ok()
+                .setResponse( new ObjectReportWebMessageResponse( objectReport ) );
         }
-        else
-        {
-            webMessage.setMessage( "One more more errors occurred, please see full details in import report." );
-            webMessage.setStatus( Status.WARNING );
-            webMessage.setHttpStatus( HttpStatus.CONFLICT );
-        }
-
-        return webMessage;
+        return new WebMessage( Status.WARNING, HttpStatus.CONFLICT )
+            .setMessage( "One more more errors occurred, please see full details in import report." )
+            .setResponse( new ObjectReportWebMessageResponse( objectReport ) );
     }
 
     public static WebMessage jobConfigurationReport( JobConfiguration jobConfiguration )
     {
-        WebMessage webMessage = WebMessageUtils.ok( "Initiated " + jobConfiguration.getName() );
-        webMessage.setResponse( new JobConfigurationWebMessageResponse( jobConfiguration ) );
-
-        return webMessage;
+        return ok( "Initiated " + jobConfiguration.getName() )
+            .setResponse( new JobConfigurationWebMessageResponse( jobConfiguration ) );
     }
 
     public static WebMessage errorReports( List<ErrorReport> errorReports )
     {
-        WebMessage webMessage = new WebMessage();
-        webMessage.setResponse( new ErrorReportsWebMessageResponse( errorReports ) );
-
         if ( !errorReports.isEmpty() )
         {
-            webMessage.setStatus( Status.ERROR );
-            webMessage.setHttpStatus( HttpStatus.BAD_REQUEST );
+            return badRequest( null )
+                .setResponse( new ErrorReportsWebMessageResponse( errorReports ) );
         }
-
-        return webMessage;
+        return ok()
+            .setResponse( new ErrorReportsWebMessageResponse( errorReports ) );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -447,11 +447,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
 
         if ( objectReport != null && webMessage.getStatus() == Status.OK )
         {
-            String location = contextService.getApiPath() + getSchema().getRelativeApiEndpoint() + "/"
-                + objectReport.getUid();
-
             webMessage.setHttpStatus( HttpStatus.CREATED );
-            webMessage.setLocation( location );
+            webMessage.setLocation( getSchema().getRelativeApiEndpoint() + "/" + objectReport.getUid() );
             T entity = manager.get( getEntityClass(), objectReport.getUid() );
             postCreateEntity( entity );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.springframework.http.CacheControl.noCache;
 
 import java.util.ArrayList;
@@ -50,7 +51,6 @@ import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
@@ -351,7 +351,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
             if ( rootNode.getChildren().isEmpty() || rootNode.getChildren().get( 0 ).getChildren().isEmpty() )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
+                    notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
             }
 
             cachePrivate( response );
@@ -374,7 +374,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
 
         if ( entities.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), uid ) );
+            throw new WebMessageException( notFound( getEntityClass(), uid ) );
         }
 
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,7 +49,6 @@ import org.hisp.dhis.appmanager.AppStatus;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.render.RenderService;
@@ -157,7 +159,7 @@ public class AppController
         {
             String message = i18nManager.getI18n().getString( status.getMessage() );
 
-            throw new WebMessageException( WebMessageUtils.conflict( message ) );
+            throw new WebMessageException( conflict( message ) );
         }
     }
 
@@ -182,7 +184,7 @@ public class AppController
 
         if ( application == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "App '" + app + "' not found." ) );
+            throw new WebMessageException( notFound( "App '" + app + "' not found." ) );
         }
 
         if ( application.isBundled() )
@@ -203,7 +205,7 @@ public class AppController
         if ( application.getAppState() == AppStatus.DELETION_IN_PROGRESS )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "App '" + app + "' deletion is still in progress." ) );
+                conflict( "App '" + app + "' deletion is still in progress." ) );
         }
 
         log.debug( String.format( "App page name: '%s'", pageName ) );
@@ -269,12 +271,12 @@ public class AppController
         App appToDelete = appManager.getApp( app );
         if ( appToDelete == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "App does not exist: " + app ) );
+            throw new WebMessageException( notFound( "App does not exist: " + app ) );
         }
 
         if ( appToDelete.getAppState() == AppStatus.DELETION_IN_PROGRESS )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "App is already being deleted: " + app ) );
+            throw new WebMessageException( conflict( "App is already being deleted: " + app ) );
         }
 
         appManager.markAppToDelete( appToDelete );
@@ -293,7 +295,7 @@ public class AppController
 
         if ( config == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "No config specified" ) );
+            throw new WebMessageException( conflict( "No config specified" ) );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -38,7 +40,6 @@ import org.hisp.dhis.apphub.WebApp;
 import org.hisp.dhis.appmanager.AppStatus;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -100,7 +101,7 @@ public class AppHubController
         {
             String message = i18nManager.getI18n().getString( status.getMessage() );
 
-            throw new WebMessageException( WebMessageUtils.conflict( message ) );
+            throw new WebMessageException( conflict( message ) );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,9 +56,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.datavalue.DataValueAudit;
 import org.hisp.dhis.datavalue.DataValueAuditService;
-import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.dxf2.webmessage.responses.FileResourceWebMessageResponse;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
@@ -164,7 +165,7 @@ public class AuditController
 
         if ( fileResource == null || fileResource.getDomain() != FileResourceDomain.DATA_VALUE )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "No file found with uid '" + uid + "'" ) );
+            throw new WebMessageException( notFound( "No file found with uid '" + uid + "'" ) );
         }
 
         FileResourceStorageStatus storageStatus = fileResource.getStorageStatus();
@@ -172,12 +173,10 @@ public class AuditController
         if ( storageStatus != FileResourceStorageStatus.STORED )
         {
             // HTTP 409, for lack of a more suitable status code
-            WebMessage webMessage = WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "The content is being processed and is not available yet. Try again later.",
-                "The content requested is in transit to the file store and will be available at a later time." );
-            webMessage.setResponse( new FileResourceWebMessageResponse( fileResource ) );
-
-            throw new WebMessageException( webMessage );
+                "The content requested is in transit to the file store and will be available at a later time." )
+                    .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
         }
 
         response.setContentType( fileResource.getContentType() );
@@ -190,7 +189,7 @@ public class AuditController
         }
         catch ( IOException e )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend, could be network or filesystem related" ) );
         }
     }
@@ -515,7 +514,7 @@ public class AuditController
         if ( trackedEntityInstance == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Illegal trackedEntityInstance identifier: " + tei ) );
+                conflict( "Illegal trackedEntityInstance identifier: " + tei ) );
         }
 
         return trackedEntityInstance;
@@ -552,7 +551,7 @@ public class AuditController
         if ( trackedEntityAttribute == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Illegal trackedEntityAttribute identifier: " + tea ) );
+                conflict( "Illegal trackedEntityAttribute identifier: " + tea ) );
         }
 
         return trackedEntityAttribute;
@@ -589,7 +588,7 @@ public class AuditController
         if ( programStageInstance == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Illegal programStageInstance identifier: " + ps ) );
+                conflict( "Illegal programStageInstance identifier: " + ps ) );
         }
 
         return programStageInstance;
@@ -606,7 +605,7 @@ public class AuditController
 
             if ( dataSet == null )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "Illegal dataSet identifier: " + ds ) );
+                throw new WebMessageException( conflict( "Illegal dataSet identifier: " + ds ) );
             }
 
             dataElements.addAll( dataSet.getDataElements() );
@@ -645,7 +644,7 @@ public class AuditController
 
         if ( dataElement == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Illegal dataElement identifier: " + de ) );
+            throw new WebMessageException( conflict( "Illegal dataElement identifier: " + de ) );
         }
 
         return dataElement;
@@ -662,7 +661,7 @@ public class AuditController
 
             if ( period == null )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "Illegal period identifier: " + pe ) );
+                throw new WebMessageException( conflict( "Illegal period identifier: " + pe ) );
             }
             else
             {
@@ -706,7 +705,7 @@ public class AuditController
         if ( categoryOptionCombo == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Illegal categoryOptionCombo identifier: " + co ) );
+                conflict( "Illegal categoryOptionCombo identifier: " + co ) );
         }
 
         return categoryOptionCombo;
@@ -725,7 +724,7 @@ public class AuditController
         if ( attributeOptionCombo == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Illegal attributeOptionCombo identifier: " + cc ) );
+                conflict( "Illegal attributeOptionCombo identifier: " + cc ) );
         }
 
         return attributeOptionCombo;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartController.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.io.IOException;
@@ -52,7 +54,6 @@ import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.indicator.Indicator;
@@ -155,7 +156,7 @@ public class ChartController
 
         if ( chart == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Chart does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "Chart does not exist: " + uid ) );
         }
 
         OrganisationUnit unit = ou != null ? organisationUnitService.getOrganisationUnit( ou ) : null;
@@ -220,35 +221,35 @@ public class ChartController
 
         if ( dataElement == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data element does not exist: " + de ) );
+            throw new WebMessageException( conflict( "Data element does not exist: " + de ) );
         }
 
         CategoryOptionCombo categoryOptionCombo = categoryService.getCategoryOptionCombo( co );
 
         if ( categoryOptionCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Category option combo does not exist: " + co ) );
+            throw new WebMessageException( conflict( "Category option combo does not exist: " + co ) );
         }
 
         CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( cp );
 
         if ( attributeOptionCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Category option combo does not exist: " + cp ) );
+            throw new WebMessageException( conflict( "Category option combo does not exist: " + cp ) );
         }
 
         Period period = PeriodType.getPeriodFromIsoString( pe );
 
         if ( period == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Period does not exist: " + pe ) );
+            throw new WebMessageException( conflict( "Period does not exist: " + pe ) );
         }
 
         OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( ou );
 
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Organisation unit does not exist: " + ou ) );
+            throw new WebMessageException( conflict( "Organisation unit does not exist: " + ou ) );
         }
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_PNG, CacheStrategy.RESPECT_SYSTEM_SETTING,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -27,6 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.objectReport;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.typeReport;
 import static org.hisp.dhis.visualization.ConversionHelper.convertToChartList;
 import static org.hisp.dhis.visualization.ConversionHelper.convertToVisualization;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
@@ -68,7 +74,6 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
@@ -384,7 +389,7 @@ public abstract class ChartFacadeController
 
         if ( entities.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         Visualization persistedObject = entities.get( 0 );
@@ -437,7 +442,7 @@ public abstract class ChartFacadeController
 
         if ( typeReport.hasErrorReports() )
         {
-            return WebMessageUtils.typeReport( typeReport );
+            return typeReport( typeReport );
         }
 
         manager.updateTranslations( persistedObject, object.getTranslations() );
@@ -458,7 +463,7 @@ public abstract class ChartFacadeController
 
         if ( entities.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( Chart.class, pvUid ) );
+            throw new WebMessageException( notFound( Chart.class, pvUid ) );
         }
 
         Visualization persistedObject = entities.get( 0 );
@@ -501,13 +506,13 @@ public abstract class ChartFacadeController
 
         if ( entities.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( Chart.class, pvUid ) );
+            throw new WebMessageException( notFound( Chart.class, pvUid ) );
         }
 
         if ( !getSchema().haveProperty( pvProperty ) )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Property " + pvProperty + " does not exist on " + getEntityName() ) );
+                notFound( "Property " + pvProperty + " does not exist on " + getEntityName() ) );
         }
 
         Property property = getSchema().getProperty( pvProperty );
@@ -527,7 +532,7 @@ public abstract class ChartFacadeController
 
         if ( object == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "Unknown payload format." ) );
+            throw new WebMessageException( badRequest( "Unknown payload format." ) );
         }
 
         Object value = property.getGetterMethod().invoke( object );
@@ -546,7 +551,7 @@ public abstract class ChartFacadeController
 
         if ( entities.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( Chart.class, uid ) );
+            throw new WebMessageException( notFound( Chart.class, uid ) );
         }
 
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
@@ -562,7 +567,7 @@ public abstract class ChartFacadeController
 
         if ( CollectionUtils.isEmpty( charts ) )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( Chart.class, uid ) );
+            throw new WebMessageException( notFound( Chart.class, uid ) );
         }
 
         handleLinksAndAccess( charts, fields, true, user );
@@ -634,7 +639,7 @@ public abstract class ChartFacadeController
 
         ImportReport importReport = importService.importMetadata( params );
         ObjectReport objectReport = getObjectReport( importReport );
-        WebMessage webMessage = WebMessageUtils.objectReport( objectReport );
+        WebMessage webMessage = objectReport( objectReport );
 
         if ( objectReport != null && webMessage.getStatus() == Status.OK )
         {
@@ -677,7 +682,7 @@ public abstract class ChartFacadeController
 
         ImportReport importReport = importService.importMetadata( params );
         ObjectReport objectReport = getObjectReport( importReport );
-        WebMessage webMessage = WebMessageUtils.objectReport( objectReport );
+        WebMessage webMessage = objectReport( objectReport );
 
         if ( objectReport != null && webMessage.getStatus() == Status.OK )
         {
@@ -703,15 +708,14 @@ public abstract class ChartFacadeController
     {
         if ( !getSchema().isFavoritable() )
         {
-            throw new WebMessageException(
-                WebMessageUtils.conflict( "Objects of this class cannot be set as favorite" ) );
+            return conflict( "Objects of this class cannot be set as favorite" );
         }
 
         List<Visualization> entity = (List<Visualization>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( Chart.class, pvUid ) );
+            return notFound( Chart.class, pvUid );
         }
 
         Visualization object = entity.get( 0 );
@@ -720,8 +724,7 @@ public abstract class ChartFacadeController
         object.setAsFavorite( user );
         manager.updateNoAcl( object );
 
-        String message = String.format( "Object '%s' set as favorite for user '%s'", pvUid, user.getUsername() );
-        return WebMessageUtils.ok( message );
+        return ok( String.format( "Object '%s' set as favorite for user '%s'", pvUid, user.getUsername() ) );
     }
 
     @PostMapping( "/{uid}/subscriber" )
@@ -730,14 +733,14 @@ public abstract class ChartFacadeController
     {
         if ( !getSchema().isSubscribable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be subscribed to" );
+            return conflict( "Objects of this class cannot be subscribed to" );
         }
 
         List<SubscribableObject> entity = (List<SubscribableObject>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         SubscribableObject object = entity.get( 0 );
@@ -746,8 +749,7 @@ public abstract class ChartFacadeController
         object.subscribe( user );
         manager.updateNoAcl( object );
 
-        String message = String.format( "User '%s' subscribed to object '%s'", user.getUsername(), pvUid );
-        return WebMessageUtils.ok( message );
+        return ok( String.format( "User '%s' subscribed to object '%s'", user.getUsername(), pvUid ) );
     }
 
     // --------------------------------------------------------------------------
@@ -764,7 +766,7 @@ public abstract class ChartFacadeController
 
         if ( objects.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -786,7 +788,7 @@ public abstract class ChartFacadeController
             .addObject( visualization );
 
         ImportReport importReport = importService.importMetadata( params );
-        WebMessage webMessage = WebMessageUtils.objectReport( importReport );
+        WebMessage webMessage = objectReport( importReport );
 
         if ( importReport.getStatus() != Status.OK )
         {
@@ -806,7 +808,7 @@ public abstract class ChartFacadeController
 
         if ( objects.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -828,7 +830,7 @@ public abstract class ChartFacadeController
             .addObject( visualization );
 
         ImportReport importReport = importService.importMetadata( params );
-        WebMessage webMessage = WebMessageUtils.objectReport( importReport );
+        WebMessage webMessage = objectReport( importReport );
 
         if ( importReport.getStatus() != Status.OK )
         {
@@ -851,7 +853,7 @@ public abstract class ChartFacadeController
 
         if ( objects.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -869,7 +871,7 @@ public abstract class ChartFacadeController
 
         ImportReport importReport = importService.importMetadata( params );
 
-        return WebMessageUtils.objectReport( importReport );
+        return objectReport( importReport );
     }
 
     @DeleteMapping( "/{uid}/favorite" )
@@ -880,14 +882,14 @@ public abstract class ChartFacadeController
     {
         if ( !getSchema().isFavoritable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be set as favorite" );
+            return conflict( "Objects of this class cannot be set as favorite" );
         }
 
         List<Visualization> entity = (List<Visualization>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         Visualization object = entity.get( 0 );
@@ -897,7 +899,7 @@ public abstract class ChartFacadeController
         manager.updateNoAcl( object );
 
         String message = String.format( "Object '%s' removed as favorite for user '%s'", pvUid, user.getUsername() );
-        return WebMessageUtils.ok( message );
+        return ok( message );
     }
 
     @DeleteMapping( "/{uid}/subscriber" )
@@ -906,14 +908,14 @@ public abstract class ChartFacadeController
     {
         if ( !getSchema().isSubscribable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be subscribed to" );
+            return conflict( "Objects of this class cannot be subscribed to" );
         }
 
         List<SubscribableObject> entity = (List<SubscribableObject>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( Chart.class, pvUid );
+            return notFound( Chart.class, pvUid );
         }
 
         SubscribableObject object = entity.get( 0 );
@@ -923,7 +925,7 @@ public abstract class ChartFacadeController
         manager.updateNoAcl( object );
 
         String message = String.format( "User '%s' removed as subscriber of object '%s'", user.getUsername(), pvUid );
-        return WebMessageUtils.ok( message );
+        return ok( message );
     }
 
     // --------------------------------------------------------------------------
@@ -968,7 +970,7 @@ public abstract class ChartFacadeController
             if ( rootNode.getChildren().isEmpty() || rootNode.getChildren().get( 0 ).getChildren().isEmpty() )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
+                    notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
             }
 
             response.setHeader( ContextUtils.HEADER_CACHE_CONTROL,
@@ -1064,7 +1066,7 @@ public abstract class ChartFacadeController
 
         if ( objects.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( getEntityClass(), pvUid ) );
+            throw new WebMessageException( notFound( getEntityClass(), pvUid ) );
         }
 
         collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
@@ -1114,7 +1116,7 @@ public abstract class ChartFacadeController
 
         if ( objects.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( Chart.class, pvUid ) );
+            throw new WebMessageException( notFound( Chart.class, pvUid ) );
         }
 
         collectionService.delCollectionItems( objects.get( 0 ), pvProperty,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -704,7 +704,6 @@ public abstract class ChartFacadeController
     @ResponseStatus( HttpStatus.OK )
     @ResponseBody
     public WebMessage setAsFavorite( @PathVariable( "uid" ) String pvUid )
-        throws Exception
     {
         if ( !getSchema().isFavoritable() )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.COMPLETE_DATA_SET_REGISTRATION_IMPORT;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
@@ -70,7 +72,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.util.InputUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
@@ -207,7 +208,7 @@ public class CompleteDataSetRegistrationController
         ImportSummary summary = registrationExchangeService
             .saveCompleteDataSetRegistrationsXml( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importSummary( summary ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     @PostMapping( consumes = CONTENT_TYPE_JSON, produces = CONTENT_TYPE_JSON )
@@ -223,7 +224,7 @@ public class CompleteDataSetRegistrationController
         ImportSummary summary = registrationExchangeService
             .saveCompleteDataSetRegistrationsJson( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importSummary( summary ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     // -------------------------------------------------------------------------
@@ -246,21 +247,21 @@ public class CompleteDataSetRegistrationController
         if ( dataSets.size() != ds.size() )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Illegal data set identifier in this list: " + ds ) );
+                conflict( "Illegal data set identifier in this list: " + ds ) );
         }
 
         Period period = PeriodType.getPeriodFromIsoString( pe );
 
         if ( period == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Illegal period identifier: " + pe ) );
+            throw new WebMessageException( conflict( "Illegal period identifier: " + pe ) );
         }
 
         OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( ou );
 
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Illegal organisation unit identifier: " + ou ) );
+            throw new WebMessageException( conflict( "Illegal organisation unit identifier: " + ou ) );
         }
 
         CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo( cc, cp, false );
@@ -290,7 +291,7 @@ public class CompleteDataSetRegistrationController
         if ( lockedDataSets.size() != 0 )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Locked Data set(s) : " + StringUtils.join( lockedDataSets, ", " ) ) );
+                conflict( "Locked Data set(s) : " + StringUtils.join( lockedDataSets, ", " ) ) );
         }
 
         // ---------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -81,7 +81,6 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
@@ -197,14 +196,13 @@ public class CompleteDataSetRegistrationController
     @PostMapping( consumes = CONTENT_TYPE_XML, produces = CONTENT_TYPE_XML )
     @ResponseBody
     public WebMessage postCompleteRegistrationsXml(
-        ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
+        ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return asyncImport( importOptions, ImportCompleteDataSetRegistrationsTask.FORMAT_XML, request, response );
+            return asyncImport( importOptions, ImportCompleteDataSetRegistrationsTask.FORMAT_XML, request );
         }
-        response.setContentType( CONTENT_TYPE_XML );
         ImportSummary summary = registrationExchangeService
             .saveCompleteDataSetRegistrationsXml( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
@@ -214,12 +212,12 @@ public class CompleteDataSetRegistrationController
     @PostMapping( consumes = CONTENT_TYPE_JSON, produces = CONTENT_TYPE_JSON )
     @ResponseBody
     public WebMessage postCompleteRegistrationsJson(
-        ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
+        ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return asyncImport( importOptions, ImportCompleteDataSetRegistrationsTask.FORMAT_JSON, request, response );
+            return asyncImport( importOptions, ImportCompleteDataSetRegistrationsTask.FORMAT_JSON, request );
         }
         ImportSummary summary = registrationExchangeService
             .saveCompleteDataSetRegistrationsJson( request.getInputStream(), importOptions );
@@ -313,8 +311,7 @@ public class CompleteDataSetRegistrationController
     // Supportive methods
     // -------------------------------------------------------------------------
 
-    private WebMessage asyncImport( ImportOptions importOptions, String format, HttpServletRequest request,
-        HttpServletResponse response )
+    private WebMessage asyncImport( ImportOptions importOptions, String format, HttpServletRequest request )
         throws IOException
     {
         Pair<InputStream, Path> tmpFile = saveTmpFile( request.getInputStream() );
@@ -328,9 +325,8 @@ public class CompleteDataSetRegistrationController
                 format,
                 jobId ) );
 
-        response.setHeader( "Location",
-            ContextUtils.getRootPath( request ) + "/system/tasks/" + COMPLETE_DATA_SET_REGISTRATION_IMPORT );
-        return jobConfigurationReport( jobId );
+        return jobConfigurationReport( jobId )
+            .setLocation( "/system/tasks/" + COMPLETE_DATA_SET_REGISTRATION_IMPORT );
     }
 
     private Pair<InputStream, Path> saveTmpFile( InputStream in )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -273,7 +273,7 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage handleConflictRequest( Exception exception )
     {
-        return WebMessageUtils.conflict( exception.getMessage() );
+        return conflict( exception.getMessage() );
     }
 
     @ExceptionHandler( MetadataVersionException.class )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -166,7 +166,7 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage notAuthenticatedExceptionHandler( NotAuthenticatedException ex )
     {
-        return WebMessageUtils.unathorized( ex.getMessage() );
+        return WebMessageUtils.unauthorized( ex.getMessage() );
     }
 
     @ExceptionHandler( NotFoundException.class )
@@ -319,7 +319,7 @@ public class CrudControllerAdvice
         }
         else
         {
-            return WebMessageUtils.unathorized( ex.getMessage() );
+            return WebMessageUtils.unauthorized( ex.getMessage() );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -27,6 +27,15 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.createWebMessage;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.forbidden;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.serviceUnavailable;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+
 import java.beans.PropertyEditorSupport;
 import java.util.Date;
 
@@ -45,7 +54,6 @@ import org.hisp.dhis.dxf2.metadata.MetadataImportException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.fieldfilter.FieldFilterException;
 import org.hisp.dhis.query.QueryException;
@@ -110,91 +118,91 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage illegalQueryExceptionHandler( IllegalQueryException ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage(), ex.getErrorCode() );
+        return conflict( ex.getMessage(), ex.getErrorCode() );
     }
 
     @ExceptionHandler( QueryRuntimeException.class )
     @ResponseBody
     public WebMessage queryRuntimeExceptionHandler( QueryRuntimeException ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage(), ex.getErrorCode() );
+        return conflict( ex.getMessage(), ex.getErrorCode() );
     }
 
     @ExceptionHandler( DeleteNotAllowedException.class )
     @ResponseBody
     public WebMessage deleteNotAllowedExceptionHandler( DeleteNotAllowedException ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage(), ex.getErrorCode() );
+        return conflict( ex.getMessage(), ex.getErrorCode() );
     }
 
     @ExceptionHandler( InvalidIdentifierReferenceException.class )
     @ResponseBody
     public WebMessage invalidIdentifierReferenceExceptionHandler( InvalidIdentifierReferenceException ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage() );
+        return conflict( ex.getMessage() );
     }
 
     @ExceptionHandler( { DataApprovalException.class, AdxException.class, IllegalStateException.class } )
     @ResponseBody
     public WebMessage dataApprovalExceptionHandler( Exception ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage() );
+        return conflict( ex.getMessage() );
     }
 
     @ExceptionHandler( { JsonParseException.class, MetadataImportException.class, MetadataExportException.class } )
     @ResponseBody
     public WebMessage jsonParseExceptionHandler( Exception ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage() );
+        return conflict( ex.getMessage() );
     }
 
     @ExceptionHandler( { QueryParserException.class, QueryException.class } )
     @ResponseBody
     public WebMessage queryExceptionHandler( Exception ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage() );
+        return conflict( ex.getMessage() );
     }
 
     @ExceptionHandler( FieldFilterException.class )
     @ResponseBody
     public WebMessage fieldFilterExceptionHandler( FieldFilterException ex )
     {
-        return WebMessageUtils.conflict( ex.getMessage() );
+        return conflict( ex.getMessage() );
     }
 
     @ExceptionHandler( NotAuthenticatedException.class )
     @ResponseBody
     public WebMessage notAuthenticatedExceptionHandler( NotAuthenticatedException ex )
     {
-        return WebMessageUtils.unauthorized( ex.getMessage() );
+        return unauthorized( ex.getMessage() );
     }
 
     @ExceptionHandler( NotFoundException.class )
     @ResponseBody
     public WebMessage notFoundExceptionHandler( NotFoundException ex )
     {
-        return WebMessageUtils.notFound( ex.getMessage() );
+        return notFound( ex.getMessage() );
     }
 
     @ExceptionHandler( ConstraintViolationException.class )
     @ResponseBody
     public WebMessage constraintViolationExceptionHandler( ConstraintViolationException ex )
     {
-        return WebMessageUtils.error( getExceptionMessage( ex ) );
+        return error( getExceptionMessage( ex ) );
     }
 
     @ExceptionHandler( MaintenanceModeException.class )
     @ResponseBody
     public WebMessage maintenanceModeExceptionHandler( MaintenanceModeException ex )
     {
-        return WebMessageUtils.serviceUnavailable( ex.getMessage() );
+        return serviceUnavailable( ex.getMessage() );
     }
 
     @ExceptionHandler( AccessDeniedException.class )
     @ResponseBody
     public WebMessage accessDeniedExceptionHandler( AccessDeniedException ex )
     {
-        return WebMessageUtils.forbidden( ex.getMessage() );
+        return forbidden( ex.getMessage() );
     }
 
     @ExceptionHandler( WebMessageException.class )
@@ -208,42 +216,42 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage httpStatusCodeExceptionHandler( HttpStatusCodeException ex )
     {
-        return WebMessageUtils.createWebMessage( ex.getMessage(), Status.ERROR, ex.getStatusCode() );
+        return createWebMessage( ex.getMessage(), Status.ERROR, ex.getStatusCode() );
     }
 
     @ExceptionHandler( HttpClientErrorException.class )
     @ResponseBody
     public WebMessage httpClientErrorExceptionHandler( HttpClientErrorException ex )
     {
-        return WebMessageUtils.createWebMessage( ex.getMessage(), Status.ERROR, ex.getStatusCode() );
+        return createWebMessage( ex.getMessage(), Status.ERROR, ex.getStatusCode() );
     }
 
     @ExceptionHandler( HttpServerErrorException.class )
     @ResponseBody
     public WebMessage httpServerErrorExceptionHandler( HttpServerErrorException ex )
     {
-        return WebMessageUtils.createWebMessage( ex.getMessage(), Status.ERROR, ex.getStatusCode() );
+        return createWebMessage( ex.getMessage(), Status.ERROR, ex.getStatusCode() );
     }
 
     @ExceptionHandler( HttpRequestMethodNotSupportedException.class )
     @ResponseBody
     public WebMessage httpRequestMethodNotSupportedExceptionHandler( HttpRequestMethodNotSupportedException ex )
     {
-        return WebMessageUtils.createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.METHOD_NOT_ALLOWED );
+        return createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.METHOD_NOT_ALLOWED );
     }
 
     @ExceptionHandler( HttpMediaTypeNotAcceptableException.class )
     @ResponseBody
     public WebMessage httpMediaTypeNotAcceptableExceptionHandler( HttpMediaTypeNotAcceptableException ex )
     {
-        return WebMessageUtils.createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.NOT_ACCEPTABLE );
+        return createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.NOT_ACCEPTABLE );
     }
 
     @ExceptionHandler( HttpMediaTypeNotSupportedException.class )
     @ResponseBody
     public WebMessage httpMediaTypeNotSupportedExceptionHandler( HttpMediaTypeNotSupportedException ex )
     {
-        return WebMessageUtils.createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.UNSUPPORTED_MEDIA_TYPE );
+        return createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.UNSUPPORTED_MEDIA_TYPE );
     }
 
     @ExceptionHandler( ServletException.class )
@@ -257,28 +265,28 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage handleBadRequest( Exception exception )
     {
-        return WebMessageUtils.badRequest( exception.getMessage() );
+        return badRequest( exception.getMessage() );
     }
 
     @ExceptionHandler( MetadataVersionException.class )
     @ResponseBody
     public WebMessage handleMetaDataVersionException( MetadataVersionException metadataVersionException )
     {
-        return WebMessageUtils.error( metadataVersionException.getMessage() );
+        return error( metadataVersionException.getMessage() );
     }
 
     @ExceptionHandler( MetadataSyncException.class )
     @ResponseBody
     public WebMessage handleMetaDataSyncException( MetadataSyncException metadataSyncException )
     {
-        return WebMessageUtils.error( metadataSyncException.getMessage() );
+        return error( metadataSyncException.getMessage() );
     }
 
     @ExceptionHandler( DhisVersionMismatchException.class )
     @ResponseBody
     public WebMessage handleDhisVersionMismatchException( DhisVersionMismatchException versionMismatchException )
     {
-        return WebMessageUtils.forbidden( versionMismatchException.getMessage() );
+        return forbidden( versionMismatchException.getMessage() );
     }
 
     @ExceptionHandler( MetadataImportConflictException.class )
@@ -287,21 +295,16 @@ public class CrudControllerAdvice
     {
         if ( conflictException.getMetadataSyncSummary() == null )
         {
-            return WebMessageUtils.conflict( conflictException.getMessage() );
+            return conflict( conflictException.getMessage() );
         }
-        else
-        {
-            WebMessage message = new WebMessage( Status.ERROR, HttpStatus.CONFLICT );
-            message.setResponse( conflictException.getMetadataSyncSummary() );
-            return message;
-        }
+        return conflict( null ).setResponse( conflictException.getMetadataSyncSummary() );
     }
 
     @ExceptionHandler( OperationNotAllowedException.class )
     @ResponseBody
     public WebMessage handleOperationNotAllowedException( OperationNotAllowedException ex )
     {
-        return WebMessageUtils.forbidden( ex.getMessage() );
+        return forbidden( ex.getMessage() );
     }
 
     @ExceptionHandler( OAuth2AuthenticationException.class )
@@ -314,13 +317,10 @@ public class CrudControllerAdvice
             BearerTokenError bearerTokenError = (BearerTokenError) error;
             HttpStatus status = ((BearerTokenError) error).getHttpStatus();
 
-            return WebMessageUtils.createWebMessage( bearerTokenError.getErrorCode(),
+            return createWebMessage( bearerTokenError.getErrorCode(),
                 bearerTokenError.getDescription(), Status.ERROR, status );
         }
-        else
-        {
-            return WebMessageUtils.unauthorized( ex.getMessage() );
-        }
+        return unauthorized( ex.getMessage() );
     }
 
     /**
@@ -331,7 +331,7 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage defaultExceptionHandler( Exception ex )
     {
-        return WebMessageUtils.error( getExceptionMessage( ex ) );
+        return error( getExceptionMessage( ex ) );
     }
 
     private String getExceptionMessage( Exception ex )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.util.List;
@@ -42,7 +43,6 @@ import org.hisp.dhis.dashboard.DashboardItemType;
 import org.hisp.dhis.dashboard.DashboardSearchResult;
 import org.hisp.dhis.dashboard.DashboardService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.reporttable.ReportTable;
 import org.hisp.dhis.schema.descriptors.DashboardSchemaDescriptor;
@@ -105,7 +105,7 @@ public class DashboardController
 
         if ( dashboard == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Dashboard not found for uid: " + dashboardId ) );
+            throw new WebMessageException( notFound( "Dashboard not found for uid: " + dashboardId ) );
         }
 
         return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dashboard, download );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardItemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardItemController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -35,7 +37,6 @@ import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dashboard.DashboardItemShape;
 import org.hisp.dhis.dashboard.DashboardService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.hibernate.exception.UpdateAccessDeniedException;
 import org.hisp.dhis.schema.descriptors.DashboardItemSchemaDescriptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,7 +71,7 @@ public class DashboardItemController
 
         if ( item == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Dashboard item does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "Dashboard item does not exist: " + uid ) );
         }
 
         Dashboard dashboard = dashboardService.getDashboardFromDashboardItem( item );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
 
 import java.util.ArrayList;
@@ -66,7 +68,6 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.expression.Operator;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nFormat;
@@ -182,7 +183,7 @@ public class DataAnalysisController
             .getOrganisationUnit( validationRulesAnalysisParams.getOu() );
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "No organisation unit defined" ) );
+            throw new WebMessageException( badRequest( "No organisation unit defined" ) );
         }
 
         ValidationAnalysisParams params = validationService.newParamsBuilder( group, organisationUnit,
@@ -217,20 +218,20 @@ public class DataAnalysisController
         if ( validationRule == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Can't find ValidationRule with id =" + validationRuleId ) );
+                notFound( "Can't find ValidationRule with id =" + validationRuleId ) );
         }
 
         OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( organisationUnitId );
         if ( organisationUnit == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Can't find OrganisationUnit with id =" + organisationUnitId ) );
+                notFound( "Can't find OrganisationUnit with id =" + organisationUnitId ) );
         }
 
         Period period = periodService.getPeriod( periodId );
         if ( period == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Can't find Period with id =" + periodId ) );
+            throw new WebMessageException( notFound( "Can't find Period with id =" + periodId ) );
         }
 
         CategoryOptionCombo attributeOptionCombo;
@@ -244,7 +245,7 @@ public class DataAnalysisController
             if ( attributeOptionCombo == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.notFound( "Can't find AttributeOptionCombo with id = " + attributeOptionComboId ) );
+                    notFound( "Can't find AttributeOptionCombo with id = " + attributeOptionComboId ) );
             }
         }
 
@@ -269,7 +270,7 @@ public class DataAnalysisController
             .getOrganisationUnit( stdDevOutlierAnalysisParams.getOu() );
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "No organisation unit defined" ) );
+            throw new WebMessageException( badRequest( "No organisation unit defined" ) );
         }
 
         Collection<Period> periods = periodService
@@ -316,7 +317,7 @@ public class DataAnalysisController
             .getOrganisationUnit( params.getOu() );
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "No organisation unit defined" ) );
+            throw new WebMessageException( badRequest( "No organisation unit defined" ) );
         }
 
         Collection<Period> periods = periodService
@@ -363,7 +364,7 @@ public class DataAnalysisController
             .getOrganisationUnit( params.getOu() );
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "No organisation unit defined" ) );
+            throw new WebMessageException( badRequest( "No organisation unit defined" ) );
         }
 
         Collection<Period> periods = periodService

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,7 +59,6 @@ import org.hisp.dhis.dataapproval.DataApprovalWorkflow;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.node.NodeUtils;
@@ -195,7 +196,7 @@ public class DataApprovalController
             if ( startDate == null || endDate == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Must have either pe or both startDate and endDate." ) );
+                    conflict( "Must have either pe or both startDate and endDate." ) );
             }
         }
         else
@@ -203,7 +204,7 @@ public class DataApprovalController
             if ( startDate != null || endDate != null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Cannot have both pe and startDate or endDate." ) );
+                    conflict( "Cannot have both pe and startDate or endDate." ) );
             }
 
             periods = new ArrayList<>();
@@ -610,7 +611,7 @@ public class DataApprovalController
             if ( dataSet.getWorkflow() == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "DataSet does not have an approval workflow: " + dataSet.getUid() ) );
+                    conflict( "DataSet does not have an approval workflow: " + dataSet.getUid() ) );
             }
         }
 
@@ -640,7 +641,7 @@ public class DataApprovalController
 
         if ( periods.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Approvals must have periods" ) );
+            throw new WebMessageException( conflict( "Approvals must have periods" ) );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -703,13 +704,13 @@ public class DataApprovalController
 
             if ( dataSet == null )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "Data set does not exist: " + ds ) );
+                throw new WebMessageException( conflict( "Data set does not exist: " + ds ) );
             }
 
             if ( dataSet.getWorkflow() == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Data set does not have an approval workflow: " + ds ) );
+                    conflict( "Data set does not have an approval workflow: " + ds ) );
             }
 
             return dataSet.getWorkflow();
@@ -721,7 +722,7 @@ public class DataApprovalController
             if ( workflow == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Data approval workflow does not exist: " + wf ) );
+                    conflict( "Data approval workflow does not exist: " + wf ) );
             }
 
             return workflow;
@@ -729,7 +730,7 @@ public class DataApprovalController
         else
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Either data set or data approval workflow must be specified" ) );
+                conflict( "Either data set or data approval workflow must be specified" ) );
         }
     }
 
@@ -766,7 +767,7 @@ public class DataApprovalController
         if ( workflows.isEmpty() )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Either data sets or data approval workflows must be specified" ) );
+                conflict( "Either data sets or data approval workflows must be specified" ) );
         }
 
         return workflows;
@@ -779,7 +780,7 @@ public class DataApprovalController
 
         if ( period == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Illegal period identifier: " + pe ) );
+            throw new WebMessageException( conflict( "Illegal period identifier: " + pe ) );
         }
 
         return period;
@@ -792,7 +793,7 @@ public class DataApprovalController
 
         if ( organisationUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Organisation unit does not exist: " + ou ) );
+            throw new WebMessageException( conflict( "Organisation unit does not exist: " + ou ) );
         }
 
         return organisationUnit;
@@ -806,7 +807,7 @@ public class DataApprovalController
         if ( dataApprovalLevel == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Approval level not found for org unit: " + unit.getUid() ) );
+                conflict( "Approval level not found for org unit: " + unit.getUid() ) );
         }
 
         return dataApprovalLevel;
@@ -822,7 +823,7 @@ public class DataApprovalController
             if ( optionCombo == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Attribute option combo does not exist: " + aoc ) );
+                    conflict( "Attribute option combo does not exist: " + aoc ) );
             }
 
             return optionCombo;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,7 +72,6 @@ import org.hisp.dhis.dxf2.metadata.Metadata;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.util.InputUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.node.NodeUtils;
 import org.hisp.dhis.node.types.RootNode;
@@ -180,7 +183,7 @@ public class DataSetController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data set does not exist: " + uid ) );
+            throw new WebMessageException( conflict( "Data set does not exist: " + uid ) );
         }
 
         Map<String, Integer> versionMap = new HashMap<>();
@@ -198,7 +201,7 @@ public class DataSetController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data set does not exist: " + uid ) );
+            throw new WebMessageException( conflict( "Data set does not exist: " + uid ) );
         }
 
         dataSet.increaseVersion();
@@ -217,7 +220,7 @@ public class DataSetController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data set does not exist: " + uid ) );
+            throw new WebMessageException( conflict( "Data set does not exist: " + uid ) );
         }
 
         List<CategoryCombo> categoryCombos = dataSet.getDataSetElements().stream()
@@ -250,7 +253,7 @@ public class DataSetController
 
         if ( dataSets.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataSet not found for uid: " + uid ) );
         }
 
         Period pe = periodService.getPeriod( period );
@@ -275,14 +278,14 @@ public class DataSetController
 
         if ( dataSets.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataSet not found for uid: " + uid ) );
         }
 
         OrganisationUnit ou = manager.get( OrganisationUnit.class, orgUnit );
 
         if ( ou == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Organisation unit does not exist: " + orgUnit ) );
+            throw new WebMessageException( notFound( "Organisation unit does not exist: " + orgUnit ) );
         }
 
         Period pe = PeriodType.getPeriodFromIsoString( period );
@@ -308,14 +311,14 @@ public class DataSetController
 
         if ( dataSets.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataSet not found for uid: " + uid ) );
         }
 
         OrganisationUnit ou = manager.get( OrganisationUnit.class, orgUnit );
 
         if ( ou == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Organisation unit does not exist: " + orgUnit ) );
+            throw new WebMessageException( notFound( "Organisation unit does not exist: " + orgUnit ) );
         }
 
         Period pe = PeriodType.getPeriodFromIsoString( period );
@@ -374,7 +377,7 @@ public class DataSetController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataSet not found for uid: " + uid ) );
         }
 
         DataEntryForm form = dataSet.getDataEntryForm();
@@ -405,7 +408,7 @@ public class DataSetController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataSet not found for uid: " + uid ) );
         }
 
         DataEntryForm form = dataSet.getDataEntryForm();
@@ -417,14 +420,14 @@ public class DataSetController
         }
         catch ( IOException e )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "Failed to parse request", e.getMessage() ) );
+            throw new WebMessageException( badRequest( "Failed to parse request", e.getMessage() ) );
         }
 
         if ( form == null )
         {
             if ( !newForm.hasForm() )
             {
-                throw new WebMessageException( WebMessageUtils.badRequest( "Missing required parameter 'htmlCode'" ) );
+                throw new WebMessageException( badRequest( "Missing required parameter 'htmlCode'" ) );
             }
 
             newForm.setName( dataSet.getName() );
@@ -459,7 +462,7 @@ public class DataSetController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataSet not found for uid: " + pvUid ) );
+            throw new WebMessageException( notFound( "DataSet not found for uid: " + pvUid ) );
         }
 
         return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dataSet, download );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -41,7 +43,6 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.datasetreport.DataSetReportService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
@@ -99,7 +100,7 @@ public class DataSetReportController
         if ( !dataSet.getFormType().isCustom() )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Data set form type must be 'custom': " + dataSet.getFormType() ) );
+                conflict( "Data set form type must be 'custom': " + dataSet.getFormType() ) );
         }
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML,
@@ -176,7 +177,7 @@ public class DataSetReportController
 
         if ( orgUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Organisation unit does not exist: " + ou ) );
+            throw new WebMessageException( conflict( "Organisation unit does not exist: " + ou ) );
         }
 
         return orgUnit;
@@ -189,7 +190,7 @@ public class DataSetReportController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data set does not exist: " + ds ) );
+            throw new WebMessageException( conflict( "Data set does not exist: " + ds ) );
         }
 
         return dataSet;
@@ -206,7 +207,7 @@ public class DataSetReportController
 
             if ( period == null )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "Period does not exist: " + pe ) );
+                throw new WebMessageException( conflict( "Period does not exist: " + pe ) );
             }
 
             periods.add( periodService.reloadPeriod( period ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -72,7 +72,6 @@ import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
 import org.hisp.dhis.dxf2.datavalueset.tasks.ImportDataValueTask;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -103,9 +102,6 @@ public class DataValueSetController
 
     @Autowired
     private AdxDataService adxDataService;
-
-    @Autowired
-    private RenderService renderService;
 
     @Autowired
     private CurrentUserService currentUserService;
@@ -258,13 +254,12 @@ public class DataValueSetController
     @PostMapping( consumes = "application/xml", produces = CONTENT_TYPE_XML )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
-    public WebMessage postDxf2DataValueSet( ImportOptions importOptions,
-        HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postDxf2DataValueSet( ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_XML, request, response );
+            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_XML, request );
         }
         ImportSummary summary = dataValueSetService.saveDataValueSet( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
@@ -275,13 +270,12 @@ public class DataValueSetController
     @PostMapping( consumes = CONTENT_TYPE_XML_ADX, produces = CONTENT_TYPE_XML )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
-    public WebMessage postAdxDataValueSet( ImportOptions importOptions,
-        HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postAdxDataValueSet( ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_ADX, request, response );
+            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_ADX, request );
         }
         ImportSummary summary = adxDataService.saveDataValueSet( request.getInputStream(), importOptions,
             null );
@@ -293,13 +287,12 @@ public class DataValueSetController
     @PostMapping( consumes = "application/json", produces = CONTENT_TYPE_JSON )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
-    public WebMessage postJsonDataValueSet( ImportOptions importOptions,
-        HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postJsonDataValueSet( ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_JSON, request, response );
+            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_JSON, request );
         }
         ImportSummary summary = dataValueSetService.saveDataValueSetJson( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
@@ -310,13 +303,12 @@ public class DataValueSetController
     @PostMapping( consumes = "application/csv", produces = CONTENT_TYPE_JSON )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
-    public WebMessage postCsvDataValueSet( ImportOptions importOptions,
-        HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postCsvDataValueSet( ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_CSV, request, response );
+            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_CSV, request );
         }
         ImportSummary summary = dataValueSetService.saveDataValueSetCsv( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
@@ -327,13 +319,12 @@ public class DataValueSetController
     @PostMapping( consumes = CONTENT_TYPE_PDF, produces = CONTENT_TYPE_JSON )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
-    public WebMessage postPdfDataValueSet( ImportOptions importOptions,
-        HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postPdfDataValueSet( ImportOptions importOptions, HttpServletRequest request )
         throws IOException
     {
         if ( importOptions.isAsync() )
         {
-            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_PDF, request, response );
+            return startAsyncImport( importOptions, ImportDataValueTask.FORMAT_PDF, request );
         }
         ImportSummary summary = dataValueSetService.saveDataValueSetPdf( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
@@ -351,10 +342,8 @@ public class DataValueSetController
      * @param importOptions the ImportOptions.
      * @param format the resource representation format.
      * @param request the HttpRequest.
-     * @param response the HttpResponse.
      */
-    private WebMessage startAsyncImport( ImportOptions importOptions, String format, HttpServletRequest request,
-        HttpServletResponse response )
+    private WebMessage startAsyncImport( ImportOptions importOptions, String format, HttpServletRequest request )
         throws IOException
     {
         InputStream inputStream = saveTmp( request.getInputStream() );
@@ -365,8 +354,8 @@ public class DataValueSetController
             new ImportDataValueTask( dataValueSetService, adxDataService, sessionFactory, inputStream, importOptions,
                 jobId, format ) );
 
-        response.setHeader( "Location", ContextUtils.getRootPath( request ) + "/system/tasks/" + DATAVALUE_IMPORT );
-        return jobConfigurationReport( jobId );
+        return jobConfigurationReport( jobId )
+            .setLocation( "/system/tasks/" + DATAVALUE_IMPORT );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.common.DhisApiVersion.V38;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
@@ -71,7 +72,6 @@ import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
 import org.hisp.dhis.dxf2.datavalueset.tasks.ImportDataValueTask;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.CurrentUserService;
@@ -269,7 +269,7 @@ public class DataValueSetController
         ImportSummary summary = dataValueSetService.saveDataValueSet( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( V38 );
+        return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
     @PostMapping( consumes = CONTENT_TYPE_XML_ADX, produces = CONTENT_TYPE_XML )
@@ -287,7 +287,7 @@ public class DataValueSetController
             null );
         summary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( V38 );
+        return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
     @PostMapping( consumes = "application/json", produces = CONTENT_TYPE_JSON )
@@ -304,7 +304,7 @@ public class DataValueSetController
         ImportSummary summary = dataValueSetService.saveDataValueSetJson( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( V38 );
+        return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
     @PostMapping( consumes = "application/csv", produces = CONTENT_TYPE_JSON )
@@ -321,7 +321,7 @@ public class DataValueSetController
         ImportSummary summary = dataValueSetService.saveDataValueSetCsv( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( V38 );
+        return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
     @PostMapping( consumes = CONTENT_TYPE_PDF, produces = CONTENT_TYPE_JSON )
@@ -338,7 +338,7 @@ public class DataValueSetController
         ImportSummary summary = dataValueSetService.saveDataValueSetPdf( request.getInputStream(), importOptions );
         summary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( summary ).withPlainResponseBefore( V38 );
+        return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DocumentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DocumentController.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -39,7 +42,6 @@ import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.document.Document;
 import org.hisp.dhis.document.DocumentService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.external.location.LocationManager;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
@@ -83,7 +85,7 @@ public class DocumentController
 
         if ( document == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Document not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "Document not found for uid: " + uid ) );
         }
 
         if ( document.isExternal() )
@@ -104,7 +106,7 @@ public class DocumentController
             }
             catch ( IOException e )
             {
-                throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+                throw new WebMessageException( error( "Failed fetching the file from storage",
                     "There was an exception when trying to fetch the file from the storage backend, could be network or filesystem related" ) );
             }
         }
@@ -121,7 +123,7 @@ public class DocumentController
             catch ( IOException e )
             {
                 log.error( "Could not retrieve file.", e );
-                throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+                throw new WebMessageException( error( "Failed fetching the file from storage",
                     "There was an exception when trying to fetch the file from the storage backend. " +
                         "Depending on the provider the root cause could be network or file system related." ) );
             }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
@@ -27,13 +27,16 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.email.Email;
 import org.hisp.dhis.email.EmailResponse;
 import org.hisp.dhis.email.EmailService;
@@ -84,7 +87,7 @@ public class EmailController
 
         if ( !currentUserService.getCurrentUser().hasEmail() )
         {
-            return WebMessageUtils.conflict( "Could not send test email, no email configured for current user" );
+            return conflict( "Could not send test email, no email configured for current user" );
         }
 
         OutboundMessageResponse emailResponse = emailService.sendTestEmail();
@@ -103,8 +106,7 @@ public class EmailController
 
         if ( !systemNotificationEmailValid )
         {
-            return WebMessageUtils
-                .conflict( "Could not send email, system notification email address not set or not valid" );
+            return conflict( "Could not send email, system notification email address not set or not valid" );
         }
 
         OutboundMessageResponse emailResponse = emailService.sendSystemEmail( email );
@@ -136,11 +138,11 @@ public class EmailController
         {
             String msg = !StringUtils.isEmpty( emailResponse.getDescription() ) ? emailResponse.getDescription()
                 : EmailResponse.SENT.getResponseMessage();
-            return WebMessageUtils.ok( msg );
+            return ok( msg );
         }
         String msg = !StringUtils.isEmpty( emailResponse.getDescription() ) ? emailResponse.getDescription()
             : EmailResponse.FAILED.getResponseMessage();
-        return WebMessageUtils.error( msg );
+        return error( msg );
     }
 
     private void checkEmailSettings()
@@ -148,7 +150,7 @@ public class EmailController
     {
         if ( !emailService.emailConfigured() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( SMTP_ERROR ) );
+            throw new WebMessageException( conflict( SMTP_ERROR ) );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
@@ -35,10 +35,10 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.ExpressionValidationOutcome;
 import org.hisp.dhis.feedback.Status;
-import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -64,19 +64,11 @@ public class ExpressionController
     @GetMapping( value = "/description", produces = MediaType.APPLICATION_JSON_VALUE )
     public WebMessage getExpressionDescription( @RequestParam String expression )
     {
-        I18n i18n = i18nManager.getI18n();
-
         ExpressionValidationOutcome result = expressionService.expressionIsValid( expression, INDICATOR_EXPRESSION );
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-        message.setStatus( result.isValid() ? Status.OK : Status.ERROR );
-        message.setMessage( i18n.getString( result.getKey() ) );
-
-        if ( result.isValid() )
-        {
-            message.setDescription( expressionService.getExpressionDescription( expression, INDICATOR_EXPRESSION ) );
-        }
-
-        return message;
+        return new DescriptiveWebMessage( result.isValid() ? Status.OK : Status.ERROR, HttpStatus.OK )
+            .setDescription( result::isValid,
+                () -> expressionService.getExpressionDescription( expression, INDICATOR_EXPRESSION ) )
+            .setMessage( i18nManager.getI18n().getString( result.getKey() ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExternalFileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExternalFileResourceController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.io.IOException;
@@ -89,7 +91,7 @@ public class ExternalFileResourceController
 
         if ( externalFileResource == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "No file found with key '" + accessToken + "'" ) );
+            throw new WebMessageException( notFound( "No file found with key '" + accessToken + "'" ) );
         }
 
         if ( externalFileResource.getExpires() != null && externalFileResource.getExpires().before( new Date() ) )
@@ -111,7 +113,7 @@ public class ExternalFileResourceController
         }
         catch ( IOException e )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend, could be network or filesystem related" ) );
         }
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.io.IOException;
 import java.io.Writer;
 
@@ -36,7 +38,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -96,7 +97,7 @@ public class FileController
         if ( content != null )
         {
             systemSettingManager.saveSystemSetting( SettingKey.CUSTOM_JS, content );
-            return WebMessageUtils.ok( "Custom script created" );
+            return ok( "Custom script created" );
         }
         return null;
     }
@@ -140,7 +141,7 @@ public class FileController
         if ( content != null )
         {
             systemSettingManager.saveSystemSetting( SettingKey.CUSTOM_CSS, content );
-            return WebMessageUtils.ok( "Custom style created" );
+            return ok( "Custom style created" );
         }
         return null;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
 import java.io.IOException;
 
@@ -38,7 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.dxf2.webmessage.responses.FileResourceWebMessageResponse;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.fileresource.FileResource;
@@ -102,7 +104,7 @@ public class FileResourceController
 
         if ( fileResource == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( FileResource.class, uid ) );
+            throw new WebMessageException( notFound( FileResource.class, uid ) );
         }
 
         FileResourceUtils.setImageFileDimensions( fileResource,
@@ -120,7 +122,7 @@ public class FileResourceController
 
         if ( fileResource == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( FileResource.class, uid ) );
+            throw new WebMessageException( notFound( FileResource.class, uid ) );
         }
 
         FileResourceUtils.setImageFileDimensions( fileResource,
@@ -129,7 +131,7 @@ public class FileResourceController
         if ( !checkSharing( fileResource ) )
         {
             throw new WebMessageException(
-                WebMessageUtils.unauthorized( "You don't have access to fileResource '" + uid
+                unauthorized( "You don't have access to fileResource '" + uid
                     + "' or this fileResource is not available from this endpoint" ) );
         }
 
@@ -145,7 +147,7 @@ public class FileResourceController
         catch ( IOException e )
         {
             log.error( "Could not retrieve file.", e );
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend. " +
                     "Depending on the provider the root cause could be network or file system related." ) );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -129,7 +129,7 @@ public class FileResourceController
         if ( !checkSharing( fileResource ) )
         {
             throw new WebMessageException(
-                WebMessageUtils.unathorized( "You don't have access to fileResource '" + uid
+                WebMessageUtils.unauthorized( "You don't have access to fileResource '" + uid
                     + "' or this fileResource is not available from this endpoint" ) );
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IconController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -39,7 +41,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.icon.Icon;
 import org.hisp.dhis.icon.IconData;
 import org.hisp.dhis.icon.IconService;
@@ -110,7 +111,7 @@ public class IconController
         if ( !icon.isPresent() )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( String.format( "Icon not found: '%s", iconKey ) ) );
+                notFound( String.format( "Icon not found: '%s", iconKey ) ) );
         }
 
         icon.get().setReference( String.format( "%s%s/%s/icon.%s", contextService.getApiPath(),
@@ -129,7 +130,7 @@ public class IconController
         if ( !icon.isPresent() )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( String.format( "Icon resource not found: '%s", iconKey ) ) );
+                notFound( String.format( "Icon resource not found: '%s", iconKey ) ) );
         }
 
         response.setHeader( "Cache-Control", CacheControl.maxAge( TTL, TimeUnit.DAYS ).getHeaderValue() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
@@ -64,22 +64,21 @@ public class IdentifiableObjectController
     }
 
     @Override
-    public WebMessage postXmlObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postXmlObject( HttpServletRequest request )
         throws Exception
     {
         throw new HttpRequestMethodNotSupportedException( "POST" );
     }
 
     @Override
-    public WebMessage postJsonObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postJsonObject( HttpServletRequest request )
         throws Exception
     {
         throw new HttpRequestMethodNotSupportedException( "POST" );
     }
 
     @Override
-    public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
-        HttpServletResponse response )
+    public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request )
         throws Exception
     {
         throw new HttpRequestMethodNotSupportedException( "PUT" );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,7 +46,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.eventchart.EventChart;
 import org.hisp.dhis.eventreport.EventReport;
 import org.hisp.dhis.fieldfilter.Defaults;
@@ -147,7 +149,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( visualization == null )
         {
-            return WebMessageUtils.conflict( "Report table does not exist or is not accessible: " + visualizationUid );
+            return conflict( "Report table does not exist or is not accessible: " + visualizationUid );
         }
 
         Period period = PeriodType.getPeriodFromIsoString( isoPeriod );
@@ -169,7 +171,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( visualization == null )
         {
-            return WebMessageUtils.conflict( "Chart does not exist or is not accessible: " + uid );
+            return conflict( "Chart does not exist or is not accessible: " + uid );
         }
 
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, visualization,
@@ -190,7 +192,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( visualization == null )
         {
-            return WebMessageUtils.conflict( "Visualization does not exist or is not accessible: " + uid );
+            return conflict( "Visualization does not exist or is not accessible: " + uid );
         }
 
         final OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, visualization,
@@ -208,7 +210,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( map == null )
         {
-            return WebMessageUtils.conflict( "Map does not exist or is not accessible: " + uid );
+            return conflict( "Map does not exist or is not accessible: " + uid );
         }
 
         return createInterpretation( new Interpretation( map, text ), response );
@@ -225,7 +227,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( eventReport == null )
         {
-            return WebMessageUtils.conflict( "Event report does not exist or is not accessible: " + uid );
+            return conflict( "Event report does not exist or is not accessible: " + uid );
         }
 
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, eventReport,
@@ -245,7 +247,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( eventChart == null )
         {
-            return WebMessageUtils.conflict( "Event chart does not exist or is not accessible: " + uid );
+            return conflict( "Event chart does not exist or is not accessible: " + uid );
         }
 
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, eventChart,
@@ -264,21 +266,21 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( dataSet == null )
         {
-            return WebMessageUtils.conflict( "Data set does not exist or is not accessible: " + dataSetUid );
+            return conflict( "Data set does not exist or is not accessible: " + dataSetUid );
         }
 
         Period period = PeriodType.getPeriodFromIsoString( isoPeriod );
 
         if ( period == null )
         {
-            return WebMessageUtils.conflict( "Period identifier not valid: " + isoPeriod );
+            return conflict( "Period identifier not valid: " + isoPeriod );
         }
 
         OrganisationUnit orgUnit = idObjectManager.get( OrganisationUnit.class, orgUnitUid );
 
         if ( orgUnit == null )
         {
-            return WebMessageUtils.conflict( "Organisation unit does not exist or is not accessible: " + orgUnitUid );
+            return conflict( "Organisation unit does not exist or is not accessible: " + orgUnitUid );
         }
 
         return createInterpretation( new Interpretation( dataSet, period, orgUnit, text ), response );
@@ -301,7 +303,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
             if ( unit == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Organisation unit does not exist or is not accessible: " + uid ) );
+                    conflict( "Organisation unit does not exist or is not accessible: " + uid ) );
             }
 
             return unit;
@@ -324,7 +326,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         response.addHeader( "Location", InterpretationSchemaDescriptor.API_ENDPOINT + "/" + interpretation.getUid() );
 
-        return WebMessageUtils.created( "Interpretation created" );
+        return created( "Interpretation created" );
     }
 
     // -------------------------------------------------------------------------
@@ -340,7 +342,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.notFound( "Interpretation does not exist: " + uid );
+            return notFound( "Interpretation does not exist: " + uid );
         }
 
         if ( !currentUserService.getCurrentUser().equals( interpretation.getCreatedBy() )
@@ -362,7 +364,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.notFound( "Interpretation does not exist: " + uid );
+            return notFound( "Interpretation does not exist: " + uid );
         }
 
         if ( !currentUserService.getCurrentUser().equals( interpretation.getCreatedBy() )
@@ -388,7 +390,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.conflict( "Interpretation does not exist: " + uid );
+            return conflict( "Interpretation does not exist: " + uid );
         }
 
         InterpretationComment comment = interpretationService.addInterpretationComment( uid, text );
@@ -396,7 +398,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         String builder = InterpretationSchemaDescriptor.API_ENDPOINT + "/" + uid + "/comments/" + comment.getUid();
 
         response.addHeader( "Location", builder );
-        return WebMessageUtils.created( "Commented created" );
+        return created( "Commented created" );
     }
 
     @PutMapping( "/{uid}/comments/{cuid}" )
@@ -409,7 +411,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.conflict( "Interpretation does not exist: " + uid );
+            return conflict( "Interpretation does not exist: " + uid );
         }
 
         for ( InterpretationComment comment : interpretation.getComments() )
@@ -440,7 +442,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.conflict( "Interpretation does not exist: " + uid );
+            return conflict( "Interpretation does not exist: " + uid );
         }
 
         Iterator<InterpretationComment> iterator = interpretation.getComments().iterator();
@@ -477,14 +479,14 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.conflict( "Interpretation does not exist: " + uid );
+            return conflict( "Interpretation does not exist: " + uid );
         }
 
         if ( interpretationService.likeInterpretation( interpretation.getId() ) )
         {
-            return WebMessageUtils.created( "Like added to interpretation" );
+            return created( "Like added to interpretation" );
         }
-        return WebMessageUtils.conflict( "Could not add like, user had already liked interpretation" );
+        return conflict( "Could not add like, user had already liked interpretation" );
     }
 
     @DeleteMapping( "/{uid}/like" )
@@ -495,14 +497,14 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         if ( interpretation == null )
         {
-            return WebMessageUtils.conflict( "Interpretation does not exist: " + uid );
+            return conflict( "Interpretation does not exist: " + uid );
         }
 
         if ( interpretationService.unlikeInterpretation( interpretation.getId() ) )
         {
-            return WebMessageUtils.created( "Like removed from interpretation" );
+            return created( "Like removed from interpretation" );
         }
-        return WebMessageUtils.conflict( "Could not remove like, user had not previously liked interpretation" );
+        return conflict( "Could not remove like, user had not previously liked interpretation" );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -141,8 +141,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     @ResponseBody
     public WebMessage writeReportTableInterpretation( @PathVariable( "uid" ) String visualizationUid,
         @RequestParam( value = "pe", required = false ) String isoPeriod,
-        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
-        HttpServletResponse response, HttpServletRequest request )
+        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text )
         throws WebMessageException
     {
         Visualization visualization = idObjectManager.get( Visualization.class, visualizationUid );
@@ -157,14 +156,13 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, visualization,
             currentUserService.getCurrentUser() );
 
-        return createInterpretation( new Interpretation( visualization, period, orgUnit, text ), response );
+        return createInterpretation( new Interpretation( visualization, period, orgUnit, text ) );
     }
 
     @PostMapping( value = "/chart/{uid}", consumes = { "text/html", "text/plain" } )
     @ResponseBody
     public WebMessage writeChartInterpretation( @PathVariable( "uid" ) String uid,
-        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
-        HttpServletResponse response, HttpServletRequest request )
+        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text )
         throws WebMessageException
     {
         Visualization visualization = idObjectManager.get( Visualization.class, uid );
@@ -177,7 +175,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, visualization,
             currentUserService.getCurrentUser() );
 
-        return createInterpretation( new Interpretation( visualization, orgUnit, text ), response );
+        return createInterpretation( new Interpretation( visualization, orgUnit, text ) );
     }
 
     @PostMapping( value = "/visualization/{uid}", consumes = { "text/html", "text/plain" } )
@@ -185,7 +183,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     public WebMessage writeVisualizationInterpretation( @PathVariable( "uid" )
     final String uid, @RequestParam( value = "ou", required = false )
     final String orgUnitUid, @RequestBody
-    final String text, final HttpServletResponse response )
+    final String text )
         throws WebMessageException
     {
         final Visualization visualization = idObjectManager.get( Visualization.class, uid );
@@ -198,13 +196,12 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         final OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, visualization,
             currentUserService.getCurrentUser() );
 
-        return createInterpretation( new Interpretation( visualization, orgUnit, text ), response );
+        return createInterpretation( new Interpretation( visualization, orgUnit, text ) );
     }
 
     @PostMapping( value = "/map/{uid}", consumes = { "text/html", "text/plain" } )
     @ResponseBody
-    public WebMessage writeMapInterpretation( @PathVariable( "uid" ) String uid, @RequestBody String text,
-        HttpServletResponse response )
+    public WebMessage writeMapInterpretation( @PathVariable( "uid" ) String uid, @RequestBody String text )
     {
         Map map = idObjectManager.get( Map.class, uid );
 
@@ -213,14 +210,13 @@ public class InterpretationController extends AbstractCrudController<Interpretat
             return conflict( "Map does not exist or is not accessible: " + uid );
         }
 
-        return createInterpretation( new Interpretation( map, text ), response );
+        return createInterpretation( new Interpretation( map, text ) );
     }
 
     @PostMapping( value = "/eventReport/{uid}", consumes = { "text/html", "text/plain" } )
     @ResponseBody
     public WebMessage writeEventReportInterpretation( @PathVariable( "uid" ) String uid,
-        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
-        HttpServletResponse response )
+        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text )
         throws WebMessageException
     {
         EventReport eventReport = idObjectManager.get( EventReport.class, uid );
@@ -233,14 +229,13 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, eventReport,
             currentUserService.getCurrentUser() );
 
-        return createInterpretation( new Interpretation( eventReport, orgUnit, text ), response );
+        return createInterpretation( new Interpretation( eventReport, orgUnit, text ) );
     }
 
     @PostMapping( value = "/eventChart/{uid}", consumes = { "text/html", "text/plain" } )
     @ResponseBody
     public WebMessage writeEventChartInterpretation( @PathVariable( "uid" ) String uid,
-        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text,
-        HttpServletResponse response )
+        @RequestParam( value = "ou", required = false ) String orgUnitUid, @RequestBody String text )
         throws WebMessageException
     {
         EventChart eventChart = idObjectManager.get( EventChart.class, uid );
@@ -253,14 +248,13 @@ public class InterpretationController extends AbstractCrudController<Interpretat
         OrganisationUnit orgUnit = getUserOrganisationUnit( orgUnitUid, eventChart,
             currentUserService.getCurrentUser() );
 
-        return createInterpretation( new Interpretation( eventChart, orgUnit, text ), response );
+        return createInterpretation( new Interpretation( eventChart, orgUnit, text ) );
     }
 
     @PostMapping( value = "/dataSetReport/{uid}", consumes = { "text/html", "text/plain" } )
     @ResponseBody
     public WebMessage writeDataSetReportInterpretation( @PathVariable( "uid" ) String dataSetUid,
-        @RequestParam( "pe" ) String isoPeriod, @RequestParam( "ou" ) String orgUnitUid, @RequestBody String text,
-        HttpServletResponse response )
+        @RequestParam( "pe" ) String isoPeriod, @RequestParam( "ou" ) String orgUnitUid, @RequestBody String text )
     {
         DataSet dataSet = idObjectManager.get( DataSet.class, dataSetUid );
 
@@ -283,7 +277,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
             return conflict( "Organisation unit does not exist or is not accessible: " + orgUnitUid );
         }
 
-        return createInterpretation( new Interpretation( dataSet, period, orgUnit, text ), response );
+        return createInterpretation( new Interpretation( dataSet, period, orgUnit, text ) );
     }
 
     /**
@@ -320,13 +314,12 @@ public class InterpretationController extends AbstractCrudController<Interpretat
      * Saves the given interpretation, adds location header and returns a web
      * message response.
      */
-    private WebMessage createInterpretation( Interpretation interpretation, HttpServletResponse response )
+    private WebMessage createInterpretation( Interpretation interpretation )
     {
         interpretationService.saveInterpretation( interpretation );
 
-        response.addHeader( "Location", InterpretationSchemaDescriptor.API_ENDPOINT + "/" + interpretation.getUid() );
-
-        return created( "Interpretation created" );
+        return created( "Interpretation created" )
+            .setLocation( InterpretationSchemaDescriptor.API_ENDPOINT + "/" + interpretation.getUid() );
     }
 
     // -------------------------------------------------------------------------
@@ -395,10 +388,8 @@ public class InterpretationController extends AbstractCrudController<Interpretat
 
         InterpretationComment comment = interpretationService.addInterpretationComment( uid, text );
 
-        String builder = InterpretationSchemaDescriptor.API_ENDPOINT + "/" + uid + "/comments/" + comment.getUid();
-
-        response.addHeader( "Location", builder );
-        return created( "Commented created" );
+        return created( "Commented created" )
+            .setLocation( InterpretationSchemaDescriptor.API_ENDPOINT + "/" + uid + "/comments/" + comment.getUid() );
     }
 
     @PutMapping( "/{uid}/comments/{cuid}" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/KeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/KeyJsonValueController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.Date;
@@ -37,7 +39,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.beanutils.BeanUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.keyjsonvalue.KeyJsonValue;
 import org.hisp.dhis.keyjsonvalue.KeyJsonValueService;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
@@ -111,7 +112,7 @@ public class KeyJsonValueController
 
         service.deleteNamespace( namespace );
 
-        return WebMessageUtils.ok( "Namespace '" + namespace + "' deleted." );
+        return ok( "Namespace '" + namespace + "' deleted." );
     }
 
     /**
@@ -163,7 +164,7 @@ public class KeyJsonValueController
 
         service.addKeyJsonValue( entry );
 
-        return WebMessageUtils.created( "Key '" + key + "' created." );
+        return created( "Key '" + key + "' created." );
     }
 
     /**
@@ -180,7 +181,7 @@ public class KeyJsonValueController
 
         service.updateKeyJsonValue( entry );
 
-        return WebMessageUtils.ok( "Key '" + key + "' updated." );
+        return ok( "Key '" + key + "' updated." );
     }
 
     /**
@@ -194,7 +195,7 @@ public class KeyJsonValueController
         KeyJsonValue entry = getExistingEntry( namespace, key );
         service.deleteKeyJsonValue( entry );
 
-        return WebMessageUtils.ok( "Key '" + key + "' deleted from namespace '" + namespace + "'." );
+        return ok( "Key '" + key + "' deleted from namespace '" + namespace + "'." );
     }
 
     private KeyJsonValue getExistingEntry( String namespace, String key )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LegendSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LegendSetController.java
@@ -48,19 +48,18 @@ public class LegendSetController
 {
     @Override
     @PreAuthorize( "hasRole('F_LEGEND_SET_PUBLIC_ADD') or hasRole('F_LEGEND_SET_PRIVATE_ADD') or hasRole('ALL')" )
-    public WebMessage postJsonObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postJsonObject( HttpServletRequest request )
         throws Exception
     {
-        return super.postJsonObject( request, response );
+        return super.postJsonObject( request );
     }
 
     @Override
     @PreAuthorize( "hasRole('F_LEGEND_SET_PUBLIC_ADD') or hasRole('F_LEGEND_SET_PRIVATE_ADD')  or hasRole('ALL')" )
-    public WebMessage putJsonObject( @PathVariable String uid, HttpServletRequest request,
-        HttpServletResponse response )
+    public WebMessage putJsonObject( @PathVariable String uid, HttpServletRequest request )
         throws Exception
     {
-        return super.putJsonObject( uid, request, response );
+        return super.putJsonObject( uid, request );
     }
 
     @Override

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -38,7 +42,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.i18n.I18nLocaleService;
 import org.hisp.dhis.i18n.locale.I18nLocale;
 import org.hisp.dhis.i18n.locale.LocaleManager;
@@ -124,7 +127,7 @@ public class LocaleController
 
         if ( locale == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Cannot find Locale with uid: " + uid ) );
+            throw new WebMessageException( notFound( "Cannot find Locale with uid: " + uid ) );
         }
 
         return locale;
@@ -138,7 +141,7 @@ public class LocaleController
     {
         if ( StringUtils.isEmpty( country ) || StringUtils.isEmpty( language ) )
         {
-            return WebMessageUtils.conflict( "Invalid country or language code." );
+            return conflict( "Invalid country or language code." );
         }
 
         String localeCode = LocaleUtils.getLocaleString( language, country, null );
@@ -151,13 +154,13 @@ public class LocaleController
 
             if ( i18nLocale != null )
             {
-                return WebMessageUtils.conflict( "Locale code existed." );
+                return conflict( "Locale code existed." );
             }
         }
 
         I18nLocale i18nLocale = localeService.addI18nLocale( language, country );
 
-        WebMessage webMessage = WebMessageUtils.created( "Locale created successfully" );
+        WebMessage webMessage = created( "Locale created successfully" );
 
         response.setHeader( ContextUtils.HEADER_LOCATION,
             contextService.getApiPath() + "/locales/" + i18nLocale.getUid() );
@@ -175,7 +178,7 @@ public class LocaleController
 
         if ( i18nLocale == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Cannot find Locale with uid " + uid ) );
+            throw new WebMessageException( notFound( "Cannot find Locale with uid " + uid ) );
         }
 
         localeService.deleteI18nLocale( i18nLocale );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
@@ -160,12 +160,8 @@ public class LocaleController
 
         I18nLocale i18nLocale = localeService.addI18nLocale( language, country );
 
-        WebMessage webMessage = created( "Locale created successfully" );
-
-        response.setHeader( ContextUtils.HEADER_LOCATION,
-            contextService.getApiPath() + "/locales/" + i18nLocale.getUid() );
-
-        return webMessage;
+        return created( "Locale created successfully" )
+            .setLocation( "/locales/" + i18nLocale.getUid() );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_LOCALE_DELETE')" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +48,6 @@ import org.hisp.dhis.dataset.LockException;
 import org.hisp.dhis.dataset.comparator.LockExceptionNameComparator;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
@@ -141,7 +144,7 @@ public class LockExceptionController
             if ( lockException == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.notFound( "Cannot find LockException with key: " + key ) );
+                    notFound( "Cannot find LockException with key: " + key ) );
             }
 
             lockExceptions.add( lockException );
@@ -229,7 +232,7 @@ public class LockExceptionController
 
         if ( dataSet == null || period == null )
         {
-            return WebMessageUtils.conflict( " DataSet or Period is invalid" );
+            return conflict( " DataSet or Period is invalid" );
         }
 
         if ( !aclService.canUpdate( user, dataSet ) )
@@ -253,7 +256,7 @@ public class LockExceptionController
 
         if ( listOrgUnitIds.isEmpty() )
         {
-            return WebMessageUtils.conflict( " OrganisationUnit ID is invalid." );
+            return conflict( " OrganisationUnit ID is invalid." );
         }
 
         for ( String id : listOrgUnitIds )
@@ -262,7 +265,7 @@ public class LockExceptionController
 
             if ( organisationUnit == null )
             {
-                return WebMessageUtils.conflict( "Can't find OrganisationUnit with id =" + id );
+                return conflict( "Can't find OrganisationUnit with id =" + id );
             }
 
             if ( organisationUnit.getDataSets().contains( dataSet ) )
@@ -279,7 +282,7 @@ public class LockExceptionController
 
         if ( created )
         {
-            return WebMessageUtils.created( "LockException created successfully." );
+            return created( "LockException created successfully." );
         }
         return null;
     }
@@ -300,7 +303,7 @@ public class LockExceptionController
 
         if ( !ObjectUtils.allNonNull( dataSet, period ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "Can't find LockException with combination: dataSet=" + dataSetId + ", period=" + periodId ) );
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummaries;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.util.List;
 
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
@@ -40,7 +44,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.util.CategoryUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.maintenance.MaintenanceService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -214,10 +217,10 @@ public class MaintenanceController
 
         if ( categoryCombo == null )
         {
-            return WebMessageUtils.conflict( "CategoryCombo does not exist: " + uid );
+            return conflict( "CategoryCombo does not exist: " + uid );
         }
 
-        return WebMessageUtils.importSummaries( categoryUtils.addAndPruneOptionCombos( categoryCombo ) );
+        return importSummaries( categoryUtils.addAndPruneOptionCombos( categoryCombo ) );
     }
 
     @RequestMapping( value = { "/cacheClear", "/cache" }, method = { RequestMethod.PUT, RequestMethod.POST } )
@@ -238,12 +241,12 @@ public class MaintenanceController
 
         if ( organisationUnit == null )
         {
-            return WebMessageUtils.conflict( "Organisation unit does not exist: " + uid );
+            return conflict( "Organisation unit does not exist: " + uid );
         }
 
         return maintenanceService.pruneData( organisationUnit )
-            ? WebMessageUtils.ok( "Data was pruned successfully" )
-            : WebMessageUtils.conflict( "Data could not be pruned" );
+            ? ok( "Data was pruned successfully" )
+            : conflict( "Data could not be pruned" );
     }
 
     @RequestMapping( value = "/dataPruning/dataElements/{uid}", method = { RequestMethod.PUT, RequestMethod.POST } )
@@ -255,12 +258,12 @@ public class MaintenanceController
 
         if ( dataElement == null )
         {
-            return WebMessageUtils.conflict( "Data element does not exist: " + uid );
+            return conflict( "Data element does not exist: " + uid );
         }
 
         return maintenanceService.pruneData( dataElement )
-            ? WebMessageUtils.ok( "Data was pruned successfully" )
-            : WebMessageUtils.conflict( "Data could not be pruned" );
+            ? ok( "Data was pruned successfully" )
+            : conflict( "Data could not be pruned" );
     }
 
     @GetMapping( "/appReload" )
@@ -269,7 +272,7 @@ public class MaintenanceController
     public WebMessage appReload()
     {
         appManager.reloadApps();
-        return WebMessageUtils.ok( "Apps reloaded" );
+        return ok( "Apps reloaded" );
     }
 
     @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,7 +48,6 @@ import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
@@ -262,7 +265,7 @@ public class MessageConversationController
             if ( organisationUnit == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Organisation Unit does not exist: " + ou.getUid() ) );
+                    conflict( "Organisation Unit does not exist: " + ou.getUid() ) );
             }
 
             usersToMessageConversation.addAll( organisationUnit.getUsers() );
@@ -274,7 +277,7 @@ public class MessageConversationController
 
             if ( user == null )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "User does not exist: " + u.getUid() ) );
+                throw new WebMessageException( conflict( "User does not exist: " + u.getUid() ) );
             }
 
             usersToMessageConversation.add( user );
@@ -287,7 +290,7 @@ public class MessageConversationController
             if ( userGroup == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.notFound( "User Group does not exist: " + ug.getUid() ) );
+                    notFound( "User Group does not exist: " + ug.getUid() ) );
             }
 
             usersToMessageConversation.addAll( userGroup.getMembers() );
@@ -307,7 +310,7 @@ public class MessageConversationController
 
         if ( messageConversation.getUsers().isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "No recipients selected." ) );
+            throw new WebMessageException( conflict( "No recipients selected." ) );
         }
 
         String metaData = MessageService.META_USER_AGENT + request.getHeader( ContextUtils.HEADER_USER_AGENT );
@@ -321,14 +324,14 @@ public class MessageConversationController
             if ( fileResource == null )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "Attachment '" + fr.getUid() + "' not found." ) );
+                    conflict( "Attachment '" + fr.getUid() + "' not found." ) );
             }
 
             if ( !fileResource.getDomain().equals( FileResourceDomain.MESSAGE_ATTACHMENT )
                 || fileResource.isAssigned() )
             {
-                throw new WebMessageException( WebMessageUtils
-                    .conflict( "Attachment '" + fr.getUid() + "' is already used or not a valid attachment." ) );
+                throw new WebMessageException(
+                    conflict( "Attachment '" + fr.getUid() + "' is already used or not a valid attachment." ) );
             }
 
             fileResource.setAssigned( true );
@@ -343,7 +346,7 @@ public class MessageConversationController
 
         response
             .addHeader( "Location", MessageConversationSchemaDescriptor.API_ENDPOINT + "/" + conversation.getUid() );
-        return WebMessageUtils.created( "Message conversation created" );
+        return created( "Message conversation created" );
     }
 
     // --------------------------------------------------------------------------
@@ -365,7 +368,7 @@ public class MessageConversationController
 
         if ( conversation == null )
         {
-            return WebMessageUtils.notFound( "Message conversation does not exist: " + uid );
+            return notFound( "Message conversation does not exist: " + uid );
         }
 
         if ( internal && !messageService.hasAccessToManageFeedbackMessages( currentUserService.getCurrentUser() ) )
@@ -386,14 +389,13 @@ public class MessageConversationController
 
             if ( fileResource == null )
             {
-                return WebMessageUtils.conflict( "Attachment '" + fileResourceUid + "' not found." );
+                return conflict( "Attachment '" + fileResourceUid + "' not found." );
             }
 
             if ( !fileResource.getDomain().equals( FileResourceDomain.MESSAGE_ATTACHMENT )
                 || fileResource.isAssigned() )
             {
-                return WebMessageUtils
-                    .conflict( "Attachment '" + fileResourceUid + "' is already used or not a valid attachment." );
+                return conflict( "Attachment '" + fileResourceUid + "' is already used or not a valid attachment." );
             }
 
             fileResource.setAssigned( true );
@@ -406,7 +408,7 @@ public class MessageConversationController
 
         response
             .addHeader( "Location", MessageConversationSchemaDescriptor.API_ENDPOINT + "/" + conversation.getUid() );
-        return WebMessageUtils.created( "Message conversation created" );
+        return created( "Message conversation created" );
     }
 
     @PostMapping( "/{uid}/recipients" )
@@ -419,7 +421,7 @@ public class MessageConversationController
 
         if ( conversation == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Message conversation does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "Message conversation does not exist: " + uid ) );
         }
 
         Set<User> additionalUsers = getUsersToMessageConversation( messageConversation,
@@ -448,7 +450,7 @@ public class MessageConversationController
 
         messageService.sendTicketMessage( subject, body, metaData );
 
-        return WebMessageUtils.created( "Feedback created" );
+        return created( "Feedback created" );
     }
 
     // --------------------------------------------------------------------------
@@ -923,7 +925,7 @@ public class MessageConversationController
 
         if ( message == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound(
+            throw new WebMessageException( notFound(
                 "No message found with id '" + msgUid + "' for message conversation with id '" + mcUid + "'" ) );
         }
 
@@ -933,12 +935,12 @@ public class MessageConversationController
         if ( fr == null || !attachmentExists )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "No messageattachment found with id '" + fileUid + "'" ) );
+                notFound( "No messageattachment found with id '" + fileUid + "'" ) );
         }
 
         if ( !fr.getDomain().equals( FileResourceDomain.MESSAGE_ATTACHMENT ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Invalid messageattachment." ) );
+            throw new WebMessageException( conflict( "Invalid messageattachment." ) );
         }
 
         fileResourceUtils.configureFileResourceResponse( response, fr );
@@ -1057,7 +1059,7 @@ public class MessageConversationController
         if ( conversation == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( String.format( "No message conversation with uid '%s'", mcUid ) ) );
+                notFound( String.format( "No message conversation with uid '%s'", mcUid ) ) );
         }
 
         if ( !canReadMessageConversation( user, conversation ) )
@@ -1071,15 +1073,15 @@ public class MessageConversationController
 
         if ( messages.size() < 1 )
         {
-            throw new WebMessageException( WebMessageUtils
-                .notFound( String.format( "No message with uid '%s' in messageConversation '%s", msgUid, mcUid ) ) );
+            throw new WebMessageException(
+                notFound( String.format( "No message with uid '%s' in messageConversation '%s", msgUid, mcUid ) ) );
         }
 
         Message message = messages.get( 0 );
 
         if ( message.isInternal() && !configurationService.isUserInFeedbackRecipientUserGroup( user ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Not authorized to access this message" ) );
+            throw new WebMessageException( conflict( "Not authorized to access this message" ) );
         }
 
         return message;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -237,21 +237,21 @@ public class MessageConversationController
     // --------------------------------------------------------------------------
 
     @Override
-    public WebMessage postXmlObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postXmlObject( HttpServletRequest request )
         throws Exception
     {
         MessageConversation messageConversation = renderService
             .fromXml( request.getInputStream(), MessageConversation.class );
-        return postObject( response, request, messageConversation );
+        return postObject( request, messageConversation );
     }
 
     @Override
-    public WebMessage postJsonObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postJsonObject( HttpServletRequest request )
         throws Exception
     {
         MessageConversation messageConversation = renderService
             .fromJson( request.getInputStream(), MessageConversation.class );
-        return postObject( response, request, messageConversation );
+        return postObject( request, messageConversation );
     }
 
     private Set<User> getUsersToMessageConversation( MessageConversation messageConversation, Set<User> users )
@@ -299,8 +299,7 @@ public class MessageConversationController
         return usersToMessageConversation;
     }
 
-    private WebMessage postObject( HttpServletResponse response, HttpServletRequest request,
-        MessageConversation messageConversation )
+    private WebMessage postObject( HttpServletRequest request, MessageConversation messageConversation )
         throws WebMessageException
     {
         Set<User> users = Sets.newHashSet( messageConversation.getUsers() );
@@ -344,9 +343,8 @@ public class MessageConversationController
 
         org.hisp.dhis.message.MessageConversation conversation = messageService.getMessageConversation( id );
 
-        response
-            .addHeader( "Location", MessageConversationSchemaDescriptor.API_ENDPOINT + "/" + conversation.getUid() );
-        return created( "Message conversation created" );
+        return created( "Message conversation created" )
+            .setLocation( MessageConversationSchemaDescriptor.API_ENDPOINT + "/" + conversation.getUid() );
     }
 
     // --------------------------------------------------------------------------
@@ -360,7 +358,7 @@ public class MessageConversationController
         @RequestBody String message,
         @RequestParam( value = "internal", defaultValue = "false" ) boolean internal,
         @RequestParam( value = "attachments", required = false ) Set<String> attachments,
-        HttpServletRequest request, HttpServletResponse response )
+        HttpServletRequest request )
     {
         String metaData = MessageService.META_USER_AGENT + request.getHeader( ContextUtils.HEADER_USER_AGENT );
 
@@ -406,9 +404,8 @@ public class MessageConversationController
 
         messageService.sendReply( conversation, message, metaData, internal, fileResources );
 
-        response
-            .addHeader( "Location", MessageConversationSchemaDescriptor.API_ENDPOINT + "/" + conversation.getUid() );
-        return created( "Message conversation created" );
+        return created( "Message conversation created" )
+            .setLocation( MessageConversationSchemaDescriptor.API_ENDPOINT + "/" + conversation.getUid() );
     }
 
     @PostMapping( "/{uid}/recipients" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -41,7 +43,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
-import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.minmax.MinMaxDataElement;
@@ -57,7 +58,6 @@ import org.hisp.dhis.schema.descriptors.MinMaxDataElementSchemaDescriptor;
 import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -149,11 +149,7 @@ public class MinMaxDataElementController
             minMaxService.updateMinMaxDataElement( persisted );
         }
 
-        WebMessage webMessage = new WebMessage();
-        webMessage.setHttpStatus( HttpStatus.CREATED );
-        webMessage.setStatus( Status.OK );
-
-        return webMessage;
+        return created();
     }
 
     // --------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 
 import java.util.List;
 import java.util.Objects;
@@ -42,7 +44,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.minmax.MinMaxDataElement;
@@ -173,12 +174,12 @@ public class MinMaxDataElementController
 
         if ( Objects.isNull( persisted ) )
         {
-            return WebMessageUtils.notFound( "Can not find MinMaxDataElement." );
+            return notFound( "Can not find MinMaxDataElement." );
         }
 
         minMaxService.deleteMinMaxDataElement( persisted );
 
-        return WebMessageUtils.ok( "MinMaxDataElement deleted." );
+        return ok( "MinMaxDataElement deleted." );
     }
 
     private void validate( MinMaxDataElement minMax )
@@ -187,7 +188,7 @@ public class MinMaxDataElementController
         if ( !ObjectUtils.allNonNull( minMax.getDataElement(), minMax.getSource(), minMax.getOptionCombo() ) )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Missing required parameters : Source, DataElement, OptionCombo." ) );
+                notFound( "Missing required parameters : Source, DataElement, OptionCombo." ) );
         }
     }
 
@@ -205,7 +206,7 @@ public class MinMaxDataElementController
         catch ( NullPointerException e )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Invalid required parameters: source, dataElement, optionCombo" ) );
+                notFound( "Invalid required parameters: source, dataElement, optionCombo" ) );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +39,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
 import org.hisp.dhis.minmax.MinMaxValueParams;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -96,13 +97,13 @@ public class MinMaxValueController
 
         if ( dataSets == null || dataSets.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( " No datasets defined" ) );
+            throw new WebMessageException( conflict( " No datasets defined" ) );
         }
 
         OrganisationUnit organisationUnit = this.organisationUnitService.getOrganisationUnit( organisationUnitId );
         if ( organisationUnitId == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( " No valid organisation unit" ) );
+            throw new WebMessageException( conflict( " No valid organisation unit" ) );
         }
 
         Collection<DataElement> dataElements = new HashSet<>();
@@ -129,13 +130,13 @@ public class MinMaxValueController
 
         if ( dataSetIds == null || dataSetIds.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( " No datasets defined" ) );
+            throw new WebMessageException( conflict( " No datasets defined" ) );
         }
 
         OrganisationUnit organisationUnit = this.organisationUnitService.getOrganisationUnit( organisationUnitId );
         if ( organisationUnitId == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( " No valid organisation unit" ) );
+            throw new WebMessageException( conflict( " No valid organisation unit" ) );
         }
 
         Collection<DataElement> dataElements = new HashSet<>();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PdfFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PdfFormController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
+
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -45,7 +47,6 @@ import org.hisp.dhis.dxf2.pdfform.PdfDataEntryFormService;
 import org.hisp.dhis.dxf2.pdfform.PdfDataEntryFormUtil;
 import org.hisp.dhis.dxf2.pdfform.PdfFormFontSettings;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
@@ -151,6 +152,6 @@ public class PdfFormController
         ImportSummary summary = dataValueSetService.saveDataValueSetPdf( in, ImportOptions.getDefaultImportOptions(),
             jobId );
 
-        return WebMessageUtils.importSummary( summary );
+        return importSummary( summary );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
@@ -34,7 +34,6 @@ import java.util.Date;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.AsyncTaskExecutor;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -46,7 +45,6 @@ import org.hisp.dhis.predictor.PredictionTask;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -85,7 +83,7 @@ public class PredictionController
         @RequestParam( value = "predictor", required = false ) List<String> predictors,
         @RequestParam( value = "predictorGroup", required = false ) List<String> predictorGroups,
         @RequestParam( defaultValue = "false", required = false ) boolean async,
-        HttpServletRequest request, HttpServletResponse response )
+        HttpServletRequest request )
     {
         if ( async )
         {
@@ -95,18 +93,14 @@ public class PredictionController
             taskExecutor.executeTask(
                 new PredictionTask( startDate, endDate, predictors, predictorGroups, predictionService, jobId ) );
 
-            response.setHeader( "Location", ContextUtils.getRootPath( request ) + "/system/tasks/" + PREDICTOR );
-
-            return jobConfigurationReport( jobId );
+            return jobConfigurationReport( jobId )
+                .setLocation( "/system/tasks/" + PREDICTOR );
         }
-        else
-        {
-            PredictionSummary predictionSummary = predictionService.predictTask( startDate, endDate, predictors,
-                predictorGroups, null );
+        PredictionSummary predictionSummary = predictionService.predictTask( startDate, endDate, predictors,
+            predictorGroups, null );
 
-            WebMessage webMessage = new WebMessage( Status.OK, HttpStatus.OK );
-            webMessage.setResponse( predictionSummary );
-            return webMessage.withPlainResponseBefore( DhisApiVersion.V38 );
-        }
+        return new WebMessage( Status.OK, HttpStatus.OK )
+            .setResponse( predictionSummary )
+            .withPlainResponseBefore( DhisApiVersion.V38 );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.ExpressionValidationOutcome;
 import org.hisp.dhis.feedback.Status;
-import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.predictor.PredictionService;
 import org.hisp.dhis.predictor.PredictionSummary;
@@ -50,6 +49,7 @@ import org.hisp.dhis.predictor.Predictor;
 import org.hisp.dhis.predictor.PredictorService;
 import org.hisp.dhis.schema.descriptors.PredictorSchemaDescriptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -145,39 +145,23 @@ public class PredictorController extends AbstractCrudController<Predictor>
     @ResponseBody
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {
-        I18n i18n = i18nManager.getI18n();
-
         ExpressionValidationOutcome result = expressionService.expressionIsValid( expression, PREDICTOR_EXPRESSION );
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-        message.setStatus( result.isValid() ? Status.OK : Status.ERROR );
-        message.setMessage( i18n.getString( result.getKey() ) );
-
-        if ( result.isValid() )
-        {
-            message.setDescription( expressionService.getExpressionDescription( expression, PREDICTOR_EXPRESSION ) );
-        }
-
-        return message;
+        return new DescriptiveWebMessage( result.isValid() ? Status.OK : Status.ERROR, HttpStatus.OK )
+            .setDescription( result::isValid,
+                () -> expressionService.getExpressionDescription( expression, PREDICTOR_EXPRESSION ) )
+            .setMessage( i18nManager.getI18n().getString( result.getKey() ) );
     }
 
     @PostMapping( value = "/skipTest/description", produces = MediaType.APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getSkipTestDescription( @RequestBody String expression )
     {
-        I18n i18n = i18nManager.getI18n();
-
         ExpressionValidationOutcome result = expressionService.expressionIsValid( expression, PREDICTOR_SKIP_TEST );
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-        message.setStatus( result.isValid() ? Status.OK : Status.ERROR );
-        message.setMessage( i18n.getString( result.getKey() ) );
-
-        if ( result.isValid() )
-        {
-            message.setDescription( expressionService.getExpressionDescription( expression, PREDICTOR_SKIP_TEST ) );
-        }
-
-        return message;
+        return new DescriptiveWebMessage( result.isValid() ? Status.OK : Status.ERROR, HttpStatus.OK )
+            .setDescription( result::isValid,
+                () -> expressionService.getExpressionDescription( expression, PREDICTOR_SKIP_TEST ) )
+            .setMessage( i18nManager.getI18n().getString( result.getKey() ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
 
@@ -38,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.ExpressionValidationOutcome;
 import org.hisp.dhis.feedback.Status;
@@ -98,13 +99,13 @@ public class PredictorController extends AbstractCrudController<Predictor>
 
             predictionService.predict( predictor, startDate, endDate, predictionSummary );
 
-            return WebMessageUtils.ok( "Generated " + predictionSummary.getPredictions() + " predictions" );
+            return ok( "Generated " + predictionSummary.getPredictions() + " predictions" );
         }
         catch ( Exception ex )
         {
             log.error( "Unable to predict " + predictor.getName(), ex );
 
-            return WebMessageUtils.conflict( "Unable to predict " + predictor.getName(), ex.getMessage() );
+            return conflict( "Unable to predict " + predictor.getName(), ex.getMessage() );
         }
     }
 
@@ -134,11 +135,11 @@ public class PredictorController extends AbstractCrudController<Predictor>
             {
                 log.error( "Unable to predict " + predictor.getName(), ex );
 
-                return WebMessageUtils.conflict( "Unable to predict " + predictor.getName(), ex.getMessage() );
+                return conflict( "Unable to predict " + predictor.getName(), ex.getMessage() );
             }
         }
 
-        return WebMessageUtils.ok( "Generated " + count + " predictions" );
+        return ok( "Generated " + count + " predictions" );
     }
 
     @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
@@ -36,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.pushanalysis.PushAnalysis;
 import org.hisp.dhis.pushanalysis.PushAnalysisService;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -88,7 +89,7 @@ public class PushAnalysisController
         if ( pushAnalysis == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Push analysis with uid " + uid + " was not found" ) );
+                notFound( "Push analysis with uid " + uid + " was not found" ) );
         }
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.NO_CACHE );
@@ -113,7 +114,7 @@ public class PushAnalysisController
         if ( pushAnalysis == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Push analysis with uid " + uid + " was not found" ) );
+                notFound( "Push analysis with uid " + uid + " was not found" ) );
         }
 
         JobConfiguration pushAnalysisJobConfiguration = new JobConfiguration( "pushAnalysisJob from controller",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
 
 import java.util.Date;
@@ -41,7 +43,6 @@ import net.sf.jasperreports.j2ee.servlets.ImageServlet;
 
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.MonthlyPeriodType;
@@ -100,7 +101,7 @@ public class ReportController
 
         if ( report == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Report not found for identifier: " + uid ) );
+            throw new WebMessageException( notFound( "Report not found for identifier: " + uid ) );
         }
 
         report.setDesignContent( designContent );
@@ -115,12 +116,12 @@ public class ReportController
 
         if ( report == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Report not found for identifier: " + uid ) );
+            throw new WebMessageException( notFound( "Report not found for identifier: " + uid ) );
         }
 
         if ( report.getDesignContent() == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Report has no design content: " + uid ) );
+            throw new WebMessageException( conflict( "Report has no design content: " + uid ) );
         }
 
         if ( report.isTypeHtml() )
@@ -207,7 +208,7 @@ public class ReportController
 
         if ( report == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Report not found for identifier: " + uid ) );
+            throw new WebMessageException( notFound( "Report not found for identifier: " + uid ) );
         }
 
         if ( organisationUnitUid == null && report.hasVisualization() && report.getVisualization().hasReportingParams()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -27,6 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.objectReport;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.typeReport;
 import static org.hisp.dhis.visualization.ConversionHelper.convertToReportTableList;
 import static org.hisp.dhis.visualization.ConversionHelper.convertToVisualization;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
@@ -67,7 +73,6 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
@@ -383,7 +388,7 @@ public abstract class ReportTableFacadeController
 
         if ( entities.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         Visualization persistedObject = entities.get( 0 );
@@ -436,7 +441,7 @@ public abstract class ReportTableFacadeController
 
         if ( typeReport.hasErrorReports() )
         {
-            return WebMessageUtils.typeReport( typeReport );
+            return typeReport( typeReport );
         }
 
         manager.updateTranslations( persistedObject, object.getTranslations() );
@@ -457,7 +462,7 @@ public abstract class ReportTableFacadeController
 
         if ( entities.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         Visualization persistedObject = entities.get( 0 );
@@ -501,13 +506,13 @@ public abstract class ReportTableFacadeController
 
         if ( entities.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( ReportTable.class, pvUid ) );
+            throw new WebMessageException( notFound( ReportTable.class, pvUid ) );
         }
 
         if ( !getSchema().haveProperty( pvProperty ) )
         {
-            throw new WebMessageException( WebMessageUtils
-                .notFound( "Property " + pvProperty + " does not exist on " + ReportTable.class.getName() ) );
+            throw new WebMessageException(
+                notFound( "Property " + pvProperty + " does not exist on " + ReportTable.class.getName() ) );
         }
 
         Property property = getSchema().getProperty( pvProperty );
@@ -527,7 +532,7 @@ public abstract class ReportTableFacadeController
 
         if ( object == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "Unknown payload format." ) );
+            throw new WebMessageException( badRequest( "Unknown payload format." ) );
         }
 
         Object value = property.getGetterMethod().invoke( object );
@@ -546,7 +551,7 @@ public abstract class ReportTableFacadeController
 
         if ( entities.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( ReportTable.class, uid ) );
+            throw new WebMessageException( notFound( ReportTable.class, uid ) );
         }
 
         Query query = queryService.getQueryFromUrl( getEntityClass(), filters, new ArrayList<>(),
@@ -562,7 +567,7 @@ public abstract class ReportTableFacadeController
 
         if ( CollectionUtils.isEmpty( reportTables ) )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( ReportTable.class, uid ) );
+            throw new WebMessageException( notFound( ReportTable.class, uid ) );
         }
 
         handleLinksAndAccess( reportTables, fields, true, user );
@@ -634,7 +639,7 @@ public abstract class ReportTableFacadeController
 
         ImportReport importReport = importService.importMetadata( params );
         ObjectReport objectReport = getObjectReport( importReport );
-        WebMessage webMessage = WebMessageUtils.objectReport( objectReport );
+        WebMessage webMessage = objectReport( objectReport );
 
         if ( objectReport != null && webMessage.getStatus() == Status.OK )
         {
@@ -677,7 +682,7 @@ public abstract class ReportTableFacadeController
 
         ImportReport importReport = importService.importMetadata( params );
         ObjectReport objectReport = getObjectReport( importReport );
-        WebMessage webMessage = WebMessageUtils.objectReport( objectReport );
+        WebMessage webMessage = objectReport( objectReport );
 
         if ( objectReport != null && webMessage.getStatus() == Status.OK )
         {
@@ -701,14 +706,14 @@ public abstract class ReportTableFacadeController
     {
         if ( !getSchema().isFavoritable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be set as favorite" );
+            return conflict( "Objects of this class cannot be set as favorite" );
         }
 
         List<Visualization> entity = (List<Visualization>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         Visualization object = entity.get( 0 );
@@ -718,7 +723,7 @@ public abstract class ReportTableFacadeController
         manager.updateNoAcl( object );
 
         String message = String.format( "Object '%s' set as favorite for user '%s'", pvUid, user.getUsername() );
-        return WebMessageUtils.ok( message );
+        return ok( message );
     }
 
     @PostMapping( "/{uid}/subscriber" )
@@ -727,14 +732,14 @@ public abstract class ReportTableFacadeController
     {
         if ( !getSchema().isSubscribable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be subscribed to" );
+            return conflict( "Objects of this class cannot be subscribed to" );
         }
 
         List<SubscribableObject> entity = (List<SubscribableObject>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         SubscribableObject object = entity.get( 0 );
@@ -744,7 +749,7 @@ public abstract class ReportTableFacadeController
         manager.updateNoAcl( object );
 
         String message = String.format( "User '%s' subscribed to object '%s'", user.getUsername(), pvUid );
-        return WebMessageUtils.ok( message );
+        return ok( message );
     }
 
     // --------------------------------------------------------------------------
@@ -761,7 +766,7 @@ public abstract class ReportTableFacadeController
 
         if ( objects.isEmpty() )
         {
-            return WebMessageUtils.notFound( getEntityClass(), pvUid );
+            return notFound( getEntityClass(), pvUid );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -783,7 +788,7 @@ public abstract class ReportTableFacadeController
             .addObject( visualization );
 
         ImportReport importReport = importService.importMetadata( params );
-        WebMessage webMessage = WebMessageUtils.objectReport( importReport );
+        WebMessage webMessage = objectReport( importReport );
 
         if ( importReport.getStatus() != Status.OK )
         {
@@ -804,7 +809,7 @@ public abstract class ReportTableFacadeController
 
         if ( objects.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -826,7 +831,7 @@ public abstract class ReportTableFacadeController
             .addObject( visualization );
 
         ImportReport importReport = importService.importMetadata( params );
-        WebMessage webMessage = WebMessageUtils.objectReport( importReport );
+        WebMessage webMessage = objectReport( importReport );
 
         if ( importReport.getStatus() != Status.OK )
         {
@@ -849,7 +854,7 @@ public abstract class ReportTableFacadeController
 
         if ( objects.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -867,7 +872,7 @@ public abstract class ReportTableFacadeController
 
         ImportReport importReport = importService.importMetadata( params );
 
-        return WebMessageUtils.objectReport( importReport );
+        return objectReport( importReport );
     }
 
     @DeleteMapping( "/{uid}/favorite" )
@@ -876,14 +881,14 @@ public abstract class ReportTableFacadeController
     {
         if ( !getSchema().isFavoritable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be set as favorite" );
+            return conflict( "Objects of this class cannot be set as favorite" );
         }
 
         List<Visualization> entity = (List<Visualization>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         Visualization object = entity.get( 0 );
@@ -893,7 +898,7 @@ public abstract class ReportTableFacadeController
         manager.updateNoAcl( object );
 
         String message = String.format( "Object '%s' removed as favorite for user '%s'", pvUid, user.getUsername() );
-        return WebMessageUtils.ok( message );
+        return ok( message );
     }
 
     @DeleteMapping( "/{uid}/subscriber" )
@@ -902,14 +907,14 @@ public abstract class ReportTableFacadeController
     {
         if ( !getSchema().isSubscribable() )
         {
-            return WebMessageUtils.conflict( "Objects of this class cannot be subscribed to" );
+            return conflict( "Objects of this class cannot be subscribed to" );
         }
 
         List<SubscribableObject> entity = (List<SubscribableObject>) getEntity( pvUid );
 
         if ( entity.isEmpty() )
         {
-            return WebMessageUtils.notFound( ReportTable.class, pvUid );
+            return notFound( ReportTable.class, pvUid );
         }
 
         SubscribableObject object = entity.get( 0 );
@@ -919,7 +924,7 @@ public abstract class ReportTableFacadeController
         manager.updateNoAcl( object );
 
         String message = String.format( "User '%s' removed as subscriber of object '%s'", user.getUsername(), pvUid );
-        return WebMessageUtils.ok( message );
+        return ok( message );
     }
 
     // --------------------------------------------------------------------------
@@ -964,7 +969,7 @@ public abstract class ReportTableFacadeController
             if ( rootNode.getChildren().isEmpty() || rootNode.getChildren().get( 0 ).getChildren().isEmpty() )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
+                    notFound( pvProperty + " with ID " + pvItemId + " could not be found." ) );
             }
 
             response.setHeader( ContextUtils.HEADER_CACHE_CONTROL,
@@ -1058,7 +1063,7 @@ public abstract class ReportTableFacadeController
 
         if ( objects.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( ReportTable.class, pvUid ) );
+            throw new WebMessageException( notFound( ReportTable.class, pvUid ) );
         }
 
         collectionService.addCollectionItems( objects.get( 0 ), pvProperty,
@@ -1111,7 +1116,7 @@ public abstract class ReportTableFacadeController
 
         if ( objects.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( ReportTable.class, pvUid ) );
+            throw new WebMessageException( notFound( ReportTable.class, pvUid ) );
         }
 
         collectionService.delCollectionItems( objects.get( 0 ), pvProperty,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.errorReports;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +38,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
@@ -154,7 +155,7 @@ public class SchemaController
         Object object = renderService.fromJson( request.getInputStream(), schema.getKlass() );
         List<ErrorReport> validationViolations = schemaValidator.validate( object );
 
-        return WebMessageUtils.errorReports( validationViolations );
+        return errorReports( validationViolations );
     }
 
     @GetMapping( "/{type}/{property}" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,7 +49,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
@@ -126,7 +129,7 @@ public class SharingController
 
         if ( !aclService.isShareable( type ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Type " + type + " is not supported." ) );
+            throw new WebMessageException( conflict( "Type " + type + " is not supported." ) );
         }
 
         Class<? extends IdentifiableObject> klass = aclService.classForType( type );
@@ -135,7 +138,7 @@ public class SharingController
         if ( object == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Object of type " + type + " with ID " + id + " was not found." ) );
+                notFound( "Object of type " + type + " with ID " + id + " was not found." ) );
         }
 
         User user = currentUserService.getCurrentUser();
@@ -245,19 +248,19 @@ public class SharingController
 
         if ( sharingClass == null || !aclService.isClassShareable( sharingClass ) )
         {
-            return WebMessageUtils.conflict( "Type " + type + " is not supported." );
+            return conflict( "Type " + type + " is not supported." );
         }
 
         BaseIdentifiableObject object = (BaseIdentifiableObject) manager.get( sharingClass, id );
 
         if ( object == null )
         {
-            return WebMessageUtils.notFound( "Object of type " + type + " with ID " + id + " was not found." );
+            return notFound( "Object of type " + type + " with ID " + id + " was not found." );
         }
 
         if ( (object instanceof SystemDefaultMetadataObject) && ((SystemDefaultMetadataObject) object).isDefault() )
         {
-            return WebMessageUtils.conflict(
+            return conflict(
                 "Sharing settings of system default metadata object of type " + type + " cannot be modified." );
         }
 
@@ -272,7 +275,7 @@ public class SharingController
 
         if ( !AccessStringHelper.isValid( sharing.getObject().getPublicAccess() ) )
         {
-            return WebMessageUtils.conflict( "Invalid public access string: " + sharing.getObject().getPublicAccess() );
+            return conflict( "Invalid public access string: " + sharing.getObject().getPublicAccess() );
         }
 
         // ---------------------------------------------------------------------
@@ -317,8 +320,7 @@ public class SharingController
 
             if ( !AccessStringHelper.isValid( sharingUserGroupAccess.getAccess() ) )
             {
-                return WebMessageUtils
-                    .conflict( "Invalid user group access string: " + sharingUserGroupAccess.getAccess() );
+                return conflict( "Invalid user group access string: " + sharingUserGroupAccess.getAccess() );
             }
 
             if ( !schema.isDataShareable() )
@@ -349,7 +351,7 @@ public class SharingController
 
             if ( !AccessStringHelper.isValid( sharingUserAccess.getAccess() ) )
             {
-                return WebMessageUtils.conflict( "Invalid user access string: " + sharingUserAccess.getAccess() );
+                return conflict( "Invalid user access string: " + sharingUserAccess.getAccess() );
             }
 
             if ( !schema.isDataShareable() )
@@ -381,7 +383,7 @@ public class SharingController
 
         log.info( sharingToString( object ) );
 
-        return WebMessageUtils.ok( "Access control set" );
+        return ok( "Access control set" );
     }
 
     @GetMapping( value = "/search", produces = MediaType.APPLICATION_JSON_VALUE )
@@ -392,7 +394,7 @@ public class SharingController
     {
         if ( key == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Search key not specified" ) );
+            throw new WebMessageException( conflict( "Search key not specified" ) );
         }
 
         int max = pageSize != null ? pageSize : Paging.DEFAULT_PAGE_SIZE;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.util.List;
 import java.util.Set;
 
@@ -35,7 +40,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.NodeService;
 import org.hisp.dhis.node.NodeUtils;
 import org.hisp.dhis.node.types.RootNode;
@@ -216,21 +220,21 @@ public class SqlViewController
 
         if ( sqlView == null )
         {
-            return WebMessageUtils.notFound( "SQL view does not exist: " + uid );
+            return notFound( "SQL view does not exist: " + uid );
         }
 
         if ( sqlView.isQuery() )
         {
-            return WebMessageUtils.conflict( "SQL view is a query, no view to create" );
+            return conflict( "SQL view is a query, no view to create" );
         }
 
         String result = sqlViewService.createViewTable( sqlView );
         if ( result != null )
         {
-            return WebMessageUtils.conflict( result );
+            return conflict( result );
         }
         response.addHeader( "Location", SqlViewSchemaDescriptor.API_ENDPOINT + "/" + sqlView.getUid() );
-        return WebMessageUtils.created( "SQL view created" );
+        return created( "SQL view created" );
     }
 
     @PostMapping( "/{uid}/refresh" )
@@ -241,14 +245,14 @@ public class SqlViewController
 
         if ( sqlView == null )
         {
-            return WebMessageUtils.notFound( "SQL view does not exist: " + uid );
+            return notFound( "SQL view does not exist: " + uid );
         }
 
         if ( !sqlViewService.refreshMaterializedView( sqlView ) )
         {
-            return WebMessageUtils.conflict( "View could not be refreshed" );
+            return conflict( "View could not be refreshed" );
         }
-        return WebMessageUtils.ok( "Materialized view refreshed" );
+        return ok( "Materialized view refreshed" );
     }
 
     private SqlView validateView( String uid )
@@ -258,7 +262,7 @@ public class SqlViewController
 
         if ( sqlView == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "SQL view does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "SQL view does not exist: " + uid ) );
         }
 
         return sqlView;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -213,8 +213,8 @@ public class SqlViewController
 
     @PostMapping( "/{uid}/execute" )
     @ResponseBody
-    public WebMessage executeView( @PathVariable( "uid" ) String uid, @RequestParam( required = false ) Set<String> var,
-        HttpServletResponse response )
+    public WebMessage executeView( @PathVariable( "uid" ) String uid,
+        @RequestParam( required = false ) Set<String> var )
     {
         SqlView sqlView = sqlViewService.getSqlViewByUid( uid );
 
@@ -233,8 +233,8 @@ public class SqlViewController
         {
             return conflict( result );
         }
-        response.addHeader( "Location", SqlViewSchemaDescriptor.API_ENDPOINT + "/" + sqlView.getUid() );
-        return created( "SQL view created" );
+        return created( "SQL view created" )
+            .setLocation( SqlViewSchemaDescriptor.API_ENDPOINT + "/" + sqlView.getUid() );
     }
 
     @PostMapping( "/{uid}/refresh" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -49,7 +52,6 @@ import org.apache.commons.lang.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -113,7 +115,7 @@ public class SystemSettingController
 
         if ( !setting.isPresent() )
         {
-            return WebMessageUtils.conflict( "Key is not supported: " + key );
+            return conflict( "Key is not supported: " + key );
         }
 
         value = ObjectUtils.firstNonNull( value, valuePayload );
@@ -131,7 +133,7 @@ public class SystemSettingController
 
         systemSettingManager.saveSystemSetting( setting, valueObject );
 
-        return WebMessageUtils.ok( "System setting '" + key + "' set to value '" + valueObject + "'." );
+        return ok( "System setting '" + key + "' set to value '" + valueObject + "'." );
     }
 
     private WebMessage saveSystemSettingTranslation( String key, String locale, String value, SettingKey setting )
@@ -142,10 +144,10 @@ public class SystemSettingController
         }
         catch ( IllegalStateException e )
         {
-            return WebMessageUtils.conflict( e.getMessage() );
+            return conflict( e.getMessage() );
         }
 
-        return WebMessageUtils.ok( "Translation for system setting '" + key +
+        return ok( "Translation for system setting '" + key +
             "' and locale: '" + locale + "' set to: '" + value + "'" );
     }
 
@@ -154,13 +156,13 @@ public class SystemSettingController
     {
         if ( key == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Key must be specified" ) );
+            throw new WebMessageException( conflict( "Key must be specified" ) );
         }
 
         if ( value == null && valuePayload == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Value must be specified as query param or as payload" ) );
+                conflict( "Value must be specified as query param or as payload" ) );
         }
     }
 
@@ -174,7 +176,7 @@ public class SystemSettingController
 
         if ( !invalidKeys.isEmpty() )
         {
-            return WebMessageUtils.conflict( "Key(s) is not supported: " + StringUtils.join( invalidKeys, ", " ) );
+            return conflict( "Key(s) is not supported: " + StringUtils.join( invalidKeys, ", " ) );
         }
 
         for ( Entry<String, Object> entry : settings.entrySet() )
@@ -184,7 +186,7 @@ public class SystemSettingController
             systemSettingManager.saveSystemSetting( SettingKey.getByName( key ).get(), valueObject );
         }
 
-        return WebMessageUtils.ok( "System settings imported" );
+        return ok( "System settings imported" );
     }
 
     // -------------------------------------------------------------------------
@@ -336,7 +338,7 @@ public class SystemSettingController
 
         if ( !setting.isPresent() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Key is not supported: " + key ) );
+            throw new WebMessageException( conflict( "Key is not supported: " + key ) );
         }
 
         if ( StringUtils.isNotEmpty( locale ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.time.LocalDateTime;
@@ -40,7 +41,6 @@ import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.external.conf.GoogleAccessToken;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -83,7 +83,7 @@ public class TokenController
 
         if ( !tokenOptional.isPresent() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Token not available" ) );
+            throw new WebMessageException( conflict( "Token not available" ) );
         }
 
         GoogleAccessToken token = tokenOptional.get();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.io.IOException;
@@ -37,7 +42,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.userkeyjsonvalue.UserKeyJsonValue;
@@ -95,7 +99,7 @@ public class UserKeyJsonValueController
         if ( !userKeyJsonValueService.getNamespacesByUser( currentUserService.getCurrentUser() ).contains( namespace ) )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "The namespace '" + namespace + "' was not found." ) );
+                notFound( "The namespace '" + namespace + "' was not found." ) );
         }
 
         setNoStore( response );
@@ -112,7 +116,7 @@ public class UserKeyJsonValueController
     {
         userKeyJsonValueService.deleteNamespaceFromUser( currentUserService.getCurrentUser(), namespace );
 
-        return WebMessageUtils.ok( "All keys from namespace '" + namespace + "' deleted." );
+        return ok( "All keys from namespace '" + namespace + "' deleted." );
     }
 
     /**
@@ -130,8 +134,8 @@ public class UserKeyJsonValueController
 
         if ( userKeyJsonValue == null )
         {
-            throw new WebMessageException( WebMessageUtils
-                .notFound( "The key '" + key + "' was not found in the namespace '" + namespace + "'." ) );
+            throw new WebMessageException(
+                notFound( "The key '" + key + "' was not found in the namespace '" + namespace + "'." ) );
         }
 
         setNoStore( response );
@@ -155,13 +159,12 @@ public class UserKeyJsonValueController
         if ( userKeyJsonValueService.getUserKeyJsonValue( currentUserService.getCurrentUser(), namespace,
             key ) != null )
         {
-            return WebMessageUtils
-                .conflict( "The key '" + key + "' already exists in the namespace '" + namespace + "'." );
+            return conflict( "The key '" + key + "' already exists in the namespace '" + namespace + "'." );
         }
 
         if ( !renderService.isValidJson( body ) )
         {
-            return WebMessageUtils.badRequest( "The data is not valid JSON." );
+            return badRequest( "The data is not valid JSON." );
         }
 
         UserKeyJsonValue userKeyJsonValue = new UserKeyJsonValue();
@@ -174,7 +177,7 @@ public class UserKeyJsonValueController
 
         userKeyJsonValueService.addUserKeyJsonValue( userKeyJsonValue );
 
-        return WebMessageUtils.created( "Key '" + key + "' in namespace '" + namespace + "' created." );
+        return created( "Key '" + key + "' in namespace '" + namespace + "' created." );
     }
 
     /**
@@ -193,20 +196,19 @@ public class UserKeyJsonValueController
 
         if ( userKeyJsonValue == null )
         {
-            return WebMessageUtils
-                .notFound( "The key '" + key + "' was not found in the namespace '" + namespace + "'." );
+            return notFound( "The key '" + key + "' was not found in the namespace '" + namespace + "'." );
         }
 
         if ( !renderService.isValidJson( body ) )
         {
-            return WebMessageUtils.badRequest( "The data is not valid JSON." );
+            return badRequest( "The data is not valid JSON." );
         }
 
         userKeyJsonValue.setValue( body );
 
         userKeyJsonValueService.updateUserKeyJsonValue( userKeyJsonValue );
 
-        return WebMessageUtils.ok( "Key '" + key + "' in namespace '" + namespace + "' updated." );
+        return ok( "Key '" + key + "' in namespace '" + namespace + "' updated." );
     }
 
     /**
@@ -223,12 +225,11 @@ public class UserKeyJsonValueController
 
         if ( userKeyJsonValue == null )
         {
-            return WebMessageUtils
-                .notFound( "The key '" + key + "' was not found in the namespace '" + namespace + "'." );
+            return notFound( "The key '" + key + "' was not found in the namespace '" + namespace + "'." );
         }
 
         userKeyJsonValueService.deleteUserKeyJsonValue( userKeyJsonValue );
 
-        return WebMessageUtils.ok( "Key '" + key + "' deleted from the namespace '" + namespace + "'." );
+        return ok( "Key '" + key + "' deleted from the namespace '" + namespace + "'." );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +45,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
@@ -150,12 +154,12 @@ public class UserSettingController
 
         if ( StringUtils.isEmpty( newValue ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "You need to specify a new value" ) );
+            throw new WebMessageException( conflict( "You need to specify a new value" ) );
         }
 
         userSettingService.saveUserSetting( userSettingKey, UserSettingKey.getAsRealClass( key, newValue ), user );
 
-        return WebMessageUtils.ok( "User setting saved" );
+        return ok( "User setting saved" );
     }
 
     @DeleteMapping( value = "/{key}" )
@@ -186,7 +190,7 @@ public class UserSettingController
 
         if ( !userSettingKey.isPresent() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "No user setting found with key: " + key ) );
+            throw new WebMessageException( notFound( "No user setting found with key: " + key ) );
         }
 
         return userSettingKey.get();
@@ -226,8 +230,8 @@ public class UserSettingController
 
         if ( user == null )
         {
-            throw new WebMessageException( WebMessageUtils
-                .conflict( "Could not find user '" + ObjectUtils.firstNonNull( uid, username ) + "'" ) );
+            throw new WebMessageException(
+                conflict( "Could not find user '" + ObjectUtils.firstNonNull( uid, username ) + "'" ) );
         }
         else
         {
@@ -237,7 +241,7 @@ public class UserSettingController
                 !currentUser.getUserCredentials().canModifyUser( user.getUserCredentials() ) )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.unauthorized( "You are not authorized to access user: " + user.getUsername() ) );
+                    unauthorized( "You are not authorized to access user: " + user.getUsername() ) );
             }
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
@@ -237,7 +237,7 @@ public class UserSettingController
                 !currentUser.getUserCredentials().canModifyUser( user.getUserCredentials() ) )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.unathorized( "You are not authorized to access user: " + user.getUsername() ) );
+                    WebMessageUtils.unauthorized( "You are not authorized to access user: " + user.getUsername() ) );
             }
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.i18n.I18nFormat;
@@ -70,11 +69,10 @@ public class VisualizationController
     }
 
     @Override
-    protected Visualization deserializeJsonEntity( final HttpServletRequest request,
-        final HttpServletResponse response )
+    protected Visualization deserializeJsonEntity( final HttpServletRequest request )
         throws IOException
     {
-        final Visualization visualization = super.deserializeJsonEntity( request, response );
+        final Visualization visualization = super.deserializeJsonEntity( request );
 
         addDimensionsInto( visualization );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/WebMessageControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/WebMessageControllerAdvice.java
@@ -30,6 +30,9 @@ package org.hisp.dhis.webapi.controller;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageResponse;
+import org.hisp.dhis.webapi.service.ContextService;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
@@ -52,6 +55,9 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 @ControllerAdvice
 public class WebMessageControllerAdvice implements ResponseBodyAdvice<WebMessageResponse>
 {
+    @Autowired
+    private ContextService contextService;
+
     @Override
     public boolean supports( MethodParameter returnType,
         Class<? extends HttpMessageConverter<?>> selectedConverterType )
@@ -79,6 +85,12 @@ public class WebMessageControllerAdvice implements ResponseBodyAdvice<WebMessage
                 response.getHeaders().addIfAbsent( "Cache-Control",
                     CacheControl.noCache().cachePrivate().getHeaderValue() );
             }
+        }
+        String location = message.getLocation();
+        if ( location != null )
+        {
+            response.getHeaders().addIfAbsent( ContextUtils.HEADER_LOCATION,
+                contextService.getApiPath() + location );
         }
         return body;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/WebMessageControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/WebMessageControllerAdvice.java
@@ -72,6 +72,12 @@ public class WebMessageControllerAdvice implements ResponseBodyAdvice<WebMessage
         ServerHttpResponse response )
     {
         WebMessage message = (WebMessage) body;
+        String location = message.getLocation();
+        if ( location != null )
+        {
+            response.getHeaders().addIfAbsent( ContextUtils.HEADER_LOCATION,
+                contextService.getApiPath() + location );
+        }
         if ( isPlainResponse( request, message ) )
         {
             return ((WebMessage) body).getResponse();
@@ -85,12 +91,6 @@ public class WebMessageControllerAdvice implements ResponseBodyAdvice<WebMessage
                 response.getHeaders().addIfAbsent( "Cache-Control",
                     CacheControl.noCache().cachePrivate().getHeaderValue() );
             }
-        }
-        String location = message.getLocation();
-        if ( location != null )
-        {
-            response.getHeaders().addIfAbsent( ContextUtils.HEADER_LOCATION,
-                contextService.getApiPath() + location );
         }
         return body;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.category;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.IOException;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.CategoryComboSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
@@ -66,7 +67,7 @@ public class CategoryComboController
 
         if ( categoryCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "CategoryCombo not found for uid: " + pvUid ) );
+            throw new WebMessageException( notFound( "CategoryCombo not found for uid: " + pvUid ) );
         }
 
         return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, categoryCombo,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.dataelement;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +46,6 @@ import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.DataElementGroupSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
@@ -88,7 +89,7 @@ public class DataElementGroupController
 
         if ( dataElementGroups.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataElementGroup not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataElementGroup not found for uid: " + uid ) );
         }
 
         WebMetadata metadata = new WebMetadata();
@@ -127,7 +128,7 @@ public class DataElementGroupController
 
         if ( dataElementGroups.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "DataElementGroup not found for uid: " + uid ) );
+            throw new WebMessageException( notFound( "DataElementGroup not found for uid: " + uid ) );
         }
 
         WebMetadata metadata = new WebMetadata();
@@ -172,7 +173,7 @@ public class DataElementGroupController
         if ( dataElementGroup == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "DataElementGroup not found for uid: " + dataElementGroupId ) );
+                notFound( "DataElementGroup not found for uid: " + dataElementGroupId ) );
         }
 
         return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, dataElementGroup,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller.datastatistics;
 
 import static java.util.Calendar.DATE;
 import static java.util.Calendar.MILLISECOND;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.Date;
@@ -45,7 +46,6 @@ import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.datastatistics.EventInterval;
 import org.hisp.dhis.datastatistics.FavoriteStatistics;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
@@ -97,7 +97,7 @@ public class DataStatisticsController
     {
         if ( startDate.after( endDate ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Start date is after end date" ) );
+            throw new WebMessageException( conflict( "Start date is after end date" ) );
         }
 
         // The endDate is arriving as: "2019-09-28". After the conversion below

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller.datavalue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.io.IOException;
@@ -50,7 +53,6 @@ import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.util.InputUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.dxf2.webmessage.responses.FileResourceWebMessageResponse;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.Status;
@@ -250,21 +252,21 @@ public class DataValueController
 
         if ( strictPeriods && !dataElement.getPeriodTypes().contains( period.getPeriodType() ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "Period type of period: " + period.getIsoDate() + " not valid for data element: "
                     + dataElement.getUid() ) );
         }
 
         if ( strictCategoryOptionCombos && !dataElement.getCategoryOptionCombos().contains( categoryOptionCombo ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "Category option combo: " + categoryOptionCombo.getUid()
                     + " must be part of category combo of data element: " + dataElement.getUid() ) );
         }
 
         if ( strictOrgUnits && !organisationUnit.hasDataElement( dataElement ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "Data element: " + dataElement.getUid() + " must be assigned through data sets to organisation unit: "
                     + organisationUnit.getUid() ) );
         }
@@ -449,7 +451,7 @@ public class DataValueController
         if ( dataValue == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Data value cannot be deleted because it does not exist" ) );
+                conflict( "Data value cannot be deleted because it does not exist" ) );
         }
 
         if ( dataValue.getDataElement().isFileType() && retentionStrategy == FileResourceRetentionStrategy.NONE )
@@ -500,7 +502,7 @@ public class DataValueController
 
         if ( dataValue == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data value does not exist" ) );
+            throw new WebMessageException( conflict( "Data value does not exist" ) );
         }
 
         // ---------------------------------------------------------------------
@@ -577,7 +579,7 @@ public class DataValueController
 
         if ( !dataElement.isFileType() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "DataElement must be of type file" ) );
+            throw new WebMessageException( conflict( "DataElement must be of type file" ) );
         }
 
         CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo( co, false );
@@ -599,7 +601,7 @@ public class DataValueController
 
         if ( dataValue == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data value does not exist" ) );
+            throw new WebMessageException( conflict( "Data value does not exist" ) );
         }
 
         // ---------------------------------------------------------------------
@@ -613,7 +615,7 @@ public class DataValueController
         if ( fileResource == null || fileResource.getDomain() != FileResourceDomain.DATA_VALUE )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "A data value file resource with id " + uid + " does not exist." ) );
+                notFound( "A data value file resource with id " + uid + " does not exist." ) );
         }
 
         FileResourceStorageStatus storageStatus = fileResource.getStorageStatus();
@@ -627,12 +629,10 @@ public class DataValueController
             // store provider.
 
             // HTTP 409, for lack of a more suitable status code
-            WebMessage webMessage = WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "The content is being processed and is not available yet. Try again later.",
-                "The content requested is in transit to the file store and will be available at a later time." );
-            webMessage.setResponse( new FileResourceWebMessageResponse( fileResource ) );
-
-            throw new WebMessageException( webMessage );
+                "The content requested is in transit to the file store and will be available at a later time." )
+                    .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
         }
 
         response.setContentType( fileResource.getContentType() );
@@ -646,7 +646,7 @@ public class DataValueController
         }
         catch ( IOException e )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend, could be network or filesystem related" ) );
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -32,6 +32,7 @@ import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hisp.dhis.common.CodeGenerator.isValidUid;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +51,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dxf2.common.OrderParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.node.AbstractNode;
@@ -239,7 +239,7 @@ public class DimensionController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Data set not found: " + uid ) );
+            throw new WebMessageException( notFound( "Data set not found: " + uid ) );
         }
 
         List<DimensionalObject> dimensions = new ArrayList<>();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -236,8 +236,7 @@ public class EnrollmentController
             return importSummaries( importSummaries )
                 .setHttpStatus( HttpStatus.CREATED );
         }
-        List<Enrollment> enrollments = enrollmentService.getEnrollmentsJson( inputStream );
-        return startAsyncImport( importOptions, enrollments, request );
+        return startAsyncImport( importOptions, enrollmentService.getEnrollmentsJson( inputStream ) );
     }
 
     @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
@@ -280,8 +279,7 @@ public class EnrollmentController
             return importSummaries( importSummaries )
                 .setHttpStatus( HttpStatus.CREATED );
         }
-        List<Enrollment> enrollments = enrollmentService.getEnrollmentsXml( inputStream );
-        return startAsyncImport( importOptions, enrollments, request );
+        return startAsyncImport( importOptions, enrollmentService.getEnrollmentsXml( inputStream ) );
     }
 
     // -------------------------------------------------------------------------
@@ -387,10 +385,8 @@ public class EnrollmentController
      *
      * @param importOptions the ImportOptions.
      * @param enrollments the enrollments to import.
-     * @param request the HttpRequest.
      */
-    private WebMessage startAsyncImport( ImportOptions importOptions, List<Enrollment> enrollments,
-        HttpServletRequest request )
+    private WebMessage startAsyncImport( ImportOptions importOptions, List<Enrollment> enrollments )
     {
         JobConfiguration jobId = new JobConfiguration( "inMemoryEventImport",
             ENROLLMENT_IMPORT, currentUserService.getCurrentUser().getUid(), true );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummaries;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.scheduling.JobType.ENROLLMENT_IMPORT;
 
 import java.io.IOException;
@@ -54,7 +57,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.importexport.ImportStrategy;
@@ -230,7 +232,7 @@ public class EnrollmentController
                 }
             }
 
-            WebMessage webMessage = WebMessageUtils.importSummaries( importSummaries );
+            WebMessage webMessage = importSummaries( importSummaries );
             webMessage.setHttpStatus( HttpStatus.CREATED );
             return webMessage;
         }
@@ -273,9 +275,7 @@ public class EnrollmentController
                 }
             }
 
-            WebMessage webMessage = WebMessageUtils.importSummaries( importSummaries );
-            webMessage.setHttpStatus( HttpStatus.CREATED );
-            return webMessage;
+            return importSummaries( importSummaries ).setHttpStatus( HttpStatus.CREATED );
         }
         List<Enrollment> enrollments = enrollmentService.getEnrollmentsXml( inputStream );
         return startAsyncImport( importOptions, enrollments, request, response );
@@ -292,7 +292,7 @@ public class EnrollmentController
     {
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
         ImportSummary importSummary = enrollmentService.updateEnrollmentForNoteJson( id, inputStream );
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
@@ -305,7 +305,7 @@ public class EnrollmentController
         ImportSummary importSummary = enrollmentService.updateEnrollmentXml( id, inputStream, importOptions );
         importSummary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
@@ -318,7 +318,7 @@ public class EnrollmentController
         ImportSummary importSummary = enrollmentService.updateEnrollmentJson( id, inputStream, importOptions );
         importSummary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( "/{id}/cancelled" )
@@ -328,7 +328,7 @@ public class EnrollmentController
     {
         if ( !programInstanceService.programInstanceExists( id ) )
         {
-            return WebMessageUtils.notFound( "Enrollment not found for ID " + id );
+            return notFound( "Enrollment not found for ID " + id );
         }
 
         enrollmentService.cancelEnrollment( id );
@@ -342,7 +342,7 @@ public class EnrollmentController
     {
         if ( !programInstanceService.programInstanceExists( id ) )
         {
-            return WebMessageUtils.notFound( "Enrollment not found for ID " + id );
+            return notFound( "Enrollment not found for ID " + id );
         }
 
         enrollmentService.completeEnrollment( id );
@@ -356,7 +356,7 @@ public class EnrollmentController
     {
         if ( !programInstanceService.programInstanceExists( id ) )
         {
-            return WebMessageUtils.notFound( "Enrollment not found for ID " + id );
+            return notFound( "Enrollment not found for ID " + id );
         }
 
         enrollmentService.incompleteEnrollment( id );
@@ -372,7 +372,7 @@ public class EnrollmentController
     public WebMessage deleteEnrollment( @PathVariable String id )
     {
         ImportSummary importSummary = enrollmentService.deleteEnrollment( id );
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
@@ -95,10 +95,10 @@ public class EventChartController
     // --------------------------------------------------------------------------
 
     @Override
-    protected EventChart deserializeJsonEntity( HttpServletRequest request, HttpServletResponse response )
+    protected EventChart deserializeJsonEntity( HttpServletRequest request )
         throws IOException
     {
-        EventChart eventChart = super.deserializeJsonEntity( request, response );
+        EventChart eventChart = super.deserializeJsonEntity( request );
         mergeEventChart( eventChart );
 
         return eventChart;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.io.IOException;
 import java.util.Date;
@@ -41,7 +42,6 @@ import org.hisp.dhis.chart.ChartService;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.eventchart.EventChart;
 import org.hisp.dhis.eventchart.EventChartService;
 import org.hisp.dhis.i18n.I18nFormat;
@@ -125,7 +125,7 @@ public class EventChartController
 
         if ( chart == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Event chart does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "Event chart does not exist: " + uid ) );
         }
 
         OrganisationUnit unit = ou != null ? organisationUnitService.getOrganisationUnit( ou ) : null;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -27,7 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummaries;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.scheduling.JobType.EVENT_IMPORT;
 
 import java.io.IOException;
@@ -80,7 +86,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.util.InputUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.dxf2.webmessage.responses.FileResourceWebMessageResponse;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
@@ -247,8 +252,8 @@ public class EventController
 
         if ( attributeOptionCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils
-                .conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
+            throw new WebMessageException(
+                conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
         }
 
         Set<String> eventIds = TextUtils.splitToArray( event, TextUtils.SEMICOLON );
@@ -321,8 +326,8 @@ public class EventController
 
         if ( attributeOptionCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils
-                .conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
+            throw new WebMessageException(
+                conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
         }
 
         Set<String> eventIds = TextUtils.splitToArray( event, TextUtils.SEMICOLON );
@@ -394,8 +399,8 @@ public class EventController
 
         if ( attributeOptionCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils
-                .conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
+            throw new WebMessageException(
+                conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
         }
 
         Set<String> eventIds = TextUtils.splitToArray( event, TextUtils.SEMICOLON );
@@ -468,8 +473,8 @@ public class EventController
 
         if ( attributeOptionCombo == null )
         {
-            throw new WebMessageException( WebMessageUtils
-                .conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
+            throw new WebMessageException(
+                conflict( "Illegal attribute option combo identifier: " + attributeCc + " " + attributeCos ) );
         }
 
         Set<String> eventIds = TextUtils.splitToArray( event, TextUtils.SEMICOLON );
@@ -684,7 +689,7 @@ public class EventController
 
         if ( event == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Event not found for ID " + uid ) );
+            throw new WebMessageException( notFound( "Event not found for ID " + uid ) );
         }
 
         event.setHref( ContextUtils.getRootPath( request ) + RESOURCE_PATH + "/" + uid );
@@ -702,7 +707,7 @@ public class EventController
 
         if ( event == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Event not found for ID " + eventUid ) );
+            throw new WebMessageException( notFound( "Event not found for ID " + eventUid ) );
         }
 
         DataElement dataElement = dataElementService.getDataElement( dataElementUid );
@@ -710,12 +715,12 @@ public class EventController
         if ( dataElement == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "DataElement not found for ID " + dataElementUid ) );
+                notFound( "DataElement not found for ID " + dataElementUid ) );
         }
 
         if ( !dataElement.isFileType() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "DataElement must be of type file" ) );
+            throw new WebMessageException( conflict( "DataElement must be of type file" ) );
         }
 
         // ---------------------------------------------------------------------
@@ -735,7 +740,7 @@ public class EventController
 
         if ( uid == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "DataElement must be of type file" ) );
+            throw new WebMessageException( conflict( "DataElement must be of type file" ) );
         }
 
         FileResource fileResource = fileResourceService.getFileResource( uid );
@@ -743,7 +748,7 @@ public class EventController
         if ( fileResource == null || fileResource.getDomain() != FileResourceDomain.DATA_VALUE )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "A data value file resource with id " + uid + " does not exist." ) );
+                notFound( "A data value file resource with id " + uid + " does not exist." ) );
         }
 
         if ( fileResource.getStorageStatus() != FileResourceStorageStatus.STORED )
@@ -753,13 +758,10 @@ public class EventController
             // underlying file content still not stored to external file store
             // -----------------------------------------------------------------
 
-            WebMessage webMessage = WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "The content is being processed and is not available yet. Try again later.",
-                "The content requested is in transit to the file store and will be available at a later time." );
-
-            webMessage.setResponse( new FileResourceWebMessageResponse( fileResource ) );
-
-            throw new WebMessageException( webMessage );
+                "The content requested is in transit to the file store and will be available at a later time." )
+                    .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
         }
 
         FileResourceUtils.setImageFileDimensions( fileResource,
@@ -775,7 +777,7 @@ public class EventController
         }
         catch ( IOException e )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend, could be network or filesystem related" ) );
         }
     }
@@ -866,7 +868,7 @@ public class EventController
                 }
             }
 
-            return WebMessageUtils.importSummaries( importSummaries );
+            return importSummaries( importSummaries );
         }
         List<Event> events = eventConverter.apply( inputStream );
         return startAsyncImport( importOptions, events, request, response );
@@ -880,7 +882,7 @@ public class EventController
     {
         if ( !programStageInstanceService.programStageInstanceExists( uid ) )
         {
-            return WebMessageUtils.notFound( "Event not found for ID " + uid );
+            return notFound( "Event not found for ID " + uid );
         }
 
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -888,7 +890,7 @@ public class EventController
         event.setEvent( uid );
 
         eventService.updateEventForNote( event );
-        return WebMessageUtils.ok( "Event updated: " + uid );
+        return ok( "Event updated: " + uid );
     }
 
     @PostMapping( consumes = { "application/csv", "text/csv" } )
@@ -906,7 +908,7 @@ public class EventController
         {
             ImportSummaries importSummaries = eventService.addEvents( events.getEvents(), importOptions, null );
             importSummaries.setImportOptions( importOptions );
-            return WebMessageUtils.importSummaries( importSummaries );
+            return importSummaries( importSummaries );
         }
         return startAsyncImport( importOptions, events.getEvents(), request, response );
     }
@@ -945,7 +947,7 @@ public class EventController
     {
         ImportSummary importSummary = eventService.updateEvent( updatedEvent, singleValue, importOptions, false );
         importSummary.setImportOptions( importOptions );
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( value = "/{uid}/{dataElementUid}", consumes = "application/json" )
@@ -958,7 +960,7 @@ public class EventController
 
         if ( dataElement == null )
         {
-            return WebMessageUtils.notFound( "DataElement not found for ID " + dataElementUid );
+            return notFound( "DataElement not found for ID " + dataElementUid );
         }
 
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -976,7 +978,7 @@ public class EventController
     {
         if ( !programStageInstanceService.programStageInstanceExists( uid ) )
         {
-            return WebMessageUtils.notFound( "Event not found for ID " + uid );
+            return notFound( "Event not found for ID " + uid );
         }
 
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -984,7 +986,7 @@ public class EventController
         updatedEvent.setEvent( uid );
 
         eventService.updateEventForEventDate( updatedEvent );
-        return WebMessageUtils.ok( "Event updated " + uid );
+        return ok( "Event updated " + uid );
     }
 
     // -------------------------------------------------------------------------
@@ -995,7 +997,7 @@ public class EventController
     @ResponseBody
     public WebMessage deleteEvent( @PathVariable( "uid" ) String uid )
     {
-        return WebMessageUtils.importSummary( eventService.deleteEvent( uid ) );
+        return importSummary( eventService.deleteEvent( uid ) );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -866,8 +866,7 @@ public class EventController
 
             return importSummaries( importSummaries );
         }
-        List<Event> events = eventConverter.apply( inputStream );
-        return startAsyncImport( importOptions, events, request );
+        return startAsyncImport( importOptions, eventConverter.apply( inputStream ) );
     }
 
     @PostMapping( value = "/{uid}/note", consumes = "application/json" )
@@ -906,7 +905,7 @@ public class EventController
             importSummaries.setImportOptions( importOptions );
             return importSummaries( importSummaries );
         }
-        return startAsyncImport( importOptions, events.getEvents(), request );
+        return startAsyncImport( importOptions, events.getEvents() );
     }
 
     // -------------------------------------------------------------------------
@@ -1005,9 +1004,8 @@ public class EventController
      *
      * @param importOptions the ImportOptions.
      * @param events the events to import.
-     * @param request the HttpRequest.
      */
-    private WebMessage startAsyncImport( ImportOptions importOptions, List<Event> events, HttpServletRequest request )
+    private WebMessage startAsyncImport( ImportOptions importOptions, List<Event> events )
     {
         JobConfiguration jobId = new JobConfiguration( "inMemoryEventImport",
             EVENT_IMPORT, currentUserService.getCurrentUser().getUid(), true );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.eventreport.EventReport;
@@ -69,10 +68,10 @@ public class EventReportController
     // --------------------------------------------------------------------------
 
     @Override
-    protected EventReport deserializeJsonEntity( HttpServletRequest request, HttpServletResponse response )
+    protected EventReport deserializeJsonEntity( HttpServletRequest request )
         throws IOException
     {
-        EventReport eventReport = super.deserializeJsonEntity( request, response );
+        EventReport eventReport = super.deserializeJsonEntity( request );
         mergeEventReport( eventReport );
 
         return eventReport;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -34,7 +36,6 @@ import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.association.IdentifiableObjectAssociations;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.program.Program;
@@ -111,7 +112,7 @@ public class ProgramController
 
         if ( program == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Program not found for uid: " + pvUid ) );
+            throw new WebMessageException( notFound( "Program not found for uid: " + pvUid ) );
         }
 
         return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, program, download );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.schema.descriptors.ProgramIndicatorSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,27 +64,18 @@ public class ProgramIndicatorController
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {
         I18n i18n = i18nManager.getI18n();
-
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-
         try
         {
-            message.setDescription( programIndicatorService.getExpressionDescription( expression ) );
-
-            message.setStatus( Status.OK );
-
-            message.setMessage( i18n.getString( ProgramIndicator.VALID ) );
+            return new DescriptiveWebMessage( Status.OK, HttpStatus.OK )
+                .setDescription( programIndicatorService.getExpressionDescription( expression ) )
+                .setMessage( i18n.getString( ProgramIndicator.VALID ) );
         }
         catch ( IllegalStateException e )
         {
-            message.setDescription( e.getMessage() );
-
-            message.setStatus( Status.ERROR );
-
-            message.setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
+            return new DescriptiveWebMessage( Status.ERROR, HttpStatus.OK )
+                .setDescription( e.getMessage() )
+                .setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
         }
-
-        return message;
     }
 
     @PostMapping( value = "/filter/description", produces = MediaType.APPLICATION_JSON_VALUE )
@@ -92,25 +84,17 @@ public class ProgramIndicatorController
     {
         I18n i18n = i18nManager.getI18n();
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-
         try
         {
-            message.setDescription( programIndicatorService.getFilterDescription( expression ) );
-
-            message.setStatus( Status.OK );
-
-            message.setMessage( i18n.getString( ProgramIndicator.VALID ) );
+            return new DescriptiveWebMessage( Status.OK, HttpStatus.OK )
+                .setDescription( programIndicatorService.getFilterDescription( expression ) )
+                .setMessage( i18n.getString( ProgramIndicator.VALID ) );
         }
         catch ( IllegalStateException e )
         {
-            message.setDescription( e.getMessage() );
-
-            message.setStatus( Status.ERROR );
-
-            message.setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
+            return new DescriptiveWebMessage( Status.ERROR, HttpStatus.OK )
+                .setDescription( e.getMessage() )
+                .setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
         }
-
-        return message;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +42,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.outboundmessage.BatchResponseStatus;
 import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageBatch;
@@ -106,7 +107,7 @@ public class ProgramMessageController
         if ( programInstance == null && programStageInstance == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "ProgramInstance or ProgramStageInstance must be specified." ) );
+                conflict( "ProgramInstance or ProgramStageInstance must be specified." ) );
         }
 
         List<ProgramMessage> programMessages = programMessageService.getProgramMessages( params );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.programrule.engine.ProgramRuleEngineService;
 import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.hisp.dhis.schema.descriptors.ProgramRuleActionSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -71,33 +72,25 @@ public class ProgramRuleActionController
     {
         I18n i18n = i18nManager.getI18n();
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-
         RuleValidationResult result = programRuleEngineService.getDataExpressionDescription( condition, programId );
 
         if ( result.isValid() )
         {
-            message.setDescription( result.getDescription() );
-
-            message.setStatus( Status.OK );
-
-            message.setMessage( i18n.getString( ProgramIndicator.VALID ) );
+            return new DescriptiveWebMessage( Status.OK, HttpStatus.OK )
+                .setDescription( result.getDescription() )
+                .setMessage( i18n.getString( ProgramIndicator.VALID ) );
         }
-        else
+        String description = null;
+        if ( result.getErrorMessage() != null )
         {
-            if ( result.getErrorMessage() != null )
-            {
-                message.setDescription( result.getErrorMessage() );
-            }
-            else if ( result.getException() != null )
-            {
-                message.setDescription( result.getException().getMessage() );
-            }
-            message.setStatus( Status.ERROR );
-
-            message.setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
+            description = result.getErrorMessage();
         }
-
-        return message;
+        else if ( result.getException() != null )
+        {
+            description = result.getException().getMessage();
+        }
+        return new DescriptiveWebMessage( Status.ERROR, HttpStatus.OK )
+            .setDescription( description )
+            .setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.programrule.engine.ProgramRuleEngineService;
 import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.hisp.dhis.schema.descriptors.ProgramRuleSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,32 +69,25 @@ public class ProgramRuleController
     {
         I18n i18n = i18nManager.getI18n();
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-
         RuleValidationResult result = programRuleEngineService.getDescription( condition, programId );
 
         if ( result.isValid() )
         {
-            message.setDescription( result.getDescription() );
-
-            message.setStatus( Status.OK );
-
-            message.setMessage( i18n.getString( ProgramIndicator.VALID ) );
+            return new DescriptiveWebMessage( Status.OK, HttpStatus.OK )
+                .setDescription( result.getDescription() )
+                .setMessage( i18n.getString( ProgramIndicator.VALID ) );
         }
-        else
+        String description = null;
+        if ( result.getErrorMessage() != null )
         {
-            if ( result.getErrorMessage() != null )
-            {
-                message.setDescription( result.getErrorMessage() );
-            }
-            else if ( result.getException() != null )
-            {
-                message.setDescription( result.getException().getMessage() );
-            }
-            message.setStatus( Status.ERROR );
-
-            message.setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
+            description = result.getErrorMessage();
         }
-        return message;
+        else if ( result.getException() != null )
+        {
+            description = result.getException().getMessage();
+        }
+        return new DescriptiveWebMessage( Status.ERROR, HttpStatus.OK )
+            .setDescription( description )
+            .setMessage( i18n.getString( ProgramIndicator.EXPRESSION_NOT_VALID ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummaries;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
@@ -52,7 +54,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
@@ -187,7 +188,7 @@ public class RelationshipController
             .filter( filterImportSummary( importOptions ) )
             .forEach( setImportSummaryHref( request ) );
 
-        return WebMessageUtils.importSummaries( importSummaries );
+        return importSummaries( importSummaries );
     }
 
     @PostMapping( value = "", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
@@ -206,7 +207,7 @@ public class RelationshipController
             .filter( filterImportSummary( importOptions ) )
             .forEach( setImportSummaryHref( request ) );
 
-        return WebMessageUtils.importSummaries( importSummaries );
+        return importSummaries( importSummaries );
     }
 
     // -------------------------------------------------------------------------
@@ -231,7 +232,7 @@ public class RelationshipController
         ImportSummary importSummary = relationshipService.updateRelationshipJson( id, inputStream, importOptions );
         importSummary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( path = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
@@ -252,7 +253,7 @@ public class RelationshipController
         ImportSummary importSummary = relationshipService.updateRelationshipXml( id, inputStream, importOptions );
         importSummary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( importSummary ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importSummary( importSummary ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     // -------------------------------------------------------------------------
@@ -270,7 +271,7 @@ public class RelationshipController
             return notFound( "No relationship with id '" + id + "' was found." );
         }
 
-        return WebMessageUtils.importSummary( relationshipService.deleteRelationship( id ) );
+        return importSummary( relationshipService.deleteRelationship( id ) );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +39,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.reservedvalue.ReserveValueException;
 import org.hisp.dhis.reservedvalue.ReservedValue;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
@@ -91,7 +95,7 @@ public class TrackedEntityAttributeController
 
         if ( trackedEntityAttribute == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( TrackedEntityAttribute.class, id ) );
+            throw new WebMessageException( notFound( TrackedEntityAttribute.class, id ) );
         }
 
         return reserve( id, numberToReserve, expiration );
@@ -120,7 +124,7 @@ public class TrackedEntityAttributeController
 
         if ( trackedEntityAttribute == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( TrackedEntityAttribute.class, id ) );
+            throw new WebMessageException( notFound( TrackedEntityAttribute.class, id ) );
         }
 
         return reserve( id, 1, expiration ).get( 0 );
@@ -135,12 +139,12 @@ public class TrackedEntityAttributeController
 
         if ( trackedEntityAttribute == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( TrackedEntityAttribute.class, id ) );
+            throw new WebMessageException( notFound( TrackedEntityAttribute.class, id ) );
         }
 
         if ( trackedEntityAttribute.getTextPattern() == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "Attribute does not contain pattern." ) );
+            throw new WebMessageException( badRequest( "Attribute does not contain pattern." ) );
         }
 
         return textPatternService.getRequiredValues( trackedEntityAttribute.getTextPattern() );
@@ -155,19 +159,19 @@ public class TrackedEntityAttributeController
         if ( numberToReserve > 1000 || numberToReserve < 1 )
         {
             throw new WebMessageException(
-                WebMessageUtils.badRequest( "You can only reserve between 1 and 1000 values in a single request." ) );
+                badRequest( "You can only reserve between 1 and 1000 values in a single request." ) );
         }
 
         Map<String, List<String>> params = context.getParameterValuesMap();
         TrackedEntityAttribute attribute = trackedEntityAttributeService.getTrackedEntityAttribute( id );
         if ( attribute == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "No attribute found with id " + id ) );
+            throw new WebMessageException( notFound( "No attribute found with id " + id ) );
         }
 
         if ( attribute.getTextPattern() == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "This attribute has no pattern" ) );
+            throw new WebMessageException( conflict( "This attribute has no pattern" ) );
         }
 
         Map<String, String> values = getRequiredValues( attribute, params );
@@ -181,19 +185,19 @@ public class TrackedEntityAttributeController
 
             if ( result.isEmpty() )
             {
-                throw new WebMessageException( WebMessageUtils
-                    .conflict( "Unable to reserve id. This may indicate that there are too few available ids left." ) );
+                throw new WebMessageException(
+                    conflict( "Unable to reserve id. This may indicate that there are too few available ids left." ) );
             }
 
             return result;
         }
         catch ( ReserveValueException ex )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( ex.getMessage() ) );
+            throw new WebMessageException( conflict( ex.getMessage() ) );
         }
         catch ( TextPatternGenerationException ex )
         {
-            throw new WebMessageException( WebMessageUtils.error( ex.getMessage() ) );
+            throw new WebMessageException( error( ex.getMessage() ) );
         }
     }
 
@@ -212,7 +216,7 @@ public class TrackedEntityAttributeController
 
         if ( requiredValues.size() > 0 )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "Missing required values: " + StringUtils.collectionToCommaDelimitedString( requiredValues ) ) );
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -221,7 +221,7 @@ public class TrackedEntityInstanceController
         if ( !trackerAccessErrors.isEmpty() )
         {
             throw new WebMessageException( WebMessageUtils
-                .unathorized( "You're not authorized to access the TrackedEntityInstance with id: " + teiId ) );
+                .unauthorized( "You're not authorized to access the TrackedEntityInstance with id: " + teiId ) );
         }
 
         if ( attribute.size() == 0 )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -27,7 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummaries;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 import static org.hisp.dhis.scheduling.JobType.TEI_IMPORT;
 
 import java.awt.*;
@@ -61,7 +67,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.fileresource.FileResource;
@@ -220,25 +225,25 @@ public class TrackedEntityInstanceController
 
         if ( !trackerAccessErrors.isEmpty() )
         {
-            throw new WebMessageException( WebMessageUtils
-                .unauthorized( "You're not authorized to access the TrackedEntityInstance with id: " + teiId ) );
+            throw new WebMessageException(
+                unauthorized( "You're not authorized to access the TrackedEntityInstance with id: " + teiId ) );
         }
 
         if ( attribute.size() == 0 )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Attribute not found for ID " + attributeId ) );
+            throw new WebMessageException( notFound( "Attribute not found for ID " + attributeId ) );
         }
 
         TrackedEntityAttributeValue value = attribute.get( 0 );
 
         if ( value == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Value not found for ID " + attributeId ) );
+            throw new WebMessageException( notFound( "Value not found for ID " + attributeId ) );
         }
 
         if ( value.getAttribute().getValueType() != ValueType.IMAGE )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Attribute must be of type image" ) );
+            throw new WebMessageException( conflict( "Attribute must be of type image" ) );
         }
 
         // ---------------------------------------------------------------------
@@ -249,8 +254,8 @@ public class TrackedEntityInstanceController
 
         if ( fileResource == null || fileResource.getDomain() != FileResourceDomain.DATA_VALUE )
         {
-            throw new WebMessageException( WebMessageUtils
-                .notFound( "A data value file resource with id " + value.getValue() + " does not exist." ) );
+            throw new WebMessageException(
+                notFound( "A data value file resource with id " + value.getValue() + " does not exist." ) );
         }
 
         if ( fileResource.getStorageStatus() != FileResourceStorageStatus.STORED )
@@ -261,7 +266,7 @@ public class TrackedEntityInstanceController
             // -----------------------------------------------------------------
 
             throw new WebMessageException(
-                WebMessageUtils.conflict( "The content is being processed and is not available yet. Try again later.",
+                conflict( "The content is being processed and is not available yet. Try again later.",
                     "The content requested is in transit to the file store and will be available at a later time." ) );
         }
 
@@ -290,7 +295,7 @@ public class TrackedEntityInstanceController
         }
         catch ( IOException ex )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend." ) );
         }
     }
@@ -417,7 +422,7 @@ public class TrackedEntityInstanceController
         if ( !importOptions.isAsync() )
         {
             finalizeTrackedEntityInstancePostRequest( importOptions, request, response, importSummaries );
-            return WebMessageUtils.importSummaries( importSummaries );
+            return importSummaries( importSummaries );
         }
         response.setHeader( "Location", ContextUtils.getRootPath( request ) + "/system/tasks/" + TEI_IMPORT );
         return jobConfigurationReport( jobId );
@@ -468,7 +473,7 @@ public class TrackedEntityInstanceController
             inputStream, importOptions );
         importSummary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE )
@@ -484,7 +489,7 @@ public class TrackedEntityInstanceController
             inputStream, importOptions );
         importSummary.setImportOptions( importOptions );
 
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     // -------------------------------------------------------------------------
@@ -496,7 +501,7 @@ public class TrackedEntityInstanceController
     public WebMessage deleteTrackedEntityInstance( @PathVariable String id )
     {
         ImportSummary importSummary = trackedEntityInstanceService.deleteTrackedEntityInstance( id );
-        return WebMessageUtils.importSummary( importSummary );
+        return importSummary( importSummary );
     }
 
     @PutMapping( "/{tei}/potentialduplicate" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -27,9 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.ProgramService;
@@ -92,7 +93,7 @@ public class TrackerOwnershipController
         trackerOwnershipAccessManager.transferOwnership(
             trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstance ),
             programService.getProgram( program ), organisationUnitService.getOrganisationUnit( ou ), false, false );
-        return WebMessageUtils.ok( "Ownership transferred" );
+        return ok( "Ownership transferred" );
     }
 
     @PostMapping( value = "/override", produces = MediaType.APPLICATION_JSON_VALUE )
@@ -104,6 +105,6 @@ public class TrackerOwnershipController
             trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstance ),
             programService.getProgram( program ), currentUserService.getCurrentUser(), reason );
 
-        return WebMessageUtils.ok( "Temporary Ownership granted" );
+        return ok( "Temporary Ownership granted" );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.webapi.controller.mapping;
 
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -44,7 +46,6 @@ import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.legend.LegendSet;
@@ -135,7 +136,7 @@ public class MapController
 
         if ( map == null )
         {
-            return WebMessageUtils.notFound( "Map does not exist: " + uid );
+            return notFound( "Map does not exist: " + uid );
         }
 
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
@@ -190,19 +191,19 @@ public class MapController
 
         if ( map == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Map does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "Map does not exist: " + uid ) );
         }
 
         if ( width != null && width < MAP_MIN_WIDTH )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Min map width is " + MAP_MIN_WIDTH + ": " + width ) );
+                conflict( "Min map width is " + MAP_MIN_WIDTH + ": " + width ) );
         }
 
         if ( height != null && height < MAP_MIN_HEIGHT )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Min map height is " + MAP_MIN_HEIGHT + ": " + height ) );
+                conflict( "Min map height is " + MAP_MIN_HEIGHT + ": " + height ) );
         }
 
         OrganisationUnit unit = ou != null ? organisationUnitService.getOrganisationUnit( ou ) : null;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -128,8 +128,7 @@ public class MapController
     @PutMapping( value = "/{uid}", consumes = "application/json" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     @ResponseBody
-    public WebMessage putJsonObject( @PathVariable String uid, HttpServletRequest request,
-        HttpServletResponse response )
+    public WebMessage putJsonObject( @PathVariable String uid, HttpServletRequest request )
         throws Exception
     {
         Map map = mappingService.getMap( uid );
@@ -141,7 +140,7 @@ public class MapController
 
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
 
-        Map newMap = deserializeJsonEntity( request, response );
+        Map newMap = deserializeJsonEntity( request );
         newMap.setUid( uid );
 
         mergeService.merge( new MergeParams<>( newMap, map )
@@ -164,10 +163,10 @@ public class MapController
     }
 
     @Override
-    protected Map deserializeJsonEntity( HttpServletRequest request, HttpServletResponse response )
+    protected Map deserializeJsonEntity( HttpServletRequest request )
         throws IOException
     {
-        Map map = super.deserializeJsonEntity( request, response );
+        Map map = super.deserializeJsonEntity( request );
         mergeMap( map );
 
         return map;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.mapping;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.awt.image.BufferedImage;
 import java.util.List;
 
@@ -35,7 +37,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.mapgeneration.MapGenerationService;
 import org.hisp.dhis.mapping.MapView;
@@ -92,7 +93,7 @@ public class MapViewController
 
         if ( mapView == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Map view does not exist: " + uid ) );
+            throw new WebMessageException( notFound( "Map view does not exist: " + uid ) );
         }
 
         renderMapViewPng( mapView, response );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.metadata;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.GML_IMPORT;
 import static org.hisp.dhis.scheduling.JobType.METADATA_IMPORT;
@@ -58,7 +60,6 @@ import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportService;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
@@ -141,7 +142,7 @@ public class MetadataImportExportController
             return startAsyncMetadata( params, request, response );
         }
         ImportReport importReport = metadataImportService.importMetadata( params );
-        return WebMessageUtils.importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     @PostMapping( value = "", consumes = "application/csv" )
@@ -155,7 +156,7 @@ public class MetadataImportExportController
 
         if ( StringUtils.isEmpty( classKey ) || !CsvImportClass.classExists( classKey ) )
         {
-            return WebMessageUtils.conflict( "Cannot find Csv import class:  " + classKey );
+            return conflict( "Cannot find Csv import class:  " + classKey );
         }
 
         params.setCsvImportClass( CsvImportClass.valueOf( classKey ) );
@@ -171,7 +172,7 @@ public class MetadataImportExportController
             return startAsyncMetadata( params, request, response );
         }
         ImportReport importReport = metadataImportService.importMetadata( params );
-        return WebMessageUtils.importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     @PostMapping( value = "/gml", consumes = MediaType.APPLICATION_XML_VALUE )
@@ -186,7 +187,7 @@ public class MetadataImportExportController
             return startAsyncGml( params, request, response );
         }
         ImportReport importReport = gmlImportService.importGml( request.getInputStream(), params );
-        return WebMessageUtils.importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
@@ -204,7 +205,7 @@ public class MetadataImportExportController
             return startAsyncMetadata( params, request, response );
         }
         ImportReport importReport = metadataImportService.importMetadata( params );
-        return WebMessageUtils.importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
+        return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
     @GetMapping( "/csvImportClasses" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
@@ -27,10 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller.option;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.option.OptionSet;
@@ -65,7 +66,7 @@ public class OptionSetController
 
         if ( optionSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "OptionSet not found for uid: " + pvUid ) );
+            throw new WebMessageException( notFound( "OptionSet not found for uid: " + pvUid ) );
         }
 
         return MetadataExportControllerUtils.getWithDependencies( contextService, exportService, optionSet, download );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,7 +38,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.metadata.Metadata;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -90,12 +91,12 @@ public class FilledOrganisationUnitLevelController
         {
             if ( level.getLevel() <= 0 )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "Level must be greater than zero" ) );
+                throw new WebMessageException( conflict( "Level must be greater than zero" ) );
             }
 
             if ( StringUtils.isBlank( level.getName() ) )
             {
-                throw new WebMessageException( WebMessageUtils.conflict( "Name must be specified" ) );
+                throw new WebMessageException( conflict( "Name must be specified" ) );
             }
 
             organisationUnitService.addOrUpdateOrganisationUnitLevel(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.system.util.GeoUtils.getCoordinatesFromGeometry;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -43,7 +44,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeQuery;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeService;
@@ -110,7 +110,7 @@ public class OrganisationUnitController
     {
         orgUnitSplitService.split( orgUnitSplitService.getFromQuery( query ) );
 
-        return WebMessageUtils.ok( "Organisation unit split" );
+        return ok( "Organisation unit split" );
     }
 
     @ResponseStatus( HttpStatus.OK )
@@ -120,7 +120,7 @@ public class OrganisationUnitController
     {
         orgUnitMergeService.merge( orgUnitMergeService.getFromQuery( query ) );
 
-        return WebMessageUtils.ok( "Organisation units merged" );
+        return ok( "Organisation units merged" );
     }
 
     @Override

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.security;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +39,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.security.SecurityUtils;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -106,11 +108,11 @@ public class SecurityController
 
         if ( !SecurityUtils.verify( currentUser.getUserCredentials(), code ) )
         {
-            return WebMessageUtils.unauthorized( "2FA code not authenticated" );
+            return unauthorized( "2FA code not authenticated" );
         }
         else
         {
-            return WebMessageUtils.ok( "2FA code authenticated" );
+            return ok( "2FA code authenticated" );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
@@ -106,7 +106,7 @@ public class SecurityController
 
         if ( !SecurityUtils.verify( currentUser.getUserCredentials(), code ) )
         {
-            return WebMessageUtils.unathorized( "2FA code not authenticated" );
+            return WebMessageUtils.unauthorized( "2FA code not authenticated" );
         }
         else
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -169,8 +169,8 @@ public class SmsGatewayController
 
         gatewayAdminService.addGateway( config );
 
-        response.addHeader( "Location", "/gateways/" + config.getUid() );
-        return ok( "Gateway configuration added" );
+        return ok( "Gateway configuration added" )
+            .setLocation( "/gateways/" + config.getUid() );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.sms;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,7 +39,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.sms.config.GatewayAdministrationService;
 import org.hisp.dhis.sms.config.SmsConfigurationManager;
@@ -100,7 +103,7 @@ public class SmsGatewayController
 
         if ( gateway == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "No gateway found" ) );
+            throw new WebMessageException( notFound( "No gateway found" ) );
         }
 
         generateOutput( response, gateway );
@@ -119,12 +122,12 @@ public class SmsGatewayController
 
         if ( gateway == null )
         {
-            return WebMessageUtils.notFound( "No gateway found" );
+            return notFound( "No gateway found" );
         }
 
         gatewayAdminService.setDefaultGateway( gateway );
 
-        return WebMessageUtils.ok( gateway.getName() + " is set to default" );
+        return ok( gateway.getName() + " is set to default" );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
@@ -136,19 +139,19 @@ public class SmsGatewayController
 
         if ( config == null )
         {
-            return WebMessageUtils.notFound( "No gateway found" );
+            return notFound( "No gateway found" );
         }
 
         SmsGatewayConfig updatedConfig = renderService.fromJson( request.getInputStream(), SmsGatewayConfig.class );
 
         if ( gatewayAdminService.hasDefaultGateway() && updatedConfig.isDefault() && !config.isDefault() )
         {
-            return WebMessageUtils.conflict( "Default gateway already exists" );
+            return conflict( "Default gateway already exists" );
         }
 
         gatewayAdminService.updateGateway( config, updatedConfig );
 
-        return WebMessageUtils.ok( String.format( "Gateway with uid: %s has been updated", uid ) );
+        return ok( String.format( "Gateway with uid: %s has been updated", uid ) );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
@@ -161,13 +164,13 @@ public class SmsGatewayController
 
         if ( config == null )
         {
-            return WebMessageUtils.conflict( "Cannot de-serialize SMS configurations" );
+            return conflict( "Cannot de-serialize SMS configurations" );
         }
 
         gatewayAdminService.addGateway( config );
 
         response.addHeader( "Location", "/gateways/" + config.getUid() );
-        return WebMessageUtils.ok( "Gateway configuration added" );
+        return ok( "Gateway configuration added" );
     }
 
     // -------------------------------------------------------------------------
@@ -183,12 +186,12 @@ public class SmsGatewayController
 
         if ( gateway == null )
         {
-            return WebMessageUtils.notFound( "No gateway found with id: " + uid );
+            return notFound( "No gateway found with id: " + uid );
         }
 
         gatewayAdminService.removeGatewayByUid( uid );
 
-        return WebMessageUtils.ok( "Gateway removed successfully" );
+        return ok( "Gateway removed successfully" );
     }
 
     private void generateOutput( HttpServletResponse response, Object value )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.sms;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 
 import java.io.IOException;
 import java.util.Date;
@@ -40,7 +42,6 @@ import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -96,18 +97,18 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
     {
         if ( originator == null || originator.length() <= 0 )
         {
-            return WebMessageUtils.conflict( "Originator must be specified" );
+            return conflict( "Originator must be specified" );
         }
 
         if ( message == null || message.length() <= 0 )
         {
-            return WebMessageUtils.conflict( "Message must be specified" );
+            return conflict( "Message must be specified" );
         }
 
         long smsId = incomingSMSService.save( message, originator, gateway, receivedTime,
             getUserByPhoneNumber( originator, message ) );
 
-        return WebMessageUtils.ok( "Received SMS: " + smsId );
+        return ok( "Received SMS: " + smsId );
     }
 
     @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
@@ -122,7 +123,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
 
         long smsId = incomingSMSService.save( sms );
 
-        return WebMessageUtils.ok( "Received SMS: " + smsId );
+        return ok( "Received SMS: " + smsId );
     }
 
     @PostMapping( value = "/import", produces = "application/json" )
@@ -137,7 +138,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
             incomingSMSService.update( sms );
         }
 
-        return WebMessageUtils.ok( "Import successful" );
+        return ok( "Import successful" );
     }
 
     // -------------------------------------------------------------------------
@@ -158,7 +159,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
 
         incomingSMSService.delete( uid );
 
-        return WebMessageUtils.ok( "IncomingSms with " + uid + " deleted" );
+        return ok( "IncomingSms with " + uid + " deleted" );
     }
 
     @DeleteMapping( produces = "application/json" )
@@ -168,7 +169,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
     {
         ids.forEach( incomingSMSService::delete );
 
-        return WebMessageUtils.ok( "Objects deleted" );
+        return ok( "Objects deleted" );
     }
 
     // -------------------------------------------------------------------------
@@ -199,7 +200,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
 
             // No user belong to this phone number
             throw new WebMessageException(
-                WebMessageUtils.conflict( "User's phone number is not registered in the system" ) );
+                conflict( "User's phone number is not registered in the system" ) );
         }
 
         return users.iterator().next();
@@ -212,7 +213,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         {
             // current user does not belong to this number
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Originator's number does not match user's Phone number" ) );
+                conflict( "Originator's number does not match user's Phone number" ) );
         }
 
         return currentUser;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.sms;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,7 +39,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.render.RenderService;
@@ -93,21 +95,21 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     {
         if ( recipient == null || recipient.length() <= 0 )
         {
-            return WebMessageUtils.conflict( "Recipient must be specified" );
+            return conflict( "Recipient must be specified" );
         }
 
         if ( message == null || message.length() <= 0 )
         {
-            return WebMessageUtils.conflict( "Message must be specified" );
+            return conflict( "Message must be specified" );
         }
 
         OutboundMessageResponse status = smsSender.sendMessage( null, message, recipient );
 
         if ( status.isOk() )
         {
-            return WebMessageUtils.ok( "SMS sent" );
+            return ok( "SMS sent" );
         }
-        return WebMessageUtils.error( status.getDescription() );
+        return error( status.getDescription() );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
@@ -122,9 +124,9 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
 
         if ( status.isOk() )
         {
-            return WebMessageUtils.ok( "SMS sent" );
+            return ok( "SMS sent" );
         }
-        return WebMessageUtils.error( status.getDescription() );
+        return error( status.getDescription() );
     }
 
     // -------------------------------------------------------------------------
@@ -145,7 +147,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
 
         outboundSmsService.delete( uid );
 
-        return WebMessageUtils.ok( "OutboundSms with " + uid + " deleted" );
+        return ok( "OutboundSms with " + uid + " deleted" );
     }
 
     @DeleteMapping( produces = "application/json" )
@@ -155,6 +157,6 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     {
         ids.forEach( outboundSmsService::delete );
 
-        return WebMessageUtils.ok( "Objects deleted" );
+        return ok( "Objects deleted" );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -43,7 +44,6 @@ import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Events;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.node.Preset;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.schema.SchemaService;
@@ -155,7 +155,7 @@ public class TrackerEventsExportController
 
         if ( event == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "Event not found for ID " + uid ) );
+            throw new WebMessageException( notFound( "Event not found for ID " + uid ) );
         }
 
         event.setHref( getUri( uid, request ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -103,13 +103,10 @@ public class TrackerImportController
             .importReport( trackerImportReportRequest );
 
         String location = ContextUtils.getRootPath( request ) + "/tracker/jobs/" + jobId;
-        response.setHeader( "Location", location );
 
         return ok( TRACKER_JOB_ADDED )
-            .setResponse(
-                TrackerJobWebMessageResponse.builder()
-                    .id( jobId ).location( location )
-                    .build() );
+            .setLocation( "/tracker/jobs/" + jobId )
+            .setResponse( TrackerJobWebMessageResponse.builder().id( jobId ).location( location ).build() );
     }
 
     @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE, params = { "async=false" } )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.R
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import java.io.IOException;
 import java.util.Deque;
 import java.util.Optional;
 
@@ -42,7 +41,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.Notification;
 import org.hisp.dhis.system.notification.Notifier;
@@ -66,6 +65,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpStatusCodeException;
 
@@ -83,16 +83,14 @@ public class TrackerImportController
 
     private final TrackerImportService trackerImportService;
 
-    private final RenderService renderService;
-
     private final ContextService contextService;
 
     private final Notifier notifier;
 
-    @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE )
-    public void asyncPostJsonTracker( HttpServletRequest request, HttpServletResponse response, User currentUser,
+    @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
+    @ResponseBody
+    public WebMessage asyncPostJsonTracker( HttpServletRequest request, HttpServletResponse response, User currentUser,
         @RequestBody TrackerBundleParams trackerBundleParams )
-        throws IOException
     {
         String jobId = CodeGenerator.generateUid();
 
@@ -106,14 +104,12 @@ public class TrackerImportController
 
         String location = ContextUtils.getRootPath( request ) + "/tracker/jobs/" + jobId;
         response.setHeader( "Location", location );
-        response.setContentType( APPLICATION_JSON_VALUE );
 
-        renderService.toJson( response.getOutputStream(), new WebMessage()
-            .setMessage( TRACKER_JOB_ADDED )
+        return WebMessageUtils.ok( TRACKER_JOB_ADDED )
             .setResponse(
                 TrackerJobWebMessageResponse.builder()
                     .id( jobId ).location( location )
-                    .build() ) );
+                    .build() );
     }
 
     @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE, params = { "async=false" } )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -41,7 +42,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.Notification;
 import org.hisp.dhis.system.notification.Notifier;
@@ -105,7 +105,7 @@ public class TrackerImportController
         String location = ContextUtils.getRootPath( request ) + "/tracker/jobs/" + jobId;
         response.setHeader( "Location", location );
 
-        return WebMessageUtils.ok( TRACKER_JOB_ADDED )
+        return ok( TRACKER_JOB_ADDED )
             .setResponse(
                 TrackerJobWebMessageResponse.builder()
                     .id( jobId ).location( location )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.user;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.io.IOException;
@@ -50,7 +53,6 @@ import org.hisp.dhis.dataapproval.DataApprovalLevel;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.interpretation.InterpretationService;
@@ -260,7 +262,7 @@ public class MeController
         if ( user.getWhatsApp() != null && !ValidationUtils.validateWhatsapp( user.getWhatsApp() ) )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Invalid format for WhatsApp value '" + user.getWhatsApp() + "'" ) );
+                conflict( "Invalid format for WhatsApp value '" + user.getWhatsApp() + "'" ) );
         }
 
         manager.update( currentUser );
@@ -351,14 +353,14 @@ public class MeController
 
         if ( !keyEnum.isPresent() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Key is not supported: " + key ) );
+            throw new WebMessageException( conflict( "Key is not supported: " + key ) );
         }
 
         Serializable value = userSettingService.getUserSetting( keyEnum.get(), currentUser );
 
         if ( value == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "User setting not found for key: " + key ) );
+            throw new WebMessageException( notFound( "User setting not found for key: " + key ) );
         }
 
         response.setContentType( MediaType.APPLICATION_JSON_VALUE );
@@ -385,14 +387,14 @@ public class MeController
 
         if ( StringUtils.isEmpty( oldPassword ) || StringUtils.isEmpty( newPassword ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "OldPassword and newPassword must be provided" ) );
+            throw new WebMessageException( conflict( "OldPassword and newPassword must be provided" ) );
         }
 
         boolean valid = passwordManager.matches( oldPassword, currentUser.getUserCredentials().getPassword() );
 
         if ( !valid )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "OldPassword is incorrect" ) );
+            throw new WebMessageException( conflict( "OldPassword is incorrect" ) );
         }
 
         updatePassword( currentUser, newPassword );
@@ -471,7 +473,7 @@ public class MeController
         if ( password == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Required attribute 'password' missing or null." ) );
+                conflict( "Required attribute 'password' missing or null." ) );
         }
 
         boolean valid = passwordManager.matches( password, currentUser.getUserCredentials().getPassword() );
@@ -488,7 +490,7 @@ public class MeController
         if ( password == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( "Required attribute 'password' missing or null." ) );
+                conflict( "Required attribute 'password' missing or null." ) );
         }
 
         CredentialsInfo credentialsInfo = new CredentialsInfo( currentUser.getUsername(), password,
@@ -514,7 +516,7 @@ public class MeController
 
         if ( user == null || user.getUserCredentials() == null )
         {
-            throw new WebMessageException( WebMessageUtils.unauthorized( "Not authenticated" ) );
+            throw new WebMessageException( unauthorized( "Not authenticated" ) );
         }
 
         return user;
@@ -573,7 +575,7 @@ public class MeController
             }
             else
             {
-                throw new WebMessageException( WebMessageUtils.conflict( result.getErrorMessage() ) );
+                throw new WebMessageException( conflict( result.getErrorMessage() ) );
             }
         }
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -514,7 +514,7 @@ public class MeController
 
         if ( user == null || user.getUserCredentials() == null )
         {
-            throw new WebMessageException( WebMessageUtils.unathorized( "Not authenticated" ) );
+            throw new WebMessageException( WebMessageUtils.unauthorized( "Not authenticated" ) );
         }
 
         return user;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -287,60 +287,60 @@ public class UserController
     @Override
     @PostMapping( consumes = { "application/xml", "text/xml" } )
     @ResponseBody
-    public WebMessage postXmlObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postXmlObject( HttpServletRequest request )
         throws Exception
     {
-        return postObject( response, renderService.fromXml( request.getInputStream(), getEntityClass() ) );
+        return postObject( renderService.fromXml( request.getInputStream(), getEntityClass() ) );
     }
 
     @Override
     @PostMapping( consumes = "application/json" )
     @ResponseBody
-    public WebMessage postJsonObject( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postJsonObject( HttpServletRequest request )
         throws Exception
     {
-        return postObject( response, renderService.fromJson( request.getInputStream(), getEntityClass() ) );
+        return postObject( renderService.fromJson( request.getInputStream(), getEntityClass() ) );
     }
 
-    private WebMessage postObject( HttpServletResponse response, User user )
+    private WebMessage postObject( User user )
         throws WebMessageException
     {
         User currentUser = currentUserService.getCurrentUser();
 
         validateCreateUser( user, currentUser );
 
-        return postObject( response, getObjectReport( createUser( user, currentUser ) ) );
+        return postObject( getObjectReport( createUser( user, currentUser ) ) );
     }
 
     @PostMapping( value = INVITE_PATH, consumes = "application/json" )
     @ResponseBody
-    public WebMessage postJsonInvite( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postJsonInvite( HttpServletRequest request )
         throws Exception
     {
-        return postInvite( request, response, renderService.fromJson( request.getInputStream(), getEntityClass() ) );
+        return postInvite( request, renderService.fromJson( request.getInputStream(), getEntityClass() ) );
     }
 
     @PostMapping( value = INVITE_PATH, consumes = { "application/xml", "text/xml" } )
     @ResponseBody
-    public WebMessage postXmlInvite( HttpServletRequest request, HttpServletResponse response )
+    public WebMessage postXmlInvite( HttpServletRequest request )
         throws Exception
     {
-        return postInvite( request, response, renderService.fromXml( request.getInputStream(), getEntityClass() ) );
+        return postInvite( request, renderService.fromXml( request.getInputStream(), getEntityClass() ) );
     }
 
-    private WebMessage postInvite( HttpServletRequest request, HttpServletResponse response, User user )
+    private WebMessage postInvite( HttpServletRequest request, User user )
         throws WebMessageException
     {
         User currentUser = currentUserService.getCurrentUser();
 
         validateInviteUser( user, currentUser );
 
-        return postObject( response, inviteUser( user, currentUser, request ) );
+        return postObject( inviteUser( user, currentUser, request ) );
     }
 
     @PostMapping( value = BULK_INVITE_PATH, consumes = "application/json" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void postJsonInvites( HttpServletRequest request, HttpServletResponse response )
+    public void postJsonInvites( HttpServletRequest request )
         throws Exception
     {
         postInvites( request, renderService.fromJson( request.getInputStream(), Users.class ) );
@@ -349,7 +349,7 @@ public class UserController
     @PostMapping( value = BULK_INVITE_PATH, consumes = { "application/xml",
         "text/xml" } )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void postXmlInvites( HttpServletRequest request, HttpServletResponse response )
+    public void postXmlInvites( HttpServletRequest request )
         throws Exception
     {
         postInvites( request, renderService.fromXml( request.getInputStream(), Users.class ) );
@@ -525,8 +525,8 @@ public class UserController
                 userReplica ) );
         }
 
-        response.addHeader( "Location", UserSchemaDescriptor.API_ENDPOINT + "/" + userReplica.getUid() );
-        return created( "User replica created" );
+        return created( "User replica created" )
+            .setLocation( UserSchemaDescriptor.API_ENDPOINT + "/" + userReplica.getUid() );
     }
 
     @PostMapping( "/{uid}/enabled" )
@@ -581,8 +581,7 @@ public class UserController
     @Override
     @PutMapping( value = "/{uid}", consumes = "application/json", produces = "application/json" )
     @ResponseBody
-    public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
-        HttpServletResponse response )
+    public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request )
         throws Exception
     {
         User parsed = renderService.fromJson( request.getInputStream(), getEntityClass() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -28,6 +28,10 @@
 package org.hisp.dhis.webapi.controller.user;
 
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importReport;
 
 import java.io.IOException;
 import java.util.Date;
@@ -56,7 +60,6 @@ import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.fieldfilter.Defaults;
@@ -264,7 +267,7 @@ public class UserController
 
         if ( user == null || user.getUserCredentials() == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "User not found: " + pvUid ) );
+            throw new WebMessageException( conflict( "User not found: " + pvUid ) );
         }
 
         User currentUser = currentUserService.getCurrentUser();
@@ -377,19 +380,19 @@ public class UserController
 
         if ( user == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "User not found: " + id ) );
+            throw new WebMessageException( conflict( "User not found: " + id ) );
         }
 
         if ( user.getUserCredentials() == null || !user.getUserCredentials().isInvitation() )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "User account is not an invitation: " + id ) );
+            throw new WebMessageException( conflict( "User account is not an invitation: " + id ) );
         }
 
         String valid = securityService.validateRestore( user.getUserCredentials() );
 
         if ( valid != null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( valid ) );
+            throw new WebMessageException( conflict( valid ) );
         }
 
         boolean isInviteUsername = securityService.isInviteUsername( user.getUsername() );
@@ -401,7 +404,7 @@ public class UserController
             .sendRestoreOrInviteMessage( user.getUserCredentials(), ContextUtils.getContextPath( request ),
                 restoreOptions ) )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed to send invite message" ) );
+            throw new WebMessageException( error( "Failed to send invite message" ) );
         }
     }
 
@@ -418,7 +421,7 @@ public class UserController
         String valid = securityService.validateRestore( user.getUserCredentials() );
         if ( valid != null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( valid ) );
+            throw new WebMessageException( conflict( valid ) );
         }
         User currentUser = currentUserService.getCurrentUser();
         if ( !aclService.canUpdate( currentUser, user ) )
@@ -449,7 +452,7 @@ public class UserController
 
         if ( existingUser == null || existingUser.getUserCredentials() == null )
         {
-            return WebMessageUtils.conflict( "User not found: " + uid );
+            return conflict( "User not found: " + uid );
         }
 
         User currentUser = currentUserService.getCurrentUser();
@@ -463,22 +466,22 @@ public class UserController
 
         if ( auth == null || username == null )
         {
-            return WebMessageUtils.conflict( "Username must be specified" );
+            return conflict( "Username must be specified" );
         }
 
         if ( userService.getUserCredentialsByUsername( username ) != null )
         {
-            return WebMessageUtils.conflict( "Username already taken: " + username );
+            return conflict( "Username already taken: " + username );
         }
 
         if ( password == null )
         {
-            return WebMessageUtils.conflict( "Password must be specified" );
+            return conflict( "Password must be specified" );
         }
 
         if ( !ValidationUtils.passwordIsValid( password ) )
         {
-            return WebMessageUtils.conflict( "Password must have at least 8 characters, one digit, one uppercase" );
+            return conflict( "Password must have at least 8 characters, one digit, one uppercase" );
         }
 
         User userReplica = new User();
@@ -523,7 +526,7 @@ public class UserController
         }
 
         response.addHeader( "Location", UserSchemaDescriptor.API_ENDPOINT + "/" + userReplica.getUid() );
-        return WebMessageUtils.created( "User replica created" );
+        return created( "User replica created" );
     }
 
     @PostMapping( "/{uid}/enabled" )
@@ -571,7 +574,7 @@ public class UserController
     {
         User parsed = renderService.fromXml( request.getInputStream(), getEntityClass() );
 
-        return WebMessageUtils.importReport( updateUser( pvUid, parsed ) )
+        return importReport( updateUser( pvUid, parsed ) )
             .withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
@@ -584,7 +587,7 @@ public class UserController
     {
         User parsed = renderService.fromJson( request.getInputStream(), getEntityClass() );
 
-        return WebMessageUtils.importReport( updateUser( pvUid, parsed ) )
+        return importReport( updateUser( pvUid, parsed ) )
             .withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
@@ -596,7 +599,7 @@ public class UserController
         if ( users.isEmpty() )
         {
             throw new WebMessageException(
-                WebMessageUtils.conflict( getEntityName() + " does not exist: " + userUid ) );
+                conflict( getEntityName() + " does not exist: " + userUid ) );
         }
 
         User currentUser = currentUserService.getCurrentUser();
@@ -625,7 +628,7 @@ public class UserController
         if ( !userService.canAddOrUpdateUser( groupsUids, currentUser )
             || !currentUser.getUserCredentials().canModifyUser( users.get( 0 ).getUserCredentials() ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "You must have permissions to create user, " +
                     "or ability to manage at least one user group for the user." ) );
         }
@@ -682,7 +685,7 @@ public class UserController
         if ( !userService.canAddOrUpdateUser( getUids( entity.getGroups() ), currentUser )
             || !currentUser.getUserCredentials().canModifyUser( entity.getUserCredentials() ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "You must have permissions to create user, or ability to manage at least one user group for the user." ) );
         }
     }
@@ -713,13 +716,13 @@ public class UserController
         if ( !userService.canAddOrUpdateUser( getUids( entity.getGroups() ), currentUser )
             || !currentUser.getUserCredentials().canModifyUser( entity.getUserCredentials() ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "You must have permissions to create user, or ability to manage at least one user group for the user." ) );
         }
 
         if ( userService.isLastSuperUser( entity.getUserCredentials() ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Can not remove the last super user." ) );
+            throw new WebMessageException( conflict( "Can not remove the last super user." ) );
         }
     }
 
@@ -742,7 +745,7 @@ public class UserController
 
         if ( !userService.canAddOrUpdateUser( getUids( user.getGroups() ), currentUser ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "You must have permissions to create user, or ability to manage at least one user group for the user." ) );
         }
 
@@ -753,7 +756,7 @@ public class UserController
             if ( !userGroupService.canAddOrRemoveMember( uid, currentUser ) )
             {
                 throw new WebMessageException(
-                    WebMessageUtils.conflict( "You don't have permissions to add user to user group: " + uid ) );
+                    conflict( "You don't have permissions to add user to user group: " + uid ) );
             }
         }
     }
@@ -794,7 +797,7 @@ public class UserController
 
         if ( credentials == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "User credentials is not present" ) );
+            throw new WebMessageException( conflict( "User credentials is not present" ) );
         }
 
         credentials.setUserInfo( user );
@@ -803,7 +806,7 @@ public class UserController
 
         if ( validateMessage != null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( validateMessage ) );
+            throw new WebMessageException( conflict( validateMessage ) );
         }
     }
 
@@ -935,7 +938,7 @@ public class UserController
         if ( !userService.canAddOrUpdateUser( getUids( userToModify.getGroups() ), currentUser )
             || !currentUser.getUserCredentials().canModifyUser( userToModify.getUserCredentials() ) )
         {
-            throw new WebMessageException( WebMessageUtils.conflict(
+            throw new WebMessageException( conflict(
                 "You must have permissions to create user, or ability to manage at least one user group for the user." ) );
         }
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.user;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+
 import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.hibernate.exception.DeleteAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.UpdateAccessDeniedException;
 import org.hisp.dhis.query.Order;
@@ -90,14 +91,14 @@ public class UserRoleController
 
         if ( userAuthorityGroup == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "UserRole does not exist: " + pvId ) );
+            throw new WebMessageException( notFound( "UserRole does not exist: " + pvId ) );
         }
 
         User user = userService.getUser( pvUserId );
 
         if ( user == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "User does not exist: " + pvId ) );
+            throw new WebMessageException( notFound( "User does not exist: " + pvId ) );
         }
 
         if ( !aclService.canUpdate( currentUserService.getCurrentUser(), userAuthorityGroup ) )
@@ -122,14 +123,14 @@ public class UserRoleController
 
         if ( userAuthorityGroup == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "UserRole does not exist: " + pvId ) );
+            throw new WebMessageException( notFound( "UserRole does not exist: " + pvId ) );
         }
 
         User user = userService.getUser( pvUserId );
 
         if ( user == null || user.getUserCredentials() == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( "User does not exist: " + pvId ) );
+            throw new WebMessageException( notFound( "User does not exist: " + pvId ) );
         }
 
         if ( !aclService.canUpdate( currentUserService.getCurrentUser(), userAuthorityGroup ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.validation;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
 import java.util.ArrayList;
 
 import javax.servlet.http.HttpServletResponse;
@@ -39,7 +42,6 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
@@ -95,21 +97,21 @@ public class ValidationController
 
         if ( dataSet == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Data set does not exist: " + ds ) );
+            throw new WebMessageException( conflict( "Data set does not exist: " + ds ) );
         }
 
         Period period = PeriodType.getPeriodFromIsoString( pe );
 
         if ( period == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Period does not exist: " + pe ) );
+            throw new WebMessageException( conflict( "Period does not exist: " + pe ) );
         }
 
         OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ou );
 
         if ( orgUnit == null )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Organisation unit does not exist: " + ou ) );
+            throw new WebMessageException( conflict( "Organisation unit does not exist: " + ou ) );
         }
 
         CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( aoc );
@@ -145,6 +147,6 @@ public class ValidationController
 
         schedulingManager.executeNow( validationResultNotification );
 
-        return WebMessageUtils.ok( "Initiated validation result notification" );
+        return ok( "Initiated validation result notification" );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationResultController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationResultController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.validation;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.List;
@@ -35,7 +36,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.node.NodeUtils;
@@ -144,7 +144,7 @@ public class ValidationResultController
         if ( result == null )
         {
             throw new WebMessageException(
-                WebMessageUtils.notFound( "Validation result with id " + id + " was not found" ) );
+                notFound( "Validation result with id " + id + " was not found" ) );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.ExpressionValidationOutcome;
 import org.hisp.dhis.feedback.Status;
-import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.QueryParserException;
@@ -49,6 +48,7 @@ import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -102,21 +102,12 @@ public class ValidationRuleController
     @ResponseBody
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {
-        I18n i18n = i18nManager.getI18n();
-
         ExpressionValidationOutcome result = expressionService.expressionIsValid( expression,
             VALIDATION_RULE_EXPRESSION );
 
-        DescriptiveWebMessage message = new DescriptiveWebMessage();
-        message.setStatus( result.isValid() ? Status.OK : Status.ERROR );
-        message.setMessage( i18n.getString( result.getKey() ) );
-
-        if ( result.isValid() )
-        {
-            message
-                .setDescription( expressionService.getExpressionDescription( expression, VALIDATION_RULE_EXPRESSION ) );
-        }
-
-        return message;
+        return new DescriptiveWebMessage( result.isValid() ? Status.OK : Status.ERROR, HttpStatus.OK )
+            .setDescription( result::isValid,
+                () -> expressionService.getExpressionDescription( expression, VALIDATION_RULE_EXPRESSION ) )
+            .setMessage( i18nManager.getI18n().getString( result.getKey() ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.security;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
@@ -34,7 +36,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -88,12 +89,12 @@ public class DHIS2BasicAuthenticationEntryPoint extends LoginUrlAuthenticationEn
             if ( acceptHeader.contains( MediaType.APPLICATION_XML_VALUE ) )
             {
                 response.setContentType( MediaType.APPLICATION_XML_VALUE );
-                renderService.toXml( response.getOutputStream(), WebMessageUtils.unauthorized( message ) );
+                renderService.toXml( response.getOutputStream(), unauthorized( message ) );
             }
             else
             {
                 response.setContentType( MediaType.APPLICATION_JSON_VALUE );
-                renderService.toJson( response.getOutputStream(), WebMessageUtils.unauthorized( message ) );
+                renderService.toJson( response.getOutputStream(), unauthorized( message ) );
             }
 
             return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/DHIS2BasicAuthenticationEntryPoint.java
@@ -88,12 +88,12 @@ public class DHIS2BasicAuthenticationEntryPoint extends LoginUrlAuthenticationEn
             if ( acceptHeader.contains( MediaType.APPLICATION_XML_VALUE ) )
             {
                 response.setContentType( MediaType.APPLICATION_XML_VALUE );
-                renderService.toXml( response.getOutputStream(), WebMessageUtils.unathorized( message ) );
+                renderService.toXml( response.getOutputStream(), WebMessageUtils.unauthorized( message ) );
             }
             else
             {
                 response.setContentType( MediaType.APPLICATION_JSON_VALUE );
-                renderService.toJson( response.getOutputStream(), WebMessageUtils.unathorized( message ) );
+                renderService.toJson( response.getOutputStream(), WebMessageUtils.unauthorized( message ) );
             }
 
             return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/Http401LoginUrlAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/Http401LoginUrlAuthenticationEntryPoint.java
@@ -27,13 +27,14 @@
  */
 package org.hisp.dhis.webapi.security;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.render.RenderService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -63,7 +64,7 @@ public class Http401LoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticat
         {
             response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
             response.setContentType( MediaType.APPLICATION_JSON_VALUE );
-            renderService.toJson( response.getOutputStream(), WebMessageUtils.unauthorized( "Unauthorized" ) );
+            renderService.toJson( response.getOutputStream(), unauthorized( "Unauthorized" ) );
             return;
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/TrackedEntityInstanceSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/TrackedEntityInstanceSupportService.java
@@ -104,10 +104,10 @@ public class TrackedEntityInstanceSupportService
                 if ( program.getAccessLevel() == AccessLevel.CLOSED )
                 {
                     throw new WebMessageException(
-                        WebMessageUtils.unathorized( TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED ) );
+                        WebMessageUtils.unauthorized( TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED ) );
                 }
                 throw new WebMessageException(
-                    WebMessageUtils.unathorized( TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED ) );
+                    WebMessageUtils.unauthorized( TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED ) );
             }
 
             if ( trackedEntityInstanceParams.isIncludeProgramOwners() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/TrackedEntityInstanceSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/TrackedEntityInstanceSupportService.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.service;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,7 +41,6 @@ import org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -104,10 +105,10 @@ public class TrackedEntityInstanceSupportService
                 if ( program.getAccessLevel() == AccessLevel.CLOSED )
                 {
                     throw new WebMessageException(
-                        WebMessageUtils.unauthorized( TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED ) );
+                        unauthorized( TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED ) );
                 }
                 throw new WebMessageException(
-                    WebMessageUtils.unauthorized( TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED ) );
+                    unauthorized( TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED ) );
             }
 
             if ( trackedEntityInstanceParams.isIncludeProgramOwners() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.utils;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,7 +43,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceService;
@@ -147,7 +149,7 @@ public class FileResourceUtils
         }
         catch ( IOException e )
         {
-            throw new WebMessageException( WebMessageUtils.error( "Failed fetching the file from storage",
+            throw new WebMessageException( error( "Failed fetching the file from storage",
                 "There was an exception when trying to fetch the file from the storage backend. "
                     + "Depending on the provider the root cause could be network or file system related." ) );
         }
@@ -171,7 +173,7 @@ public class FileResourceUtils
 
         if ( contentLength <= 0 )
         {
-            throw new WebMessageException( WebMessageUtils.conflict( "Could not read file or file is empty." ) );
+            throw new WebMessageException( conflict( "Could not read file or file is empty." ) );
         }
 
         ByteSource bytes = new MultipartFileByteSource( file );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -106,7 +106,6 @@ public class TrackerImportControllerTest
 
         // Controller under test
         final TrackerImportController controller = new TrackerImportController( importStrategy, trackerImportService,
-            renderService,
             new DefaultContextService(), notifier );
 
         mockMvc = MockMvcBuilders.standaloneSetup( controller ).build();

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -188,8 +188,11 @@ public class AbstractCrudControllerTest extends DhisControllerConvenienceTest
     @Test
     public void testPostJsonObject()
     {
-        assertStatus( HttpStatus.CREATED,
-            POST( "/constants/", "{'name':'answer', 'value': 42}" ) );
+        HttpResponse response = POST( "/constants/", "{'name':'answer', 'value': 42}" );
+        assertWebMessage( "Created", 201, "OK", null,
+            response.content( HttpStatus.CREATED ) );
+        assertEquals( "http://localhost/constants/" + assertStatus( HttpStatus.CREATED, response ),
+            response.header( "Location" ) );
     }
 
     @Test

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
@@ -25,48 +25,25 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.security;
+package org.hisp.dhis.webapi.controller;
 
-import java.io.IOException;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
-import org.hisp.dhis.render.RenderService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * Tests the
+ * {@link org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportController}
+ * using (mocked) REST requests.
+ *
+ * @author Jan Bernitt
  */
-public class Http401LoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticationEntryPoint
+public class TrackerImportControllerTest extends DhisControllerConvenienceTest
 {
-    @Autowired
-    private RenderService renderService;
-
-    public Http401LoginUrlAuthenticationEntryPoint( String loginFormUrl )
+    @Test
+    public void testAsyncPostJsonTracker()
     {
-        super( loginFormUrl );
-    }
-
-    @Override
-    public void commence( HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException authException )
-        throws IOException,
-        ServletException
-    {
-        if ( "XMLHttpRequest".equals( request.getHeader( "X-Requested-With" ) ) )
-        {
-            response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
-            response.setContentType( MediaType.APPLICATION_JSON_VALUE );
-            renderService.toJson( response.getOutputStream(), WebMessageUtils.unauthorized( "Unauthorized" ) );
-            return;
-        }
-
-        super.commence( request, response, authException );
+        assertWebMessage( "OK", 200, "OK", "Tracker job added",
+            POST( "/tracker?async=true", "{}" ).content( HttpStatus.OK ) );
     }
 }

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/WebClientUtils.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/WebClientUtils.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -102,6 +103,7 @@ public class WebClientUtils
                 assertEquals( msg, expected, actualStatus );
             }
         }
+        assertValidLocation( actual );
         return getCreatedId( actual );
     }
 
@@ -128,7 +130,21 @@ public class WebClientUtils
             String msg = actual.error( actualSeries ).summary();
             assertEquals( msg, expected, actualSeries );
         }
+        assertValidLocation( actual );
         return getCreatedId( actual );
+    }
+
+    public static void assertValidLocation( HttpResponse actual )
+    {
+        String location = actual.location();
+        if ( location == null )
+        {
+            return;
+        }
+        assertTrue( "Location header does not start with http or https",
+            location.startsWith( "http://" ) || location.startsWith( "https://" ) );
+        assertTrue( "Location header does contain multiple protocol parts",
+            location.indexOf( "http://", 4 ) < 0 && location.indexOf( "https://", 4 ) < 0 );
     }
 
     private static String getCreatedId( HttpResponse response )


### PR DESCRIPTION
### Summary
This is a cleanup PR around `WebMessage`s.

It...
* makes sure `WebMessage` is always created with `Status` and `HttpStatus` set
* makes use of the factory methods in `WebMessageUtils` to create messages where possible
* uses static imports for factory methods
* uses builder style setters to avoid assigning messages to local variables before returning them
* allows to set the `Location` HTTP response header using the `WebMessage` by suing a new field `setLocation`

### Location Header
Within the `WebMessage` the location is set relative (without context or servlet path).
The `WebMessageControllerAdvice` converts the relative location to an absolute one using `ContextService#getApiPath()`and sets the absolute path in the HTTP response.

The main idea is to avoid dealing with HTTP level details within the controllers.
With location now being present in the `WebMessage` many controller methods no longer need the HTTP response injected.

There were places where the `Location` HTTP header was set relative before. 
This PR assumes that this was a mistake and corrects it so that even those will now be absolute URLs.

### Automatic Testing
I modified an existing test for the generic `POST` for objects to explicitly check the `Location` header returned.
In addition all checks done via `assertStatus` will now also check that the  `Location` header does not contain `http://` or `https://` twice (which is the risk when switching from absolute to relative locations being set in the controllers).
This will indirectly check many tests for having a reasonable header.

Another way the `Location` header is indirectly tested by unit tests is that it is used to extract the UID of objects created when using the `assertStatus` method (which often is used). Those tests would break if the ID would not be contained or the header would not be set.