### PR TITLE
feat: add translations to Predictor

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TranslatableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TranslatableObject.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2004-2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.schema.annotation.Gist;
+import org.hisp.dhis.translation.Translation;
+import org.hisp.dhis.user.UserSettingKey;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Base class for translatable object.
+ * <p>
+ * Contains necessary methods for storing and retrieving translation values.
+ * <p>
+ * Beside extending this object, translatable object needs to have a column
+ * translations with type jblTranslations defined in hibernate mapping file.
+ */
+public class TranslatableObject
+{
+    /**
+     * Set of available object translation, normally filtered by locale.
+     */
+    protected Set<Translation> translations = new HashSet<>();
+
+    /**
+     * Cache for object translations, where the cache key is a combination of
+     * locale and translation property, and value is the translated value.
+     */
+    protected final Map<String, String> translationCache = new ConcurrentHashMap<>();
+
+    // -------------------------------------------------------------------------
+    // Getters and setters
+    // -------------------------------------------------------------------------
+
+    @Gist( included = Gist.Include.FALSE )
+    @JsonProperty
+    @JacksonXmlElementWrapper( localName = "translations", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "translation", namespace = DxfNamespaces.DXF_2_0 )
+    public Set<Translation> getTranslations()
+    {
+        if ( translations == null )
+        {
+            translations = new HashSet<>();
+        }
+
+        return translations;
+    }
+
+    /**
+     * Clears out cache when setting translations.
+     */
+    public void setTranslations( Set<Translation> translations )
+    {
+        this.translationCache.clear();
+        this.translations = translations;
+    }
+
+    // -------------------------------------------------------------------------
+    // Util methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a translated value for this object for the given property. The
+     * current locale is read from the user context.
+     *
+     * @param translationKey the translation key.
+     * @param defaultValue the value to use if there are no translations.
+     * @return a translated value.
+     */
+    protected String getTranslation( String translationKey, String defaultValue )
+    {
+        Locale locale = UserContext.getUserSetting( UserSettingKey.DB_LOCALE );
+
+        defaultValue = defaultValue != null ? defaultValue.trim() : null;
+
+        if ( locale == null || translationKey == null || CollectionUtils.isEmpty( translations ) )
+        {
+            return defaultValue;
+        }
+
+        return translationCache.computeIfAbsent( Translation.getCacheKey( locale.toString(), translationKey ),
+            key -> getTranslationValue( locale.toString(), translationKey ) );
+    }
+
+    /**
+     * Get Translation value from {@code Set<Translation>} by given locale and
+     * translationKey
+     *
+     * @return Translation value if exists, otherwise return null.
+     */
+    private String getTranslationValue( String locale, String translationKey )
+    {
+        for ( Translation translation : translations )
+        {
+            if ( locale.equals( translation.getLocale() ) && translationKey.equals( translation.getProperty() ) &&
+                !StringUtils.isEmpty( translation.getValue() ) )
+            {
+                return translation.getValue();
+            }
+        }
+
+        return null;
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/Expression.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/Expression.java
@@ -31,6 +31,8 @@ import java.io.Serializable;
 
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
+import org.hisp.dhis.common.TranslatableObject;
+import org.hisp.dhis.translation.Translatable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -56,6 +58,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  */
 @JacksonXmlRootElement( localName = "expression", namespace = DxfNamespaces.DXF_2_0 )
 public class Expression
+    extends TranslatableObject
     implements Serializable, EmbeddedObject
 {
     /**
@@ -240,6 +243,14 @@ public class Expression
     public void setDescription( String description )
     {
         this.description = description;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @Translatable( propertyName = "description", key = "DESCRIPTION" )
+    public String getDisplayDescription()
+    {
+        return getTranslation( "DESCRIPTION", getDescription() );
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expression/hibernate/Expression.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expression/hibernate/Expression.hbm.xml
@@ -26,5 +26,7 @@
             </type>
         </property>
 
+        <property name="translations" type="jblTranslations"/>
+
     </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
@@ -45,6 +45,8 @@
 
     <property name="sequentialSkipCount" column="sequentialskipcount" />
 
+    <property name="translations" type="jblTranslations"/>
+
     <set name="groups" table="predictorgroupmembers" inverse="true">
       <key column="predictorid" />
       <many-to-many class="org.hisp.dhis.predictor.PredictorGroup" column="predictorgroupid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -36,16 +36,22 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.chart.ChartType;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.expression.Expression;
 import org.hisp.dhis.mapping.*;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.predictor.Predictor;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramSection;
 import org.hisp.dhis.program.ProgramStage;
@@ -64,6 +70,8 @@ import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.visualization.Visualization;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.collect.Sets;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
@@ -384,6 +392,46 @@ public class TranslationServiceTest
         assertEquals( "translated Name", template.getDisplayName() );
         assertEquals( "translated SUBJECT TEMPLATE", template.getDisplaySubjectTemplate() );
         assertEquals( "translated MESSAGE TEMPLATE", template.getDisplayMessageTemplate() );
+    }
 
+    @Test
+    public void testPredictorTranslations()
+    {
+        DataElement dataElementX = createDataElement( 'X', ValueType.NUMBER, AggregationType.NONE );
+        DataElement dataElementA = createDataElement( 'A' );
+        DataElement dataElementB = createDataElement( 'B' );
+        manager.save( dataElementA );
+        manager.save( dataElementB );
+        manager.save( dataElementX );
+
+        OrganisationUnitLevel orgUnitLevel1 = new OrganisationUnitLevel( 1, "Level1" );
+        manager.save( orgUnitLevel1 );
+
+        CategoryOptionCombo defaultCombo = categoryService.getDefaultCategoryOptionCombo();
+        PeriodType periodTypeMonthly = PeriodType.getPeriodTypeByName( "Monthly" );
+
+        Expression expressionA = new Expression(
+            "AVG(#{" + dataElementA.getUid() + "})+1.5*STDDEV(#{" + dataElementA.getUid() + "})", "descriptionA" );
+        expressionA.setTranslations( Sets.newHashSet( new Translation( locale.getLanguage(), "DESCRIPTION",
+            "translated descriptionA" ) ) );
+
+        Expression expressionB = new Expression( "AVG(#{" + dataElementB.getUid() + "." + defaultCombo.getUid() + "})",
+            "descriptionB" );
+        expressionB.setTranslations( Sets.newHashSet( new Translation( locale.getLanguage(), "DESCRIPTION",
+            "translated descriptionB" ) ) );
+
+        Predictor predictor = createPredictor( dataElementX, defaultCombo, "A", expressionA, expressionB,
+            periodTypeMonthly, orgUnitLevel1, 6, 1, 0 );
+
+        manager.save( predictor );
+
+        manager.updateTranslations( predictor, Sets.newHashSet( new Translation( locale.getLanguage(), "NAME",
+            "translated Predictor Name" ) ) );
+
+        predictor = manager.get( Predictor.class, predictor.getUid() );
+
+        assertEquals( "translated Predictor Name", predictor.getDisplayName() );
+        assertEquals( "translated descriptionA", predictor.getGenerator().getDisplayDescription() );
+        assertEquals( "translated descriptionB", predictor.getSampleSkipTest().getDisplayDescription() );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_29__Add_translations_column_expression_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_29__Add_translations_column_expression_table.sql
@@ -1,0 +1,1 @@
+alter table expression add column if not exists translations jsonb default '[]'::jsonb;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_30__Add_translations_column_predictor_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_30__Add_translations_column_predictor_table.sql
@@ -1,0 +1,1 @@
+alter table predictor add column if not exists translations jsonb default '[]'::jsonb;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11574

- This PR added `translations` column to `Predictor` and `Expression` tables

- After the change, the translation dialog in Maintenance app works correctly with Predictor.

- Predictor has `Expression` fields: `generator` and `sampleSkipTest`, which are `EmbeddedObject`. Therefore, front-end code needs to be updated to in order to add a custom translation dialog for those fields.

- This PR also added a new `TranslatableObject` which contains common methods for enabling translations. This is useful if we want to enable translation for other `EmbeddedObject` in the future.

- Updating translation for `Predictor` can be done nornamlly using `api/predictors/{uid}/translations` . But for embedded object, its translations need to be included in the `Predictor` object's payload and sent with PUT request to `api/predictors/{uid}`


Test
- Added unit test for both `Predictor` and `Expression` fields.
- Manual test can be done for `Predictor` in Maintenance app.
- Translation for `Expression` fields can only be tested using web api.
  - Send PUT request to `api/predictors/{predictorUID}?mergeMode=REPLACE` ( same request as in Maintenance app )
  - The payload needs to include translations for `generator` or `sampleSkipTest` property as below

_Sample Predictor payload_
```json
"description": "Malaria Outbreak Threshold test",
"generator": {
  "displayDescription": "Malaria outbreak threshold",
  "expression": "avg(#{r6nrJANOqMw})+1.5*stddevPop(#{r6nrJANOqMw})",
  "description": "Malaria outbreak threshold",
  "missingValueStrategy": "SKIP_IF_ALL_VALUES_MISSING",
  "slidingWindow": false,
  "translations": [
  {
    "property": "DESCRIPTION",
    "locale": "fr",
    "value": "description french"
  },
  {
    "property": "DESCRIPTION",
    "locale": "vn",
    "value": "description vietnamese"
  }
  ]
},
"lastUpdated": "2021-08-30T16:02:13.461",
"id": "tEK1OEqS4O1",
"sequentialSampleCount": 6,
"annualSampleCount": 3,
"created": "2016-10-11T10:15:29.174",
"periodType": "Monthly",
```