### PR TITLE
fix: notLike filter is not working correctly

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -130,6 +130,8 @@ public class JpaQueryUtils
         {
         case EQUALS:
             return builder.equal( path, attrValue );
+        case NOT_EQUALS:
+            return builder.notEqual( path, attrValue );
         case ENDING_LIKE:
             return builder.like( path, "%" + attrValue );
         case NOT_ENDING_LIKE:
@@ -140,6 +142,8 @@ public class JpaQueryUtils
             return builder.notLike( path, attrValue + "%" );
         case ANYWHERE:
             return builder.like( path, "%" + attrValue + "%" );
+        case NOT_ANYWHERE:
+            return builder.notLike( path, "%" + attrValue + "%" );
         case LIKE:
             return builder.like( path, (String) attrValue ); // assume user
                                                              // provide the wild
@@ -158,14 +162,16 @@ public class JpaQueryUtils
     {
 
         EQUALS( "eq" ), // Match exactly
+        NOT_EQUALS( "neq" ),
         ANYWHERE( "any" ), // Like search with '%' prefix and suffix
+        NOT_ANYWHERE( "nany" ), // Like search with '%' prefix and suffix
         STARTING_LIKE( "sl" ), // Like search and add a '%' prefix before
                                // searching
         NOT_STARTING_LIKE( "nsl" ),
         LIKE( "li" ), // User provides the wild card
+        NOT_LIKE( "nli" ), // User provides the wild card
         ENDING_LIKE( "el" ), // LIKE search and add a '%' suffix before
                              // searching
-        NOT_LIKE( "nli" ),
         NOT_ENDING_LIKE( "nel" );
 
         private final String code;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotLikeOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotLikeOperator.java
@@ -27,29 +27,98 @@
  */
 package org.hisp.dhis.query.operators;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+import org.hisp.dhis.query.JpaQueryUtils;
+import org.hisp.dhis.query.Type;
+import org.hisp.dhis.query.Typed;
 import org.hisp.dhis.query.planner.QueryPath;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class NotLikeOperator<T extends Comparable<? super T>> extends LikeOperator<T>
+public class NotLikeOperator<T extends Comparable<? super T>> extends Operator<T>
 {
-    public NotLikeOperator( T arg, boolean caseSensitive, MatchMode matchMode )
+    private final boolean caseSensitive;
+
+    private final JpaQueryUtils.StringSearchMode jpaMatchMode;
+
+    private final org.hibernate.criterion.MatchMode matchMode;
+
+    public NotLikeOperator( T arg, boolean caseSensitive, org.hisp.dhis.query.operators.MatchMode matchMode )
     {
-        super( "!like", arg, caseSensitive, matchMode );
+        super( "!like", Typed.from( String.class ), arg );
+        this.caseSensitive = caseSensitive;
+        this.matchMode = getMatchMode( matchMode );
+        this.jpaMatchMode = getNotLikeJpaMatchMode( matchMode );
     }
 
     @Override
     public Criterion getHibernateCriterion( QueryPath queryPath )
     {
-        return Restrictions.not( super.getHibernateCriterion( queryPath ) );
+        if ( caseSensitive )
+        {
+            return Restrictions.like( queryPath.getPath(), String.valueOf( args.get( 0 ) ).replace( "%", "\\%" ),
+                matchMode );
+        }
+        else
+        {
+            return Restrictions.ilike( queryPath.getPath(), String.valueOf( args.get( 0 ) ).replace( "%", "\\%" ),
+                matchMode );
+        }
+    }
+
+    @Override
+    public <Y> Predicate getPredicate( CriteriaBuilder builder, Root<Y> root, QueryPath queryPath )
+    {
+        if ( caseSensitive )
+        {
+            return JpaQueryUtils.stringPredicateCaseSensitive( builder, root.get( queryPath.getPath() ),
+                String.valueOf( args.get( 0 ) ).replace( "%", "" ),
+                jpaMatchMode );
+        }
+        else
+        {
+            return JpaQueryUtils.stringPredicateIgnoreCase( builder, root.get( queryPath.getPath() ),
+                String.valueOf( args.get( 0 ) ).replace( "%", "" ),
+                jpaMatchMode );
+        }
     }
 
     @Override
     public boolean test( Object value )
     {
-        return !super.test( value );
+        if ( args.isEmpty() || value == null )
+        {
+            return false;
+        }
+
+        Type type = new Type( value );
+
+        if ( type.isString() )
+        {
+            String s1 = caseSensitive ? getValue( String.class ) : getValue( String.class ).toLowerCase();
+            String s2 = caseSensitive ? (String) value : ((String) value).toLowerCase();
+
+            switch ( jpaMatchMode )
+            {
+            case NOT_EQUALS:
+                return !s2.equals( s1 );
+            case NOT_STARTING_LIKE:
+                return !s2.startsWith( s1 );
+            case NOT_ENDING_LIKE:
+                return !s2.endsWith( s1 );
+            case NOT_ANYWHERE:
+                return !s2.contains( s1 );
+            default:
+                return false;
+            }
+        }
+
+        return false;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/Operator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/Operator.java
@@ -205,6 +205,30 @@ public abstract class Operator<T extends Comparable<? super T>>
         }
     }
 
+    /**
+     * Get JPA String search mode for NOT LIKE match mode.
+     *
+     * @param matchMode {@link MatchMode}
+     * @return {@link JpaQueryUtils.StringSearchMode} used for generating JPA
+     *         Api Query
+     */
+    protected JpaQueryUtils.StringSearchMode getNotLikeJpaMatchMode( MatchMode matchMode )
+    {
+        switch ( matchMode )
+        {
+        case EXACT:
+            return JpaQueryUtils.StringSearchMode.NOT_EQUALS;
+        case START:
+            return JpaQueryUtils.StringSearchMode.NOT_STARTING_LIKE;
+        case END:
+            return JpaQueryUtils.StringSearchMode.NOT_ENDING_LIKE;
+        case ANYWHERE:
+            return JpaQueryUtils.StringSearchMode.NOT_ANYWHERE;
+        default:
+            return null;
+        }
+    }
+
     @Override
     public String toString()
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/CriteriaQueryEngineTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/CriteriaQueryEngineTest.java
@@ -205,6 +205,46 @@ public class CriteriaQueryEngineTest extends TransactionalIntegrationTest
     }
 
     @Test
+    public void getNotLikeQueryAll()
+    {
+        Query query = Query.from( schemaService.getDynamicSchema( DataElement.class ) );
+        query.add( Restrictions.notLike( "name", "G", MatchMode.ANYWHERE ) );
+        List<? extends IdentifiableObject> objects = queryEngine.query( query );
+
+        assertEquals( 6, objects.size() );
+    }
+
+    @Test
+    public void getNotILikeQueryAll()
+    {
+        Query query = Query.from( schemaService.getDynamicSchema( DataElement.class ) );
+        query.add( Restrictions.notLike( "name", "a", MatchMode.ANYWHERE ) );
+        List<? extends IdentifiableObject> objects = queryEngine.query( query );
+
+        assertEquals( 0, objects.size() );
+    }
+
+    @Test
+    public void getNotILikeQueryOne()
+    {
+        Query query = Query.from( schemaService.getDynamicSchema( DataElement.class ) );
+        query.add( Restrictions.notIlike( "name", "b", MatchMode.ANYWHERE ) );
+        List<? extends IdentifiableObject> objects = queryEngine.query( query );
+
+        assertEquals( 5, objects.size() );
+    }
+
+    @Test
+    public void getNotLikeQueryOne()
+    {
+        Query query = Query.from( schemaService.getDynamicSchema( DataElement.class ) );
+        query.add( Restrictions.notLike( "name", "A", MatchMode.ANYWHERE ) );
+        List<? extends IdentifiableObject> objects = queryEngine.query( query );
+
+        assertEquals( 5, objects.size() );
+    }
+
+    @Test
     public void getGtQuery()
     {
         Query query = Query.from( schemaService.getDynamicSchema( DataElement.class ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OperatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OperatorTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.query.operators.LessThanOperator;
 import org.hisp.dhis.query.operators.LikeOperator;
 import org.hisp.dhis.query.operators.MatchMode;
 import org.hisp.dhis.query.operators.NotEqualOperator;
+import org.hisp.dhis.query.operators.NotLikeOperator;
 import org.hisp.dhis.query.operators.NotNullOperator;
 import org.hisp.dhis.query.operators.NullOperator;
 import org.junit.Test;
@@ -410,5 +411,77 @@ public class OperatorTest
         assertTrue( operator.test( TestEnum.B ) );
         assertFalse( operator.test( TestEnum.C ) );
         assertFalse( operator.test( "abc" ) );
+    }
+
+    @Test
+    public void testNotLikeValidTypes()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "operator", true, MatchMode.ANYWHERE );
+
+        assertTrue( operator.isValid( String.class ) );
+        assertFalse( operator.isValid( Number.class ) );
+        assertFalse( operator.isValid( Date.class ) );
+        assertFalse( operator.isValid( Boolean.class ) );
+        assertFalse( operator.isValid( Collection.class ) );
+    }
+
+    @Test
+    public void testNotLikeAnywhere()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "oper", true, MatchMode.ANYWHERE );
+
+        assertFalse( operator.test( "operator" ) );
+        assertTrue( operator.test( "OPERATOR" ) );
+        assertTrue( operator.test( "abc" ) );
+    }
+
+    @Test
+    public void testNotLikeStart()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "oper", true, MatchMode.START );
+
+        assertFalse( operator.test( "operator" ) );
+        assertTrue( operator.test( "OPERATOR" ) );
+        assertTrue( operator.test( "abc" ) );
+    }
+
+    @Test
+    public void tesNotLikeEnd()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "ator", true, MatchMode.END );
+
+        assertFalse( operator.test( "operator" ) );
+        assertTrue( operator.test( "OPERATOR" ) );
+        assertTrue( operator.test( "abc" ) );
+    }
+
+    @Test
+    public void testINotLikeAnywhere()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "erat", false, MatchMode.ANYWHERE );
+
+        assertFalse( operator.test( "operator" ) );
+        assertFalse( operator.test( "OPERATOR" ) );
+        assertTrue( operator.test( "abc" ) );
+    }
+
+    @Test
+    public void testINotLikeStart()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "oper", false, MatchMode.START );
+
+        assertFalse( operator.test( "operator" ) );
+        assertFalse( operator.test( "OPERATOR" ) );
+        assertTrue( operator.test( "abc" ) );
+    }
+
+    @Test
+    public void testINotLikeEnd()
+    {
+        NotLikeOperator<String> operator = new NotLikeOperator<>( "ator", false, MatchMode.END );
+
+        assertFalse( operator.test( "operator" ) );
+        assertFalse( operator.test( "OPERATOR" ) );
+        assertTrue( operator.test( "abc" ) );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11383

- Issue: NotLike operator hasn't been convert to JPA query
- Fix: implement JPA Query generation for NotLike operator
- Added unit tests and integration tests
- Manual test: use this api query `api/programIndicators?filter=name:!like:generated&fields=:owner` , it should return 117 records as on play/2.35.