### PR TITLE
fix: Hibernate-compatible clone DHIS2-10551

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.beanutils.BeanUtils;
 import org.hisp.dhis.category.*;
 import org.hisp.dhis.common.*;
 import org.hisp.dhis.commons.collection.UniqueArrayList;
@@ -629,7 +629,14 @@ public class DefaultDimensionService
     {
         if ( id.getPeriodOffset() != 0 )
         {
-            return SerializationUtils.clone( item );
+            try
+            {
+                return (BaseDimensionalItemObject) BeanUtils.cloneBean( item );
+            }
+            catch ( Exception e )
+            {
+                return null;
+            }
         }
 
         return item;


### PR DESCRIPTION
[PR 7423](https://github.com/dhis2/dhis2-core/pull/7423) for Jira [DHIS2-10551: Indicator .periodOffset() doesn't work for multiple offsets](https://jira.dhis2.org/browse/DHIS2-10551) used `SerializationUtils.clone()` to copy a `BaseDimensionalItemObject`. Unfortunately, that copied some Hibernate lazy initialization collections such that the copy subsequently returned a lazy initialization exception when referencing them. The JUnit tests worked, but the instance did not.

After much Internet searching about how to safely clone a Hibernate object, I came across `BeanUtils.cloneBean()`, which uses the Java bean getters and setters to make the copy, thus invoking the Hibernate initializers and avoiding the subsequent lazy initialization exception. I've well-tested the instance and it works.