### PR TITLE
fix: return Created for /userDataStore PUT [DHIS2-11587]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueController.java
@@ -209,7 +209,7 @@ public class UserKeyJsonValueController
 
         userKeyJsonValueService.updateUserKeyJsonValue( userKeyJsonValue );
 
-        return ok( "Key '" + key + "' in namespace '" + namespace + "' updated." );
+        return created( "Key '" + key + "' in namespace '" + namespace + "' updated." );
     }
 
     /**

--- a/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueControllerTest.java
+++ b/dhis-2/dhis-web/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserKeyJsonValueControllerTest.java
@@ -78,8 +78,8 @@ public class UserKeyJsonValueControllerTest extends DhisControllerConvenienceTes
     {
         assertStatus( HttpStatus.CREATED, POST( "/userDataStore/test/key1", "true" ) );
 
-        assertWebMessage( "OK", 200, "OK", "Key 'key1' in namespace 'test' updated.",
-            PUT( "/userDataStore/test/key1", "false" ).content( HttpStatus.OK ) );
+        assertWebMessage( "Created", 201, "OK", "Key 'key1' in namespace 'test' updated.",
+            PUT( "/userDataStore/test/key1", "false" ).content( HttpStatus.CREATED ) );
     }
 
     @Test


### PR DESCRIPTION
This method was a bit ambiguous as it had this sequence before setting both OK and Created.
```java
response.setStatus( HttpServletResponse.SC_OK );
messageService.sendJson( WebMessageUtils.created
```
I opted for `OK` as it is the more appropriate of the two but as `Created` did win this would mean a change of the API - therefore I make a PR that switched back to `Created`.