### PR TITLE
DHIS2-11396 - Deduplication: Manual Merging

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationMergeParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationMergeParams.java
@@ -34,7 +34,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 
 @Data
 @Builder
-public class DeduplicationMergeRequest
+public class DeduplicationMergeParams
 {
     private TrackedEntityInstance original;
 
@@ -42,5 +42,5 @@ public class DeduplicationMergeRequest
 
     private MergeObject mergeObject;
 
-    private String potentialDuplicateUid;
+    private PotentialDuplicate potentialDuplicate;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/DeduplicationService.java
@@ -47,7 +47,7 @@ public interface DeduplicationService
 
     void updatePotentialDuplicate( PotentialDuplicate potentialDuplicate );
 
-    void autoMerge( DeduplicationMergeRequest deduplicationRequest );
+    void autoMerge( DeduplicationMergeParams deduplicationRequest );
 
-    void manualMerge( DeduplicationMergeRequest deduplicationRequest );
+    void manualMerge( DeduplicationMergeParams deduplicationRequest );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
@@ -57,6 +57,11 @@ public class DeduplicationHelper
 
     private final OrganisationUnitService organisationUnitService;
 
+    public boolean hasInvalidReferences( DeduplicationMergeParams params )
+    {
+        return false;
+    }
+
     public MergeObject generateMergeObject( TrackedEntityInstance original, TrackedEntityInstance duplicate )
     {
         return null;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
@@ -83,11 +83,9 @@ public class DeduplicationServiceTest
     @Mock
     private CurrentUserService currentUserService;
 
-    private DeduplicationMergeRequest deduplicationMergeRequest;
+    private DeduplicationMergeParams deduplicationMergeParams;
 
     private PotentialDuplicate potentialDuplicate;
-
-    private static final String potentialDuplicateId = "uid";
 
     private static final String sexUid = "sexAttributUid";
 
@@ -106,7 +104,7 @@ public class DeduplicationServiceTest
     {
         potentialDuplicate = new PotentialDuplicate( "original", "duplicate" );
 
-        deduplicationMergeRequest = DeduplicationMergeRequest.builder().potentialDuplicateUid( potentialDuplicateId )
+        deduplicationMergeParams = DeduplicationMergeParams.builder().potentialDuplicate( potentialDuplicate )
             .original( trackedEntityInstanceA ).duplicate( trackedEntityInstanceB )
             .mergeObject( MergeObject.builder().build() ).build();
 
@@ -180,10 +178,7 @@ public class DeduplicationServiceTest
         when( deduplicationHelper.generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB ) )
             .thenReturn( mergeObject );
 
-        when( deduplicationService.getPotentialDuplicateByUid( deduplicationMergeRequest.getPotentialDuplicateUid() ) )
-            .thenReturn( potentialDuplicate );
-
-        deduplicationService.autoMerge( deduplicationMergeRequest );
+        deduplicationService.autoMerge( deduplicationMergeParams );
 
         verify( deduplicationHelper ).hasUserAccess( trackedEntityInstanceA, trackedEntityInstanceB, mergeObject );
         verify( deduplicationHelper ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
@@ -209,7 +204,7 @@ public class DeduplicationServiceTest
 
         assertThrows(
             PotentialDuplicateConflictException.class,
-            () -> deduplicationService.autoMerge( deduplicationMergeRequest ) );
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
         verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
@@ -222,13 +217,13 @@ public class DeduplicationServiceTest
         when( trackedEntityInstanceA.isDeleted() ).thenReturn( true );
 
         assertThrows( PotentialDuplicateConflictException.class,
-            () -> deduplicationService.autoMerge( deduplicationMergeRequest ) );
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         when( trackedEntityInstanceA.isDeleted() ).thenReturn( false );
         when( trackedEntityInstanceB.isDeleted() ).thenReturn( true );
 
         assertThrows( PotentialDuplicateConflictException.class,
-            () -> deduplicationService.autoMerge( deduplicationMergeRequest ) );
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
         verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
@@ -247,7 +242,7 @@ public class DeduplicationServiceTest
         when( programInstanceB.getProgram() ).thenReturn( program );
 
         assertThrows( PotentialDuplicateConflictException.class,
-            () -> deduplicationService.autoMerge( deduplicationMergeRequest ) );
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
         verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
@@ -268,7 +263,7 @@ public class DeduplicationServiceTest
             .thenReturn( new HashSet<>( Arrays.asList( sexAttributeValueB, nameAttributeValueB ) ) );
 
         assertThrows( PotentialDuplicateConflictException.class,
-            () -> deduplicationService.autoMerge( deduplicationMergeRequest ) );
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
         verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
@@ -287,7 +282,7 @@ public class DeduplicationServiceTest
             .thenReturn( false );
 
         assertThrows( PotentialDuplicateForbiddenException.class,
-            () -> deduplicationService.autoMerge( deduplicationMergeRequest ) );
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
         verify( deduplicationHelper ).hasUserAccess( trackedEntityInstanceA, trackedEntityInstanceB, mergeObject );
@@ -306,10 +301,7 @@ public class DeduplicationServiceTest
         when( deduplicationHelper.generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB ) )
             .thenReturn( mergeObject );
 
-        when( deduplicationService.getPotentialDuplicateByUid( deduplicationMergeRequest.getPotentialDuplicateUid() ) )
-            .thenReturn( potentialDuplicate );
-
-        deduplicationService.autoMerge( deduplicationMergeRequest );
+        deduplicationService.autoMerge( deduplicationMergeParams );
 
         verify( deduplicationHelper ).hasUserAccess( trackedEntityInstanceA, trackedEntityInstanceB, mergeObject );
         verify( deduplicationHelper ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -40,7 +40,13 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.deduplication.*;
+import org.hisp.dhis.deduplication.DeduplicationMergeParams;
+import org.hisp.dhis.deduplication.DeduplicationService;
+import org.hisp.dhis.deduplication.DeduplicationStatus;
+import org.hisp.dhis.deduplication.MergeObject;
+import org.hisp.dhis.deduplication.MergeStrategy;
+import org.hisp.dhis.deduplication.PotentialDuplicate;
+import org.hisp.dhis.deduplication.PotentialDuplicateQuery;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.node.Node;
@@ -175,11 +181,6 @@ public class DeduplicationController
     {
         PotentialDuplicate potentialDuplicate = getPotentialDuplicateBy( id );
 
-        if ( potentialDuplicate == null )
-        {
-            throw new NotFoundException( "PotentialDuplicate with uid '" + id + "' not found." );
-        }
-
         if ( potentialDuplicate.getTeiA() == null || potentialDuplicate.getTeiB() == null )
         {
             throw new ConflictException( "PotentialDuplicate is missing references and cannot be merged." );
@@ -205,20 +206,13 @@ public class DeduplicationController
             .duplicate( duplicate )
             .build();
 
-        try
+        if ( MergeStrategy.MANUAL.equals( mergeStrategy ) )
         {
-            if ( MergeStrategy.MANUAL.equals( mergeStrategy ) )
-            {
-                deduplicationService.manualMerge( params );
-            }
-            else
-            {
-                deduplicationService.autoMerge( params );
-            }
+            deduplicationService.manualMerge( params );
         }
-        catch ( PotentialDuplicateConflictException ex )
+        else
         {
-            throw new ConflictException( ex.getMessage() );
+            deduplicationService.autoMerge( params );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerMvcTest.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.controller.exception.BadRequestException;
-import org.hisp.dhis.webapi.controller.exception.ConflictException;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.Before;
@@ -391,7 +390,7 @@ public class DeduplicationControllerMvcTest
             .accept( MediaType.APPLICATION_JSON ) )
             .andExpect( status().isConflict() )
             .andExpect(
-                result -> assertTrue( result.getResolvedException() instanceof ConflictException ) );
+                result -> assertTrue( result.getResolvedException() instanceof PotentialDuplicateConflictException ) );
 
         verify( deduplicationService ).autoMerge( deduplicationMergeParams );
         verify( deduplicationService, times( 0 ) ).manualMerge( deduplicationMergeParams );


### PR DESCRIPTION
- Rename DeduplicationMergeRequest to DeduplicationMergeParams (similar to other code)
- Changed from using UID of PotentialDuplicate to PotentialDuplicate in DeduplicationMergeParams (Also update method)
- Added manualMerge method
- Added dummy for hasInvalidReferences
- Minor codestyle issues with brackets fixed
- Call store directly to update PotentialDuplicate to avoid double Transaction.
- Rewrote some error messages
- Add try-catch to controller to present exceptions as 409-conflict and not 500 errors.
- Moved hasInvalidReference to Helper class and changed parameter