### PR TITLE
feat: OrgUnit.group, ancestor functs DHIS2-11637

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.period.Period;
 
@@ -261,6 +262,15 @@ public interface ExpressionService
     Object getExpressionValue( String expression, ParseType parseType );
 
     /**
+     * Returns set of all OrganisationUnitGroup UIDs in the given expression.
+     *
+     * @param expression the expression string.
+     * @param parseType the type of expression to parse.
+     * @return Map of UIDs to OrganisationUnitGroups in the expression string.
+     */
+    Set<String> getExpressionOrgUnitGroupIds( String expression, ParseType parseType );
+
+    /**
      * Generates the calculated numeric value for an expression.
      *
      * @param expression the expression holding the formula for calculation.
@@ -268,15 +278,17 @@ public interface ExpressionService
      * @param valueMap the DimensionalItemObject values to use for calculation.
      * @param constantMap map of constants to use for calculation.
      * @param orgUnitCountMap the map of organisation unit group member counts.
+     * @param orgUnitGroupMap the map of organisation unit groups.
      * @param days the number of days to use in the calculation.
      * @param missingValueStrategy the strategy to use when data values are
      *        missing when calculating the expression.
+     * @param orgUnit the current organisation unit.
      * @return the calculated value as a double.
      */
     Double getExpressionValue( String expression, ParseType parseType,
         Map<DimensionalItemObject, Double> valueMap, Map<String, Constant> constantMap,
-        Map<String, Integer> orgUnitCountMap, Integer days,
-        MissingValueStrategy missingValueStrategy );
+        Map<String, Integer> orgUnitCountMap, Map<String, OrganisationUnitGroup> orgUnitGroupMap, Integer days,
+        MissingValueStrategy missingValueStrategy, OrganisationUnit orgUnit );
 
     /**
      * Generates the calculated value for an expression.
@@ -286,16 +298,18 @@ public interface ExpressionService
      * @param valueMap the DimensionalItemObject values to use for calculation.
      * @param constantMap map of constants to use for calculation.
      * @param orgUnitCountMap the map of organisation unit group member counts.
+     * @param orgUnitGroupMap the map of organisation unit groups.
      * @param days the number of days to use in the calculation.
      * @param missingValueStrategy the strategy to use when data values are
      *        missing when calculating the expression.
+     * @param orgUnit the current organisation unit.
      * @param samplePeriods periods for samples to aggregate.
      * @param periodValueMap values for aggregate functions by period.
      * @return the calculated value.
      */
     Object getExpressionValue( String expression, ParseType parseType,
         Map<DimensionalItemObject, Double> valueMap, Map<String, Constant> constantMap,
-        Map<String, Integer> orgUnitCountMap, Integer days,
-        MissingValueStrategy missingValueStrategy, List<Period> samplePeriods,
+        Map<String, Integer> orgUnitCountMap, Map<String, OrganisationUnitGroup> orgUnitGroupMap, Integer days,
+        MissingValueStrategy missingValueStrategy, OrganisationUnit orgUnit, List<Period> samplePeriods,
         MapMap<Period, DimensionalItemObject, Double> periodValueMap );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.function;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
+
+/**
+ * Function orgUnit.ancestor
+ * <p>
+ * Is current orgUnit a descendant of one of the ancestors?
+ *
+ * @author Jim Grace
+ */
+public class FunctionOrgUnitAncestor
+    implements ExpressionItem
+{
+    @Override
+    public Object getDescription( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        for ( TerminalNode uid : ctx.UID() )
+        {
+            OrganisationUnit orgUnit = visitor.getOrganisationUnitService().getOrganisationUnit( uid.getText() );
+
+            if ( orgUnit == null )
+            {
+                throw new ParserExceptionWithoutContext( "No organization unit defined for " + uid.getText() );
+            }
+
+            visitor.getItemDescriptions().put( uid.getText(), orgUnit.getDisplayName() );
+        }
+
+        return false;
+    }
+
+    @Override
+    public Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        if ( visitor.getOrganizationUnit() != null )
+        {
+            for ( TerminalNode uid : ctx.UID() )
+            {
+                if ( visitor.getOrganizationUnit().getPath().contains( uid.getText() + "/" ) )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.function;
+
+import java.util.stream.Collectors;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
+
+/**
+ * Function orgUnit.group
+ * <p>
+ * Does the current orgUnit belong to one of the orgUnit groups?
+ *
+ * @author Jim Grace
+ */
+public class FunctionOrgUnitGroup
+    implements ExpressionItem
+{
+    @Override
+    public Object getDescription( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        for ( TerminalNode uid : ctx.UID() )
+        {
+            OrganisationUnitGroup orgUnitGroup = visitor.getOrganisationUnitGroupService()
+                .getOrganisationUnitGroup( uid.getText() );
+
+            if ( orgUnitGroup == null )
+            {
+                throw new ParserExceptionWithoutContext( "No organization unit group defined for " + uid.getText() );
+            }
+
+            visitor.getItemDescriptions().put( uid.getText(), orgUnitGroup.getDisplayName() );
+        }
+
+        return false;
+    }
+
+    @Override
+    public Object getOrgUnitGroup( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        visitor.getOrgUnitGroupIds().addAll(
+            ctx.UID().stream()
+                .map( TerminalNode::getText )
+                .collect( Collectors.toList() ) );
+
+        return false;
+    }
+
+    @Override
+    public Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        if ( visitor.getOrganizationUnit() != null )
+        {
+            for ( TerminalNode uid : ctx.UID() )
+            {
+                OrganisationUnitGroup oug = visitor.getOrgUnitGroupMap().get( uid.getText() );
+
+                if ( oug != null && oug.getMembers().contains( visitor.getOrganizationUnit() ) )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -84,6 +84,7 @@ import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramIndicator;
@@ -118,6 +119,9 @@ public class ExpressionService2Test extends DhisSpringTest
 
     @Mock
     private ConstantService constantService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
 
     @Mock
     private OrganisationUnitGroupService organisationUnitGroupService;
@@ -244,7 +248,7 @@ public class ExpressionService2Test extends DhisSpringTest
     public void setUp()
     {
         target = new DefaultExpressionService( hibernateGenericStore, dataElementService, constantService,
-            organisationUnitGroupService, dimensionService, idObjectManager, cacheProvider );
+            organisationUnitService, organisationUnitGroupService, dimensionService, idObjectManager, cacheProvider );
 
         rnd = new BeanRandomizer();
 
@@ -667,28 +671,23 @@ public class ExpressionService2Test extends DhisSpringTest
         Map<String, Integer> orgUnitCountMap = new HashMap<>();
         orgUnitCountMap.put( groupA.getUid(), groupA.getMembers().size() );
 
-        assertEquals( 46d, target
-            .getExpressionValue( expressionA, INDICATOR_EXPRESSION, valueMap, constantMap(), null, null, NEVER_SKIP ),
-            DELTA );
-        assertEquals( 17d,
-            target
-                .getExpressionValue( expressionD, INDICATOR_EXPRESSION, valueMap, constantMap(), null, 5, NEVER_SKIP ),
-            DELTA );
-        assertEquals( 24d, target
-            .getExpressionValue( expressionE, INDICATOR_EXPRESSION, valueMap, constantMap(), null, null, NEVER_SKIP ),
-            DELTA );
-        assertEquals( 36d, target
-            .getExpressionValue( expressionH, INDICATOR_EXPRESSION, valueMap, constantMap(), orgUnitCountMap, null,
-                NEVER_SKIP ),
-            DELTA );
-        assertEquals( 10d, target
-            .getExpressionValue( expressionN, INDICATOR_EXPRESSION, valueMap, constantMap(), orgUnitCountMap, null,
-                NEVER_SKIP ),
-            DELTA );
-        assertEquals( 54d, target
-            .getExpressionValue( expressionR, INDICATOR_EXPRESSION, valueMap, constantMap(), orgUnitCountMap, null,
-                NEVER_SKIP ),
-            DELTA );
+        assertEquals( 46d, target.getExpressionValue( expressionA, INDICATOR_EXPRESSION,
+            valueMap, constantMap(), null, null, null, NEVER_SKIP, null ), DELTA );
+
+        assertEquals( 17d, target.getExpressionValue( expressionD, INDICATOR_EXPRESSION,
+            valueMap, constantMap(), null, null, 5, NEVER_SKIP, null ), DELTA );
+
+        assertEquals( 24d, target.getExpressionValue( expressionE, INDICATOR_EXPRESSION,
+            valueMap, constantMap(), null, null, null, NEVER_SKIP, null ), DELTA );
+
+        assertEquals( 36d, target.getExpressionValue( expressionH, INDICATOR_EXPRESSION,
+            valueMap, constantMap(), orgUnitCountMap, null, null, NEVER_SKIP, null ), DELTA );
+
+        assertEquals( 10d, target.getExpressionValue( expressionN, INDICATOR_EXPRESSION,
+            valueMap, constantMap(), orgUnitCountMap, null, null, NEVER_SKIP, null ), DELTA );
+
+        assertEquals( 54d, target.getExpressionValue( expressionR, INDICATOR_EXPRESSION,
+            valueMap, constantMap(), orgUnitCountMap, null, null, NEVER_SKIP, null ), DELTA );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -582,8 +582,8 @@ public class ExpressionServiceTest
             .getExpressionDimensionalItemObjects( expr, parseType );
 
         Object value = expressionService.getExpressionValue( expr, parseType,
-            valueMap, constantMap, ORG_UNIT_COUNT_MAP, DAYS, missingValueStrategy,
-            TEST_SAMPLE_PERIODS, samples );
+            valueMap, constantMap, ORG_UNIT_COUNT_MAP, null, DAYS, missingValueStrategy,
+            null, TEST_SAMPLE_PERIODS, samples );
 
         return result( value, items );
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -272,8 +272,8 @@ public class DefaultPredictionService
         Set<DimensionalItemObject> sampledItems = new HashSet<>();
         expressionService.getExpressionDimensionalItemObjects( generator.getExpression(), PREDICTOR_EXPRESSION,
             outputPeriodItems, sampledItems );
-        Set<String> orgUnitGroupIds =
-            expressionService.getExpressionOrgUnitGroupIds( generator.getExpression(), PREDICTOR_EXPRESSION );
+        Set<String> orgUnitGroupIds = expressionService.getExpressionOrgUnitGroupIds( generator.getExpression(),
+            PREDICTOR_EXPRESSION );
         if ( skipTest != null )
         {
             expressionService.getExpressionDimensionalItemObjects(

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -495,8 +495,8 @@ public class DataValidationTask
             }
 
             Double value = expressionService.getExpressionValue( expression.getExpression(),
-                VALIDATION_RULE_EXPRESSION, values, context.getConstantMap(), null,
-                period.getDaysInPeriod(), expression.getMissingValueStrategy() );
+                VALIDATION_RULE_EXPRESSION, values, context.getConstantMap(), null, context.getOrgUnitGroupMap(),
+                period.getDaysInPeriod(), expression.getMissingValueStrategy(), orgUnit );
 
             if ( MathUtils.isValidDouble( value ) )
             {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -31,6 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,6 +49,7 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
@@ -90,6 +92,8 @@ public class DefaultValidationService
 
     private final ConstantService constantService;
 
+    private final IdentifiableObjectManager idObjectManager;
+
     private final ValidationNotificationService notificationService;
 
     private final ValidationRuleService validationRuleService;
@@ -104,7 +108,7 @@ public class DefaultValidationService
 
     public DefaultValidationService( PeriodService periodService, OrganisationUnitService organisationUnitService,
         ExpressionService expressionService, DimensionService dimensionService, DataValueService dataValueService,
-        CategoryService categoryService, ConstantService constantService,
+        CategoryService categoryService, ConstantService constantService, IdentifiableObjectManager idObjectManager,
         ValidationNotificationService notificationService, ValidationRuleService validationRuleService,
         ApplicationContext applicationContext, ValidationResultService validationResultService,
         AnalyticsService analyticsService, CurrentUserService currentUserService )
@@ -116,6 +120,7 @@ public class DefaultValidationService
         checkNotNull( dataValueService );
         checkNotNull( categoryService );
         checkNotNull( constantService );
+        checkNotNull( idObjectManager );
         checkNotNull( notificationService );
         checkNotNull( validationRuleService );
         checkNotNull( applicationContext );
@@ -130,6 +135,7 @@ public class DefaultValidationService
         this.dataValueService = dataValueService;
         this.categoryService = categoryService;
         this.constantService = constantService;
+        this.idObjectManager = idObjectManager;
         this.notificationService = notificationService;
         this.validationRuleService = validationRuleService;
         this.applicationContext = applicationContext;
@@ -313,6 +319,8 @@ public class DefaultValidationService
         Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap = addRulesToContext( periodTypeXMap,
             parameters.getValidationRules() );
 
+        Map<String, OrganisationUnitGroup> orgUnitGroupMap = getOrgUnitGroupMap( parameters.getValidationRules() );
+
         removeAnyUnneededPeriodTypes( periodTypeXMap );
 
         ValidationRunContext.Builder builder = ValidationRunContext.newBuilder()
@@ -328,6 +336,7 @@ public class DefaultValidationService
             .withAttributeCombo( parameters.getAttributeOptionCombo() )
             .withDefaultAttributeCombo( categoryService.getDefaultCategoryOptionCombo() )
             .withDimensionItemMap( dimensionItemMap )
+            .withOrgUnitGroupMap( orgUnitGroupMap )
             .withMaxResults( parameters.getMaxResults() );
 
         if ( currentUser != null )
@@ -412,6 +421,26 @@ public class DefaultValidationService
         saveObjectsInPeriodTypeX( periodItemIds, dimensionItemMap );
 
         return dimensionItemMap;
+    }
+
+    private Map<String, OrganisationUnitGroup> getOrgUnitGroupMap( Collection<ValidationRule> rules )
+    {
+        Set<String> orgUnitGroupIds = new HashSet<>();
+
+        for ( ValidationRule rule : rules )
+        {
+            orgUnitGroupIds.addAll( expressionService.getExpressionOrgUnitGroupIds( rule.getLeftSide().getExpression(),
+                VALIDATION_RULE_EXPRESSION ) );
+
+            orgUnitGroupIds.addAll( expressionService.getExpressionOrgUnitGroupIds( rule.getRightSide().getExpression(),
+                VALIDATION_RULE_EXPRESSION ) );
+        }
+
+        List<OrganisationUnitGroup> orgUnitGroups = idObjectManager.getNoAcl( OrganisationUnitGroup.class,
+            orgUnitGroupIds );
+
+        return orgUnitGroups.stream()
+            .collect( Collectors.toMap( OrganisationUnitGroup::getUid, g -> g ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.common.MapMapMap;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.period.Period;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -76,6 +77,8 @@ public class ValidationRunContext
     private Set<CategoryOption> coDimensionConstraints;
 
     private Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap;
+
+    private Map<String, OrganisationUnitGroup> orgUnitGroupMap;
 
     // -------------------------------------------------------------------------
     // Properties to configure analysis
@@ -170,6 +173,11 @@ public class ValidationRunContext
     public Map<DimensionalItemId, DimensionalItemObject> getDimensionItemMap()
     {
         return dimensionItemMap;
+    }
+
+    public Map<String, OrganisationUnitGroup> getOrgUnitGroupMap()
+    {
+        return orgUnitGroupMap;
     }
 
     public boolean isSendNotifications()
@@ -274,8 +282,7 @@ public class ValidationRunContext
          */
         public ValidationRunContext build()
         {
-            Validate
-                .notNull( this.context.periodTypeXs, "Missing required property 'periodTypeXs'" );
+            Validate.notNull( this.context.periodTypeXs, "Missing required property 'periodTypeXs'" );
             Validate.notNull( this.context.constantMap, "Missing required property 'constantMap'" );
             Validate.notNull( this.context.orgUnits, "Missing required property 'orgUnits'" );
             Validate.notNull( this.context.defaultAttributeCombo, "Missing required property 'defaultAttributeCombo'" );
@@ -383,6 +390,12 @@ public class ValidationRunContext
         public Builder withDimensionItemMap( Map<DimensionalItemId, DimensionalItemObject> dimensionItemMap )
         {
             this.context.dimensionItemMap = dimensionItemMap;
+            return this;
+        }
+
+        public Builder withOrgUnitGroupMap( Map<String, OrganisationUnitGroup> orgUnitGroupMap )
+        {
+            this.context.orgUnitGroupMap = orgUnitGroupMap;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -1590,7 +1590,8 @@ public class PredictionServiceTest
         dataValueBatchHandler.flush();
 
         Expression expression = new Expression(
-            "if(orgUnit.ancestor( " + sourceC.getUid() + " , " + sourceD.getUid() + " ), #{" + dataElementA.getUid() + "}, 64)",
+            "if(orgUnit.ancestor( " + sourceC.getUid() + " , " + sourceD.getUid() + " ), #{" + dataElementA.getUid()
+                + "}, 64)",
             "description", MissingValueStrategy.SKIP_IF_ALL_VALUES_MISSING );
 
         Set<OrganisationUnitLevel> allLevels = Sets.newHashSet( orgUnitLevel1, orgUnitLevel2, orgUnitLevel3 );
@@ -1623,7 +1624,8 @@ public class PredictionServiceTest
         dataValueBatchHandler.flush();
 
         Expression expression = new Expression(
-            "if(orgUnit.group( " + ouGroupA.getUid() + " , " + ouGroupB.getUid() + " ), #{" + dataElementA.getUid() + "}, 64)",
+            "if(orgUnit.group( " + ouGroupA.getUid() + " , " + ouGroupB.getUid() + " ), #{" + dataElementA.getUid()
+                + "}, 64)",
             "description", MissingValueStrategy.SKIP_IF_ALL_VALUES_MISSING );
 
         Set<OrganisationUnitLevel> allLevels = Sets.newHashSet( orgUnitLevel1, orgUnitLevel2, orgUnitLevel3 );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -228,15 +228,15 @@ public class DataValidationTaskTest
         ValidationRunContext ctx, Double val )
     {
         when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
-            ctx.getConstantMap(), null, null, p1.getDaysInPeriod(), expression.getMissingValueStrategy(), null ) )
+            ctx.getConstantMap(), null, null, p1.getDaysInPeriod(), expression.getMissingValueStrategy(), ouA ) )
                 .thenReturn( val );
 
         when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
-            ctx.getConstantMap(), null, null, p2.getDaysInPeriod(), expression.getMissingValueStrategy(), null ) )
+            ctx.getConstantMap(), null, null, p2.getDaysInPeriod(), expression.getMissingValueStrategy(), ouA ) )
                 .thenReturn( val );
 
         when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
-            ctx.getConstantMap(), null, null, p3.getDaysInPeriod(), expression.getMissingValueStrategy(), null ) )
+            ctx.getConstantMap(), null, null, p3.getDaysInPeriod(), expression.getMissingValueStrategy(), ouA ) )
                 .thenReturn( val );
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -227,17 +227,16 @@ public class DataValidationTaskTest
     private void mockExpressionService( Expression expression, Map<DimensionalItemObject, Double> vals,
         ValidationRunContext ctx, Double val )
     {
-
         when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
-            ctx.getConstantMap(), null, p1.getDaysInPeriod(), expression.getMissingValueStrategy() ) )
+            ctx.getConstantMap(), null, null, p1.getDaysInPeriod(), expression.getMissingValueStrategy(), null ) )
                 .thenReturn( val );
 
         when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
-            ctx.getConstantMap(), null, p2.getDaysInPeriod(), expression.getMissingValueStrategy() ) )
+            ctx.getConstantMap(), null, null, p2.getDaysInPeriod(), expression.getMissingValueStrategy(), null ) )
                 .thenReturn( val );
 
         when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, vals,
-            ctx.getConstantMap(), null, p3.getDaysInPeriod(), expression.getMissingValueStrategy() ) )
+            ctx.getConstantMap(), null, null, p3.getDaysInPeriod(), expression.getMissingValueStrategy(), null ) )
                 .thenReturn( val );
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -1541,7 +1541,8 @@ public class ValidationServiceTest
             "if(orgUnit.ancestor(" + sourceB.getUid() + "), #{" + dataElementA.getUid() + "}, 20)", "left" );
         Expression expressionRight = new Expression(
             "if(orgUnit.ancestor(" + sourceC.getUid() + "," + sourceD.getUid() + "), #{" + dataElementB.getUid()
-                + "}, 30)", "right" );
+                + "}, 30)",
+            "right" );
 
         ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 
@@ -1582,7 +1583,8 @@ public class ValidationServiceTest
             "if(orgUnit.group( " + orgUnitGroupA.getUid() + " ), #{" + dataElementA.getUid() + "}, 20)", "left" );
         Expression expressionRight = new Expression(
             "if(orgUnit.group( " + orgUnitGroupB.getUid() + " , " + orgUnitGroupC.getUid() + " ), #{"
-                + dataElementB.getUid() + "}, 30)", "right" );
+                + dataElementB.getUid() + "}, 30)",
+            "right" );
 
         ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -1540,7 +1540,8 @@ public class ValidationServiceTest
         Expression expressionLeft = new Expression(
             "if(orgUnit.ancestor(" + sourceB.getUid() + "), #{" + dataElementA.getUid() + "}, 20)", "left" );
         Expression expressionRight = new Expression(
-            "if(orgUnit.ancestor(" + sourceC.getUid() + "," + sourceD.getUid() + "), #{" + dataElementB.getUid() + "}, 30)", "right" );
+            "if(orgUnit.ancestor(" + sourceC.getUid() + "," + sourceD.getUid() + "), #{" + dataElementB.getUid()
+                + "}, 30)", "right" );
 
         ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 
@@ -1580,7 +1581,8 @@ public class ValidationServiceTest
         Expression expressionLeft = new Expression(
             "if(orgUnit.group( " + orgUnitGroupA.getUid() + " ), #{" + dataElementA.getUid() + "}, 20)", "left" );
         Expression expressionRight = new Expression(
-            "if(orgUnit.group( " + orgUnitGroupB.getUid() + " , " + orgUnitGroupC.getUid() + " ), #{" + dataElementB.getUid() + "}, 30)", "right" );
+            "if(orgUnit.group( " + orgUnitGroupB.getUid() + " , " + orgUnitGroupC.getUid() + " ), #{"
+                + dataElementB.getUid() + "}, 30)", "right" );
 
         ValidationRule rule = createValidationRule( "R", equal_to, expressionLeft, expressionRight, ptMonthly );
 

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -54,7 +54,10 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.expression.MissingValueStrategy;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -73,6 +76,8 @@ public class CommonExpressionVisitor
     extends AntlrExpressionVisitor
 {
     private DimensionService dimensionService;
+
+    private OrganisationUnitService organisationUnitService;
 
     private OrganisationUnitGroupService organisationUnitGroupService;
 
@@ -139,6 +144,16 @@ public class CommonExpressionVisitor
      * Organisation unit group counts to use in evaluating an expression.
      */
     Map<String, Integer> orgUnitCountMap = new HashMap<>();
+
+    /**
+     * Organisation unit groups to use in evaluating an expression.
+     */
+    Map<String, OrganisationUnitGroup> orgUnitGroupMap = new HashMap<>();
+
+    /**
+     * The current organisation unit.
+     */
+    OrganisationUnit organisationUnit;
 
     /**
      * Count of days in period to use in evaluating an expression.
@@ -393,6 +408,11 @@ public class CommonExpressionVisitor
         return dimensionService;
     }
 
+    public OrganisationUnitService getOrganisationUnitService()
+    {
+        return organisationUnitService;
+    }
+
     public OrganisationUnitGroupService getOrganisationUnitGroupService()
     {
         return organisationUnitGroupService;
@@ -540,6 +560,26 @@ public class CommonExpressionVisitor
         this.orgUnitCountMap = orgUnitCountMap;
     }
 
+    public Map<String, OrganisationUnitGroup> getOrgUnitGroupMap()
+    {
+        return orgUnitGroupMap;
+    }
+
+    public void setOrgUnitGroupMap( Map<String, OrganisationUnitGroup> orgUnitGroupMap )
+    {
+        this.orgUnitGroupMap = orgUnitGroupMap;
+    }
+
+    public OrganisationUnit getOrganizationUnit()
+    {
+        return organisationUnit;
+    }
+
+    public void setOrganisationUnit( OrganisationUnit organisationUnit )
+    {
+        this.organisationUnit = organisationUnit;
+    }
+
     public Map<String, Double> getItemValueMap()
     {
         return itemValueMap;
@@ -631,6 +671,12 @@ public class CommonExpressionVisitor
         public Builder withDimensionService( DimensionService dimensionService )
         {
             this.visitor.dimensionService = dimensionService;
+            return this;
+        }
+
+        public Builder withOrganisationUnitService( OrganisationUnitService organisationUnitService )
+        {
+            this.visitor.organisationUnitService = organisationUnitService;
             return this;
         }
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -56,7 +56,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine-->
-    <dhis2-rule-engine.version>2.0.24-SNAPSHOT</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.0.25</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.3.5</dhis-hisp-quick.version>
@@ -229,7 +229,7 @@
     <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.6</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.17</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.18</dhis-antlr-expression-parser.version>
     <ow2.asm.version>9.0</ow2.asm.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.8.2</gson.version>


### PR DESCRIPTION
See [DHIS2-11637](https://jira.dhis2.org/browse/DHIS2-11637). This adds two new functions for predictor and validation rule expressions: orgUnit.group() and orgUnit.ancestor().

These functions allow predictors and/or validation rules to behave differently (or not at all) for organisation units depending on organisation unit subtree and organisation unit group membership.