### PR TITLE
fix: parent pom of dhis-web-api-test

### DIFF
--- a/dhis-2/dhis-web-api-test/pom.xml
+++ b/dhis-2/dhis-web-api-test/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.hisp.dhis</groupId>
-    <artifactId>dhis-web</artifactId>
+    <artifactId>dhis</artifactId>
     <version>2.37-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
Parent was not updated when moving to a new model in #8514