### PR TITLE
chore: Move JsonFilteringRequestFilter to API web initializer

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -36,6 +36,7 @@ import javax.servlet.SessionTrackingMode;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.commons.jsonfiltering.web.JsonFilteringRequestFilter;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -102,6 +103,9 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer
             .addMappingForUrlPatterns( null, true, "/*" );
 
         context.addFilter( "AppOverrideFilter", new DelegatingFilterProxy( "appOverrideFilter" ) )
+            .addMappingForUrlPatterns( null, true, "/*" );
+
+        context.addFilter( "JsonFilteringRequestFilter", JsonFilteringRequestFilter.class )
             .addMappingForUrlPatterns( null, true, "/*" );
 
         context.addListener( new StartupListener() );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/DhisWebCommonsWebAppInitializer.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/DhisWebCommonsWebAppInitializer.java
@@ -33,7 +33,6 @@ import javax.servlet.DispatcherType;
 import javax.servlet.ServletContext;
 
 import org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter;
-import org.hisp.dhis.commons.jsonfiltering.web.JsonFilteringRequestFilter;
 import org.springframework.core.annotation.Order;
 import org.springframework.web.WebApplicationInitializer;
 
@@ -47,8 +46,5 @@ public class DhisWebCommonsWebAppInitializer implements WebApplicationInitialize
         context
             .addFilter( "StrutsDispatcher", new StrutsPrepareAndExecuteFilter() )
             .addMappingForUrlPatterns( EnumSet.of( DispatcherType.REQUEST ), true, "*.action" );
-
-        context.addFilter( "JsonFilteringRequestFilter", JsonFilteringRequestFilter.class )
-            .addMappingForUrlPatterns( null, true, "/*" );
     }
 }


### PR DESCRIPTION
Move JsonFilteringRequestFilter from DhisWebCommonsWebAppInitializer to DhisWebApiWebAppInitializer.
This filter should only be applied to /api requests and should therefore not be in the commons web app initializer where only the filters that applies to the Struts pages should be. 