### PR TITLE
fix: sharing is not saved when create new ProgramStage [DHIS2-11742]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
@@ -120,10 +120,7 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program>
                 ps.setProgram( program );
             }
 
-            programStageService.saveProgramStage( ps );
         } );
-
-        programService.updateProgram( program );
     }
 
     private void addProgramInstance( Program program )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -1130,6 +1130,37 @@ public class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( ThematicMapType.CHOROPLETH, mapView.getThematicMapType() );
     }
 
+    /**
+     * Payload includes Program and ProgramStage with sharing settings.
+     * <p>
+     * Expected: after created, both Program and ProgramStage are saved
+     * correctly together with sharing settings.
+     */
+    @Test
+    public void testImportProgramWithProgramStageAndSharing()
+        throws IOException
+    {
+        User user = createUser( "A", "ALL" );
+        manager.save( user );
+
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/program_programStage_with_sharing.json" ).getInputStream(),
+            RenderFormat.JSON );
+
+        MetadataImportParams params = createParams( ImportStrategy.CREATE, metadata );
+        params.setSkipSharing( false );
+        params.setUser( user );
+
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+
+        ProgramStage programStage = programStageService.getProgramStage( "oORy3Rg9hLE" );
+        assertEquals( 1, programStage.getSharing().getUserGroups().size() );
+
+        Program program = manager.get( "QIHW6CBdLsP" );
+        assertEquals( 1, program.getSharing().getUserGroups().size() );
+    }
+
     private MetadataImportParams createParams( ImportStrategy importStrategy,
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -28,12 +28,13 @@
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramStage;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -185,23 +186,10 @@ public class ProgramObjectBundleHookTest
         ProgramStage programStage = createProgramStage( 'A', 1 );
         programA.getProgramStages().add( programStage );
 
-        ArgumentCaptor<Program> argument = ArgumentCaptor.forClass( Program.class );
-        ArgumentCaptor<ProgramStage> argPS = ArgumentCaptor.forClass( ProgramStage.class );
-
-        programService.addProgram( programA );
+        assertNull( programA.getProgramStages().iterator().next().getProgram() );
 
         subject.postCreate( programA, null );
 
-        verify( programService ).updateProgram( argument.capture() );
-
-        verify( programStageService ).saveProgramStage( argPS.capture() );
-
-        assertThat( argPS.getValue().getName(), is( equalToIgnoringCase( "ProgramStageA" ) ) );
-        assertThat( argPS.getValue().getProgram(), is( programA ) );
-
-        assertThat( argument.getValue().getName(), is( equalToIgnoringCase( "ProgramA" ) ) );
-        assertThat( argument.getValue().getProgramStages().size(), is( 1 ) );
-        assertThat( argument.getValue().getProgramStages().iterator().next().getName(),
-            is( equalToIgnoringCase( "ProgramStageA" ) ) );
+        assertNotNull( programA.getProgramStages().iterator().next().getProgram() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/program_programStage_with_sharing.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/program_programStage_with_sharing.json
@@ -1,0 +1,320 @@
+{
+  "programs": [
+    {
+      "name": "test program 3",
+      "shortName": "test program 3",
+      "id":"QIHW6CBdLsP",
+      "publicAccess": "rw------",
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "onlyEnrollOnce": false,
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {
+          "H9XnHoWRKCg": {
+            "access": "r-rw----",
+            "id": "fvz8d3u6jFd"
+          }
+
+        },
+        "public": "rw------"
+      },
+      "version": 6,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "incidentDateLabel": "LMP Date",
+      "selectEnrollmentDatesInFuture": false,
+      "registration": true,
+      "favorite": false,
+      "useFirstStageDuringRegistration": false,
+      "completeEventsExpiryDays": 0,
+      "externalAccess": false,
+      "withoutRegistration": false,
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "programType": "WITH_REGISTRATION",
+      "accessLevel": "OPEN",
+      "displayIncidentDate": true,
+      "expiryDays": 0,
+      "categoryCombo": {
+        "id": "faV8QvLgIwB"
+      },
+      "style": {
+        "color": "#f06292",
+        "icon": "rmnh_positive"
+      }
+    ,
+      "programStages":[
+        {"id":"oORy3Rg9hLE"}
+      ]
+
+    }
+  ]
+,
+
+  "programStages": [
+    {
+      "name": "test ps 4",
+      "id":"oORy3Rg9hLE",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "reportDateToUse": "false",
+      "description": "test ps 4",
+      "openAfterEnrollment": false,
+      "repeatable": false,
+      "featureType": "NONE",
+      "remindCompleted": false,
+      "displayGenerateEventBox": false,
+      "generatedByEnrollmentDate": false,
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {
+          "H9XnHoWRKCg": {
+            "access": "r-rw----",
+            "id": "fvz8d3u6jFd"
+          }
+        },
+        "public": "rw------"
+      },
+      "program":{ "id":"QIHW6CBdLsP"},
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "style": {
+        "color": "#f57f17"
+      },
+      "notificationTemplates": [],
+      "translations": [],
+      "attributeValues": [],
+      "programStageSections": []
+    }
+  ],
+  "categoryCombos": [
+    {
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------",
+      "lastUpdated": "2016-03-08T07:29:15.719+0000",
+      "created": "2016-03-08T07:29:07.104+0000",
+      "categories": [
+        {
+          "id": "XJGLlMAMCcn"
+        }
+      ],
+      "name": "Gender",
+      "userGroupAccesses": [
+        {
+          "access": "rwrw----",
+          "userGroupUid": "fvz8d3u6jFd",
+          "id": "fvz8d3u6jFd"
+        }
+      ],
+      "skipTotal": false,
+      "dataDimensionType": "DISAGGREGATION",
+      "id": "faV8QvLgIwB",
+      "userGroupAccesses": [
+        {
+          "access": "rwrw----",
+          "userGroupUid": "fvz8d3u6jFd",
+          "id": "fvz8d3u6jFd"
+        }
+      ]
+    }
+  ],
+  "organisationUnits": [
+    {
+      "lastUpdated": "2016-03-08T07:27:17.772+0000",
+      "name": "Country",
+      "created": "2016-03-08T07:27:17.757+0000",
+      "uuid": "d981e7c4-3c72-4e0d-8995-078f16830473",
+      "shortName": "Country",
+      "description": "",
+      "id": "x3gVvpbVgqy",
+      "attributeValues": [],
+      "path": "/x3gVvpbVgqy",
+      "featureType": "NONE",
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "openingDate": "2016-03-08"
+    }
+  ],
+  "categoryOptions": [
+    {
+      "id": "JYiFOMKa25J",
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "shortName": "Female",
+      "name": "Female",
+      "created": "2016-03-08T07:28:50.372+0000",
+      "lastUpdated": "2016-03-08T07:28:50.374+0000",
+      "organisationUnits": [],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------",
+      "userGroupAccesses": [
+        {
+          "access": "rwrw----",
+          "userGroupUid": "fvz8d3u6jFd",
+          "id": "fvz8d3u6jFd"
+        }
+      ]
+    },
+    {
+      "shortName": "Male",
+      "userGroupAccesses": [],
+      "id": "tdaMRD34m8o",
+      "attributeValues": [],
+      "lastUpdated": "2016-03-08T07:28:44.217+0000",
+      "name": "Male",
+      "created": "2016-03-08T07:28:44.214+0000",
+      "organisationUnits": [],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "publicAccess": "rw------",
+      "userGroupAccesses": [
+        {
+          "access": "rwrw----",
+          "userGroupUid": "fvz8d3u6jFd",
+          "id": "fvz8d3u6jFd"
+        }
+      ]
+    }
+  ],
+  "userRoles": [
+    {
+      "name": "Superuser",
+      "created": "2016-03-08T07:26:51.925+0000",
+      "lastUpdated": "2016-03-08T07:26:51.925+0000",
+      "userGroupAccesses": [],
+      "id": "wSdzlWUHmEu",
+      "dataSets": [],
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_MAP_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_PROGRAM_ENROLLMENT",
+        "F_SQLVIEW_EXTERNAL",
+        "F_GIS_ADMIN",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_VISUALIZATION_PUBLIC_ADD",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_VISUALIZATION_EXTERNAL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_MAP_EXTERNAL",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE"
+      ],
+      "publicAccess": "--------",
+      "programs": []
+    }
+  ],
+  "categories": [
+    {
+
+      "publicAccess": "rw------",
+      "categoryOptions": [
+        {
+          "id": "JYiFOMKa25J"
+        },
+        {
+          "id": "tdaMRD34m8o"
+        }
+      ],
+      "created": "2016-03-08T07:28:58.738+0000",
+      "name": "Gender",
+      "shortName": "Gender",
+      "lastUpdated": "2016-03-08T07:28:58.740+0000",
+      "dataDimension": true,
+      "dataDimensionType": "DISAGGREGATION",
+      "userGroupAccesses": [
+        {
+          "access": "rwrw----",
+          "userGroupUid": "fvz8d3u6jFd",
+          "id": "fvz8d3u6jFd"
+        }
+      ],
+      "id": "XJGLlMAMCcn"
+    }
+  ],
+  "userGroups": [
+    {
+      "name": "Administrators",
+      "id": "fvz8d3u6jFd",
+      "displayName": "Administrators",
+      "publicAccess": "rw------",
+      "externalAccess": false,
+      "favorite": false,
+      "users": [
+        {
+          "id": "T12jeH7KPzk"
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "organisationUnits": [
+        {
+          "id": "x3gVvpbVgqy"
+        }
+      ],
+      "dataViewOrganisationUnits": [],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "catDimensionConstraints": [],
+        "userInfo": {
+          "id": "T12jeH7KPzk"
+        },
+        "disabled": false,
+        "username": "admin",
+        "created": "2016-03-08T07:26:52.033+0000",
+        "selfRegistered": false,
+        "cogsDimensionConstraints": [],
+        "passwordLastUpdated": "2016-03-08T07:26:51.942+0000",
+        "userRoles": [
+          {
+            "id": "wSdzlWUHmEu"
+          }
+        ],
+        "invitation": false,
+        "externalAuth": false,
+        "lastLogin": "2016-03-08T07:26:51.942+0000"
+      },
+      "surname": "admin",
+      "attributeValues": [],
+      "id": "T12jeH7KPzk",
+      "created": "2016-03-08T07:26:51.909+0000",
+      "firstName": "admin",
+      "lastUpdated": "2016-03-08T07:26:51.909+0000",
+      "teiSearchOrganisationUnits": []
+    }
+  ]
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11742

### Issue:
- POST request to `api/metadata`  with payload contains `Program`, `ProgramStage` with sharings.
- New `Program` is created correctly with sharings.
- New `ProgramStage` is created but **without sharings**.
- In `ProgramObjectBundleHook` the method `updateProgramStage()` removes  sharing data from `ProgramStage` by calling `programStageService.saveProgramStage( ps );`
### Fix: 
- Remove redundant  call to `saveProgramStage` and also `updateProgram` in method `updateProgramStage()`. 
- The updated objects will be flushed when `session.flush()` is called by importService.

### Test:  
- Added integration test.
- Manual test can be done by POST request to `api/metadata` with payload contains `Program`, `ProgramStage` with sharings.

