### PR TITLE
feat: adds automatic user account disable reminder email [DHIS2-11589]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DisableInactiveUsersJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DisableInactiveUsersJobParameters.java
@@ -51,6 +51,8 @@ public class DisableInactiveUsersJobParameters implements JobParameters
 
     private int inactiveMonths;
 
+    private Integer reminderDaysBefore;
+
     public DisableInactiveUsersJobParameters()
     {
 
@@ -73,6 +75,18 @@ public class DisableInactiveUsersJobParameters implements JobParameters
         this.inactiveMonths = inactiveMonths;
     }
 
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getReminderDaysBefore()
+    {
+        return reminderDaysBefore;
+    }
+
+    public void setReminderDaysBefore( Integer reminderDaysBefore )
+    {
+        this.reminderDaysBefore = reminderDaysBefore;
+    }
+
     @Override
     public Optional<ErrorReport> validate()
     {
@@ -80,6 +94,11 @@ public class DisableInactiveUsersJobParameters implements JobParameters
         {
             return Optional.of(
                 new ErrorReport( getClass(), ErrorCode.E4008, "inactiveMonths", 1, 24, inactiveMonths ) );
+        }
+        if ( reminderDaysBefore != null && reminderDaysBefore < 1 || reminderDaysBefore > 24 )
+        {
+            return Optional.of(
+                new ErrorReport( getClass(), ErrorCode.E4008, "reminderDaysBefore", 1, 24, reminderDaysBefore ) );
         }
         return Optional.empty();
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DisableInactiveUsersJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DisableInactiveUsersJobParameters.java
@@ -95,7 +95,7 @@ public class DisableInactiveUsersJobParameters implements JobParameters
             return Optional.of(
                 new ErrorReport( getClass(), ErrorCode.E4008, "inactiveMonths", 1, 24, inactiveMonths ) );
         }
-        if ( reminderDaysBefore != null && reminderDaysBefore < 1 || reminderDaysBefore > 24 )
+        if ( reminderDaysBefore != null && (reminderDaysBefore < 1 || reminderDaysBefore > 24) )
         {
             return Optional.of(
                 new ErrorReport( getClass(), ErrorCode.E4008, "reminderDaysBefore", 1, 24, reminderDaysBefore ) );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.user;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -465,6 +466,22 @@ public interface UserService
      * @return number of users disabled
      */
     int disableUsersInactiveSince( Date inactiveSince );
+
+    /**
+     * Selects all users where the {@link UserCredentials#getLastLogin()} is
+     * before or equal to the provided pivot {@link Date}.
+     *
+     * Does a comparable query to {@link #disableUsersInactiveSince(Date)} but
+     * instead of disabling the found uses it returns them (without making a
+     * change).
+     *
+     * @see #disableUsersInactiveSince(Date)
+     *
+     * @param inactiveSince the most recent point in time that is considered *
+     *        inactive together with accounts only active further in the past.
+     * @return user emails that were inactive since the provided date
+     */
+    Set<String> findUsersInactiveSince( Date inactiveSince );
 
     /**
      * Get user display name by concat( firstname,' ', surname ) Return null if

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.user;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -114,6 +115,22 @@ public interface UserStore
      * @return number of users disabled
      */
     int disableUsersInactiveSince( Date inactiveSince );
+
+    /**
+     * Selects all users where the {@link UserCredentials#getLastLogin()} is
+     * before or equal to the provided pivot {@link Date}.
+     *
+     * Does a comparable query to {@link #disableUsersInactiveSince(Date)} but
+     * instead of disabling the found uses it returns them (without making a
+     * change).
+     *
+     * @see #disableUsersInactiveSince(Date)
+     *
+     * @param inactiveSince the most recent point in time that is considered *
+     *        inactive together with accounts only active further in the past.
+     * @return user emails that were inactive at least since the provided date
+     */
+    Set<String> findUsersInactiveSince( Date inactiveSince );
 
     String getDisplayName( String userUid );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -40,6 +40,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -814,6 +815,13 @@ public class DefaultUserService
             return 0;
         }
         return userStore.disableUsersInactiveSince( inactiveSince );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public Set<String> findUsersInactiveSince( Date inactiveSince )
+    {
+        return userStore.findUsersInactiveSince( inactiveSince );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.user.hibernate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -568,6 +569,17 @@ public class HibernateUserStore
             builder.lessThanOrEqualTo( uc.get( "lastLogin" ), inactiveSince ) ) );
         update.set( DISABLED_COLUMN, true );
         return getSession().createQuery( update ).executeUpdate();
+    }
+
+    @Override
+    public Set<String> findUsersInactiveSince( Date inactiveSince )
+    {
+        String hql = "select u.email " +
+            "from User u inner join u.userCredentials uc " +
+            "where u.email is not null and uc.disabled = false and uc.lastLogin <= :since";
+        return getSession().createQuery( hql, String.class )
+            .setParameter( "since", inactiveSince ).stream()
+            .collect( toSet() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -31,9 +31,11 @@ import static java.time.ZoneId.systemDefault;
 
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.Set;
 
 import lombok.AllArgsConstructor;
 
+import org.hisp.dhis.email.EmailService;
 import org.hisp.dhis.scheduling.AbstractJob;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
@@ -53,6 +55,8 @@ public class DisableInactiveUsersJob extends AbstractJob
 
     private final Notifier notifier;
 
+    private final EmailService emailService;
+
     @Override
     public JobType getJobType()
     {
@@ -70,5 +74,24 @@ public class DisableInactiveUsersJob extends AbstractJob
         int disabledUserCount = userService.disableUsersInactiveSince( nMonthsAgo );
         notifier.notify( jobConfiguration, String.format( "Disabled %d users with %d months of inactivity",
             disabledUserCount, parameters.getInactiveMonths() ) );
+
+        Integer reminderDaysBefore = parameters.getReminderDaysBefore();
+        if ( reminderDaysBefore == null )
+        {
+            return; // done
+        }
+        since = since.plusDays( reminderDaysBefore );
+        Date nDaysPriorToDisabling = Date.from( since.atStartOfDay( systemDefault() ).toInstant() );
+        Set<String> receivers = userService.findUsersInactiveSince( nDaysPriorToDisabling );
+        if ( !receivers.isEmpty() )
+        {
+            emailService.sendEmail(
+                "Your DHIS2 account gets disabled soon",
+                String.format(
+                    "Your DHIS2 user account was inactive for a while. " +
+                        "Login during the next %d days to prevent your account from being disabled.",
+                    reminderDaysBefore - 1 ),
+                receivers );
+        }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -395,6 +396,12 @@ public class MockUserService
     public int disableUsersInactiveSince( Date inactiveSince )
     {
         throw new UnsupportedOperationException( "Not supported by this mock!" );
+    }
+
+    @Override
+    public Set<String> findUsersInactiveSince( Date inactiveSince )
+    {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
### Summary
PR adds a job parameter to the _disable inactive users_ job. The parameter allows to specify the number of days before disabling a user a reminder email should be send to remind or make the user aware that disabling would happen unless he logs into the account.

The new parameter is optional. If it is not set no reminder emails are send.
The number of days should be between 1 and 24 days. I just chose this because minimum for inactive in month is 1. So a maximum of 4 weeks in advance seems reasonable. 1 days minimum is almost unreasonable but if someone wants it to be that close it is technically possible. 

In some sense this is an extension to #7307

The target emails to remind are selected in a single dedicated query. Users that do not have an email configured cannot get notified before the account gets disabled.

### Automatic Testing
Added tests for the database query and service layer.
The full feature needs manual testing.

### Manual Testing
1. Create a user with last login being in the past and an email set you can check. For a inactivity of 1 month user should be inactive since about 4 weeks (`lastLogin` needs be about 4 weeks ago). 
2. go to scheduler app
3. add a _Disable Inactive Users_ job. Set _Reminder days before_ to 14 days or so to be on save side.
4. run the job manually
5. check the email was send but user is not yet disabled (again make sure `lastLogin` is not so far in the past user gets disabled right away when running the job)

### Documentation
https://github.com/dhis2/dhis2-docs/pull/802