### PR TITLE
feat: adds last updated user and timestamp to data approval [DHIS2-5075]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApproval.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApproval.java
@@ -35,11 +35,19 @@ import java.util.Objects;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.annotation.Description;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.annotation.Property;
+import org.hisp.dhis.schema.annotation.Property.Value;
+import org.hisp.dhis.schema.annotation.PropertyTransformer;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 import org.hisp.dhis.user.User;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
@@ -107,6 +115,18 @@ public class DataApproval
      */
     private User creator;
 
+    /**
+     * The Date (including time) when {@link #accepted} status of this approval
+     * was last changed
+     */
+    private Date lastUpdated;
+
+    /**
+     * The User who made the last change to the {@link #accepted} status of this
+     * approval
+     */
+    private User lastUpdatedBy;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -139,6 +159,8 @@ public class DataApproval
         this.accepted = accepted;
         this.created = created;
         this.creator = creator;
+        this.lastUpdated = created;
+        this.lastUpdatedBy = creator;
     }
 
     public DataApproval( DataApproval da )
@@ -151,6 +173,8 @@ public class DataApproval
         this.accepted = da.accepted;
         this.created = da.created;
         this.creator = da.creator;
+        this.lastUpdated = da.lastUpdated;
+        this.lastUpdatedBy = da.lastUpdatedBy;
     }
 
     // -------------------------------------------------------------------------
@@ -273,6 +297,13 @@ public class DataApproval
         this.accepted = accepted;
     }
 
+    public void setAccepted( boolean accepted, User by )
+    {
+        setAccepted( accepted );
+        setLastUpdatedBy( by );
+        setLastUpdated( new Date() );
+    }
+
     public Date getCreated()
     {
         return created;
@@ -291,6 +322,35 @@ public class DataApproval
     public void setCreator( User creator )
     {
         this.creator = creator;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( isAttribute = true )
+    @Description( "The date this object was last updated." )
+    @Property( value = PropertyType.DATE, required = Value.FALSE )
+    public Date getLastUpdated()
+    {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated( Date lastUpdated )
+    {
+        this.lastUpdated = lastUpdated;
+    }
+
+    @JsonProperty
+    @JsonSerialize( using = UserPropertyTransformer.JacksonSerialize.class )
+    @JsonDeserialize( using = UserPropertyTransformer.JacksonDeserialize.class )
+    @PropertyTransformer( UserPropertyTransformer.class )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public User getLastUpdatedBy()
+    {
+        return lastUpdatedBy;
+    }
+
+    public void setLastUpdatedBy( User lastUpdatedBy )
+    {
+        this.lastUpdatedBy = lastUpdatedBy;
     }
 
     // ----------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalService.java
@@ -28,7 +28,10 @@
 package org.hisp.dhis.dataapproval;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.dataapproval.DataApprovalAction.*;
+import static org.hisp.dhis.dataapproval.DataApprovalAction.ACCEPT;
+import static org.hisp.dhis.dataapproval.DataApprovalAction.APPROVE;
+import static org.hisp.dhis.dataapproval.DataApprovalAction.UNACCEPT;
+import static org.hisp.dhis.dataapproval.DataApprovalAction.UNAPPROVE;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -277,7 +280,7 @@ public class DefaultDataApprovalService
                 throw new DataMayNotBeApprovedException();
             }
 
-            da.setAccepted( accepted );
+            da.setAccepted( accepted, currentUser );
 
             checkedList.add( da );
         }
@@ -392,7 +395,7 @@ public class DefaultDataApprovalService
         {
             log.debug( "accepting " + da );
 
-            da.setAccepted( true );
+            da.setAccepted( true, currentUser );
 
             audit( da, currentUser, ACCEPT );
 
@@ -450,7 +453,7 @@ public class DefaultDataApprovalService
         {
             log.debug( "unaccepting " + da );
 
-            da.setAccepted( false );
+            da.setAccepted( false, currentUser );
 
             audit( da, currentUser, UNACCEPT );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataapproval/hibernate/DataApproval.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataapproval/hibernate/DataApproval.hbm.xml
@@ -8,20 +8,39 @@
   <class name="org.hisp.dhis.dataapproval.DataApproval" table="dataapproval">
 
     <id name="id" column="dataapprovalid">
-      <generator class="native" />
+      <generator class="native"/>
     </id>
 
-    <many-to-one name="dataApprovalLevel" class="org.hisp.dhis.dataapproval.DataApprovalLevel" column="dataapprovallevelid" not-null="true" foreign-key="fk_dataapproval_dataapprovallevel" />
-    <many-to-one name="workflow" class="org.hisp.dhis.dataapproval.DataApprovalWorkflow" column="workflowid" foreign-key="fk_dataapproval_workflowid" />
-    <many-to-one name="period" class="org.hisp.dhis.period.Period" column="periodid" not-null="true" foreign-key="fk_dataapproval_periodid" />
-    <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit" not-null="true" column="organisationunitid" foreign-key="fk_dataapproval_organisationunitid" />
-    <many-to-one name="attributeOptionCombo" class="org.hisp.dhis.category.CategoryOptionCombo" column="attributeoptioncomboid" foreign-key="fk_dataapproval_attributeoptioncomboid" />
+    <many-to-one name="dataApprovalLevel"
+                 class="org.hisp.dhis.dataapproval.DataApprovalLevel"
+                 column="dataapprovallevelid" not-null="true"
+                 foreign-key="fk_dataapproval_dataapprovallevel"/>
+    <many-to-one name="workflow"
+                 class="org.hisp.dhis.dataapproval.DataApprovalWorkflow"
+                 column="workflowid" foreign-key="fk_dataapproval_workflowid"/>
+    <many-to-one name="period" class="org.hisp.dhis.period.Period"
+                 column="periodid" not-null="true"
+                 foreign-key="fk_dataapproval_periodid"/>
+    <many-to-one name="organisationUnit"
+                 class="org.hisp.dhis.organisationunit.OrganisationUnit"
+                 not-null="true" column="organisationunitid"
+                 foreign-key="fk_dataapproval_organisationunitid"/>
+    <many-to-one name="attributeOptionCombo"
+                 class="org.hisp.dhis.category.CategoryOptionCombo"
+                 column="attributeoptioncomboid"
+                 foreign-key="fk_dataapproval_attributeoptioncomboid"/>
 
-    <property name="accepted" type="boolean" />
+    <property name="accepted" type="boolean"/>
 
-    <property name="created" column="created" not-null="true" type="timestamp" />
+    <property name="created" column="created" not-null="true" type="timestamp"/>
 
-    <many-to-one name="creator" class="org.hisp.dhis.user.User" column="creator" not-null="true" foreign-key="fk_dataapproval_creator" />
+    <property name="lastUpdated" column="lastupdated" type="timestamp"/>
+
+    <many-to-one name="lastUpdatedBy" column="lastupdatedby"
+                 not-null="false" foreign-key="fk_dataapproval_lastupdateby"/>
+
+    <many-to-one name="creator" class="org.hisp.dhis.user.User" column="creator"
+                 not-null="true" foreign-key="fk_dataapproval_creator"/>
 
   </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceTest.java
@@ -665,14 +665,12 @@ public class DataApprovalServiceTest
     @Test
     public void testLastUpdatedBy()
     {
-        User admin = createAdminUser( "ALL" );
-
-        User approveUserA = switchToApprovalUser( organisationUnitA, DataApproval.AUTH_APPROVE,
-            DataApproval.AUTH_APPROVE_LOWER_LEVELS );
-
-        injectSecurityContext( admin );
-        User approveUserB = switchToApprovalUser( organisationUnitA, DataApproval.AUTH_APPROVE,
-            DataApproval.AUTH_APPROVE_LOWER_LEVELS );
+        User approveUserA = createUser( "approveA", DataApproval.AUTH_APPROVE, DataApproval.AUTH_APPROVE_LOWER_LEVELS );
+        approveUserA.setOrganisationUnits( singleton( organisationUnitA ) );
+        userService.updateUser( approveUserA );
+        User approveUserB = createUser( "approveB", DataApproval.AUTH_APPROVE, DataApproval.AUTH_APPROVE_LOWER_LEVELS );
+        approveUserB.setOrganisationUnits( singleton( organisationUnitA ) );
+        userService.updateUser( approveUserB );
 
         injectSecurityContext( approveUserA );
         Date now = new Date();

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_4__add_columns_for_last_updated_to_data_approval.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_4__add_columns_for_last_updated_to_data_approval.sql
@@ -1,0 +1,8 @@
+alter table dataapproval
+    add column if not exists lastupdated timestamp;
+
+alter table dataapproval
+    add column if not exists lastupdatedby bigint;
+
+alter table dataapproval
+    add constraint fk_dataapproval_lastupdateby foreign key (lastupdatedby) references userinfo(userinfoid);

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2315,17 +2315,16 @@ public abstract class DhisConvenienceTest
 
         if ( auths != null )
         {
-            authorities.addAll( asList( auths ) );
+            authorities.addAll( Lists.newArrayList( auths ) );
         }
 
-        char uniqueCharacter = nextUserName++;
         UserAuthorityGroup group = new UserAuthorityGroup();
-        group.setName( "Superuser_" + uniqueCharacter );
+        group.setName( "Superuser" );
         group.getAuthorities().addAll( authorities );
 
         userService.addUserAuthorityGroup( group );
 
-        User user = createUser( uniqueCharacter );
+        User user = createUser( nextUserName++ );
 
         if ( organisationUnits != null )
         {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2315,16 +2315,17 @@ public abstract class DhisConvenienceTest
 
         if ( auths != null )
         {
-            authorities.addAll( Lists.newArrayList( auths ) );
+            authorities.addAll( asList( auths ) );
         }
 
+        char uniqueCharacter = nextUserName++;
         UserAuthorityGroup group = new UserAuthorityGroup();
-        group.setName( "Superuser" );
+        group.setName( "Superuser_" + uniqueCharacter );
         group.getAuthorities().addAll( authorities );
 
         userService.addUserAuthorityGroup( group );
 
-        User user = createUser( nextUserName++ );
+        User user = createUser( uniqueCharacter );
 
         if ( organisationUnits != null )
         {


### PR DESCRIPTION
### Summary

Adds last updated date and user to `DataApproval`.
These will not be updated on any update of the object but each time the accepted state is updated. 

### Automatic Testing
Added a simple tests that checks the update works with two different users approving.