### PR TITLE
chore: GatewayAdministrationService cleanup

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GatewayAdministrationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GatewayAdministrationService.java
@@ -27,21 +27,17 @@
  */
 package org.hisp.dhis.sms.config;
 
-import java.util.Map;
-
 /**
  * @author Zubair <rajazubair.asghar@gmail.com>
  *
  */
 public interface GatewayAdministrationService
 {
-    void setDefaultGateway( String uid );
-
     void setDefaultGateway( SmsGatewayConfig config );
 
     boolean removeGatewayByUid( String uid );
 
-    Map<String, SmsGatewayConfig> getGatewayConfigurationMap();
+    boolean hasGateways();
 
     SmsGatewayConfig getDefaultGateway();
 
@@ -53,7 +49,4 @@ public interface GatewayAdministrationService
 
     void updateGateway( SmsGatewayConfig persisted, SmsGatewayConfig updatedConfig );
 
-    boolean loadGatewayConfigurationMap( SmsConfiguration smsConfiguration );
-
-    Class<? extends SmsGatewayConfig> getGatewayType( SmsGatewayConfig config );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsMessageSender.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsMessageSender.java
@@ -30,7 +30,10 @@ package org.hisp.dhis.sms.config;
 import static org.hisp.dhis.commons.util.TextUtils.LN;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -40,7 +43,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.message.MessageSender;
-import org.hisp.dhis.outboundmessage.*;
+import org.hisp.dhis.outboundmessage.OutboundMessage;
+import org.hisp.dhis.outboundmessage.OutboundMessageBatch;
+import org.hisp.dhis.outboundmessage.OutboundMessageBatchStatus;
+import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.outboundmessage.OutboundMessageResponseSummary;
 import org.hisp.dhis.sms.outbound.GatewayResponse;
 import org.hisp.dhis.sms.outbound.OutboundSms;
 import org.hisp.dhis.sms.outbound.OutboundSmsService;
@@ -226,9 +233,7 @@ public class SmsMessageSender
     @Override
     public boolean isConfigured()
     {
-        Map<String, SmsGatewayConfig> configMap = gatewayAdminService.getGatewayConfigurationMap();
-
-        return !configMap.isEmpty();
+        return gatewayAdminService.hasGateways();
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
@@ -242,8 +242,6 @@ public class ProgramMessageServiceTest
         smsConfig.getGateways().add( bulkSmsConfig );
 
         smsConfigurationManager.updateSmsConfiguration( smsConfig );
-
-        gatewayAdminService.loadGatewayConfigurationMap( smsConfig );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
@@ -27,17 +27,42 @@
  */
 package org.hisp.dhis.sms;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DeliveryChannel;
-import org.hisp.dhis.outboundmessage.*;
-import org.hisp.dhis.sms.config.*;
+import org.hisp.dhis.outboundmessage.OutboundMessage;
+import org.hisp.dhis.outboundmessage.OutboundMessageBatch;
+import org.hisp.dhis.outboundmessage.OutboundMessageBatchStatus;
+import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.outboundmessage.OutboundMessageResponseSummary;
+import org.hisp.dhis.sms.config.BulkSmsGatewayConfig;
+import org.hisp.dhis.sms.config.BulkSmsHttpGateway;
+import org.hisp.dhis.sms.config.GatewayAdministrationService;
+import org.hisp.dhis.sms.config.SmsGateway;
+import org.hisp.dhis.sms.config.SmsGatewayConfig;
+import org.hisp.dhis.sms.config.SmsMessageSender;
 import org.hisp.dhis.sms.outbound.GatewayResponse;
 import org.hisp.dhis.sms.outbound.OutboundSmsService;
 import org.hisp.dhis.user.User;
@@ -173,7 +198,7 @@ public class SmsMessageSenderTest
     @Test
     public void testIsConfiguredWithOutGatewayConfig()
     {
-        when( gatewayAdministrationService.getGatewayConfigurationMap() ).thenReturn( new HashMap<>() );
+        when( gatewayAdministrationService.hasGateways() ).thenReturn( false );
 
         boolean isConfigured = smsMessageSender.isConfigured();
 
@@ -183,7 +208,7 @@ public class SmsMessageSenderTest
     @Test
     public void testIsConfiguredWithGatewayConfig()
     {
-        when( gatewayAdministrationService.getGatewayConfigurationMap() ).thenReturn( configMap );
+        when( gatewayAdministrationService.hasGateways() ).thenReturn( true );
 
         boolean isConfigured = smsMessageSender.isConfigured();
 


### PR DESCRIPTION
Noticed a couple of details when I came across the `DefaultGatewayAdministrationService` and decided to do a general cleanup.

This PR:
* removes service methods only used by tests
* fixes thread-safety issues with map of available gateways by name by not maintaining or exposing such a map (as it wasn't needed except by tests) - what was needed was only a true/false whether or not there is any gateway configured which now is available using `hasGateways()`
* replaces loops with stream API where this improves readability