### PR TITLE
fix: [DHIS2-11567] add caching layer when fetching program org unit associations (2.35.7)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/jdbc/JdbcProgramOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/jdbc/JdbcProgramOrgUnitAssociationsStore.java
@@ -30,13 +30,24 @@ package org.hisp.dhis.program.jdbc;
 import static java.util.stream.Collectors.joining;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
 
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.hisp.dhis.commons.util.SystemUtils;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -64,22 +75,70 @@ public class JdbcProgramOrgUnitAssociationsStore
 
     private final JdbcTemplate jdbcTemplate;
 
+    private final CacheProvider cacheProvider;
+
+    private final Environment env;
+
+    private Cache<Set<String>> programOrgUnitAssociationCache;
+
+    @PostConstruct
+    public void init()
+    {
+        programOrgUnitAssociationCache = cacheProvider.newCacheBuilderForSet( String.class )
+            .forRegion( "pgmOrgUnitAssocCache" )
+            .expireAfterWrite( 1, TimeUnit.HOURS )
+            .withInitialCapacity( 100 )
+            .withMaximumSize( SystemUtils.isTestRun( env.getActiveProfiles() ) ? 0 : 1000 )
+            .build();
+    }
+
+    @EventListener
+    public void handleApplicationCachesCleared( ApplicationCacheClearedEvent event )
+    {
+        programOrgUnitAssociationCache.invalidateAll();
+    }
+
     public SetValuedMap<String, String> getOrganisationUnitsAssociations( Set<String> uids )
     {
+        SetValuedMap<String, String> setValuedMap = new HashSetValuedHashMap<String, String>();
+        boolean cached = true;
+        for ( String uid : uids )
+        {
+            Optional<Set<String>> orgUnitUids = programOrgUnitAssociationCache.get( uid );
+            if ( !orgUnitUids.isPresent() )
+            {
+                cached = false;
+                break;
+            }
+            else
+            {
+                setValuedMap.putAll( uid, orgUnitUids.get() );
+            }
+        }
 
-        return jdbcTemplate.query(
-            buildSqlQueryForRawAssociation( uids ),
-            resultSet -> {
-                SetValuedMap<String, String> setValuedMap = new HashSetValuedHashMap<String, String>();
-                while ( resultSet.next() )
-                {
-                    setValuedMap.putAll(
-                        resultSet.getString( 1 ),
-                        Arrays.asList( (String[]) resultSet.getArray( 2 ).getArray() ) );
+        if ( cached )
+        {
+            return setValuedMap;
+        }
+        else
+        {
+            setValuedMap.clear();
+            jdbcTemplate.query(
+                buildSqlQueryForRawAssociation( uids ),
+                resultSet -> {
+                    while ( resultSet.next() )
+                    {
+                        setValuedMap.putAll(
+                            resultSet.getString( 1 ),
+                            Arrays.asList( (String[]) resultSet.getArray( 2 ).getArray() ) );
+                        programOrgUnitAssociationCache.put( resultSet.getString( 1 ),
+                            new HashSet<String>( setValuedMap.get( resultSet.getString( 1 ) ) ) );
+                    }
+                    return setValuedMap;
+                } );
 
-                }
-                return setValuedMap;
-            } );
+            return setValuedMap;
+        }
     }
 
     private String buildSqlQueryForRawAssociation( Set<String> uids )

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.cache;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Provides cache builder to build instances.
@@ -55,4 +56,16 @@ public interface CacheProvider
      *         {@link ExtendedCacheBuilder}.
      */
     <K, V> ExtendedCacheBuilder<Map<K, V>> newCacheBuilder( Class<K> keyType, Class<V> valueType );
+
+    /**
+     * Creates a new {@link ExtendedCacheBuilder} that can be used to build a
+     * cache that stores the Map of keyType and value is a Set holding items of
+     * the specified valueType.
+     *
+     * @param valueType The class type of the individual items in the value set
+     *        to be stored in cache.
+     * @return A cache builder instance for the specified value type. Returns a
+     *         {@link ExtendedCacheBuilder}.
+     */
+    <V> ExtendedCacheBuilder<Set<V>> newCacheBuilderForSet( Class<V> valueType );
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.cache;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +59,12 @@ public class DefaultCacheProvider implements CacheProvider
     public <K, V> ExtendedCacheBuilder<Map<K, V>> newCacheBuilder( Class<K> keyType, Class<V> valueType )
     {
         return new ExtendedCacheBuilder<Map<K, V>>( redisTemplate, configurationProvider );
+    }
+
+    @Override
+    public <V> ExtendedCacheBuilder<Set<V>> newCacheBuilderForSet( Class<V> valueType )
+    {
+        return new ExtendedCacheBuilder<Set<V>>( redisTemplate, configurationProvider );
     }
 
     @Autowired


### PR DESCRIPTION
Add a cache to store program org unit associations fetched via jdbc. 
At the moment this method is only used when **adding an enrollment**, to check whether the program to which enrollment is created has the enrollment org unit assigned to it. 