### PR TITLE
fix: [ DHIS2-11338 ] Potential duplicate remove /tei endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationService.java
@@ -43,8 +43,6 @@ public interface DeduplicationService
 
     List<PotentialDuplicate> getAllPotentialDuplicatesBy( PotentialDuplicateQuery query );
 
-    List<PotentialDuplicate> getPotentialDuplicateByTei( String tei, DeduplicationStatus status );
-
     void addPotentialDuplicate( PotentialDuplicate potentialDuplicate );
 
     void updatePotentialDuplicate( PotentialDuplicate potentialDuplicate );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicateStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicateStore.java
@@ -38,7 +38,5 @@ public interface PotentialDuplicateStore
 
     List<PotentialDuplicate> getAllByQuery( PotentialDuplicateQuery query );
 
-    List<PotentialDuplicate> getAllByTei( String tei, DeduplicationStatus status );
-
     boolean exists( PotentialDuplicate potentialDuplicate );
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
@@ -166,7 +166,7 @@ public class PotentialDuplicatesTests
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=OPEN" ) )
             .validate().statusCode( 200 )
-            .body( "identifiableObjects", hasSize( 1 ) );
+            .body( "identifiableObjects", hasSize( 2 ) );
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=MERGED" ) )
             .validate().statusCode( 200 )
@@ -174,7 +174,7 @@ public class PotentialDuplicatesTests
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=ALL" ) )
             .validate().statusCode( 200 )
-            .body( "identifiableObjects", hasSize( 2 ) );
+            .body( "identifiableObjects", hasSize( 3 ) );
 
     }
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
@@ -146,9 +146,11 @@ public class PotentialDuplicatesTests
         String teiA = createTei();
         String teiB = createTei();
         String teiC = createTei();
+        String teiD = createTei();
 
         potentialDuplicatesActions.createPotentialDuplicate( teiA, teiB, "OPEN" ).validate().statusCode( 200 );
         potentialDuplicatesActions.createPotentialDuplicate( teiC, teiA, "INVALID" ).validate().statusCode( 200 );
+        potentialDuplicatesActions.createPotentialDuplicate( teiD, teiA, "OPEN" ).validate().statusCode( 200 );
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().add( "teis=" + teiA ) )
             .validate().statusCode( 200 )
@@ -156,7 +158,7 @@ public class PotentialDuplicatesTests
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().add( "teis=" + teiB + "," + teiC) )
             .validate().statusCode( 200 )
-            .body( "identifiableObjects", hasSize( 2 ) );
+            .body( "identifiableObjects", hasSize( 1 ) );
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=INVALID" ) )
             .validate().statusCode( 200 )

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
@@ -140,6 +140,42 @@ public class PotentialDuplicatesTests
         response.validate().statusCode( 400 ).body( "status", equalTo( "ERROR" ) );
     }
 
+    @Test
+    public void shouldGetDuplicatesByTei()
+    {
+        String teiA = createTei();
+        String teiB = createTei();
+        String teiC = createTei();
+
+        potentialDuplicatesActions.createPotentialDuplicate( teiA, teiB, "OPEN" ).validate().statusCode( 200 );
+        potentialDuplicatesActions.createPotentialDuplicate( teiC, teiA, "INVALID" ).validate().statusCode( 200 );
+
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().add( "teis=" + teiA ) )
+            .validate().statusCode( 200 )
+            .body( "identifiableObjects", hasSize( 2 ) );
+
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().add( "teis=" + teiB + "," + teiC) )
+            .validate().statusCode( 200 )
+            .body( "identifiableObjects", hasSize( 2 ) );
+
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=INVALID" ) )
+            .validate().statusCode( 200 )
+            .body( "identifiableObjects", hasSize( 1 ) );
+
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=OPEN" ) )
+            .validate().statusCode( 200 )
+            .body( "identifiableObjects", hasSize( 1 ) );
+
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=MERGED" ) )
+            .validate().statusCode( 200 )
+            .body( "identifiableObjects", hasSize( 0 ) );
+
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=ALL" ) )
+            .validate().statusCode( 200 )
+            .body( "identifiableObjects", hasSize( 2 ) );
+
+    }
+
     private String createTei()
     {
         JsonObject object = trackerActions.buildTei( Constants.TRACKED_ENTITY_TYPE, Constants.ORG_UNIT_IDS[0] );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
@@ -140,34 +140,6 @@ public class PotentialDuplicatesTests
         response.validate().statusCode( 400 ).body( "status", equalTo( "ERROR" ) );
     }
 
-    @Test
-    public void shouldGetDuplicatesByTei()
-    {
-        String teiA = createTei();
-
-        potentialDuplicatesActions.createPotentialDuplicate( teiA, createTei(), "OPEN" ).validate().statusCode( 200 );
-        potentialDuplicatesActions.createPotentialDuplicate( createTei(), teiA, "INVALID" ).validate().statusCode( 200 );
-
-        potentialDuplicatesActions.get( "/tei/" + teiA )
-            .validate().statusCode( 200 )
-            .body( "", hasSize( 2 ) );
-
-        potentialDuplicatesActions.get( "/tei/" + teiA + "?status=INVALID" )
-            .validate().statusCode( 200 )
-            .body( "", hasSize( 1 ) );
-
-        potentialDuplicatesActions.get( "/tei/" + teiA + "?status=OPEN" )
-            .validate().statusCode( 200 )
-            .body( "", hasSize( 1 ) );
-
-        potentialDuplicatesActions.get( "/tei/" + teiA + "?status=MERGED" )
-            .validate().statusCode( 200 )
-            .body( "", hasSize( 0 ) );
-
-        potentialDuplicatesActions.get( "/tei/" + teiA + "?status=ALL" )
-            .validate().statusCode( 200 )
-            .body("", hasSize( 2 ) );
-    }
     private String createTei()
     {
         JsonObject object = trackerActions.buildTei( Constants.TRACKED_ENTITY_TYPE, Constants.ORG_UNIT_IDS[0] );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesTests.java
@@ -156,9 +156,9 @@ public class PotentialDuplicatesTests
             .validate().statusCode( 200 )
             .body( "identifiableObjects", hasSize( 2 ) );
 
-        potentialDuplicatesActions.get( "", new QueryParamsBuilder().add( "teis=" + teiB + "," + teiC) )
+        potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiB + "," + teiC, "status=ALL") )
             .validate().statusCode( 200 )
-            .body( "identifiableObjects", hasSize( 1 ) );
+            .body( "identifiableObjects", hasSize( 2 ) );
 
         potentialDuplicatesActions.get( "", new QueryParamsBuilder().addAll( "teis=" + teiA, "status=INVALID" ) )
             .validate().statusCode( 200 )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DefaultDeduplicationService.java
@@ -86,13 +86,6 @@ public class DefaultDeduplicationService
 
     @Override
     @Transactional( readOnly = true )
-    public List<PotentialDuplicate> getPotentialDuplicateByTei( String tei, DeduplicationStatus status )
-    {
-        return potentialDuplicateStore.getAllByTei( tei, status );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
     public int countPotentialDuplicates( PotentialDuplicateQuery query )
     {
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
@@ -64,7 +64,7 @@ public class HibernatePotentialDuplicateStore
 
         return Optional.ofNullable( query.getTeis() ).filter( teis -> !teis.isEmpty() ).map( teis -> {
             Query<Long> hibernateQuery = getTypedQuery(
-                queryString + " and pr.teiA in (:uids) or pr.teiB in (:uids)" );
+                queryString + " and ( pr.teiA in (:uids) or pr.teiB in (:uids) )" );
 
             hibernateQuery.setParameterList( "uids", teis );
 
@@ -88,7 +88,7 @@ public class HibernatePotentialDuplicateStore
 
         return Optional.ofNullable( query.getTeis() ).filter( teis -> !teis.isEmpty() ).map( teis -> {
             Query<PotentialDuplicate> hibernateQuery = getTypedQuery(
-                queryString + " and pr.teiA in (:uids) or pr.teiB in (:uids)" );
+                queryString + " and ( pr.teiA in (:uids) or pr.teiB in (:uids) )" );
 
             hibernateQuery.setParameterList( "uids", teis );
 
@@ -103,19 +103,6 @@ public class HibernatePotentialDuplicateStore
 
             return hibernateQuery.getResultList();
         } );
-    }
-
-    @Override
-    public List<PotentialDuplicate> getAllByTei( String tei, DeduplicationStatus status )
-    {
-        Query<PotentialDuplicate> query = getTypedQuery(
-            "from PotentialDuplicate pr where pr.status in (:status) and ( pr.teiA = :tei or pr.teiB = :tei )" );
-
-        query.setParameter( "tei", tei );
-
-        setStatusParameter( status, query );
-
-        return query.getResultList();
     }
 
     private void setStatusParameter( DeduplicationStatus status, Query<?> hibernateQuery )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceIntegrationTest.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.deduplication;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -126,18 +129,7 @@ public class DeduplicationServiceIntegrationTest
     }
 
     @Test
-    public void testGetPotentialDuplicateByTei()
-    {
-        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, teiB );
-        potentialDuplicate.setStatus( DeduplicationStatus.INVALID );
-        deduplicationService.addPotentialDuplicate( potentialDuplicate );
-
-        assertEquals( Collections.singletonList( potentialDuplicate ),
-            deduplicationService.getPotentialDuplicateByTei( teiA, DeduplicationStatus.INVALID ) );
-    }
-
-    @Test
-    public void testGetPotentialDuplicateByTeiDifferentStatus()
+    public void testGetPotentialDuplicateDifferentStatus()
     {
         PotentialDuplicate potentialDuplicate = new PotentialDuplicate( teiA, teiB );
         potentialDuplicate.setStatus( DeduplicationStatus.INVALID );
@@ -147,8 +139,12 @@ public class DeduplicationServiceIntegrationTest
         potentialDuplicate1.setStatus( DeduplicationStatus.MERGED );
         deduplicationService.addPotentialDuplicate( potentialDuplicate1 );
 
+        PotentialDuplicateQuery potentialDuplicateQuery = new PotentialDuplicateQuery();
+        potentialDuplicateQuery.setTeis( Collections.singletonList( teiB ) );
+        potentialDuplicateQuery.setStatus( DeduplicationStatus.INVALID );
+
         assertEquals( Collections.singletonList( potentialDuplicate ),
-            deduplicationService.getPotentialDuplicateByTei( teiB, DeduplicationStatus.INVALID ) );
+            deduplicationService.getAllPotentialDuplicatesBy( potentialDuplicateQuery ) );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeduplicationController.java
@@ -117,30 +117,6 @@ public class DeduplicationController
         return rootNode;
     }
 
-    @GetMapping( value = "/tei/{tei}" )
-    public List<PotentialDuplicate> getPotentialDuplicateByTei( @PathVariable String tei,
-        @RequestParam( value = "status", defaultValue = "ALL", required = false ) String status )
-        throws NotFoundException,
-        OperationNotAllowedException,
-        BadRequestException,
-        HttpStatusCodeException
-    {
-        canReadTei( tei );
-
-        checkDeduplicationStatusRequestParam( status );
-
-        List<PotentialDuplicate> potentialDuplicateList = deduplicationService.getPotentialDuplicateByTei( tei,
-            DeduplicationStatus.valueOf( status ) );
-
-        for ( PotentialDuplicate potentialDuplicate : potentialDuplicateList )
-        {
-            canReadTei( potentialDuplicate.getTeiA() );
-            canReadTei( potentialDuplicate.getTeiB() );
-        }
-
-        return potentialDuplicateList;
-    }
-
     @GetMapping( value = "/{id}" )
     public PotentialDuplicate getPotentialDuplicateById(
         @PathVariable String id )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.controller.DeduplicationController;
 import org.hisp.dhis.webapi.controller.exception.BadRequestException;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
-import org.hisp.dhis.webapi.controller.exception.OperationNotAllowedException;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.Before;
 import org.junit.Test;
@@ -240,84 +239,6 @@ public class DeduplicationControllerMvcTest
             .andExpect( content().contentType( "application/json" ) );
 
         verify( deduplicationService ).getPotentialDuplicateByUid( uid );
-    }
-
-    @Test
-    public void shouldGetPotentialDuplicateByTei()
-        throws Exception
-    {
-        String tei = "tei";
-
-        when( deduplicationService.getPotentialDuplicateByTei( eq( tei ), any() ) )
-            .thenReturn( Collections.singletonList( new PotentialDuplicate( teiA, teiB ) ) );
-
-        when( trackedEntityInstanceService.getTrackedEntityInstance( tei ) )
-            .thenReturn( new TrackedEntityInstance() );
-
-        mockMvc.perform( get( ENDPOINT + "/tei/" + tei ).param( "status", DeduplicationStatus.INVALID.name() )
-            .content( "{}" )
-            .contentType( MediaType.APPLICATION_JSON )
-            .accept( MediaType.APPLICATION_JSON ) )
-            .andExpect( status().isOk() )
-            .andExpect( content().contentType( "application/json" ) );
-
-        verify( deduplicationService ).getPotentialDuplicateByTei( tei, DeduplicationStatus.INVALID );
-    }
-
-    @Test
-    public void shouldThrowGetPotentialDuplicateByTeiWrongStatus()
-        throws Exception
-    {
-        String tei = "tei";
-
-        when( trackedEntityInstanceService.getTrackedEntityInstance( tei ) )
-            .thenReturn( new TrackedEntityInstance() );
-
-        mockMvc.perform( get( ENDPOINT + "/tei/" + tei ).param( "status", "wrong status" )
-            .content( "{}" )
-            .contentType( MediaType.APPLICATION_JSON )
-            .accept( MediaType.APPLICATION_JSON ) )
-            .andExpect( status().isBadRequest() )
-            .andExpect( result -> assertTrue( result.getResolvedException() instanceof BadRequestException ) );
-    }
-
-    @Test
-    public void shouldThrowGetPotentialDuplicateByTeiNotExistingTei()
-        throws Exception
-    {
-        String tei = "tei";
-
-        when( trackedEntityInstanceService.getTrackedEntityInstance( tei ) )
-            .thenReturn( null );
-
-        mockMvc.perform( get( ENDPOINT + "/tei/" + tei )
-            .content( "{}" )
-            .contentType( MediaType.APPLICATION_JSON )
-            .accept( MediaType.APPLICATION_JSON ) )
-            .andExpect( status().isNotFound() )
-            .andExpect( result -> assertTrue( result.getResolvedException() instanceof NotFoundException ) );
-    }
-
-    @Test
-    public void shouldThrowGetPotentialDuplicateByTeiMissingReadAccess()
-        throws Exception
-    {
-        String tei = "tei";
-
-        when( trackedEntityInstanceService.getTrackedEntityInstance( tei ) )
-            .thenReturn( new TrackedEntityInstance() );
-
-        when( trackerAccessManager.canRead( any(), any( TrackedEntityInstance.class ) ) )
-            .thenReturn( Collections.singletonList( "Read Error" ) );
-
-        mockMvc.perform( get( ENDPOINT + "/tei/" + tei )
-            .content( "{}" )
-            .contentType( MediaType.APPLICATION_JSON )
-            .accept( MediaType.APPLICATION_JSON ) )
-            .andExpect( status().isForbidden() )
-            .andExpect( result -> assertTrue( result.getResolvedException() instanceof OperationNotAllowedException ) );
-
-        verify( deduplicationService, times( 0 ) ).getPotentialDuplicateByTei( tei, DeduplicationStatus.ALL );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
@@ -32,9 +32,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Collections;
-import java.util.List;
-
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.deduplication.DeduplicationService;
@@ -152,31 +149,6 @@ public class DeduplicationControllerTest
 
         assertEquals( teiA, pd.getTeiA() );
         verify( deduplicationService ).getPotentialDuplicateByUid( uid );
-    }
-
-    @Test
-    public void getPotentialDuplicateByTei()
-        throws NotFoundException,
-        BadRequestException,
-        OperationNotAllowedException
-    {
-        when( deduplicationService.getPotentialDuplicateByTei( eq( teiA ), any() ) )
-            .thenReturn( Collections.singletonList( new PotentialDuplicate( teiA, teiB ) ) );
-
-        List<PotentialDuplicate> pd = deduplicationController.getPotentialDuplicateByTei( teiA,
-            DeduplicationStatus.INVALID.name() );
-
-        assertEquals( 1, pd.size() );
-        verify( deduplicationService ).getPotentialDuplicateByTei( teiA, DeduplicationStatus.INVALID );
-    }
-
-    @Test( expected = BadRequestException.class )
-    public void shouldThrowGetPotentialDuplicateByTeiMissingStatus()
-        throws NotFoundException,
-        BadRequestException,
-        OperationNotAllowedException
-    {
-        deduplicationController.getPotentialDuplicateByTei( teiA, null );
     }
 
     @Test


### PR DESCRIPTION
In potential duplicate, we don't need to filter by tei as a filter by a list of teis already exists, so can filter by a list of a single tei