### PR TITLE
build: Remove CVE patch stage from dev pipeline [DEVOPS-83]

### DIFF
--- a/Jenkinsfile-core-dev
+++ b/Jenkinsfile-core-dev
@@ -20,16 +20,9 @@ pipeline {
         AWX_TEMPLATE = 37
         HOST = 'play.dhis2.org'
         INSTANCE_NAME = "${env.GIT_BRANCH == 'master' ? 'dev' : env.GIT_BRANCH + 'dev'}"
-        GITHUB_TOKEN = credentials('github-token')
     }
 
     stages {
-        stage ('Patch') {
-            steps {
-                sh './run-cve-patcher.sh'
-            }
-        }
-
         stage ('Build') {
             steps {
                 echo 'Building DHIS2 ...'


### PR DESCRIPTION
Removing the CVE "Patch" stage from the dev pipeline, as it's not needed for "dev" builds.