### PR TITLE
feat: system job to send account expiry alert emails [DHIS2-11589]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -102,6 +102,7 @@ public enum JobType
     TEI_IMPORT( false ),
     DISABLE_INACTIVE_USERS( true, SchedulingType.CRON,
         DisableInactiveUsersJobParameters.class, null ),
+    ACCOUNT_EXPIRY_ALERT( false ),
 
     // Testing purposes
     MOCK( false, SchedulingType.CRON, MockJobParameters.class, null ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountExpiryInfo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountExpiryInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Bean used when finding user accounts that are soon to expire.
+ *
+ * @author Jan Bernitt
+ */
+@Getter
+@AllArgsConstructor
+public final class UserAccountExpiryInfo
+{
+    private final String username;
+
+    private final String email;
+
+    private final Date accountExpiry;
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -437,6 +437,13 @@ public interface UserService
      */
     List<User> getExpiringUsers();
 
+    /**
+     * @param inDays number of days to include
+     * @return list of those users that are about to expire in the provided
+     *         number of days (or less) and which have an email configured
+     */
+    List<UserAccountExpiryInfo> getExpiringUserAccounts( int inDays );
+
     void set2FA( User user, Boolean twoFA );
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -80,6 +80,13 @@ public interface UserStore
     List<User> getExpiringUsers( UserQueryParams userQueryParams );
 
     /**
+     * @param inDays number of days to include
+     * @return list of those users that are about to expire in the provided
+     *         number of days (or less) and which have an email configured
+     */
+    List<UserAccountExpiryInfo> getExpiringUserAccounts( int inDays );
+
+    /**
      * Returns UserCredentials for given username.
      *
      * @param username username for which the UserCredentials will be returned

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/CodeGeneratorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/CodeGeneratorTest.java
@@ -59,7 +59,6 @@ public class CodeGeneratorTest
             // Test uniqueness
             assertTrue( codes.add( code ) );
         }
-        System.out.println( CodeGenerator.generateUid() );
     }
 
     @Test

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/CodeGeneratorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/CodeGeneratorTest.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.common;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -56,6 +59,7 @@ public class CodeGeneratorTest
             // Test uniqueness
             assertTrue( codes.add( code ) );
         }
+        System.out.println( CodeGenerator.generateUid() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.startup;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.scheduling.JobStatus.FAILED;
 import static org.hisp.dhis.scheduling.JobStatus.SCHEDULED;
+import static org.hisp.dhis.scheduling.JobType.ACCOUNT_EXPIRY_ALERT;
 import static org.hisp.dhis.scheduling.JobType.CREDENTIALS_EXPIRY_ALERT;
 import static org.hisp.dhis.scheduling.JobType.DATA_SET_NOTIFICATION;
 import static org.hisp.dhis.scheduling.JobType.DATA_STATISTICS;
@@ -63,39 +64,43 @@ import org.hisp.dhis.system.startup.AbstractStartupRoutine;
 @Slf4j
 public class SchedulerStart extends AbstractStartupRoutine
 {
-    private final String CRON_DAILY_2AM = "0 0 2 ? * *";
+    private static final String CRON_DAILY_2AM = "0 0 2 ? * *";
 
-    private final String CRON_DAILY_7AM = "0 0 7 ? * *";
+    private static final String CRON_DAILY_7AM = "0 0 7 ? * *";
 
-    private final String LEADER_JOB_CRON_FORMAT = "0 0/%s * * * *";
+    private static final String LEADER_JOB_CRON_FORMAT = "0 0/%s * * * *";
 
-    private final String DEFAULT_FILE_RESOURCE_CLEANUP_UID = "pd6O228pqr0";
+    private static final String DEFAULT_FILE_RESOURCE_CLEANUP_UID = "pd6O228pqr0";
 
-    private final String DEFAULT_FILE_RESOURCE_CLEANUP = "File resource clean up";
+    private static final String DEFAULT_FILE_RESOURCE_CLEANUP = "File resource clean up";
 
-    private final String DEFAULT_DATA_STATISTICS_UID = "BFa3jDsbtdO";
+    private static final String DEFAULT_DATA_STATISTICS_UID = "BFa3jDsbtdO";
 
-    private final String DEFAULT_DATA_STATISTICS = "Data statistics";
+    private static final String DEFAULT_DATA_STATISTICS = "Data statistics";
 
-    private final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION_UID = "Js3vHn2AVuG";
+    private static final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION_UID = "Js3vHn2AVuG";
 
-    private final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION = "Validation result notification";
+    private static final String DEFAULT_VALIDATION_RESULTS_NOTIFICATION = "Validation result notification";
 
-    private final String DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID = "sHMedQF7VYa";
+    private static final String DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID = "sHMedQF7VYa";
 
-    private final String DEFAULT_CREDENTIALS_EXPIRY_ALERT = "Credentials expiry alert";
+    private static final String DEFAULT_CREDENTIALS_EXPIRY_ALERT = "Credentials expiry alert";
 
-    private final String DEFAULT_DATA_SET_NOTIFICATION_UID = "YvAwAmrqAtN";
+    private static final String DEFAULT_DATA_SET_NOTIFICATION_UID = "YvAwAmrqAtN";
 
-    private final String DEFAULT_DATA_SET_NOTIFICATION = "Dataset notification";
+    private static final String DEFAULT_DATA_SET_NOTIFICATION = "Dataset notification";
 
-    private final String DEFAULT_REMOVE_EXPIRED_OR_USED_RESERVED_VALUES_UID = "uwWCT2BMmlq";
+    private static final String DEFAULT_REMOVE_EXPIRED_OR_USED_RESERVED_VALUES_UID = "uwWCT2BMmlq";
 
-    private final String DEFAULT_REMOVE_EXPIRED_OR_USED_RESERVED_VALUES = "Remove expired or used reserved values";
+    private static final String DEFAULT_REMOVE_EXPIRED_OR_USED_RESERVED_VALUES = "Remove expired or used reserved values";
 
-    private final String DEFAULT_LEADER_ELECTION_UID = "MoUd5BTQ3lY";
+    private static final String DEFAULT_LEADER_ELECTION_UID = "MoUd5BTQ3lY";
 
-    private final String DEFAULT_LEADER_ELECTION = "Leader election in cluster";
+    private static final String DEFAULT_LEADER_ELECTION = "Leader election in cluster";
+
+    private static final String DEFAULT_ACCOUNT_EXPIRY_ALERT_UID = "fUWM1At1TUx";
+
+    private static final String DEFAULT_ACCOUNT_EXPIRY_ALERT = "User account expiry alert";
 
     private final SystemSettingManager systemSettingManager;
 
@@ -212,6 +217,15 @@ public class SchedulerStart extends AbstractStartupRoutine
             credentialsExpiryAlert.setLeaderOnlyJob( true );
             credentialsExpiryAlert.setUid( DEFAULT_CREDENTIALS_EXPIRY_ALERT_UID );
             addAndScheduleJob( credentialsExpiryAlert );
+        }
+
+        if ( verifyNoJobExist( DEFAULT_ACCOUNT_EXPIRY_ALERT, jobConfigurations ) )
+        {
+            JobConfiguration accountExpiryAlert = new JobConfiguration( DEFAULT_ACCOUNT_EXPIRY_ALERT,
+                ACCOUNT_EXPIRY_ALERT, CRON_DAILY_2AM, null );
+            accountExpiryAlert.setLeaderOnlyJob( true );
+            accountExpiryAlert.setUid( DEFAULT_ACCOUNT_EXPIRY_ALERT_UID );
+            addAndScheduleJob( accountExpiryAlert );
         }
 
         if ( verifyNoJobExist( DEFAULT_DATA_SET_NOTIFICATION, jobConfigurations ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -788,6 +788,12 @@ public class DefaultUserService
     }
 
     @Override
+    public List<UserAccountExpiryInfo> getExpiringUserAccounts( int inDays )
+    {
+        return userStore.getExpiringUserAccounts( inDays );
+    }
+
+    @Override
     @Transactional
     public void set2FA( User user, Boolean twoFa )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.job;
+
+import static java.lang.String.format;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.scheduling.AbstractJob;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.UserAccountExpiryInfo;
+import org.hisp.dhis.user.UserCredentials;
+import org.hisp.dhis.user.UserService;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sends an email alert to all users that are soon to expire due to an account
+ * expire date being set in {@link UserCredentials#getAccountExpiry()} that is
+ * within the next {@link SettingKey#ACCOUNT_EXPIRES_IN_DAYS} interval.
+ *
+ * The job only works when enabled via {@link SettingKey#ACCOUNT_EXPIRY_ALERT}.
+ *
+ * @author Jan Bernitt
+ */
+@Slf4j
+@Component
+@AllArgsConstructor
+public class AccountExpiryAlertJob extends AbstractJob
+{
+    @Override
+    public JobType getJobType()
+    {
+        return JobType.ACCOUNT_EXPIRY_ALERT;
+    }
+
+    private final UserService userService;
+
+    private final MessageSender emailMessageSender;
+
+    private final SystemSettingManager systemSettingManager;
+
+    @Override
+    public ErrorReport validate()
+    {
+        if ( !emailMessageSender.isConfigured() )
+        {
+            return new ErrorReport( AccountExpiryAlertJob.class, ErrorCode.E7010,
+                "EMAIL gateway configuration does not exist" );
+        }
+        return null;
+    }
+
+    @Override
+    public void execute( JobConfiguration jobConfiguration )
+    {
+        if ( systemSettingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRY_ALERT, Boolean.class ) == Boolean.FALSE )
+        {
+            log.info( format( "%s aborted. Expiry alerts are disabled", getJobType().name() ) );
+            return;
+        }
+
+        log.info( format( "%s has started", getJobType().name() ) );
+        Integer inDays = systemSettingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRES_IN_DAYS, Integer.class );
+        List<UserAccountExpiryInfo> soonExpiring = userService.getExpiringUserAccounts( inDays );
+
+        if ( soonExpiring.isEmpty() )
+        {
+            return;
+        }
+
+        log.info( format( "%d user accounts expire within next %d days", soonExpiring.size(), inDays ) );
+        int notified = 0;
+        int failed = 0;
+        for ( UserAccountExpiryInfo user : soonExpiring )
+        {
+            try
+            {
+                emailMessageSender.sendMessage( "Account Expiry Alert",
+                    format( "Dear %s, your account is about to expire on %2$tY-%2$tm-%2$te. "
+                        + "If your use of the account needs to continue, get in touch with your system administrator.",
+                        user.getUsername(), user.getAccountExpiry() ),
+                    user.getEmail() );
+                notified++;
+            }
+            catch ( Exception ex )
+            {
+                log.debug( ex.getMessage(), ex );
+                failed++;
+            }
+        }
+        log.info( format( "%d user accounts have been notified about their expiring accounts", notified ) );
+        if ( failed > 0 )
+        {
+            log.warn( format(
+                "%d user accounts were not notified about their expiring accounts due to errors while sending the email",
+                failed ) );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -592,6 +592,35 @@ public class UserServiceTest
     }
 
     @Test
+    public void testGetExpiringUserAccounts()
+    {
+        ZonedDateTime now = ZonedDateTime.now();
+        Date inFiveDays = Date.from( now.plusDays( 5 ).toInstant() );
+        Date inSixDays = Date.from( now.plusDays( 6 ).toInstant() );
+        Date inEightDays = Date.from( now.plusDays( 8 ).toInstant() );
+        User userA = addUser( 'A' );
+        addUser( 'B', UserCredentials::setAccountExpiry, inFiveDays );
+        User userC = addUser( 'C' );
+        addUser( 'D', UserCredentials::setAccountExpiry, inSixDays );
+        addUser( 'E', UserCredentials::setAccountExpiry, inEightDays );
+
+        List<UserAccountExpiryInfo> soonExpiringAccounts = userService.getExpiringUserAccounts( 7 );
+        Set<String> soonExpiringAccountNames = soonExpiringAccounts.stream()
+            .map( UserAccountExpiryInfo::getUsername ).collect( toSet() );
+        assertEquals( new HashSet<>( asList( "UsernameB", "UsernameD" ) ), soonExpiringAccountNames );
+
+        soonExpiringAccounts = userService.getExpiringUserAccounts( 9 );
+        soonExpiringAccountNames = soonExpiringAccounts.stream()
+            .map( UserAccountExpiryInfo::getUsername ).collect( toSet() );
+        assertEquals( new HashSet<>( asList( "UsernameB", "UsernameD", "UsernameE" ) ), soonExpiringAccountNames );
+
+        for ( UserAccountExpiryInfo expiryInfo : soonExpiringAccounts )
+        {
+            assertEquals( expiryInfo.getUsername().replace( "Username", "Email" ), expiryInfo.getEmail() );
+        }
+    }
+
+    @Test
     public void testDisableUsersInactiveSince()
     {
         ZonedDateTime now = ZonedDateTime.now();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.job;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Date;
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.UserAccountExpiryInfo;
+import org.hisp.dhis.user.UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Tests the {@link AccountExpiryAlertJob} using mocks to only test the logic of
+ * the job.
+ *
+ * @author Jan Bernitt
+ */
+public class AccountExpiryAlertJobTest
+{
+
+    private final UserService userService = mock( UserService.class );
+
+    private final MessageSender messageSender = mock( MessageSender.class );
+
+    private final SystemSettingManager settingManager = mock( SystemSettingManager.class );
+
+    private final AccountExpiryAlertJob job = new AccountExpiryAlertJob( userService, messageSender, settingManager );
+
+    @Before
+    public void setUp()
+    {
+        // mock normal run conditions
+        when( settingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRY_ALERT, Boolean.class ) ).thenReturn( true );
+        when( settingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRES_IN_DAYS, Integer.class ) ).thenReturn( 7 );
+    }
+
+    @Test
+    public void testDisabledJobDoesNotExecute()
+    {
+        when( settingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRY_ALERT, Boolean.class ) ).thenReturn( false );
+
+        job.execute( new JobConfiguration() );
+
+        verify( userService, never() ).getExpiringUserAccounts( anyInt() );
+    }
+
+    @Test
+    public void testEnabledJobSendsEmail()
+    {
+        when( userService.getExpiringUserAccounts( anyInt() ) )
+            .thenReturn( singletonList( new UserAccountExpiryInfo( "username", "email@example.com",
+                Date.valueOf( "2021-08-23" ) ) ) );
+
+        job.execute( new JobConfiguration() );
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass( String.class );
+        ArgumentCaptor<String> text = ArgumentCaptor.forClass( String.class );
+        ArgumentCaptor<String> recipient = ArgumentCaptor.forClass( String.class );
+        verify( messageSender ).sendMessage( subject.capture(), text.capture(), recipient.capture() );
+        assertEquals( "Account Expiry Alert", subject.getValue() );
+        assertEquals(
+            "Dear username, your account is about to expire on 2021-08-23. If your use of the account needs to continue, get in touch with your system administrator.",
+            text.getValue() );
+        assertEquals( "email@example.com", recipient.getValue() );
+    }
+
+    @Test
+    public void testValidate()
+    {
+        when( messageSender.isConfigured() ).thenReturn( true );
+
+        assertNull( job.validate() );
+    }
+
+    @Test
+    public void testValidate_Error()
+    {
+        when( messageSender.isConfigured() ).thenReturn( false );
+
+        ErrorReport report = job.validate();
+        assertEquals( ErrorCode.E7010, report.getErrorCode() );
+        assertEquals( "Failed to validate job runtime: `EMAIL gateway configuration does not exist`",
+            report.getMessage() );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -95,6 +95,8 @@ public enum SettingKey
     GOOGLE_ANALYTICS_UA( "googleAnalyticsUA" ),
     CREDENTIALS_EXPIRES( "credentialsExpires", 0, Integer.class ),
     CREDENTIALS_EXPIRY_ALERT( "credentialsExpiryAlert", false, Boolean.class ),
+    ACCOUNT_EXPIRES_IN_DAYS( "accountExpiresInDays", 7, Integer.class ),
+    ACCOUNT_EXPIRY_ALERT( "accountExpiryAlert", false, Boolean.class ),
     SELF_REGISTRATION_NO_RECAPTCHA( "keySelfRegistrationNoRecaptcha", Boolean.FALSE, Boolean.class ),
     RECAPTCHA_SECRET( "recaptchaSecret", "6LcVwT0UAAAAAAtMWnPoerWwLx_DSwrcEncHCiWu", String.class, true, false ),
     RECAPTCHA_SITE( "recaptchaSite", "6LcVwT0UAAAAAAkO_EGPiYOiymIszZUeHfqWIYX5", String.class, true, false ),

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSettingManager.java
@@ -75,6 +75,11 @@ public interface SystemSettingManager
      */
     Serializable getSystemSetting( SettingKey key );
 
+    default <T extends Serializable> T getSystemSetting( SettingKey key, Class<T> as )
+    {
+        return as.cast( getSystemSetting( key ) );
+    }
+
     /**
      * Returns the system setting value for the given key. If no value exists,
      * returns the default value as defined by the given default value.

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAccountExpiryInfo;
 import org.hisp.dhis.user.UserAuthorityGroup;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserQueryParams;
@@ -365,6 +366,12 @@ public class MockUserService
 
     @Override
     public List<User> getExpiringUsers()
+    {
+        return null;
+    }
+
+    @Override
+    public List<UserAccountExpiryInfo> getExpiringUserAccounts( int inDays )
     {
         return null;
     }


### PR DESCRIPTION
### Summary
Adds a system job that sends an account expiry alert to those users that
* have an email address 
* have an expiry date set that is within the next N days
* are not disabled

The number of days can be configured through a new system setting `ACCOUNT_EXPIRES_IN_DAYS`. 
The job needs to be enabled through another new system setting `ACCOUNT_EXPIRY_ALERT`.

### Automatic Testing
The database query to find affected users is tested with service level tests.
The job is tested with mock tests.

### Manual Testing
* set an expiry date within next 7 days for your test user which should have an email you receive
* enable the system job `ACCOUNT_EXPIRY_ALERT` (key `accountExpiryAlert`) to `true`
* make sure email gateway is configured
* wait 24h so the job can run over night
* check that the you got mail

For completeness one would naturally have to run scenarios with other users that have no expiry date, one further in the future, or one just a day ahead. I don't think this is necessary though since I tested this in automatic testing. If a expiring user is notified I am quite certain the feature works as intended.

### Documentation
https://github.com/dhis2/dhis2-docs/pull/802