### PR TITLE
feat: Implement basic logic to merge enrollments [DHIS2-11626]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/MergeObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/MergeObject.java
@@ -43,4 +43,6 @@ public class MergeObject
     private List<String> trackedEntityAttributes;
 
     private List<String> relationships;
+
+    private List<String> enrollments;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicateStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicateStore.java
@@ -46,5 +46,7 @@ public interface PotentialDuplicateStore
 
     void moveRelationships( String originalUid, String duplicateUid, List<String> relationships );
 
+    void moveEnrollments( String originalUid, String duplicateUid, List<String> enrollments );
+
     void removeTrackedEntity( TrackedEntityInstance trackedEntityInstance );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstanceService.java
@@ -100,6 +100,14 @@ public interface ProgramInstanceService
     ProgramInstance getProgramInstance( String uid );
 
     /**
+     * Returns a list of existing ProgramInstances from the provided UIDs
+     *
+     * @param uids PSI UIDs to check
+     * @return ProgramInstance list
+     */
+    List<ProgramInstance> getProgramInstances( List<String> uids );
+
+    /**
      * Checks for the existence of a PI by UID. Deleted values are not taken
      * into account.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DefaultDeduplicationService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.deduplication;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
@@ -146,6 +147,11 @@ public class DefaultDeduplicationService
             return false;
         }
 
+        if ( haveSameEnrollment( original.getProgramInstances(), duplicate.getProgramInstances() ) )
+        {
+            return false;
+        }
+
         Set<TrackedEntityAttributeValue> trackedEntityAttributeValueA = original
             .getTrackedEntityAttributeValues();
         Set<TrackedEntityAttributeValue> trackedEntityAttributeValueB = duplicate
@@ -168,8 +174,23 @@ public class DefaultDeduplicationService
             mergeObject.getTrackedEntityAttributes() );
         potentialDuplicateStore.moveRelationships( original.getUid(), duplicate.getUid(),
             mergeObject.getRelationships() );
+        potentialDuplicateStore.moveEnrollments( original.getUid(), duplicate.getUid(),
+            mergeObject.getEnrollments() );
         potentialDuplicateStore.removeTrackedEntity( duplicate );
         updateTeiAndPotentialDuplicate( deduplicationMergeParams, original );
+    }
+
+    private boolean haveSameEnrollment( Set<ProgramInstance> originalEnrollments,
+        Set<ProgramInstance> duplicateEnrollments )
+    {
+        Set<String> originalPrograms = originalEnrollments.stream().map( e -> e.getProgram().getUid() )
+            .collect( Collectors.toSet() );
+        Set<String> duplicatePrograms = duplicateEnrollments.stream().map( e -> e.getProgram().getUid() )
+            .collect( Collectors.toSet() );
+
+        originalPrograms.retainAll( duplicatePrograms );
+
+        return !originalPrograms.isEmpty();
     }
 
     private void updateTeiAndPotentialDuplicate( DeduplicationMergeParams deduplicationMergeParams,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hibernate.SessionFactory;
@@ -43,10 +44,13 @@ import org.hisp.dhis.deduplication.PotentialDuplicate;
 import org.hisp.dhis.deduplication.PotentialDuplicateConflictException;
 import org.hisp.dhis.deduplication.PotentialDuplicateQuery;
 import org.hisp.dhis.deduplication.PotentialDuplicateStore;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
 import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -59,13 +63,16 @@ public class HibernatePotentialDuplicateStore
 {
     private RelationshipStore relationshipStore;
 
+    private TrackedEntityInstanceStore trackedEntityInstanceStore;
+
     public HibernatePotentialDuplicateStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
         ApplicationEventPublisher publisher, CurrentUserService currentUserService, AclService aclService,
-        RelationshipStore relationshipStore )
+        RelationshipStore relationshipStore, TrackedEntityInstanceStore trackedEntityInstanceStore )
     {
         super( sessionFactory, jdbcTemplate, publisher, PotentialDuplicate.class, currentUserService,
             aclService, false );
         this.relationshipStore = relationshipStore;
+        this.trackedEntityInstanceStore = trackedEntityInstanceStore;
     }
 
     @Override
@@ -203,13 +210,74 @@ public class HibernatePotentialDuplicateStore
     }
 
     @Override
+    public void moveEnrollments( String originalUid, String duplicateUid, List<String> enrollments )
+    {
+        String moveEnrollmentsSQL = "UPDATE programinstance "
+            + "SET trackedentityinstanceid = ("
+            + "SELECT trackedentityinstanceid FROM trackedentityinstance WHERE uid = :original"
+            + ") WHERE trackedentityinstanceid = ("
+            + "SELECT trackedentityinstanceid FROM trackedentityinstance WHERE uid = :duplicate"
+            + ") AND uid IN (:enrollments)";
+
+        getSession()
+            .createNativeQuery( moveEnrollmentsSQL )
+            .setParameter( "original", originalUid )
+            .setParameter( "duplicate", duplicateUid )
+            .setParameterList( "enrollments", enrollments )
+            .executeUpdate();
+    }
+
+    @Override
     public void removeTrackedEntity( TrackedEntityInstance trackedEntityInstance )
     {
-        removeRelationships( trackedEntityInstance );
+        trackedEntityInstanceStore.delete( trackedEntityInstance );
+        // removeRelationships( trackedEntityInstance );
+        //
+        // removeTrackedEntityAttributeValues( trackedEntityInstance );
+        //
+        // if ( !trackedEntityInstance.getProgramInstances().isEmpty() ){
+        // Set<ProgramStageInstance> events =
+        // trackedEntityInstance.getProgramInstances()
+        // .stream()
+        // .flatMap( e -> e.getProgramStageInstances().stream() )
+        // .collect(Collectors.toSet());
+        // if (!events.isEmpty()){
+        // removeEvents( events );
+        // }
+        // removeEnrollments( trackedEntityInstance.getProgramInstances() );
+        // }
+        //
+        // removeTrackedEntityInstance( trackedEntityInstance );
+    }
 
-        removeTrackedEntityAttributeValues( trackedEntityInstance );
+    private void removeEvents( Set<ProgramStageInstance> programStageInstances )
+    {
+        List<String> eventUids = programStageInstances
+            .stream()
+            .map( e -> e.getUid() )
+            .collect( Collectors.toList() );
 
-        removeTrackedEntityInstance( trackedEntityInstance );
+        String removeProgramStageInstancesSQL = "DELETE FROM programstageinstance " +
+            " WHERE uid in (:events) ";
+
+        getSession().createNativeQuery( removeProgramStageInstancesSQL )
+            .setParameter( "events", eventUids )
+            .executeUpdate();
+    }
+
+    private void removeEnrollments( Set<ProgramInstance> programInstances )
+    {
+        List<String> enrollmentUids = programInstances
+            .stream()
+            .map( e -> e.getUid() )
+            .collect( Collectors.toList() );
+
+        String removeProgramInstancesSQL = "DELETE FROM programinstance " +
+            " WHERE uid in (:enrollments) ";
+
+        getSession().createNativeQuery( removeProgramInstancesSQL )
+            .setParameter( "enrollments", enrollmentUids )
+            .executeUpdate();
     }
 
     private void removeTrackedEntityInstance( TrackedEntityInstance trackedEntityInstance )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -162,6 +162,13 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional( readOnly = true )
+    public List<ProgramInstance> getProgramInstances( List<String> uids )
+    {
+        return programInstanceStore.getByUid( uids );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
     public boolean programInstanceExists( String uid )
     {
         return programInstanceStore.exists( uid );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
@@ -53,6 +53,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.google.common.collect.Sets;
+
 @RunWith( MockitoJUnitRunner.class )
 public class DeduplicationServiceTest
 {
@@ -201,6 +203,26 @@ public class DeduplicationServiceTest
         trackedEntityOther.setUid( uidOther );
 
         when( trackedEntityInstanceB.getTrackedEntityType() ).thenReturn( trackedEntityOther );
+
+        assertThrows(
+            PotentialDuplicateConflictException.class,
+            () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
+
+        verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
+        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+    }
+
+    @Test
+    public void shouldNotBeAutoMergeableSameProgramInstance()
+    {
+        Program program = new Program();
+        program.setUid( "programUid" );
+        when( programInstanceA.getProgram() ).thenReturn( program );
+        when( programInstanceB.getProgram() ).thenReturn( program );
+
+        when( trackedEntityInstanceA.getProgramInstances() ).thenReturn( Sets.newHashSet( programInstanceA ) );
+        when( trackedEntityInstanceB.getProgramInstances() ).thenReturn( Sets.newHashSet( programInstanceB ) );
 
         assertThrows(
             PotentialDuplicateConflictException.class,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -208,8 +208,6 @@ public class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalInte
         assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( control1.getUid() ) );
         assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( control2.getUid() ) );
 
-        dbmsManager.clearSession();
-
         removeTrackedEntity( duplicate );
 
         assertNull( programInstanceService.getProgramInstance( programInstance2.getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -30,10 +30,14 @@ package org.hisp.dhis.deduplication.hibernate;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import org.hisp.dhis.IntegrationTestBase;
+import org.hisp.dhis.TransactionalIntegrationTest;
 import org.hisp.dhis.deduplication.PotentialDuplicateStore;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.relationship.RelationshipType;
@@ -46,7 +50,7 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueServ
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class PotentialDuplicateRemoveTrackedEntityTest extends IntegrationTestBase
+public class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegrationTest
 {
 
     @Autowired
@@ -69,6 +73,12 @@ public class PotentialDuplicateRemoveTrackedEntityTest extends IntegrationTestBa
 
     @Autowired
     private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
+    @Autowired
+    private ProgramInstanceService programInstanceService;
+
+    @Autowired
+    private ProgramService programService;
 
     @Test
     public void shouldDeleteTrackedEntityInstance()
@@ -154,6 +164,62 @@ public class PotentialDuplicateRemoveTrackedEntityTest extends IntegrationTestBa
         assertNull( trackedEntityInstanceService.getTrackedEntityInstance( duplicate.getUid() ) );
     }
 
+    @Test
+    public void shouldDeleteEnrollments()
+    {
+        OrganisationUnit ou = createOrganisationUnit( "OU_A" );
+        organisationUnitService.addOrganisationUnit( ou );
+
+        TrackedEntityInstance original = createTrackedEntityInstance( ou );
+        TrackedEntityInstance duplicate = createTrackedEntityInstance( ou );
+        TrackedEntityInstance control1 = createTrackedEntityInstance( ou );
+        TrackedEntityInstance control2 = createTrackedEntityInstance( ou );
+
+        trackedEntityInstanceService.addTrackedEntityInstance( original );
+        trackedEntityInstanceService.addTrackedEntityInstance( duplicate );
+        trackedEntityInstanceService.addTrackedEntityInstance( control1 );
+        trackedEntityInstanceService.addTrackedEntityInstance( control2 );
+
+        Program program = createProgram( 'A' );
+        programService.addProgram( program );
+
+        ProgramInstance programInstance1 = createProgramInstance( program, original, ou );
+        ProgramInstance programInstance2 = createProgramInstance( program, duplicate, ou );
+        ProgramInstance programInstance3 = createProgramInstance( program, control1, ou );
+        ProgramInstance programInstance4 = createProgramInstance( program, control2, ou );
+
+        programInstanceService.addProgramInstance( programInstance1 );
+        programInstanceService.addProgramInstance( programInstance2 );
+        programInstanceService.addProgramInstance( programInstance3 );
+        programInstanceService.addProgramInstance( programInstance4 );
+
+        original.getProgramInstances().add( programInstance1 );
+        duplicate.getProgramInstances().add( programInstance2 );
+        control1.getProgramInstances().add( programInstance3 );
+        control2.getProgramInstances().add( programInstance4 );
+
+        trackedEntityInstanceService.updateTrackedEntityInstance( original );
+        trackedEntityInstanceService.updateTrackedEntityInstance( duplicate );
+        trackedEntityInstanceService.updateTrackedEntityInstance( control1 );
+        trackedEntityInstanceService.updateTrackedEntityInstance( control2 );
+
+        assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( original.getUid() ) );
+        assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( duplicate.getUid() ) );
+        assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( control1.getUid() ) );
+        assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( control2.getUid() ) );
+
+        dbmsManager.clearSession();
+
+        removeTrackedEntity( duplicate );
+
+        assertNull( programInstanceService.getProgramInstance( programInstance2.getUid() ) );
+        assertNotNull( programInstanceService.getProgramInstance( programInstance1.getUid() ) );
+        assertNotNull( programInstanceService.getProgramInstance( programInstance3.getUid() ) );
+        assertNotNull( programInstanceService.getProgramInstance( programInstance4.getUid() ) );
+
+        assertNull( trackedEntityInstanceService.getTrackedEntityInstance( duplicate.getUid() ) );
+    }
+
     private TrackedEntityInstance createTei( TrackedEntityAttribute trackedEntityAttribute )
     {
         OrganisationUnit ou = createOrganisationUnit( "OU_A" );
@@ -167,10 +233,7 @@ public class PotentialDuplicateRemoveTrackedEntityTest extends IntegrationTestBa
 
     private void removeTrackedEntity( TrackedEntityInstance trackedEntityInstance )
     {
-        transactionTemplate.execute( status -> {
-            potentialDuplicateStore.removeTrackedEntity( trackedEntityInstance );
-            return null;
-        } );
+        potentialDuplicateStore.removeTrackedEntity( trackedEntityInstance );
     }
 
 }


### PR DESCRIPTION
- [x] MergeObject updated with enrollments field
- [x] isAutoMergeable updated to check if there are no enrollments with the same program in original and duplicate TEI
- [x] hasInvalidReference updated to check if there are no enrollments with the same program in original and duplicate TEI
- [x] hasAccess updated to check ownership for all enrollments
- [x] moveEnrollment implemented to move enrollments from duplicate to original TEI
- [x] removeTrackedEntity updated to soft delete TEI and all related objects (Enrollments, events, attributes...)
- [ ] generatedMergeObject not updated yet as the implementation is missing