### PR TITLE
test: adds JSON assertion utility

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/Expected.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/Expected.java
@@ -1,0 +1,25 @@
+package org.hisp.dhis.webapi.json;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to mark members in {@link JsonObject} that are expected to exist.
+ *
+ * This can only be applied to methods without parameters.
+ *
+ * @author Jan Bernitt
+ */
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface Expected
+{
+    /**
+     * @return Can be set to {@code true} to allow {@link JsonValue}s either
+     *         being set or being a JSON {@code null} value. Default value is
+     *         {@code false}.
+     */
+    boolean nullable() default false;
+}

--- a/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/Expected.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/Expected.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.webapi.json;
 
 import java.lang.annotation.ElementType;

--- a/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/main/java/org/hisp/dhis/webapi/json/JsonObject.java
@@ -27,8 +27,13 @@
  */
 package org.hisp.dhis.webapi.json;
 
+import static java.util.Arrays.stream;
+
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Represents a JSON object node.
@@ -123,5 +128,92 @@ public interface JsonObject extends JsonCollection
     default <E extends JsonValue> JsonMultiMap<E> getMultiMap( String name, Class<E> as )
     {
         return JsonCollection.asMultiMap( getObject( name ), as );
+    }
+
+    /**
+     * Uses the {@link Expected} annotations present to check whether this
+     * object conforms to the provided type
+     *
+     * @param type object type to check
+     * @return true if this is an object and has all {@link Expected} members of
+     *         the provided type
+     */
+    default boolean isA( Class<? extends JsonObject> type )
+    {
+        try
+        {
+            asObject( type );
+            return true;
+        }
+        catch ( NoSuchElementException ex )
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @see #asObject(Class, boolean, String)
+     */
+    default <T extends JsonObject> T asObject( Class<T> type )
+    {
+        return asObject( type, true, "" );
+    }
+
+    /**
+     * In contrast to {@link #as(Class)} this method does check that this object
+     * {@link #exists()}, that it is indeed an object node and that it has all
+     * {@link Expected} values expected for the provided object type.
+     *
+     * @param type expected object type
+     * @param recursive true to apply the check to nested {@link JsonObject}s
+     * @param <T> type check and of the result
+     * @return this node as the provided object type
+     * @throws NoSuchElementException when this does not exist, is not an object
+     *         node or does not have all of the {@link Expected} members present
+     */
+    default <T extends JsonObject> T asObject( Class<T> type, boolean recursive, String path )
+        throws NoSuchElementException
+    {
+        if ( !exists() )
+        {
+            throw new NoSuchElementException(
+                String.format( "Expected %s %s node does not exist", path, type.getSimpleName() ) );
+        }
+        if ( !isObject() )
+        {
+            throw new NoSuchElementException(
+                String.format( "Expected %s %s node is not an object but a %s", path, type.getSimpleName(),
+                    node().getType() ) );
+        }
+        T obj = as( type );
+        String parent = path.isEmpty() ? "" : path + ".";
+        stream( type.getMethods() )
+            .filter( m -> m.getParameterCount() == 0 && m.isAnnotationPresent( Expected.class ) )
+            .sorted( Comparator.comparing( Method::getName ) )
+            .forEach( m -> {
+                Object member = null;
+                try
+                {
+                    member = m.invoke( obj );
+                }
+                catch ( Exception e )
+                {
+                    throw new NoSuchElementException( String.format( "Expected %s node member %s had invalid value: %s",
+                        type.getSimpleName(), parent + m.getName(), e.getMessage() ) );
+                }
+                if ( member == null || member instanceof JsonValue && (!((JsonValue) member).exists()
+                    || !m.getAnnotation( Expected.class ).nullable() && ((JsonValue) member).isNull()) )
+                {
+                    throw new NoSuchElementException( String.format( "Expected %s node member %s was not defined",
+                        type.getSimpleName(), parent + m.getName() ) );
+                }
+                if ( recursive && member instanceof JsonObject && !((JsonObject) member).isNull() )
+                {
+                    @SuppressWarnings( "unchecked" )
+                    Class<? extends JsonObject> memberType = (Class<? extends JsonObject>) m.getReturnType();
+                    ((JsonObject) member).asObject( memberType, true, parent + m.getName() );
+                }
+            } );
+        return obj;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonExpectedTest.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonExpectedTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.webapi.json;
 
 import static org.junit.Assert.assertEquals;

--- a/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonExpectedTest.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonExpectedTest.java
@@ -1,0 +1,199 @@
+package org.hisp.dhis.webapi.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+/**
+ * Tests the {@link Expected} annotation feature.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonExpectedTest
+{
+    private interface JsonFoo extends JsonObject
+    {
+        @Expected
+        default String getBar()
+        {
+            return getString( "bar" ).string();
+        }
+    }
+
+    private interface JsonEntry extends JsonObject
+    {
+        @Expected
+        default String getKey()
+        {
+            return getString( "key" ).string();
+        }
+
+        @Expected
+        default Number getValue()
+        {
+            return getNumber( "value" ).number();
+        }
+    }
+
+    private interface JsonRoot extends JsonObject
+    {
+
+        @Expected( nullable = true )
+        default JsonFoo getA()
+        {
+            return get( "a", JsonFoo.class );
+        }
+
+        @Expected
+        default JsonFoo getB()
+        {
+            return get( "b", JsonFoo.class );
+        }
+    }
+
+    @Test
+    public void testIsA()
+    {
+        assertTrue( createJSON( "{'bar':'x'}" ).isA( JsonFoo.class ) );
+        assertTrue( createJSON( "{'key':'x', 'value': 1}" ).isA( JsonEntry.class ) );
+        JsonResponse both = createJSON( "{'key':'x', 'value': 1, 'bar':'y'}" );
+        assertTrue( both.isA( JsonFoo.class ) );
+        assertTrue( both.isA( JsonEntry.class ) );
+    }
+
+    @Test
+    public void testIsA_MissingMember()
+    {
+        assertFalse( createJSON( "{'bar':'x'}" ).isA( JsonEntry.class ) );
+        assertFalse( createJSON( "{'key':'x', 'value': 1}" ).isA( JsonFoo.class ) );
+    }
+
+    @Test
+    public void testIsA_WrongNodeType()
+    {
+        assertFalse( createJSON( "{'bar':true}" ).isA( JsonFoo.class ) );
+        assertFalse( createJSON( "{'key':'x', 'value': '1'}" ).isA( JsonEntry.class ) );
+    }
+
+    @Test
+    public void testIsA_NotAnObject()
+    {
+        assertFalse( createJSON( "[]" ).isA( JsonEntry.class ) );
+        assertFalse( createJSON( "'test'" ).isA( JsonEntry.class ) );
+        assertFalse( createJSON( "12" ).isA( JsonEntry.class ) );
+        assertFalse( createJSON( "false" ).isA( JsonEntry.class ) );
+        assertFalse( createJSON( "null" ).isA( JsonEntry.class ) );
+    }
+
+    @Test
+    public void testAsObject()
+    {
+        assertAsObject( JsonFoo.class, "{'bar': 'yes'}" );
+        assertAsObject( JsonEntry.class, "{'key':'x', 'value': 42}" );
+        String both = "{'key':'x', 'value': 1, 'bar':'y'}";
+        assertAsObject( JsonFoo.class, both );
+        assertAsObject( JsonEntry.class, both );
+    }
+
+    @Test
+    public void testAsObject_Nullable()
+    {
+        assertAsObject( JsonRoot.class, "{'a':null,'b':{'bar':'x'}}" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectArray()
+    {
+        assertAsObjectThrows( JsonFoo.class, "[]", "Expected  JsonFoo node is not an object but a ARRAY" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectString()
+    {
+        assertAsObjectThrows( JsonFoo.class, "'nop'", "Expected  JsonFoo node is not an object but a STRING" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectNumber()
+    {
+        assertAsObjectThrows( JsonFoo.class, "13", "Expected  JsonFoo node is not an object but a NUMBER" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectBoolean()
+    {
+        assertAsObjectThrows( JsonFoo.class, "true", "Expected  JsonFoo node is not an object but a BOOLEAN" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectNull()
+    {
+        assertAsObjectThrows( JsonFoo.class, "null", "Expected  JsonFoo node is not an object but a NULL" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectUndefined()
+    {
+        assertAsObjectThrows( () -> createJSON( "{}" ).getObject( "x" ).asObject( JsonFoo.class ),
+            "Expected  JsonFoo node does not exist" );
+    }
+
+    @Test
+    public void testAsObject_MissingMemberUndefined()
+    {
+        assertAsObjectThrows( JsonRoot.class, "{'b':{'bar':''}}",
+            "Expected JsonRoot node member getA was not defined" );
+    }
+
+    @Test
+    public void testAsObject_MissingMemberRecursive()
+    {
+        assertAsObjectThrows( JsonRoot.class, "{'a': {}, 'b':{'bar':''}}",
+            "Expected JsonFoo node member getA.getBar was not defined" );
+    }
+
+    @Test
+    public void testAsObject_NotAnObjectRecursive()
+    {
+        assertAsObjectThrows( JsonRoot.class, "{'a': [], 'b':{'bar':''}}",
+            "Expected getA JsonFoo node is not an object but a ARRAY" );
+    }
+
+    private static void assertAsObjectThrows( Class<? extends JsonObject> of, String actualJson,
+        String expectedMessage )
+    {
+        assertAsObjectThrows( () -> assertNotNull( createJSON( actualJson ).asObject( of ) ), expectedMessage );
+    }
+
+    private static void assertAsObjectThrows( Runnable test, String expectedMessage )
+    {
+        try
+        {
+            test.run();
+        }
+        catch ( NoSuchElementException ex )
+        {
+            assertEquals( expectedMessage, ex.getMessage() );
+            return;
+        }
+        fail( "Expected NoSuchElementException with message: " + expectedMessage );
+    }
+
+    private static void assertAsObject( Class<? extends JsonObject> of, String actualJson )
+    {
+        JsonObject obj = createJSON( actualJson ).asObject( of );
+        assertNotNull( obj );
+        assertTrue( of.isInstance( obj ) );
+    }
+
+    private static JsonResponse createJSON( String content )
+    {
+        return new JsonResponse( content.replace( '\'', '"' ) );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test-json/src/test/java/org/hisp/dhis/webapi/json/JsonResponseTest.java
@@ -267,7 +267,7 @@ public class JsonResponseTest
         assertEquals( "Expected \" but reach EOI: {\"a:12}", map.toString() );
     }
 
-    private JsonResponse createJSON( String content )
+    private static JsonResponse createJSON( String content )
     {
         return new JsonResponse( content.replace( '\'', '"' ) );
     }


### PR DESCRIPTION
### Summary
PR adds two new methods to the `JsonObject` API:
* `isA(Class)`
* `asObject(Class)`

These use a new annotation `@Expected` which can be added to the getters of a subclass of `JsonObject` to express that one does expect the property accessed in the getter to be present. To then check if a given `JsonObject` conforms to the expectations the `isA` method can be used. The `asObject` can be used to "cast" a `JsonObject` to a subclass while making sure all expected values are present. If expected values are missing or of the wrong type this will throw a `NoSuchElementException`.

Both methods do work recursive. This means one can check that a JSON tree conforms to the expectations with regards to existence and type in a single method call.

### Automatic Testing
Added a unit tests that checks the feature in detail.
This also gives an example of how it is used.