### PR TITLE
feat: Provide datasource to quick library to avoid adhoc connection creations [DHIS2-11752] (2.37)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/config/JdbcConfig.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/config/JdbcConfig.java
@@ -27,9 +27,10 @@
  */
 package org.hisp.dhis.jdbc.config;
 
+import javax.sql.DataSource;
+
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.hibernate.HibernateConfigurationProvider;
 import org.hisp.dhis.jdbc.dialect.StatementDialectFactoryBean;
 import org.hisp.dhis.jdbc.statementbuilder.StatementBuilderFactoryBean;
 import org.hisp.quick.StatementDialect;
@@ -40,7 +41,6 @@ import org.hisp.quick.statement.JdbcStatementManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 
 import com.google.common.collect.Lists;
 
@@ -48,11 +48,10 @@ import com.google.common.collect.Lists;
  * @author Luciano Fiandesio
  */
 @Configuration
-@DependsOn( "dataSource" )
 public class JdbcConfig
 {
     @Autowired
-    private HibernateConfigurationProvider hibernateConfigurationProvider;
+    private DataSource dataSource;
 
     @Autowired
     private DhisConfigurationProvider dhisConfigurationProvider;
@@ -79,10 +78,7 @@ public class JdbcConfig
         JdbcConfigurationFactoryBean jdbcConf = new JdbcConfigurationFactoryBean();
         StatementDialect statementDialect = statementDialect().getObject();
         jdbcConf.setDialect( statementDialect );
-        jdbcConf.setDriverClass( dhisConfigurationProvider.getProperty( ConfigurationKey.CONNECTION_DRIVER_CLASS ) );
-        jdbcConf.setConnectionUrl( dhisConfigurationProvider.getProperty( ConfigurationKey.CONNECTION_URL ) );
-        jdbcConf.setUsername( dhisConfigurationProvider.getProperty( ConfigurationKey.CONNECTION_USERNAME ) );
-        jdbcConf.setPassword( dhisConfigurationProvider.getProperty( ConfigurationKey.CONNECTION_PASSWORD ) );
+        jdbcConf.setDataSource( dataSource );
 
         return jdbcConf;
     }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/batchhandler/MockBatchHandler.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/batchhandler/MockBatchHandler.java
@@ -48,6 +48,8 @@ public class MockBatchHandler<T>
 
     private UnaryOperator<T> findObject = obj -> null;
 
+    private int addObjectCount = 0;
+
     public MockBatchHandler()
     {
     }
@@ -66,6 +68,7 @@ public class MockBatchHandler<T>
     @Override
     public BatchHandler<T> init()
     {
+        this.addObjectCount = 0;
         return this;
     }
 
@@ -78,6 +81,7 @@ public class MockBatchHandler<T>
     @Override
     public boolean addObject( T object )
     {
+        addObjectCount++;
         return inserts.add( object );
     }
 
@@ -119,6 +123,7 @@ public class MockBatchHandler<T>
     @Override
     public void flush()
     {
+        addObjectCount = 0;
     }
 
     public List<T> getInserts()
@@ -134,5 +139,11 @@ public class MockBatchHandler<T>
     public List<T> getDeletes()
     {
         return deletes;
+    }
+
+    @Override
+    public int getAddObjectCount()
+    {
+        return addObjectCount;
     }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -59,7 +59,7 @@
         <dhis2-rule-engine.version>2.0.26</dhis2-rule-engine.version>
 
         <!-- HISP Quick and Staxwax -->
-        <dhis-hisp-quick.version>1.3.5</dhis-hisp-quick.version>
+        <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>
         <dhis-hisp-staxwax.version>1.4</dhis-hisp-staxwax.version>
 
         <!-- Security-->


### PR DESCRIPTION
This PR uses the latest quick library version which accepts a connection pool backed Datasource instead of creating its own connections.
The same datasource is passed onto the quick library.