### PR TITLE
fix: Logic for dashboard of type APP [DHIS2-11739]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -156,13 +156,13 @@ public class DashboardController
         {
             for ( final DashboardItem item : items )
             {
-                final boolean hasAssociatedType = item != null
+                final boolean hasAssociationType = item != null
                     && (item.getLinkItems() != null || item.getEmbeddedItem() != null || item.getText() != null
                         || item.getMessages() != null);
 
                 final boolean hasType = item != null && item.getType() != null;
 
-                if ( !hasType || !hasAssociatedType )
+                if ( !hasType && !hasAssociationType )
                 {
                     return false;
                 }


### PR DESCRIPTION
This is a bug introduced in 2.37.
It blocks the inclusion of dashboard items of type APP.

**This fix has to be approved by the change control team. It can be merged only after approval.**