### PR TITLE
fix: data value import - delete with zero or no value [DHIS2-11624] 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
@@ -154,7 +154,6 @@ public class DataValueSetImportValidator
         register( DataValueSetImportValidator::checkDataValueStrictCategoryOptionCombos );
         register( DataValueSetImportValidator::checkDataValueStrictAttrOptionCombos );
         register( DataValueSetImportValidator::checkDataValueStrictOrgUnits );
-        register( DataValueSetImportValidator::checkDataValueIsNotZeroAndInsignificant );
         register( DataValueSetImportValidator::checkDataValueStoredByIsValid );
         register( DataValueSetImportValidator::checkDataValuePeriodWithinAttrOptionComboRange );
         register( DataValueSetImportValidator::checkDataValueOrgUnitValidForAttrOptionCombo );
@@ -360,10 +359,10 @@ public class DataValueSetImportValidator
     private static void validateDataValueIsDefined( DataValue dataValue, ImportContext context,
         DataSetContext dataSetContext, DataValueContext valueContext )
     {
-        if ( dataValue.isNullValue() && !dataValue.isDeletedValue() )
+        if ( dataValue.isNullValue() && !dataValue.isDeletedValue() && !context.getStrategy().isDelete() )
         {
-            context.addConflict( valueContext.getIndex(),
-                DataValueImportConflict.DATA_ELEMENT_VALUE_NOT_DEFINED, dataValue.getDataElement() );
+            context.addConflict( valueContext.getIndex(), DataValueImportConflict.DATA_ELEMENT_VALUE_NOT_DEFINED,
+                dataValue.getDataElement() );
         }
     }
 
@@ -514,19 +513,6 @@ public class DataValueSetImportValidator
         {
             context.addConflict( valueContext.getIndex(),
                 DataValueImportConflict.ORG_UNIT_STRICT, dataValue.getOrgUnit(), dataValue.getDataElement() );
-        }
-    }
-
-    private static void checkDataValueIsNotZeroAndInsignificant( DataValue dataValue, ImportContext context,
-        DataSetContext dataSetContext, DataValueContext valueContext )
-    {
-        boolean zeroAndInsignificant = ValidationUtils.dataValueIsZeroAndInsignificant(
-            dataValue.getValue(), valueContext.getDataElement() );
-
-        if ( zeroAndInsignificant )
-        {
-            // Ignore value
-            context.getSummary().skipValue();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
@@ -41,7 +41,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -57,6 +56,7 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.LockExceptionStore;
 import org.hisp.dhis.datavalue.AggregateAccessManager;
 import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalue.DataValue;
 import org.hisp.dhis.dxf2.datavalueset.ImportContext.DataSetContext;
 import org.hisp.dhis.dxf2.datavalueset.ImportContext.DataSetContext.DataSetContextBuilder;
@@ -515,23 +515,6 @@ public class DataValueSetImportValidatorTest
     }
 
     @Test
-    public void testCheckDataValueIsNotZeroAndInsignificant()
-    {
-        DataValue dataValue = createRandomDataValue();
-        dataValue.setValue( "0" );
-
-        DataValueContext valueContext = createDataValueContext( dataValue ).build();
-        valueContext.getDataElement().setValueType( ValueType.INTEGER );
-        valueContext.getDataElement().setZeroIsSignificant( false );
-        valueContext.getDataElement().setAggregationType( AggregationType.COUNT );
-        DataSetContext dataSetContext = createMinimalDataSetContext().build();
-        ImportContext context = createMinimalImportContext( valueContext ).build();
-
-        assertTrue( validator.skipDataValue( dataValue, context, dataSetContext, valueContext ) );
-        assertEquals( 0, context.getSummary().getConflictCount() );
-    }
-
-    @Test
     public void testCheckDataValueStoredByIsValid()
     {
         DataValue dataValue = createRandomDataValue();
@@ -809,6 +792,7 @@ public class DataValueSetImportValidatorTest
         return ImportContext.builder()
             .summary( new ImportSummary() )
             .strategy( ImportStrategy.CREATE )
+            .importOptions( new ImportOptions() )
             .currentUser( currentUser )
             .i18n( i18n )
             .currentOrgUnits( valueContext == null ? null : singleton( valueContext.getOrgUnit() ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJ.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJ.json
@@ -1,0 +1,10 @@
+{
+  "dataValues": [
+    {
+      "period": "201201",
+      "orgUnit": "DiszpKrYNg8",
+      "dataElement": "f7n9E0hX8qk",
+      "value": "10"
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJDeleteNewValue.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJDeleteNewValue.json
@@ -1,0 +1,10 @@
+{
+  "dataValues": [
+    {
+      "period": "201201",
+      "orgUnit": "DiszpKrYNg8",
+      "dataElement": "f7n9E0hX8qk",
+      "value": "9"
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJDeleteNoValue.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJDeleteNoValue.json
@@ -1,0 +1,9 @@
+{
+  "dataValues": [
+    {
+      "period": "201201",
+      "orgUnit": "DiszpKrYNg8",
+      "dataElement": "f7n9E0hX8qk"
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJDeleteZeroValue.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/datavalueset/dataValueSetJDeleteZeroValue.json
@@ -1,0 +1,10 @@
+{
+  "dataValues": [
+    {
+      "period": "201201",
+      "orgUnit": "DiszpKrYNg8",
+      "dataElement": "f7n9E0hX8qk",
+      "value": "0"
+    }
+  ]
+}


### PR DESCRIPTION
cherry picked #8610

Takes care of three cases:
* delete by updating to zero should work
* delete by using strategy DELETE with no value or the old value should work
* delete by using strategy DELETE with new value different to the old one should work (did work before but now is tested as well)