### PR TITLE
fix: Link core to rule engine version with logs implemented [TECH-652]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -55,7 +55,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine-->
-    <dhis2-rule-engine.version>2.0.21</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.0.23</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.3.5</dhis-hisp-quick.version>


### PR DESCRIPTION
Rule engine logs are registered in INFO level, so to show them the level of the log configuration must be change from WARN to INFO