### PR TITLE
fix: Invalid data statistics snapshot date [DHIS2-11047]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.datastatistics;
 
-import static java.util.Calendar.DATE;
-import static java.util.Calendar.MILLISECOND;
-
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -47,7 +44,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserInvitationStatus;
 import org.hisp.dhis.user.UserQueryParams;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.visualization.Visualization;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,13 +148,7 @@ public class DefaultDataStatisticsService
     @Override
     public long saveDataStatisticsSnapshot()
     {
-        // This ensures we set a date in the format "2021-08-28 23:59:59.999".
-        // So the query will compare against the full day, instead of the
-        // default 2021-08-28 00:00:00.000.
-        Date day = DateUtils.calculateDateFrom( new Date(), 1, DATE );
-        day = DateUtils.calculateDateFrom( day, -1, MILLISECOND );
-
-        return saveDataStatistics( getDataStatisticsSnapshot( day ) );
+        return saveDataStatistics( getDataStatisticsSnapshot( new Date() ) );
     }
 
     @Override


### PR DESCRIPTION
This issue was supposed to fix a bug reported by the front-end during the chart/report table drop task.
The problem was that the snapshot endpoint, when consumed, was not updating the DB correctly. The events from "today" were missing. So I added a "fix" so it would consider the events from "today".

But later I found out that it was a mistake. All data statistics snapshot logic, actually, is based on D-1 events. So the behaviour was expected and events from "today" are not taken into consideration. It should remain like that based on the existing logic.

This fix is just a rollback, so this endpoint will behave as before.

**This fix has to be approved by the change control team. It can be merged only after approval.**