### PR TITLE
chore: use constants with static imports for controller media types [TECH-651]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -35,6 +35,9 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.objectReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.typeReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.validateAndThrowErrors;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -337,7 +340,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
      * removed.
      */
     @ResponseBody
-    @PatchMapping( path = "/{uid}", consumes = { "application/json-patch+json" } )
+    @PatchMapping( path = "/{uid}", consumes = "application/json-patch+json" )
     public WebMessage patchObject(
         @PathVariable( "uid" ) String pvUid,
         @RequestParam Map<String, String> rpParameters,
@@ -366,7 +369,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         prePatchEntity( persistedObject );
 
         final JsonPatch patch = jsonMapper.readValue( request.getInputStream(), JsonPatch.class );
-        final T patchedObject = (T) jsonPatchManager.apply( patch, persistedObject );
+        final T patchedObject = jsonPatchManager.apply( patch, persistedObject );
 
         // we don't allow changing UIDs
         ((BaseIdentifiableObject) patchedObject).setUid( persistedObject.getUid() );
@@ -404,7 +407,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     // POST
     // --------------------------------------------------------------------------
 
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonObject( HttpServletRequest request )
         throws Exception
@@ -412,7 +415,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         return postObject( deserializeJsonEntity( request ) );
     }
 
-    @PostMapping( consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage postXmlObject( HttpServletRequest request )
         throws Exception
@@ -519,7 +522,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     // PUT
     // --------------------------------------------------------------------------
 
-    @PutMapping( value = "/{uid}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request )
         throws Exception
@@ -571,7 +574,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         return webMessage;
     }
 
-    @PutMapping( value = "/{uid}", consumes = { MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE } )
+    @PutMapping( value = "/{uid}", consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -712,7 +715,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     // Identifiable object collections add, delete
     // --------------------------------------------------------------------------
 
-    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -724,7 +727,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
-    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -745,7 +748,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         postUpdateItems( object, items );
     }
 
-    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -757,7 +760,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
-    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -801,7 +804,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         postUpdateItems( object, items );
     }
 
-    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -813,7 +816,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
-    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -853,7 +856,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         deleteCollectionItems( pvProperty, objects.get( 0 ), items );
     }
 
-    @PutMapping( value = "/{uid}/sharing", consumes = "application/json" )
+    @PutMapping( value = "/{uid}/sharing", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public WebMessage setSharing( @PathVariable( "uid" ) String uid, HttpServletRequest request )
@@ -961,16 +964,16 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         throws IOException
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
         else if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         if ( isCompatibleWith( type, MediaType.APPLICATION_JSON ) )
@@ -994,12 +997,12 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     private boolean isJson( HttpServletRequest request )
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
 
         return isCompatibleWith( type, MediaType.APPLICATION_JSON );
@@ -1014,12 +1017,12 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     private boolean isXml( HttpServletRequest request )
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         return isCompatibleWith( type, MediaType.APPLICATION_XML );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import static java.util.Arrays.asList;
 import static org.springframework.http.CacheControl.noCache;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -58,7 +59,6 @@ import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -90,7 +90,7 @@ public abstract class AbstractGistReadOnlyController<T extends IdentifiableObjec
     // GET Gist
     // --------------------------------------------------------------------------
 
-    @GetMapping( value = "/{uid}/gist", produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/{uid}/gist", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody ResponseEntity<JsonNode> getObjectGist(
         @PathVariable( "uid" ) String uid,
         HttpServletRequest request, HttpServletResponse response )
@@ -100,7 +100,7 @@ public abstract class AbstractGistReadOnlyController<T extends IdentifiableObjec
             .withFilter( new Filter( "id", Comparison.EQ, uid ) ) );
     }
 
-    @GetMapping( value = "/gist", produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/gist", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody ResponseEntity<JsonNode> getObjectListGist(
         HttpServletRequest request, HttpServletResponse response )
     {
@@ -108,7 +108,7 @@ public abstract class AbstractGistReadOnlyController<T extends IdentifiableObjec
             getSchema() );
     }
 
-    @GetMapping( value = "/{uid}/{property}/gist", produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/{uid}/{property}/gist", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody ResponseEntity<JsonNode> getObjectPropertyGist(
         @PathVariable( "uid" ) String uid,
         @PathVariable( "property" ) String property,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -72,14 +73,14 @@ public class AppHubController
     /**
      * Deprecated as of version 2.35 and should be removed eventually.
      */
-    @GetMapping( produces = "application/json" )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public List<WebApp> listAppHub()
         throws IOException
     {
         return appHubService.getAppHub();
     }
 
-    @GetMapping( value = "/{apiVersion}/**", produces = "application/json" )
+    @GetMapping( value = "/{apiVersion}/**", produces = APPLICATION_JSON_VALUE )
     public String getAppHubApiResponse(
         @PathVariable String apiVersion, HttpServletRequest request )
         throws URISyntaxException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CacheController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -65,7 +67,7 @@ public class CacheController
 
     private final CappedLocalCache cache;
 
-    @GetMapping( produces = "application/json" )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public @ResponseBody CacheInfo getInfo( @RequestParam( value = "condensed", required = false ) Boolean condensed )
     {
         CacheInfo info = getCacheInfo();
@@ -80,14 +82,14 @@ public class CacheController
                 .collect( Collectors.toList() ) );
     }
 
-    @GetMapping( value = "/regions", produces = "application/json" )
+    @GetMapping( value = "/regions", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody Set<String> getRegions()
     {
         // sort alphabetically
         return new TreeSet<>( cache.getRegions() );
     }
 
-    @GetMapping( value = "/regions/{region}", produces = "application/json" )
+    @GetMapping( value = "/regions/{region}", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody CacheGroupInfo getRegionInfo( @PathVariable( "region" ) String region )
         throws NotFoundException
     {
@@ -102,7 +104,7 @@ public class CacheController
         throw new NotFoundException( region );
     }
 
-    @GetMapping( value = "/cap", produces = "application/json" )
+    @GetMapping( value = "/cap", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody CacheCapInfo getCapInfo()
     {
         return getCacheInfo().getCap();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChartFacadeController.java
@@ -37,6 +37,9 @@ import static org.hisp.dhis.visualization.ConversionHelper.convertToChartList;
 import static org.hisp.dhis.visualization.ConversionHelper.convertToVisualization;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 import static org.hisp.dhis.webapi.utils.PaginationUtils.getPaginationData;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -614,7 +617,7 @@ public abstract class ChartFacadeController
     // POST
     // --------------------------------------------------------------------------
 
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -657,7 +660,7 @@ public abstract class ChartFacadeController
         return webMessage;
     }
 
-    @PostMapping( consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage postXmlObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -755,7 +758,7 @@ public abstract class ChartFacadeController
     // PUT
     // --------------------------------------------------------------------------
 
-    @PutMapping( value = "/{uid}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -797,7 +800,7 @@ public abstract class ChartFacadeController
         return webMessage;
     }
 
-    @PutMapping( value = "/{uid}", consumes = { MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE } )
+    @PutMapping( value = "/{uid}", consumes = { APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -983,7 +986,7 @@ public abstract class ChartFacadeController
         }
     }
 
-    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1001,7 +1004,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1019,7 +1022,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1035,7 +1038,7 @@ public abstract class ChartFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1072,7 +1075,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
     }
 
-    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     public void deleteCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1087,7 +1090,7 @@ public abstract class ChartFacadeController
             Lists.newArrayList( identifiableObjects.getIdentifiableObjects() ) );
     }
 
-    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     public void deleteCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
@@ -1327,16 +1330,16 @@ public abstract class ChartFacadeController
     {
         String type = request.getHeader( "Accept" );
         type = !StringUtils.isEmpty( type ) ? type : request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
         else if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         if ( isCompatibleWith( type, MediaType.APPLICATION_JSON ) )
@@ -1359,16 +1362,16 @@ public abstract class ChartFacadeController
         throws IOException
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
         else if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         if ( isCompatibleWith( type, MediaType.APPLICATION_JSON ) )
@@ -1392,12 +1395,12 @@ public abstract class ChartFacadeController
     protected boolean isJson( HttpServletRequest request )
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
 
         return isCompatibleWith( type, MediaType.APPLICATION_JSON );
@@ -1412,12 +1415,12 @@ public abstract class ChartFacadeController
     protected boolean isXml( HttpServletRequest request )
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         return isCompatibleWith( type, MediaType.APPLICATION_XML );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.io.IOException;
 import java.util.Set;
 import java.util.UUID;
@@ -379,7 +381,7 @@ public class ConfigurationController
         return (String) systemSettingManager.getSystemSetting( SettingKey.REMOTE_INSTANCE_USERNAME );
     }
 
-    @GetMapping( value = "/corsWhitelist", produces = "application/json" )
+    @GetMapping( value = "/corsWhitelist", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody Set<String> getCorsWhitelist( Model model, HttpServletRequest request )
     {
         return configurationService.getConfiguration().getCorsWhitelist();
@@ -387,7 +389,7 @@ public class ConfigurationController
 
     @SuppressWarnings( "unchecked" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
-    @PostMapping( value = "/corsWhitelist", consumes = "application/json" )
+    @PostMapping( value = "/corsWhitelist", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void setCorsWhitelist( @RequestBody String input )
         throws IOException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,7 +93,6 @@ import org.hisp.dhis.webapi.webdomain.ValidationResultView;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -163,7 +163,7 @@ public class DataAnalysisController
     @Autowired
     private FollowupAnalysisService followupAnalysisService;
 
-    @PostMapping( value = "/validationRules", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/validationRules", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<ValidationResultView> performValidationRulesAnalysis(
         @RequestBody ValidationRulesAnalysisParams validationRulesAnalysisParams,
@@ -257,7 +257,7 @@ public class DataAnalysisController
         return validationService.getValidationRuleExpressionDetails( params );
     }
 
-    @PostMapping( value = "/stdDevOutlier", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/stdDevOutlier", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<DeflatedDataValue> performStdDevOutlierAnalysis(
         @RequestBody DataAnalysisParams stdDevOutlierAnalysisParams,
@@ -304,7 +304,7 @@ public class DataAnalysisController
         return deflatedValuesListToResponse( dataValues );
     }
 
-    @PostMapping( value = "/minMaxOutlier", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/minMaxOutlier", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<DeflatedDataValue> performMinMaxOutlierAnalysis(
         @RequestBody DataAnalysisParams params,
@@ -352,7 +352,7 @@ public class DataAnalysisController
         return deflatedValuesListToResponse( dataValues );
     }
 
-    @PostMapping( value = "/followup", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/followup", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody List<DeflatedDataValue> performFollowupAnalysis( @RequestBody DataAnalysisParams params,
         HttpSession session )
@@ -392,14 +392,14 @@ public class DataAnalysisController
         return deflatedValuesListToResponse( dataValues );
     }
 
-    @GetMapping( value = "/followup", produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/followup", produces = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.OK )
     public @ResponseBody FollowupAnalysisResponse performFollowupAnalysis( FollowupAnalysisRequest request )
     {
         return followupAnalysisService.getFollowupDataValues( request );
     }
 
-    @PostMapping( value = "/followup/mark", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/followup/mark", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public @ResponseBody void markDataValues( @RequestBody UpdateFollowUpForDataValuesRequest params )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -30,6 +30,10 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -90,7 +94,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -262,7 +265,7 @@ public class DataSetController
             dataElementIdScheme );
     }
 
-    @GetMapping( value = "/{uid}/form", produces = "application/json" )
+    @GetMapping( value = "/{uid}/form", produces = APPLICATION_JSON_VALUE )
     public void getFormJson(
         @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnit,
@@ -295,7 +298,7 @@ public class DataSetController
         renderService.toJson( response.getOutputStream(), form );
     }
 
-    @GetMapping( value = "/{uid}/form", produces = { "application/xml", "text/xml" } )
+    @GetMapping( value = "/{uid}/form", produces = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     public void getFormXml(
         @PathVariable( "uid" ) String uid,
         @RequestParam( value = "ou", required = false ) String orgUnit,
@@ -366,7 +369,7 @@ public class DataSetController
     }
 
     @RequestMapping( value = { "/{uid}/customDataEntryForm", "/{uid}/form" }, method = { RequestMethod.PUT,
-        RequestMethod.POST }, consumes = "text/html" )
+        RequestMethod.POST }, consumes = TEXT_HTML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCustomDataEntryFormHtml( @PathVariable( "uid" ) String uid,
         @RequestBody String formContent,
@@ -398,7 +401,7 @@ public class DataSetController
         dataSetService.updateDataSet( dataSet );
     }
 
-    @PostMapping( value = "/{uid}/form", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/form", consumes = APPLICATION_JSON_VALUE )
     @ApiVersion( value = DhisApiVersion.ALL )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void updateCustomDataEntryFormJson( @PathVariable( "uid" ) String uid, HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_HTML;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,7 +86,7 @@ public class DataSetReportController
     @Autowired
     IdentifiableObjectManager idObjectManager;
 
-    @GetMapping( value = RESOURCE_PATH + "/custom", produces = "text/html;charset=UTF-8" )
+    @GetMapping( value = RESOURCE_PATH + "/custom", produces = CONTENT_TYPE_HTML )
     public @ResponseBody String getCustomDataSetReport( HttpServletResponse response,
         @RequestParam String ou,
         @RequestParam String ds,
@@ -103,13 +105,13 @@ public class DataSetReportController
                 conflict( "Data set form type must be 'custom': " + dataSet.getFormType() ) );
         }
 
-        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML,
+        contextUtils.configureResponse( response, CONTENT_TYPE_HTML,
             CacheStrategy.RESPECT_SYSTEM_SETTING );
 
         return dataSetReportService.getCustomDataSetReport( dataSet, periods, orgUnit, filter, selectedUnitOnly );
     }
 
-    @GetMapping( value = RESOURCE_PATH, produces = "application/json" )
+    @GetMapping( value = RESOURCE_PATH, produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<Grid> getDataSetReportAsJson( HttpServletResponse response,
         @RequestParam String ou,
         @RequestParam String ds,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -37,6 +37,8 @@ import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_PDF;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_XML;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_XML_ADX;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -251,7 +253,7 @@ public class DataValueSetController
     // Post
     // -------------------------------------------------------------------------
 
-    @PostMapping( consumes = "application/xml", produces = CONTENT_TYPE_XML )
+    @PostMapping( consumes = APPLICATION_XML_VALUE, produces = CONTENT_TYPE_XML )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postDxf2DataValueSet( ImportOptions importOptions, HttpServletRequest request )
@@ -284,7 +286,7 @@ public class DataValueSetController
         return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
-    @PostMapping( consumes = "application/json", produces = CONTENT_TYPE_JSON )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE, produces = CONTENT_TYPE_JSON )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postJsonDataValueSet( ImportOptions importOptions, HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Set;
 
@@ -95,7 +96,7 @@ public class EmailController
         return emailResponseHandler( emailResponse );
     }
 
-    @PostMapping( value = "/notification", consumes = "application/json" )
+    @PostMapping( value = "/notification", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage sendSystemNotificationEmail( @RequestBody Email email )
         throws WebMessageException
@@ -115,7 +116,7 @@ public class EmailController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SEND_EMAIL')" )
-    @PostMapping( value = "/notification", produces = "application/json" )
+    @PostMapping( value = "/notification", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage sendEmailNotification( @RequestParam Set<String> recipients, @RequestParam String message,
         @RequestParam( defaultValue = "DHIS 2" ) String subject )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsService;
@@ -65,7 +67,7 @@ public class EnrollmentAnalyticsController
     @Autowired
     private ContextUtils contextUtils;
 
-    @GetMapping( value = "/query/{program}", produces = { "application/json", "application/javascript" } )
+    @GetMapping( value = "/query/{program}", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public @ResponseBody Grid getQueryJson( // JSON, JSONP
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
@@ -39,7 +40,6 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -61,7 +61,7 @@ public class ExpressionController
     private I18nManager i18nManager;
 
     @ResponseBody
-    @GetMapping( value = "/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/description", produces = APPLICATION_JSON_VALUE )
     public WebMessage getExpressionDescription( @RequestParam String expression )
     {
         ExpressionValidationOutcome result = expressionService.expressionIsValid( expression, INDICATOR_EXPRESSION );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/KeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/KeyJsonValueController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Date;
 import java.util.List;
@@ -70,7 +71,7 @@ public class KeyJsonValueController
      * Returns a JSON array of strings representing the different namespaces
      * used. If no namespaces exist, an empty array is returned.
      */
-    @GetMapping( value = "", produces = "application/json" )
+    @GetMapping( value = "", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<String> getNamespaces( HttpServletResponse response )
     {
         setNoStore( response );
@@ -81,7 +82,7 @@ public class KeyJsonValueController
     /**
      * Returns a list of strings representing keys in the given namespace.
      */
-    @GetMapping( value = "/{namespace}", produces = "application/json" )
+    @GetMapping( value = "/{namespace}", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<String> getKeysInNamespace( @RequestParam( required = false ) Date lastUpdated,
         @PathVariable String namespace,
         HttpServletResponse response )
@@ -119,7 +120,7 @@ public class KeyJsonValueController
      * Retrieves the value of the KeyJsonValue represented by the given key from
      * the given namespace.
      */
-    @GetMapping( value = "/{namespace}/{key}", produces = "application/json" )
+    @GetMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody String getKeyJsonValue( @PathVariable String namespace, @PathVariable String key,
         HttpServletResponse response )
         throws Exception
@@ -131,7 +132,7 @@ public class KeyJsonValueController
      * Retrieves the KeyJsonValue represented by the given key from the given
      * namespace.
      */
-    @GetMapping( value = "/{namespace}/{key}/metaData", produces = "application/json" )
+    @GetMapping( value = "/{namespace}/{key}/metaData", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody KeyJsonValue getKeyJsonValueMetaData( @PathVariable String namespace, @PathVariable String key,
         HttpServletResponse response )
         throws Exception
@@ -151,7 +152,7 @@ public class KeyJsonValueController
      * value supplied.
      */
     @ResponseBody
-    @PostMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
+    @PostMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE )
     public WebMessage addKeyJsonValue( @PathVariable String namespace, @PathVariable String key,
         @RequestBody String body,
         @RequestParam( defaultValue = "false" ) boolean encrypt )
@@ -171,7 +172,7 @@ public class KeyJsonValueController
      * Update a key in the given namespace.
      */
     @ResponseBody
-    @PutMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
+    @PutMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE )
     public WebMessage updateKeyJsonValue( @PathVariable String namespace, @PathVariable String key,
         @RequestBody String value )
         throws Exception
@@ -188,7 +189,7 @@ public class KeyJsonValueController
      * Delete a key from the given namespace.
      */
     @ResponseBody
-    @DeleteMapping( value = "/{namespace}/{key}", produces = "application/json" )
+    @DeleteMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE )
     public WebMessage deleteKeyJsonValue( @PathVariable String namespace, @PathVariable String key )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
 import java.util.Locale;
@@ -100,25 +101,25 @@ public class LocaleController
         return webLocales;
     }
 
-    @GetMapping( value = "/languages", produces = "application/json" )
+    @GetMapping( value = "/languages", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody Map<String, String> getAvailableLanguages()
     {
         return localeService.getAvailableLanguages();
     }
 
-    @GetMapping( value = "/countries", produces = "application/json" )
+    @GetMapping( value = "/countries", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody Map<String, String> getAvailableCountries()
     {
         return localeService.getAvailableCountries();
     }
 
-    @GetMapping( value = "/dbLocales", produces = "application/json" )
+    @GetMapping( value = "/dbLocales", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<I18nLocale> getDbLocalesWithId()
     {
         return localeService.getAllI18nLocales();
     }
 
-    @GetMapping( value = "/dbLocales/{uid}", produces = "application/json" )
+    @GetMapping( value = "/dbLocales/{uid}", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody I18nLocale getObject( @PathVariable( "uid" ) String uid, HttpServletResponse response )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MenuController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MenuController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.io.InputStream;
 import java.util.List;
 
@@ -61,7 +63,7 @@ public class MenuController
 
     @ResponseStatus( HttpStatus.NO_CONTENT )
     @SuppressWarnings( "unchecked" )
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     public void saveMenuOrder( InputStream input )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
 import java.util.List;
 import java.util.Objects;
@@ -125,7 +126,7 @@ public class MinMaxDataElementController
     // POST
     // --------------------------------------------------------------------------
 
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_ADD')" )
     @ResponseBody
     public WebMessage postJsonObject( HttpServletRequest request )
@@ -157,7 +158,7 @@ public class MinMaxDataElementController
     // DELETE
     // --------------------------------------------------------------------------
 
-    @DeleteMapping( consumes = "application/json" )
+    @DeleteMapping( consumes = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_DELETE')" )
     @ResponseBody
     public WebMessage deleteObject( HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -48,7 +49,6 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -86,7 +86,7 @@ public class MinMaxValueController
     @Autowired
     private SystemSettingManager systemSettingManager;
 
-    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_GENERATE_MIN_MAX_VALUES')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void generateMinMaxValue( @RequestBody MinMaxValueParams minMaxValueParams )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OrgUnitAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OrgUnitAnalyticsController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.analytics.orgunit.OrgUnitAnalyticsService;
@@ -58,7 +60,7 @@ public class OrgUnitAnalyticsController
     @Autowired
     private ContextUtils contextUtils;
 
-    @GetMapping( value = RESOURCE_PATH, produces = { "application/json" } )
+    @GetMapping( value = RESOURCE_PATH, produces = APPLICATION_JSON_VALUE )
     public @ResponseBody Grid getJson(
         @RequestParam String ou,
         @RequestParam String ougs,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PeriodTypeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PeriodTypeController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -90,7 +92,7 @@ public class PeriodTypeController
         return rootNode;
     }
 
-    @GetMapping( value = "/relativePeriodTypes", produces = { "application/json", "application/javascript" } )
+    @GetMapping( value = "/relativePeriodTypes", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public @ResponseBody RelativePeriodEnum[] getRelativePeriodTypes()
     {
         return RelativePeriodEnum.values();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Date;
 import java.util.List;
@@ -51,7 +52,6 @@ import org.hisp.dhis.predictor.PredictorService;
 import org.hisp.dhis.schema.descriptors.PredictorSchemaDescriptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -142,7 +142,7 @@ public class PredictorController extends AbstractCrudController<Predictor>
         return ok( "Generated " + count + " predictions" );
     }
 
-    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {
@@ -154,7 +154,7 @@ public class PredictorController extends AbstractCrudController<Predictor>
             .setMessage( i18nManager.getI18n().getString( result.getKey() ) );
     }
 
-    @PostMapping( value = "/skipTest/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/skipTest/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getSkipTestDescription( @RequestBody String expression )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTableFacadeController.java
@@ -37,6 +37,9 @@ import static org.hisp.dhis.visualization.ConversionHelper.convertToReportTableL
 import static org.hisp.dhis.visualization.ConversionHelper.convertToVisualization;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 import static org.hisp.dhis.webapi.utils.PaginationUtils.getPaginationData;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -614,7 +617,7 @@ public abstract class ReportTableFacadeController
     // POST
     // --------------------------------------------------------------------------
 
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -657,7 +660,7 @@ public abstract class ReportTableFacadeController
         return webMessage;
     }
 
-    @PostMapping( consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage postXmlObject( HttpServletRequest request, HttpServletResponse response )
         throws Exception
@@ -756,7 +759,7 @@ public abstract class ReportTableFacadeController
     // PUT
     // --------------------------------------------------------------------------
 
-    @PutMapping( value = "/{uid}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -798,7 +801,7 @@ public abstract class ReportTableFacadeController
         return webMessage;
     }
 
-    @PutMapping( value = "/{uid}", consumes = { MediaType.APPLICATION_XML_VALUE,
+    @PutMapping( value = "/{uid}", consumes = { APPLICATION_XML_VALUE,
         MediaType.TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
@@ -983,7 +986,7 @@ public abstract class ReportTableFacadeController
         }
     }
 
-    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1001,7 +1004,7 @@ public abstract class ReportTableFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @PostMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1019,7 +1022,7 @@ public abstract class ReportTableFacadeController
             Lists.newArrayList( identifiableObjects.getAdditions() ) );
     }
 
-    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1035,7 +1038,7 @@ public abstract class ReportTableFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @PutMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void replaceCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1070,7 +1073,7 @@ public abstract class ReportTableFacadeController
             Lists.newArrayList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
     }
 
-    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
@@ -1086,7 +1089,7 @@ public abstract class ReportTableFacadeController
             identifiableObjects.getIdentifiableObjects() );
     }
 
-    @DeleteMapping( value = "/{uid}/{property}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
@@ -1319,16 +1322,16 @@ public abstract class ReportTableFacadeController
     {
         String type = request.getHeader( "Accept" );
         type = !StringUtils.isEmpty( type ) ? type : request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
         else if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         if ( isCompatibleWith( type, MediaType.APPLICATION_JSON ) )
@@ -1351,16 +1354,16 @@ public abstract class ReportTableFacadeController
         throws IOException
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
         else if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         if ( isCompatibleWith( type, MediaType.APPLICATION_JSON ) )
@@ -1384,12 +1387,12 @@ public abstract class ReportTableFacadeController
     protected boolean isJson( HttpServletRequest request )
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".json" ) )
         {
-            type = MediaType.APPLICATION_JSON_VALUE;
+            type = APPLICATION_JSON_VALUE;
         }
 
         return isCompatibleWith( type, MediaType.APPLICATION_JSON );
@@ -1404,12 +1407,12 @@ public abstract class ReportTableFacadeController
     protected boolean isXml( HttpServletRequest request )
     {
         String type = request.getContentType();
-        type = !StringUtils.isEmpty( type ) ? type : MediaType.APPLICATION_JSON_VALUE;
+        type = !StringUtils.isEmpty( type ) ? type : APPLICATION_JSON_VALUE;
 
         // allow type to be overridden by path extension
         if ( request.getPathInfo().endsWith( ".xml" ) )
         {
-            type = MediaType.APPLICATION_XML_VALUE;
+            type = APPLICATION_XML_VALUE;
         }
 
         return isCompatibleWith( type, MediaType.APPLICATION_XML );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTemplateController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -52,14 +54,14 @@ public class ReportTemplateController
     @Autowired
     private ContextUtils contextUtils;
 
-    @GetMapping( value = "/reportTemplate.xml", produces = "application/xml" )
+    @GetMapping( value = "/reportTemplate.xml", produces = APPLICATION_XML_VALUE )
     public void getReportDesignJrxml( HttpServletResponse response )
         throws Exception
     {
         serveTemplate( response, ContextUtils.CONTENT_TYPE_XML, "jasper-report-template.jrxml" );
     }
 
-    @GetMapping( value = "/reportTemplate.html", produces = "application/xml" )
+    @GetMapping( value = "/reportTemplate.html", produces = APPLICATION_XML_VALUE )
     public void getReportDesignHtml( HttpServletResponse response )
         throws Exception
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -74,7 +75,6 @@ import org.hisp.dhis.webapi.webdomain.sharing.SharingUserGroupAccess;
 import org.hisp.dhis.webapi.webdomain.sharing.comparator.SharingUserGroupAccessNameComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -120,7 +120,7 @@ public class SharingController
     // Resources
     // -------------------------------------------------------------------------
 
-    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public void getSharing( @RequestParam String type, @RequestParam String id, HttpServletResponse response )
         throws IOException,
         WebMessageException
@@ -223,12 +223,12 @@ public class SharingController
 
         sharing.getObject().getUserGroupAccesses().sort( SharingUserGroupAccessNameComparator.INSTANCE );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         response.setHeader( ContextUtils.HEADER_CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue() );
         renderService.toJson( response.getOutputStream(), sharing );
     }
 
-    @PutMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putSharing( @RequestParam String type, @RequestParam String id,
         HttpServletRequest request )
@@ -237,7 +237,7 @@ public class SharingController
         return postSharing( type, id, request );
     }
 
-    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postSharing( @RequestParam String type, @RequestParam String id, HttpServletRequest request )
         throws Exception
@@ -386,7 +386,7 @@ public class SharingController
         return ok( "Access control set" );
     }
 
-    @GetMapping( value = "/search", produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( value = "/search", produces = APPLICATION_JSON_VALUE )
     public void searchUserGroups( @RequestParam String key, @RequestParam( required = false ) Integer pageSize,
         HttpServletResponse response )
         throws IOException,
@@ -406,7 +406,7 @@ public class SharingController
         output.put( "userGroups", userGroupAccesses );
         output.put( "users", userAccesses );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         response.setHeader( ContextUtils.HEADER_CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue() );
         renderService.toJson( response.getOutputStream(), output );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SynchronizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SynchronizationController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 
@@ -92,13 +93,13 @@ public class SynchronizationController
         renderService.toJson( response.getOutputStream(), importReport );
     }
 
-    @GetMapping( value = "/availability", produces = "application/json" )
+    @GetMapping( value = "/availability", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody AvailabilityStatus remoteServerAvailable()
     {
         return synchronizationManager.isRemoteServerAvailable();
     }
 
-    @GetMapping( value = "/metadataRepo", produces = "application/json" )
+    @GetMapping( value = "/metadataRepo", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody String getMetadataRepoIndex()
     {
         return restTemplate.getForObject( SettingKey.METADATA_REPO_URL.getDefaultValue().toString(), String.class );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
@@ -31,6 +31,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -125,7 +126,7 @@ public class SystemController
     // -------------------------------------------------------------------------
 
     @GetMapping( value = { "/uid", "/id" }, produces = {
-        MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
+        APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode getUid( @RequestParam( required = false, defaultValue = "1" ) Integer limit,
         HttpServletResponse response )
         throws IOException,
@@ -147,7 +148,7 @@ public class SystemController
         return rootNode;
     }
 
-    @GetMapping( value = { "/uid", "/id" }, produces = { "application/csv" } )
+    @GetMapping( value = { "/uid", "/id" }, produces = "application/csv" )
     public void getUidCsv( @RequestParam( required = false, defaultValue = "1" ) Integer limit,
         HttpServletResponse response )
         throws IOException,
@@ -173,7 +174,7 @@ public class SystemController
         csvGenerator.flush();
     }
 
-    @GetMapping( value = "/uuid", produces = { MediaType.APPLICATION_JSON_VALUE,
+    @GetMapping( value = "/uuid", produces = { APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_XML_VALUE } )
     public @ResponseBody RootNode getUuid( @RequestParam( required = false, defaultValue = "1" ) Integer limit,
         HttpServletResponse response )
@@ -200,7 +201,7 @@ public class SystemController
     // Tasks
     // -------------------------------------------------------------------------
 
-    @GetMapping( value = "/tasks", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/tasks", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getTasksJson( HttpServletResponse response )
         throws IOException
     {
@@ -210,7 +211,7 @@ public class SystemController
         renderService.toJson( response.getOutputStream(), notifier.getNotifications() );
     }
 
-    @GetMapping( value = "/tasks/{jobType}", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/tasks/{jobType}", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getTasksExtendedJson( @PathVariable( "jobType" ) String jobType, HttpServletResponse response )
         throws IOException
     {
@@ -224,7 +225,7 @@ public class SystemController
         renderService.toJson( response.getOutputStream(), notifications );
     }
 
-    @GetMapping( value = "/tasks/{jobType}/{jobId}", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/tasks/{jobType}/{jobId}", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getTaskJsonByUid( @PathVariable( "jobType" ) String jobType, @PathVariable( "jobId" ) String jobId,
         HttpServletResponse response )
         throws IOException
@@ -243,7 +244,7 @@ public class SystemController
     // Tasks summary
     // -------------------------------------------------------------------------
 
-    @GetMapping( value = "/taskSummaries/{jobType}", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/taskSummaries/{jobType}", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getTaskSummaryExtendedJson( @PathVariable( "jobType" ) String jobType, HttpServletResponse response )
         throws IOException
     {
@@ -259,7 +260,7 @@ public class SystemController
         response.setContentType( CONTENT_TYPE_JSON );
     }
 
-    @GetMapping( value = "/taskSummaries/{jobType}/{jobId}", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/taskSummaries/{jobType}/{jobId}", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getTaskSummaryJson( @PathVariable( "jobType" ) String jobType, @PathVariable( "jobId" ) String jobId,
         HttpServletResponse response )
         throws IOException
@@ -295,7 +296,7 @@ public class SystemController
     // Various
     // -------------------------------------------------------------------------
 
-    @GetMapping( value = "/info", produces = { "application/json", "application/javascript" } )
+    @GetMapping( value = "/info", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public @ResponseBody SystemInfo getSystemInfo( Model model, HttpServletRequest request,
         HttpServletResponse response )
     {
@@ -337,13 +338,13 @@ public class SystemController
         return "pong";
     }
 
-    @GetMapping( value = "/flags", produces = { "application/json" } )
+    @GetMapping( value = "/flags", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<StyleObject> getFlags()
     {
         return getFlagObjects();
     }
 
-    @GetMapping( value = "/styles", produces = { "application/json" } )
+    @GetMapping( value = "/styles", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<StyleObject> getStyles()
     {
         return styleManager.getStyles();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -166,7 +166,7 @@ public class SystemSettingController
         }
     }
 
-    @PostMapping( consumes = { ContextUtils.CONTENT_TYPE_JSON } )
+    @PostMapping( consumes = ContextUtils.CONTENT_TYPE_JSON )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_SYSTEM_SETTING')" )
     @ResponseBody
     public WebMessage setSystemSettingV29( @RequestBody Map<String, Object> settings )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -71,7 +72,7 @@ public class TokenController
         this.tokenCache = cacheProvider.createGoogleAccessTokenCache();
     }
 
-    @GetMapping( value = "/google", produces = "application/json" )
+    @GetMapping( value = "/google", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody GoogleAccessToken getEarthEngineToken( HttpServletResponse response )
         throws WebMessageException,
         ExecutionException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.List;
@@ -80,7 +81,7 @@ public class UserKeyJsonValueController
      * Returns a JSON array of strings representing the different namespaces
      * used. If no namespaces exist, an empty array is returned.
      */
-    @GetMapping( value = "", produces = "application/json" )
+    @GetMapping( value = "", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<String> getNamespaces( HttpServletResponse response )
     {
         setNoStore( response );
@@ -92,7 +93,7 @@ public class UserKeyJsonValueController
      * Returns a JSON array of strings representing the different keys used in a
      * given namespace. If no namespaces exist, an empty array is returned.
      */
-    @GetMapping( value = "/{namespace}", produces = "application/json" )
+    @GetMapping( value = "/{namespace}", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<String> getKeys( @PathVariable String namespace, HttpServletResponse response )
         throws WebMessageException
     {
@@ -123,7 +124,7 @@ public class UserKeyJsonValueController
      * Retrieves the value of the KeyJsonValue represented by the given key and
      * namespace from the current user.
      */
-    @GetMapping( value = "/{namespace}/{key}", produces = "application/json" )
+    @GetMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody String getUserKeyJsonValue(
         @PathVariable String namespace,
         @PathVariable String key, HttpServletResponse response )
@@ -147,7 +148,7 @@ public class UserKeyJsonValueController
      * Creates a new KeyJsonValue Object on the current user with the key,
      * namespace and value supplied.
      */
-    @PostMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
+    @PostMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage addUserKeyJsonValue(
         @PathVariable String namespace,
@@ -183,7 +184,7 @@ public class UserKeyJsonValueController
     /**
      * Update a key.
      */
-    @PutMapping( value = "/{namespace}/{key}", produces = "application/json", consumes = "application/json" )
+    @PutMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage updateUserKeyJsonValue(
         @PathVariable String namespace,
@@ -214,7 +215,7 @@ public class UserKeyJsonValueController
     /**
      * Delete a key.
      */
-    @DeleteMapping( value = "/{namespace}/{key}", produces = "application/json" )
+    @DeleteMapping( value = "/{namespace}/{key}", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage deleteUserKeyJsonValue(
         @PathVariable String namespace,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -32,6 +32,8 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.scheduling.JobType.ENROLLMENT_IMPORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,7 +75,6 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -196,7 +197,7 @@ public class EnrollmentController
     // CREATE
     // -------------------------------------------------------------------------
 
-    @PostMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postEnrollmentJson( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request )
@@ -239,7 +240,7 @@ public class EnrollmentController
         return startAsyncImport( importOptions, enrollmentService.getEnrollmentsJson( inputStream ) );
     }
 
-    @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage postEnrollmentXml( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request )
@@ -286,7 +287,7 @@ public class EnrollmentController
     // UPDATE
     // -------------------------------------------------------------------------
 
-    @PostMapping( value = "/{id}/note", consumes = "application/json" )
+    @PostMapping( value = "/{id}/note", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage updateEnrollmentForNoteJson( @PathVariable String id, HttpServletRequest request )
         throws IOException
@@ -296,7 +297,7 @@ public class EnrollmentController
         return importSummary( importSummary );
     }
 
-    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{id}", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage updateEnrollmentXml( @PathVariable String id, ImportOptions importOptions,
         HttpServletRequest request )
@@ -309,7 +310,7 @@ public class EnrollmentController
         return importSummary( importSummary );
     }
 
-    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{id}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage updateEnrollmentJson( @PathVariable String id, ImportOptions importOptions,
         HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -35,6 +35,9 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationRepo
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.scheduling.JobType.EVENT_IMPORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -554,7 +557,7 @@ public class EventController
         return rootNode;
     }
 
-    @GetMapping( produces = { "application/xml", "application/xml+gzip", "text/xml" } )
+    @GetMapping( produces = { APPLICATION_XML_VALUE, "application/xml+gzip", TEXT_XML_VALUE } )
     public @ResponseBody RootNode getXmlEvents(
         EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
         HttpServletResponse response,
@@ -786,7 +789,7 @@ public class EventController
     // Create
     // -------------------------------------------------------------------------
 
-    @PostMapping( consumes = "application/xml" )
+    @PostMapping( consumes = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage postXmlEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletRequest request, ImportOptions importOptions )
@@ -806,7 +809,7 @@ public class EventController
         return eventService.addEventsXml( inputStream, importOptions );
     }
 
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletRequest request, ImportOptions importOptions )
@@ -869,7 +872,7 @@ public class EventController
         return startAsyncImport( importOptions, eventConverter.apply( inputStream ) );
     }
 
-    @PostMapping( value = "/{uid}/note", consumes = "application/json" )
+    @PostMapping( value = "/{uid}/note", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonEventForNote( @PathVariable( "uid" ) String uid,
         HttpServletRequest request, ImportOptions importOptions )
@@ -912,7 +915,7 @@ public class EventController
     // Update
     // -------------------------------------------------------------------------
 
-    @PutMapping( value = "/{uid}", consumes = { "application/xml", "text/xml" } )
+    @PutMapping( value = "/{uid}", consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage putXmlEvent( HttpServletRequest request,
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )
@@ -925,7 +928,7 @@ public class EventController
         return updateEvent( updatedEvent, false, importOptions );
     }
 
-    @PutMapping( value = "/{uid}", consumes = "application/json" )
+    @PutMapping( value = "/{uid}", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonEvent( HttpServletRequest request,
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )
@@ -945,7 +948,7 @@ public class EventController
         return importSummary( importSummary );
     }
 
-    @PutMapping( value = "/{uid}/{dataElementUid}", consumes = "application/json" )
+    @PutMapping( value = "/{uid}/{dataElementUid}", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonEventSingleValue( HttpServletRequest request,
         @PathVariable( "uid" ) String uid, @PathVariable( "dataElementUid" ) String dataElementUid )
@@ -965,7 +968,7 @@ public class EventController
         return updateEvent( updatedEvent, true, null );
     }
 
-    @PutMapping( value = "/{uid}/eventDate", consumes = "application/json" )
+    @PutMapping( value = "/{uid}/eventDate", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonEventForEventDate( HttpServletRequest request,
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.Status;
@@ -38,7 +40,6 @@ import org.hisp.dhis.schema.descriptors.ProgramIndicatorSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,7 +60,7 @@ public class ProgramIndicatorController
     @Autowired
     private I18nManager i18nManager;
 
-    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {
@@ -78,7 +79,7 @@ public class ProgramIndicatorController
         }
     }
 
-    @PostMapping( value = "/filter/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/filter/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage validateFilter( @RequestBody String expression )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.Date;
@@ -54,7 +55,6 @@ import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -90,7 +90,7 @@ public class ProgramMessageController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @GetMapping( produces = { "application/json" } )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public void getProgramMessages( @RequestParam( required = false ) Set<String> ou,
         @RequestParam( required = false ) String programInstance,
         @RequestParam( required = false ) String programStageInstance,
@@ -156,7 +156,7 @@ public class ProgramMessageController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     public void saveMessages( HttpServletRequest request, HttpServletResponse response )
         throws IOException,
         WebMessageException
@@ -170,7 +170,7 @@ public class ProgramMessageController
 
         BatchResponseStatus status = programMessageService.sendMessages( batch.getProgramMessages() );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
 
         renderService.toJson( response.getOutputStream(), status );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.Status;
@@ -39,7 +41,6 @@ import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.hisp.dhis.schema.descriptors.ProgramRuleActionSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,7 +67,7 @@ public class ProgramRuleActionController
         this.programRuleEngineService = programRuleEngineService;
     }
 
-    @PostMapping( value = "/data/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/data/expression/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getDataExpressionDescription( @RequestBody String condition, @RequestParam String programId )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
@@ -41,7 +43,6 @@ import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.hisp.dhis.schema.descriptors.ProgramRuleSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,7 +64,7 @@ public class ProgramRuleController
 
     private final ProgramRuleEngineService programRuleEngineService;
 
-    @PostMapping( value = "/condition/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/condition/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage validateCondition( @RequestBody String condition, @RequestParam String programId )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
@@ -64,7 +64,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -214,7 +213,7 @@ public class RelationshipController
     // UPDATE
     // -------------------------------------------------------------------------
 
-    @PutMapping( path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
+    @PutMapping( path = "/{id}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage updateRelationshipJson(
         @PathVariable String id,
@@ -235,7 +234,7 @@ public class RelationshipController
         return importSummary( importSummary );
     }
 
-    @PutMapping( path = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
+    @PutMapping( path = "/{id}", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage updateRelationshipXml(
         @PathVariable String id,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -35,6 +35,8 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationRepo
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 import static org.hisp.dhis.scheduling.JobType.TEI_IMPORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -100,7 +102,6 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.utils.FileResourceUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -375,7 +376,7 @@ public class TrackedEntityInstanceController
     // CREATE
     // -------------------------------------------------------------------------
 
-    @PostMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postTrackedEntityInstanceJson(
         @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
@@ -383,10 +384,10 @@ public class TrackedEntityInstanceController
         throws IOException,
         BadRequestException
     {
-        return postTrackedEntityInstance( strategy, importOptions, request, MediaType.APPLICATION_JSON_VALUE );
+        return postTrackedEntityInstance( strategy, importOptions, request, APPLICATION_JSON_VALUE );
     }
 
-    @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage postTrackedEntityInstanceXml(
         @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
@@ -394,7 +395,7 @@ public class TrackedEntityInstanceController
         throws IOException,
         BadRequestException
     {
-        return postTrackedEntityInstance( strategy, importOptions, request, MediaType.APPLICATION_XML_VALUE );
+        return postTrackedEntityInstance( strategy, importOptions, request, APPLICATION_XML_VALUE );
     }
 
     private WebMessage postTrackedEntityInstance( ImportStrategy strategy, ImportOptions importOptions,
@@ -466,7 +467,7 @@ public class TrackedEntityInstanceController
     // UPDATE
     // -------------------------------------------------------------------------
 
-    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PutMapping( value = "/{id}", consumes = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage updateTrackedEntityInstanceXml(
         @PathVariable String id,
@@ -482,7 +483,7 @@ public class TrackedEntityInstanceController
         return importSummary( importSummary );
     }
 
-    @PutMapping( value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/{id}", consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage updateTrackedEntityInstanceJson(
         @PathVariable String id,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -40,7 +41,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -84,7 +84,7 @@ public class TrackerOwnershipController
     // 2. Break the glass and override ownership.
     // -------------------------------------------------------------------------
 
-    @PutMapping( value = "/transfer", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "/transfer", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage updateTrackerProgramOwner( @RequestParam String trackedEntityInstance,
         @RequestParam String program,
@@ -96,7 +96,7 @@ public class TrackerOwnershipController
         return ok( "Ownership transferred" );
     }
 
-    @PostMapping( value = "/override", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/override", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage overrideOwnershipAccess( @RequestParam String trackedEntityInstance, @RequestParam String reason,
         @RequestParam String program )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.indicator;
 
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import org.hisp.dhis.analytics.resolver.ExpressionResolver;
 import org.hisp.dhis.analytics.resolver.ExpressionResolverCollection;
@@ -42,7 +43,6 @@ import org.hisp.dhis.schema.descriptors.IndicatorSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,7 +66,7 @@ public class IndicatorController
     @Autowired
     private I18nManager i18nManager;
 
-    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
@@ -140,7 +140,7 @@ public class GeoFeatureController
             .body( features );
     }
 
-    @GetMapping( produces = { "application/javascript" } )
+    @GetMapping( produces = "application/javascript" )
     public void getGeoFeaturesJsonP(
         @RequestParam( required = false ) String ou,
         @RequestParam( required = false ) String oug,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.mapping;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -125,7 +126,7 @@ public class MapController
     // --------------------------------------------------------------------------
 
     @Override
-    @PutMapping( value = "/{uid}", consumes = "application/json" )
+    @PutMapping( value = "/{uid}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     @ResponseBody
     public WebMessage putJsonObject( @PathVariable String uid, HttpServletRequest request )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -32,6 +32,8 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.scheduling.JobType.GML_IMPORT;
 import static org.hisp.dhis.scheduling.JobType.METADATA_IMPORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -71,7 +73,6 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -124,7 +125,7 @@ public class MetadataImportExportController
     @Autowired
     private ObjectFactory<GmlAsyncImporter> gmlAsyncImporterFactory;
 
-    @PostMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonMetadata( HttpServletRequest request )
         throws IOException
@@ -173,7 +174,7 @@ public class MetadataImportExportController
         return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
-    @PostMapping( value = "/gml", consumes = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "/gml", consumes = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage postGmlMetadata( HttpServletRequest request )
         throws IOException
@@ -188,7 +189,7 @@ public class MetadataImportExportController
         return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
-    @PostMapping( value = "", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage postXmlMetadata( HttpServletRequest request )
         throws IOException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.metadata.version;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -272,7 +274,7 @@ public class MetadataVersionController
     // endpoint to download metadata
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
     @GetMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT
-        + "/{versionName}/data", produces = "application/json" )
+        + "/{versionName}/data", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody String downloadVersion( @PathVariable( "versionName" ) String versionName )
         throws MetadataVersionException,
         BadRequestException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.organisationunit;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
 
@@ -42,7 +43,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,13 +72,13 @@ public class FilledOrganisationUnitLevelController
         this.organisationUnitService = organisationUnitService;
     }
 
-    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public @ResponseBody List<OrganisationUnitLevel> getList()
     {
         return organisationUnitService.getFilledOrganisationUnitLevels();
     }
 
-    @PostMapping( consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.CREATED )
     public void setList( HttpServletRequest request, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -105,7 +105,7 @@ public class OrganisationUnitController
 
     @ResponseStatus( HttpStatus.OK )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_ORGANISATION_UNIT_SPLIT')" )
-    @PostMapping( value = "/split", produces = { APPLICATION_JSON_VALUE } )
+    @PostMapping( value = "/split", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody WebMessage splitOrgUnits( @RequestBody OrgUnitSplitQuery query )
     {
         orgUnitSplitService.split( orgUnitSplitService.getFromQuery( query ) );
@@ -115,7 +115,7 @@ public class OrganisationUnitController
 
     @ResponseStatus( HttpStatus.OK )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_ORGANISATION_UNIT_MERGE')" )
-    @PostMapping( value = "/merge", produces = { APPLICATION_JSON_VALUE } )
+    @PostMapping( value = "/merge", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody WebMessage mergeOrgUnits( @RequestBody OrgUnitMergeQuery query )
     {
         orgUnitMergeService.merge( orgUnitMergeService.getFromQuery( query ) );
@@ -329,7 +329,7 @@ public class OrganisationUnitController
         List<OrganisationUnit> organisationUnits = organisationUnitService.getOrganisationUnitsAtLevels( rpLevels,
             parents );
 
-        response.setContentType( "application/json" );
+        response.setContentType( APPLICATION_JSON_VALUE );
 
         JsonFactory jsonFactory = new JsonFactory();
         JsonGenerator generator = jsonFactory.createGenerator( response.getOutputStream() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLocationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLocationController.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -69,7 +71,7 @@ public class OrganisationUnitLocationController
     /**
      * Get Organisation Units within a distance from a location
      */
-    @GetMapping( value = "/withinRange", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/withinRange", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getEntitiesWithinRange(
         @RequestParam Double longitude,
         @RequestParam Double latitude,
@@ -120,7 +122,7 @@ public class OrganisationUnitLocationController
      * Get lowest level Org Units that includes the location in their polygon
      * shape.
      */
-    @GetMapping( value = "/orgUnitByLocation", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/orgUnitByLocation", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void getParentByLocation(
         @RequestParam Double longitude,
         @RequestParam Double latitude,
@@ -148,7 +150,7 @@ public class OrganisationUnitLocationController
     /**
      * Check if the location lies within the organisation unit boundary
      */
-    @GetMapping( value = "/locationWithinOrgUnitBoundary", produces = { "*/*", "application/json" } )
+    @GetMapping( value = "/locationWithinOrgUnitBoundary", produces = { "*/*", APPLICATION_JSON_VALUE } )
     public void checkLocationWithinOrgUnit( @RequestParam String orgUnitUid,
         @RequestParam Double longitude, @RequestParam Double latitude, HttpServletResponse response )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitProfileController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitProfileController.java
@@ -60,7 +60,7 @@ public class OrganisationUnitProfileController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_ORG_UNIT_PROFILE_ADD')" )
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void saveProfile( @RequestBody OrgUnitProfile profile )
         throws WebMessageException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/OutlierDetectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/OutlierDetectionController.java
@@ -63,7 +63,7 @@ public class OutlierDetectionController
 
     private final ContextUtils contextUtils;
 
-    @GetMapping( value = "/outlierDetection", produces = { APPLICATION_JSON_VALUE } )
+    @GetMapping( value = "/outlierDetection", produces = APPLICATION_JSON_VALUE )
     public OutlierDetectionResponse getOutliersJson( OutlierDetectionQuery query )
     {
         OutlierDetectionRequest request = outlierService.getFromQuery( query );
@@ -71,7 +71,7 @@ public class OutlierDetectionController
         return outlierService.getOutlierValues( request );
     }
 
-    @GetMapping( value = "/outlierDetection", produces = { CONTENT_TYPE_CSV } )
+    @GetMapping( value = "/outlierDetection", produces = CONTENT_TYPE_CSV )
     public void getOutliersCsv( OutlierDetectionQuery query,
         HttpServletResponse response )
         throws IOException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller.scheduling;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.createWebMessage;
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Map;
 
@@ -74,20 +75,20 @@ public class JobConfigurationController
         this.schedulingManager = schedulingManager;
     }
 
-    @GetMapping( value = "/jobTypesExtended", produces = { "application/json",
+    @GetMapping( value = "/jobTypesExtended", produces = { APPLICATION_JSON_VALUE,
         "application/javascript" } )
     public @ResponseBody Map<String, Map<String, Property>> getJobTypesExtended()
     {
         return jobConfigurationService.getJobParametersSchema();
     }
 
-    @GetMapping( value = "/jobTypes", produces = "application/json" )
+    @GetMapping( value = "/jobTypes", produces = APPLICATION_JSON_VALUE )
     public JobTypes getJobTypeInfo()
     {
         return new JobTypes( jobConfigurationService.getJobTypeInfo() );
     }
 
-    @GetMapping( value = "{uid}/execute", produces = { "application/json", "application/javascript" } )
+    @GetMapping( value = "{uid}/execute", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public ObjectReport executeJobConfiguration( @PathVariable( "uid" ) String uid )
         throws WebMessageException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SecurityController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -72,7 +73,7 @@ public class SecurityController
     @Autowired
     private ObjectMapper jsonMapper;
 
-    @GetMapping( value = "/qr", produces = "application/json" )
+    @GetMapping( value = "/qr", produces = APPLICATION_JSON_VALUE )
     public void getQrCode( HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -91,11 +92,11 @@ public class SecurityController
         map.put( "url", url );
 
         response.setStatus( HttpServletResponse.SC_ACCEPTED );
-        response.setContentType( "application/json" );
+        response.setContentType( APPLICATION_JSON_VALUE );
         jsonMapper.writeValue( response.getOutputStream(), map );
     }
 
-    @GetMapping( value = "/authenticate", produces = "application/json" )
+    @GetMapping( value = "/authenticate", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage authenticate2FA( @RequestParam String code )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.sms;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 
@@ -86,7 +87,7 @@ public class SmsGatewayController
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @GetMapping( produces = { "application/json" } )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public void getGateways( HttpServletResponse response )
         throws IOException
     {
@@ -94,7 +95,7 @@ public class SmsGatewayController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @GetMapping( value = "/{uid}", produces = "application/json" )
+    @GetMapping( value = "/{uid}", produces = APPLICATION_JSON_VALUE )
     public void getGatewayConfiguration( @PathVariable String uid, HttpServletResponse response )
         throws WebMessageException,
         IOException
@@ -197,7 +198,7 @@ public class SmsGatewayController
     private void generateOutput( HttpServletResponse response, Object value )
         throws IOException
     {
-        response.setContentType( "application/json" );
+        response.setContentType( APPLICATION_JSON_VALUE );
 
         ObjectMapper jsonMapper = new ObjectMapper();
         jsonMapper.disable( MapperFeature.DEFAULT_VIEW_INCLUSION );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.sms;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.Date;
@@ -87,7 +88,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
     // POST
     // -------------------------------------------------------------------------
 
-    @PostMapping( produces = { "application/json" } )
+    @PostMapping( produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage receiveSMSMessage( @RequestParam String originator,
@@ -111,7 +112,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         return ok( "Received SMS: " + smsId );
     }
 
-    @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage receiveSMSMessage( HttpServletRequest request )
@@ -126,7 +127,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         return ok( "Received SMS: " + smsId );
     }
 
-    @PostMapping( value = "/import", produces = "application/json" )
+    @PostMapping( value = "/import", produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage importUnparsedSMSMessages()
@@ -145,7 +146,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
     // DELETE
     // -------------------------------------------------------------------------
 
-    @DeleteMapping( value = "/{uid}", produces = "application/json" )
+    @DeleteMapping( value = "/{uid}", produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage deleteInboundMessage( @PathVariable String uid )
@@ -162,7 +163,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms>
         return ok( "IncomingSms with " + uid + " deleted" );
     }
 
-    @DeleteMapping( produces = "application/json" )
+    @DeleteMapping( produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage deleteInboundMessages( @RequestParam List<String> ids )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.List;
@@ -89,7 +90,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     // -------------------------------------------------------------------------
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @PostMapping( produces = { "application/json" } )
+    @PostMapping( produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage sendSMSMessage( @RequestParam String recipient, @RequestParam String message )
     {
@@ -113,7 +114,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SENDSMS')" )
-    @PostMapping( consumes = { "application/json" }, produces = { "application/json" } )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage sendSMSMessage( HttpServletRequest request )
         throws IOException
@@ -133,7 +134,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
     // DELETE
     // -------------------------------------------------------------------------
 
-    @DeleteMapping( value = "/{uid}", produces = "application/json" )
+    @DeleteMapping( value = "/{uid}", produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage deleteOutboundMessage( @PathVariable String uid )
@@ -150,7 +151,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms>
         return ok( "OutboundSms with " + uid + " deleted" );
     }
 
-    @DeleteMapping( produces = "application/json" )
+    @DeleteMapping( produces = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_MOBILE_SETTINGS')" )
     @ResponseBody
     public WebMessage deleteOutboundMessages( @RequestParam List<String> ids )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -83,7 +84,6 @@ import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.webdomain.Dashboard;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -177,7 +177,7 @@ public class MeController
         CollectionNode collectionNode = fieldFilterService.toCollectionNode( User.class,
             new FieldFilterParams( Collections.singletonList( user ), fields ) );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         setNoStore( response );
 
         RootNode rootNode = NodeUtils.createRootNode( collectionNode.getChildren().get( 0 ) );
@@ -211,7 +211,7 @@ public class MeController
                     .collect( Collectors.toList() ) ) );
         }
 
-        nodeService.serialize( rootNode, "application/json", response.getOutputStream() );
+        nodeService.serialize( rootNode, APPLICATION_JSON_VALUE, response.getOutputStream() );
     }
 
     private boolean fieldsContains( String key, List<String> fields )
@@ -240,10 +240,10 @@ public class MeController
 
         RootNode rootNode = userControllerUtils.getUserDataApprovalWorkflows( user );
 
-        nodeService.serialize( rootNode, "application/json", response.getOutputStream() );
+        nodeService.serialize( rootNode, APPLICATION_JSON_VALUE, response.getOutputStream() );
     }
 
-    @PutMapping( value = "", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PutMapping( value = "", consumes = APPLICATION_JSON_VALUE )
     public void updateCurrentUser( HttpServletRequest request, HttpServletResponse response )
         throws Exception
     {
@@ -275,8 +275,9 @@ public class MeController
         CollectionNode collectionNode = fieldFilterService.toCollectionNode( User.class,
             new FieldFilterParams( Collections.singletonList( currentUser ), fields ) );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
-        nodeService.serialize( NodeUtils.createRootNode( collectionNode.getChildren().get( 0 ) ), "application/json",
+        response.setContentType( APPLICATION_JSON_VALUE );
+        nodeService.serialize( NodeUtils.createRootNode( collectionNode.getChildren().get( 0 ) ),
+            APPLICATION_JSON_VALUE,
             response.getOutputStream() );
     }
 
@@ -292,7 +293,7 @@ public class MeController
             throw new NotAuthenticatedException();
         }
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         setNoStore( response );
         renderService.toJson( response.getOutputStream(), currentUser.getUserCredentials().getAllAuthorities() );
     }
@@ -311,7 +312,7 @@ public class MeController
 
         boolean hasAuthority = currentUser.getUserCredentials().isAuthorized( authority );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         setNoStore( response );
         renderService.toJson( response.getOutputStream(), hasAuthority );
     }
@@ -331,7 +332,7 @@ public class MeController
         Map<String, Serializable> userSettings = userSettingService.getUserSettingsWithFallbackByUserAsMap(
             currentUser, USER_SETTING_KEYS, true );
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         setNoStore( response );
         renderService.toJson( response.getOutputStream(), userSettings );
     }
@@ -363,7 +364,7 @@ public class MeController
             throw new WebMessageException( notFound( "User setting not found for key: " + key ) );
         }
 
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         setNoStore( response );
         renderService.toJson( response.getOutputStream(), value );
     }
@@ -417,7 +418,7 @@ public class MeController
         return validatePasswordInternal( password, getCurrentUserOrThrow() );
     }
 
-    @PostMapping( value = "/verifyPassword", consumes = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/verifyPassword", consumes = APPLICATION_JSON_VALUE )
     public @ResponseBody RootNode verifyPasswordJson( @RequestBody Map<String, String> body,
         HttpServletResponse response )
         throws WebMessageException
@@ -452,13 +453,13 @@ public class MeController
         interpretationService.updateCurrentUserLastChecked();
     }
 
-    @GetMapping( value = "/dataApprovalLevels", produces = { "application/json", "text/*" } )
+    @GetMapping( value = "/dataApprovalLevels", produces = { APPLICATION_JSON_VALUE, "text/*" } )
     public void getApprovalLevels( HttpServletResponse response )
         throws IOException
     {
         List<DataApprovalLevel> approvalLevels = approvalLevelService
             .getUserDataApprovalLevels( currentUserService.getCurrentUser() );
-        response.setContentType( MediaType.APPLICATION_JSON_VALUE );
+        response.setContentType( APPLICATION_JSON_VALUE );
         setNoStore( response );
         renderService.toJson( response.getOutputStream(), approvalLevels );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -32,6 +32,9 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importReport;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.IOException;
 import java.util.Date;
@@ -285,7 +288,7 @@ public class UserController
     // -------------------------------------------------------------------------
 
     @Override
-    @PostMapping( consumes = { "application/xml", "text/xml" } )
+    @PostMapping( consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage postXmlObject( HttpServletRequest request )
         throws Exception
@@ -294,7 +297,7 @@ public class UserController
     }
 
     @Override
-    @PostMapping( consumes = "application/json" )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonObject( HttpServletRequest request )
         throws Exception
@@ -312,7 +315,7 @@ public class UserController
         return postObject( getObjectReport( createUser( user, currentUser ) ) );
     }
 
-    @PostMapping( value = INVITE_PATH, consumes = "application/json" )
+    @PostMapping( value = INVITE_PATH, consumes = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage postJsonInvite( HttpServletRequest request )
         throws Exception
@@ -320,7 +323,7 @@ public class UserController
         return postInvite( request, renderService.fromJson( request.getInputStream(), getEntityClass() ) );
     }
 
-    @PostMapping( value = INVITE_PATH, consumes = { "application/xml", "text/xml" } )
+    @PostMapping( value = INVITE_PATH, consumes = { APPLICATION_XML_VALUE, TEXT_XML_VALUE } )
     @ResponseBody
     public WebMessage postXmlInvite( HttpServletRequest request )
         throws Exception
@@ -338,7 +341,7 @@ public class UserController
         return postObject( inviteUser( user, currentUser, request ) );
     }
 
-    @PostMapping( value = BULK_INVITE_PATH, consumes = "application/json" )
+    @PostMapping( value = BULK_INVITE_PATH, consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void postJsonInvites( HttpServletRequest request )
         throws Exception
@@ -346,8 +349,8 @@ public class UserController
         postInvites( request, renderService.fromJson( request.getInputStream(), Users.class ) );
     }
 
-    @PostMapping( value = BULK_INVITE_PATH, consumes = { "application/xml",
-        "text/xml" } )
+    @PostMapping( value = BULK_INVITE_PATH, consumes = { APPLICATION_XML_VALUE,
+        TEXT_XML_VALUE } )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void postXmlInvites( HttpServletRequest request )
         throws Exception
@@ -566,7 +569,8 @@ public class UserController
     // -------------------------------------------------------------------------
 
     @Override
-    @PutMapping( value = "/{uid}", consumes = { "application/xml", "text/xml" }, produces = "application/xml" )
+    @PutMapping( value = "/{uid}", consumes = { APPLICATION_XML_VALUE,
+        TEXT_XML_VALUE }, produces = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage putXmlObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request,
         HttpServletResponse response )
@@ -579,7 +583,7 @@ public class UserController
     }
 
     @Override
-    @PutMapping( value = "/{uid}", consumes = "application/json", produces = "application/json" )
+    @PutMapping( value = "/{uid}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage putJsonObject( @PathVariable( "uid" ) String pvUid, HttpServletRequest request )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.validation;
 
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
 
@@ -49,7 +50,6 @@ import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -98,7 +98,7 @@ public class ValidationRuleController
         return super.getEntityList( metadata, options, filters, orders );
     }
 
-    @PostMapping( value = "/expression/description", produces = MediaType.APPLICATION_JSON_VALUE )
+    @PostMapping( value = "/expression/description", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public WebMessage getExpressionDescription( @RequestBody String expression )
     {


### PR DESCRIPTION
Cleanup around media/mime types in controllers.

* avoids `{..}` for single values
* uses constants available in `MediaType`
* uses static imports for used constants