### PR TITLE
feat: support system.mode for switching between prod and dev mode

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -46,6 +46,7 @@ public enum ConfigurationKey
     SYSTEM_PROGRAM_RULE_SERVER_EXECUTION( "system.program_rule.server_execution", Constants.ON, false ),
     SYSTEM_CACHE_MAX_SIZE_FACTOR( "system.cache.max_size.factor", "0.5", false ),
     SYSTEM_CACHE_CAP_PERCENTAGE( "system.cache.cap.percentage", "0", false ),
+    SYSTEM_MODE( "system.mode", "PRODUCTION", false ),
     NODE_ID( "node.id", "", false ),
     ENCRYPTION_PASSWORD( "encryption.password", "", true ),
     CONNECTION_DIALECT( "connection.dialect", "", false ),

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
@@ -34,11 +34,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -313,6 +309,12 @@ public class DefaultDhisConfigurationProvider extends LogOnceLogger
         }
 
         return EncryptionStatus.OK;
+    }
+
+    @Override
+    public boolean isProduction()
+    {
+        return StringUtils.equals( getProperty( ConfigurationKey.SYSTEM_MODE ), "PRODUCTION" );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
@@ -34,7 +34,11 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
@@ -158,6 +158,11 @@ public interface DhisConfigurationProvider
     EncryptionStatus getEncryptionStatus();
 
     /**
+     * Are we in development or production mode.
+     */
+    boolean isProduction();
+
+    /**
      * Gets map of all properties except those which are confidential
      *
      * @return map containing name of property and its value.

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/H2DhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/H2DhisConfigurationProvider.java
@@ -160,6 +160,12 @@ public class H2DhisConfigurationProvider implements DhisConfigurationProvider
     }
 
     @Override
+    public boolean isProduction()
+    {
+        return StringUtils.equals( getProperty( ConfigurationKey.SYSTEM_MODE ), "PRODUCTION" );
+    }
+
+    @Override
     public Map<String, Serializable> getConfigurationsAsMap()
     {
         return Stream.of( ConfigurationKey.values() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -27,7 +27,14 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.*;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.createWebMessage;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.forbidden;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.serviceUnavailable;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
 import java.beans.PropertyEditorSupport;
 import java.util.Date;
@@ -36,7 +43,11 @@ import java.util.function.Function;
 import javax.servlet.ServletException;
 
 import org.hibernate.exception.ConstraintViolationException;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.DeleteNotAllowedException;
+import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.MaintenanceModeException;
+import org.hisp.dhis.common.QueryRuntimeException;
 import org.hisp.dhis.common.exception.InvalidIdentifierReferenceException;
 import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatchException;
 import org.hisp.dhis.dataapproval.exceptions.DataApprovalException;
@@ -55,7 +66,14 @@ import org.hisp.dhis.query.QueryException;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.SchemaPathException;
 import org.hisp.dhis.util.DateUtils;
-import org.hisp.dhis.webapi.controller.exception.*;
+import org.hisp.dhis.webapi.controller.exception.BadRequestException;
+import org.hisp.dhis.webapi.controller.exception.ConflictException;
+import org.hisp.dhis.webapi.controller.exception.MetadataImportConflictException;
+import org.hisp.dhis.webapi.controller.exception.MetadataSyncException;
+import org.hisp.dhis.webapi.controller.exception.MetadataVersionException;
+import org.hisp.dhis.webapi.controller.exception.NotAuthenticatedException;
+import org.hisp.dhis.webapi.controller.exception.NotFoundException;
+import org.hisp.dhis.webapi.controller.exception.OperationNotAllowedException;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthenticationException;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenError;
 import org.springframework.dao.DataAccessResourceFailureException;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncImportException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.RemoteServerUnavailableException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageResponse;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
 import org.hisp.dhis.webapi.controller.exception.BadRequestException;
@@ -74,7 +75,7 @@ public class MetadataSyncController
     @Autowired
     private MetadataSyncService metadataSyncService;
 
-    public MetadataSyncController()
+    public MetadataSyncController( DhisConfigurationProvider configurationProvider )
     {
         super( configurationProvider );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
@@ -74,6 +74,11 @@ public class MetadataSyncController
     @Autowired
     private MetadataSyncService metadataSyncService;
 
+    public MetadataSyncController()
+    {
+        super( configurationProvider );
+    }
+
     @PreAuthorize( "hasRole('ALL') or hasRole('F_METADATA_MANAGE')" )
     @GetMapping
     public ResponseEntity<? extends WebMessageResponse> metadataSync( HttpServletRequest request,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.metadata.version.exception.MetadataVersionServiceException;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
@@ -83,7 +84,7 @@ public class MetadataVersionController
     @Autowired
     private ContextUtils contextUtils;
 
-    public MetadataVersionController()
+    public MetadataVersionController( DhisConfigurationProvider configurationProvider )
     {
         super( configurationProvider );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -62,11 +62,7 @@ import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * Controller for MetadataVersion
@@ -86,6 +82,11 @@ public class MetadataVersionController
 
     @Autowired
     private ContextUtils contextUtils;
+
+    public MetadataVersionController()
+    {
+        super( configurationProvider );
+    }
 
     // Gets the version by versionName or latest system version
     @GetMapping( value = MetadataVersionSchemaDescriptor.API_ENDPOINT, produces = ContextUtils.CONTENT_TYPE_JSON )


### PR DESCRIPTION
Adds a new `dhis.conf` configuration key called `system.mode` where if it equals `PRODUCTION` (also default) it means we are in production mode and less debug information will be logged (stack traces etc).

[DHIS2-11777](https://jira.dhis2.org/browse/DHIS2-11777)