### PR TITLE
fix: update CascadeSharingReport variable name

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sharing/CascadeSharingReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sharing/CascadeSharingReport.java
@@ -58,7 +58,7 @@ public class CascadeSharingReport
      * Number of DashboardItem updated for cascade sharing
      */
     @JsonProperty
-    private int countUpdatedDashBoardItems = 0;
+    private int countUpdatedDashboardItems = 0;
 
     /**
      * Map contains objects that will be updated for cascade sharing.
@@ -85,7 +85,7 @@ public class CascadeSharingReport
 
     public void incUpdatedDashboardItem()
     {
-        countUpdatedDashBoardItems++;
+        countUpdatedDashboardItems++;
     }
 
     public boolean hasErrors()


### PR DESCRIPTION
A feedback from front-end to change variable name from `countUpdatedDashBoardItems ` to `countUpdatedDashboardItems`