### PR TITLE
feat: unique shortname for indicatorgroupset and categoryoptiongroupset [DHIS2-7317]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSet.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.schema.annotation.PropertyRange;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -69,7 +70,9 @@ public class CategoryOptionGroupSet
 
     public CategoryOptionGroupSet( String name )
     {
+
         this.name = name;
+        this.shortName = name;
     }
 
     // -------------------------------------------------------------------------
@@ -95,16 +98,12 @@ public class CategoryOptionGroupSet
     }
 
     @Override
+    @JsonProperty
+    @JacksonXmlProperty( isAttribute = true )
+    @PropertyRange( min = 1, max = 50 )
     public String getShortName()
     {
-        if ( getName() == null || getName().length() <= 50 )
-        {
-            return getName();
-        }
-        else
-        {
-            return getName().substring( 0, 49 );
-        }
+        return shortName;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
@@ -54,6 +54,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 public class IndicatorGroupSet
     extends BaseIdentifiableObject implements MetadataObject
 {
+    private String shortName;
+
     private String description;
 
     private Boolean compulsory = false;
@@ -71,19 +73,19 @@ public class IndicatorGroupSet
 
     public IndicatorGroupSet( String name )
     {
-        this.name = name;
-        this.compulsory = false;
+        this( name, false );
     }
 
     public IndicatorGroupSet( String name, Boolean compulsory )
     {
-        this( name );
-        this.compulsory = compulsory;
+        this( name, null, compulsory );
     }
 
     public IndicatorGroupSet( String name, String description, Boolean compulsory )
     {
-        this( name, compulsory );
+        this.name = name;
+        this.shortName = name;
+        this.compulsory = compulsory;
         this.description = description;
     }
 
@@ -167,6 +169,19 @@ public class IndicatorGroupSet
     // -------------------------------------------------------------------------
     // Getters and setters
     // -------------------------------------------------------------------------
+
+    @JsonProperty
+    @JacksonXmlProperty( isAttribute = true )
+    @PropertyRange( min = 1, max = 50 )
+    public String getShortName()
+    {
+        return shortName;
+    }
+
+    public void setShortName( String shortName )
+    {
+        this.shortName = shortName;
+    }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSet.hbm.xml
@@ -8,24 +8,30 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroupSet" table="categoryoptiongroupset">
 
-    <cache usage="read-write" />
+    <cache usage="read-write"/>
 
     <id name="id" column="categoryoptiongroupsetid">
-      <generator class="native" />
+      <generator class="native"/>
     </id>
     &identifiableProperties;
 
-    <property name="name" column="name" not-null="true" unique="true" length="230" />
+    <property name="name" column="name" not-null="true" unique="true"
+              length="230"/>
 
-    <property name="description" type="text" />
+    <property name="shortName" column="shortname" not-null="true" unique="true"
+              length="50"/>
 
-    <property name="dataDimension" column="datadimension" not-null="true" />
+    <property name="description" type="text"/>
+
+    <property name="dataDimension" column="datadimension" not-null="true"/>
 
     <list name="members" table="categoryoptiongroupsetmembers">
-      <cache usage="read-write" />
-      <key column="categoryoptiongroupsetid" foreign-key="fk_categoryoptiongroupsetmembers_categoryoptiongroupsetid" />
-      <list-index column="sort_order" base="1" />
-      <many-to-many class="org.hisp.dhis.category.CategoryOptionGroup" column="categoryoptiongroupid"
+      <cache usage="read-write"/>
+      <key column="categoryoptiongroupsetid"
+           foreign-key="fk_categoryoptiongroupsetmembers_categoryoptiongroupsetid"/>
+      <list-index column="sort_order" base="1"/>
+      <many-to-many class="org.hisp.dhis.category.CategoryOptionGroup"
+                    column="categoryoptiongroupid"
         foreign-key="fk_categoryoptiongroupsetmembers_categoryoptiongroupid" />
     </list>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroupSet.hbm.xml
@@ -8,25 +8,30 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.indicator.IndicatorGroupSet" table="indicatorgroupset">
 
-    <cache usage="read-write" />
+    <cache usage="read-write"/>
 
     <id name="id" column="indicatorgroupsetid">
-      <generator class="native" />
+      <generator class="native"/>
     </id>
     &identifiableProperties;
 
-    <property name="name" column="name" not-null="true" unique="false" length="230" />
+    <property name="name" column="name" not-null="true" unique="false"
+              length="230"/>
 
-    <property name="description" type="text" />
+    <property name="shortName" column="shortname" not-null="true" unique="true"
+              length="50"/>
 
-    <property name="compulsory" />
+    <property name="description" type="text"/>
+
+    <property name="compulsory"/>
 
     <property name="translations" type="jblTranslations"/>
 
     <list name="members" table="indicatorgroupsetmembers">
-      <cache usage="read-write" />
-      <key column="indicatorgroupsetid" foreign-key="fk_indicatorgroupsetmembers_indicatorgroupsetid" />
-      <list-index column="sort_order" base="1" />
+      <cache usage="read-write"/>
+      <key column="indicatorgroupsetid"
+           foreign-key="fk_indicatorgroupsetmembers_indicatorgroupsetid"/>
+      <list-index column="sort_order" base="1"/>
       <many-to-many class="org.hisp.dhis.indicator.IndicatorGroup" column="indicatorgroupid" unique="true"
         foreign-key="fk_indicatorgroupset_indicatorgroupid" />
     </list>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v38/V2_38_2__Add_unique_shortName_to_group_sets.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v38/V2_38_2__Add_unique_shortName_to_group_sets.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.migration.v38;
+
+import static org.hisp.dhis.db.migration.helper.UniqueValueUtils.copyUniqueValue;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+/**
+ * Initialises the {@code shortname} column with a unique name based on the
+ * {@code name} column for {@link org.hisp.dhis.indicator.IndicatorGroupSet}s
+ * and {@link org.hisp.dhis.category.CategoryOptionGroupSet}s.
+ *
+ * @author Jan Bernitt
+ */
+public class V2_38_2__Add_unique_shortName_to_group_sets extends BaseJavaMigration
+{
+    @Override
+    public void migrate( Context context )
+        throws Exception
+    {
+        copyUniqueValue( context, "indicatorgroupset", "indicatorgroupsetid", "name", "shortname", 50 );
+        copyUniqueValue( context, "categoryoptiongroupset", "categoryoptiongroupsetid", "name", "shortname", 50 );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_1__Add_column_shortName_to_group_sets.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_1__Add_column_shortName_to_group_sets.sql
@@ -1,0 +1,4 @@
+alter table indicatorgroupset
+    add column if not exists shortname character varying(50);
+alter table categoryoptiongroupset
+    add column if not exists shortname character varying(50);

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_3__Add_unique_and_not_null_to_group_sets_shortName.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_3__Add_unique_and_not_null_to_group_sets_shortName.sql
@@ -1,0 +1,7 @@
+alter table indicatorgroupset alter column shortname set not null;
+alter table indicatorgroupset drop constraint if exists indicatorgroupset_unique_shortname;
+alter table indicatorgroupset add constraint indicatorgroupset_unique_shortname unique (shortname);
+
+alter table categoryoptiongroupset alter column shortname set not null;
+alter table categoryoptiongroupset drop constraint if exists categoryoptiongroupset_unique_shortname;
+alter table categoryoptiongroupset add constraint categoryoptiongroupset_unique_shortname unique (shortname);


### PR DESCRIPTION
### Summary
Adds `shortname` column to `IndicatorGroupSet` and `CategoryOptionGroupSet` which are unique and with a max length of 50 characters.

Constructors with arguments were only used in tests. Therefore `shortName` is set to `name`.

### Manual Testing
Start server and check table `indicatorgroupset` and `categoryoptiongroupset` have a `shortname` column with unique constraint. 
Stop and start server again and check no migration issues occur during startup. 