### PR TITLE
ci: make the name of the log artifact more explicit

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -39,5 +39,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: "logs"
+          name: "tomcat_logs"
           path: '~/logs.txt'


### PR DESCRIPTION
If there are failures, action uploads logs from web container as an artifact. I renamed logs to tomcat_logs to make it more clear what the file contains.