### PR TITLE
fix : [ DHIS2-11563 ] missing update on lastUpdated and lastUpdatedBy

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.ProgramInstance;
@@ -52,7 +52,7 @@ import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class DeduplicationHelper
 {
     private final CurrentUserService currentUserService;
@@ -65,7 +65,7 @@ public class DeduplicationHelper
 
     private final OrganisationUnitService organisationUnitService;
 
-    private ProgramInstanceService programInstanceService;
+    private final ProgramInstanceService programInstanceService;
 
     public String getInvalidReferenceErrors( DeduplicationMergeParams params )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DefaultDeduplicationService.java
@@ -36,7 +36,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.stereotype.Service;
@@ -49,7 +49,7 @@ public class DefaultDeduplicationService
 {
     private final PotentialDuplicateStore potentialDuplicateStore;
 
-    private final TrackedEntityInstanceService trackedEntityInstanceService;
+    private final TrackedEntityInstanceStore trackedEntityInstanceStore;
 
     private final DeduplicationHelper deduplicationHelper;
 
@@ -220,7 +220,7 @@ public class DefaultDeduplicationService
     {
         original.setLastUpdated( new Date() );
         original.setLastUpdatedBy( currentUserService.getCurrentUser() );
-        trackedEntityInstanceService.updateTrackedEntityInstance( original );
+        trackedEntityInstanceStore.update( original );
     }
 
     private boolean sameAttributesAreEquals( Set<TrackedEntityAttributeValue> trackedEntityAttributeValueA,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.CurrentUserService;
@@ -62,7 +62,7 @@ public class DeduplicationServiceTest
     private DefaultDeduplicationService deduplicationService;
 
     @Mock
-    private TrackedEntityInstanceService trackedEntityInstanceService;
+    private TrackedEntityInstanceStore trackedEntityInstanceStore;
 
     @Mock
     private TrackedEntityInstance trackedEntityInstanceA;
@@ -87,8 +87,6 @@ public class DeduplicationServiceTest
 
     private DeduplicationMergeParams deduplicationMergeParams;
 
-    private PotentialDuplicate potentialDuplicate;
-
     private static final String sexUid = "sexAttributUid";
 
     private static final String sexName = "sex";
@@ -104,7 +102,7 @@ public class DeduplicationServiceTest
     @Before
     public void setUp()
     {
-        potentialDuplicate = new PotentialDuplicate( "original", "duplicate" );
+        PotentialDuplicate potentialDuplicate = new PotentialDuplicate( "original", "duplicate" );
 
         deduplicationMergeParams = DeduplicationMergeParams.builder().potentialDuplicate( potentialDuplicate )
             .original( trackedEntityInstanceA ).duplicate( trackedEntityInstanceB )
@@ -190,8 +188,9 @@ public class DeduplicationServiceTest
         verify( potentialDuplicateStore ).moveRelationships( trackedEntityInstanceA,
             trackedEntityInstanceB, mergeObject.getRelationships() );
         verify( potentialDuplicateStore ).removeTrackedEntity( trackedEntityInstanceB );
-        verify( trackedEntityInstanceService ).updateTrackedEntityInstance( trackedEntityInstanceA );
+        verify( trackedEntityInstanceStore ).update( trackedEntityInstanceA );
         verify( potentialDuplicateStore ).update( argThat( t -> t.getStatus().equals( DeduplicationStatus.MERGED ) ) );
+        verify( potentialDuplicateStore ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -210,8 +209,9 @@ public class DeduplicationServiceTest
             () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
-        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( trackedEntityInstanceStore, times( 0 ) ).update( any() );
         verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -230,8 +230,9 @@ public class DeduplicationServiceTest
             () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
-        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( trackedEntityInstanceStore, times( 0 ) ).update( any() );
         verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -249,8 +250,9 @@ public class DeduplicationServiceTest
             () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
-        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( trackedEntityInstanceStore, times( 0 ) ).update( any() );
         verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -268,8 +270,9 @@ public class DeduplicationServiceTest
             () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
-        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( trackedEntityInstanceStore, times( 0 ) ).update( any() );
         verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -289,8 +292,9 @@ public class DeduplicationServiceTest
             () -> deduplicationService.autoMerge( deduplicationMergeParams ) );
 
         verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
-        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( trackedEntityInstanceStore, times( 0 ) ).update( any() );
         verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -310,8 +314,9 @@ public class DeduplicationServiceTest
         verify( deduplicationHelper ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
         verify( deduplicationHelper ).getUserAccessErrors( trackedEntityInstanceA, trackedEntityInstanceB,
             mergeObject );
-        verify( trackedEntityInstanceService, times( 0 ) ).updateTrackedEntityInstance( any() );
+        verify( trackedEntityInstanceStore, times( 0 ) ).update( any() );
         verify( potentialDuplicateStore, times( 0 ) ).update( any() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     @Test
@@ -335,6 +340,40 @@ public class DeduplicationServiceTest
         verify( potentialDuplicateStore ).moveRelationships( trackedEntityInstanceA,
             trackedEntityInstanceB, mergeObject.getRelationships() );
         verify( potentialDuplicateStore ).removeTrackedEntity( trackedEntityInstanceB );
+        verify( trackedEntityInstanceStore ).update( trackedEntityInstanceA );
+        verify( potentialDuplicateStore ).auditMerge( deduplicationMergeParams );
+    }
+
+    @Test
+    public void shouldBeManualMergeable()
+    {
+        deduplicationService.manualMerge( deduplicationMergeParams );
+
+        verify( deduplicationHelper, times( 1 ) ).getInvalidReferenceErrors( deduplicationMergeParams );
+        verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
+        verify( deduplicationHelper ).getUserAccessErrors( trackedEntityInstanceA, trackedEntityInstanceB,
+            deduplicationMergeParams.getMergeObject() );
+        verify( potentialDuplicateStore ).moveTrackedEntityAttributeValues( trackedEntityInstanceA,
+            trackedEntityInstanceB, deduplicationMergeParams.getMergeObject().getTrackedEntityAttributes() );
+        verify( potentialDuplicateStore ).moveRelationships( trackedEntityInstanceA,
+            trackedEntityInstanceB, deduplicationMergeParams.getMergeObject().getRelationships() );
+        verify( potentialDuplicateStore ).removeTrackedEntity( trackedEntityInstanceB );
+        verify( trackedEntityInstanceStore ).update( trackedEntityInstanceA );
+        verify( potentialDuplicateStore ).auditMerge( deduplicationMergeParams );
+    }
+
+    @Test
+    public void shouldThrowManualMergeableHasInvalidReference()
+    {
+        when( deduplicationHelper.getInvalidReferenceErrors( deduplicationMergeParams ) ).thenReturn( "Error" );
+        assertThrows( PotentialDuplicateConflictException.class,
+            () -> deduplicationService.manualMerge( deduplicationMergeParams ) );
+
+        verify( deduplicationHelper, times( 1 ) ).getInvalidReferenceErrors( deduplicationMergeParams );
+        verify( deduplicationHelper, times( 0 ) ).generateMergeObject( trackedEntityInstanceA, trackedEntityInstanceB );
+        verify( deduplicationHelper, times( 0 ) ).getUserAccessErrors( trackedEntityInstanceA, trackedEntityInstanceB,
+            deduplicationMergeParams.getMergeObject() );
+        verify( potentialDuplicateStore, times( 0 ) ).auditMerge( deduplicationMergeParams );
     }
 
     private TrackedEntityAttributeValue getTrackedEntityAttributeValue( String uid, String name,


### PR DESCRIPTION
Not sure this is fixing the missing update on tei lastUpdated and lastUpdatedBy, but it was used the tei update service causing double transaction. 
Replaced with store. Tests seem to prove it

- [x] Replace store with service and add service integration tests
- [x] Update service unit tests
- [x] Fix helper constructor 