### PR TITLE
build: create advisories reference file for build-time patches

### DIFF
--- a/.patches/security/advisories.json
+++ b/.patches/security/advisories.json
@@ -1,0 +1,24 @@
+{
+    "cves": [
+      {
+        "cveID": "CVE-2021-XXXXX",
+        "privateForkUrl": "https://github.com/dhis2/dhis2-core-ghsa-cmpc-frjv-rrmw",
+        "status": "DRAFT",
+        "pullRequests": [
+          {
+            "parent": "b76c38b612fb0cb3250c3cd59e44722eeafed482",
+            "prNumber": 1,
+            "status": "DRAFT"
+          },
+          {
+            "parent": "73be95b7097a73ac687fcccb74e160a32a5deea5",
+            "prNumber": 3
+          },
+          {
+            "parent": "599b189d38c393ebc68b15365600f2ca6aee7a82",
+            "prNumber": 4
+          }
+        ]
+      }
+    ]
+}


### PR DESCRIPTION

This file will be the reference point for build-time patching.
This initial version contains the current security advisory in DRAFT (will not be patched).
Possible status:
- DRAFT (in progress; do not apply the patches yet) 
- FIXED (CVE is complete and patches should be applied to builds)
- MERGED (CVE has been merged; vulnerability is disclosed and patch is no longer necessary)
Status can be set on individual pullRequests in order override the parent CVE status.

Note: this DRAFT CVE also has a dummy CVE number, and the PR details should be checked when updating to FIXED.