### PR TITLE
fix: web api tests pom config

### DIFF
--- a/dhis-2/dhis-web-api-test/pom.xml
+++ b/dhis-2/dhis-web-api-test/pom.xml
@@ -41,7 +41,6 @@
           <plugin>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-maven-plugin</artifactId>
-            <version>1.5.3</version>
             <executions>
               <execution>
                 <id>generate-docs</id>
@@ -63,7 +62,6 @@
           </plugin>
           <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>2.7</version>
             <executions>
               <execution>
                 <id>copy-resources</id>
@@ -180,6 +178,7 @@
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-web-commons</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -206,6 +205,6 @@
   </dependencies>
 
   <properties>
-    <rootDir>../../</rootDir>
+    <rootDir>../</rootDir>
   </properties>
 </project>

--- a/dhis-2/pom-full.xml
+++ b/dhis-2/pom-full.xml
@@ -8,7 +8,7 @@
 		<groupId>org.hisp.dhis</groupId>
 		<artifactId>dhis</artifactId>
 		<version>2.37-SNAPSHOT</version>
-		<relativePath>.</relativePath>		
+		<relativePath>.</relativePath>
 	</parent>
 
 	<artifactId>dhis-full</artifactId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -590,9 +590,10 @@
           </dependencies>
           <configuration>
             <xmlOutput>true</xmlOutput>
-            <excludeFilterFile>${rootDir}findbugs-exclude.xml</excludeFilterFile>
+            <excludeFilterFile>${rootDir}findbugs-exclude.xml
+            </excludeFilterFile>
           </configuration>
-        </plugin>        
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
@@ -877,6 +878,12 @@
         <artifactId>dhis-support-cache-invalidation</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.hisp.dhis</groupId>
+        <artifactId>dhis-web-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.hisp.dhis.rules</groupId>
         <artifactId>rule-engine</artifactId>


### PR DESCRIPTION
These changes now pass locally

    mvn -X -T 4 clean install -f dhis-2/pom-full.xml -Pjdk8 --update-snapshots

Might still fail in CI due to `dhis-web-commons` being under `dhis2-web` but as a quick fix this might help.