### PR TITLE
fix: restored query filter for "in" operator [DHIS2-11549]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.analytics.QueryKey.NV;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -136,7 +137,18 @@ public class QueryFilter
                 return "null";
             }
         }
+        else if ( QueryOperator.IN.equals( operator ) )
+        {
+            return getFilterItems( encodedFilter ).stream()
+                .map( this::quote )
+                .collect( Collectors.joining( ",", "(", ")" ) );
+        }
         return "'" + encodedFilter + "'";
+    }
+
+    private String quote( String filterItem )
+    {
+        return "'" + filterItem + "'";
     }
 
     /**


### PR DESCRIPTION
This was removed in an analytics ticket since it needed to be handled in a different way.