### PR TITLE
docs(apps): fix feature toggling apps index table

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/README.md
+++ b/dhis-2/dhis-web/dhis-web-apps/README.md
@@ -3,7 +3,7 @@
 The following shows the mapping of app repos to the DHIS2 versions that use the `master` branch of the app (feature toggling)
 
 |app repository|2.29|2.30|2.31|2.32|2.33|2.34|2.35|2.36|2.37|
-|---|---|---|---|---|---|---|---|---|
+|---|---|---|---|---|---|---|---|---|---|
 |git@github.com:dhis2/approval-app.git|n/a|n/a|n/a|n/a|n/a|n/a|n/a|n/a|master|
 |git@github.com:dhis2/cache-cleaner-app.git|n/a|n/a|2.31|2.32|2.33|2.34|master|master|master|
 |git@github.com:dhis2/core-resource-app.git|master|master|2.31|2.32|master|DELETED|DELETED|DELETED|DELETED|


### PR DESCRIPTION
The feature toggling apps index is [currently not being rendered as a table](https://github.com/dhis2/dhis2-core/blob/921becda76d4dba7b46003e227606c4b9434fbdc/dhis-2/dhis-web/dhis-web-apps/README.md) due to a missing column.