### PR TITLE
chore: add debug option to mvn command [DEVOPS-81]

### DIFF
--- a/Jenkinsfile-core-dev
+++ b/Jenkinsfile-core-dev
@@ -28,7 +28,7 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven {
-                        sh 'mvn -T 4 clean install -f dhis-2/pom-full.xml -Pjdk8 --update-snapshots'
+                        sh 'mvn -X -T 4 clean install -f dhis-2/pom-full.xml -Pjdk8 --update-snapshots'
                     }
                 }
             }


### PR DESCRIPTION
Add debug option `-X` to `mvn` command in attempt to find root cause of builds getting stuck (and aborted).