### PR TITLE
feat: Metadata attributes for analytical objects [DHIS2-3789]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
@@ -51,9 +51,12 @@ import org.hisp.dhis.dataelement.DataElementGroupSet;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.Section;
 import org.hisp.dhis.document.Document;
+import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.eventreport.EventReport;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.legend.LegendSet;
+import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -71,6 +74,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.validation.ValidationRule;
 import org.hisp.dhis.validation.ValidationRuleGroup;
+import org.hisp.dhis.visualization.Visualization;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -149,7 +153,15 @@ public class Attribute
 
         VALIDATION_RULE_GROUP( ValidationRuleGroup.class ),
 
-        CATEGORY( Category.class );
+        CATEGORY( Category.class ),
+
+        VISUALIZATION( Visualization.class ),
+
+        MAP( Map.class ),
+
+        EVENT_REPORT( EventReport.class ),
+
+        EVENT_CHART( EventChart.class );
 
         final Class<? extends IdentifiableObject> type;
 
@@ -661,6 +673,54 @@ public class Attribute
     public void setCategoryAttribute( boolean categoryAttribute )
     {
         setAttribute( ObjectType.CATEGORY, categoryAttribute );
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isVisualizationAttribute()
+    {
+        return isAttribute( ObjectType.VISUALIZATION );
+    }
+
+    public void setVisualizationAttribute( boolean visualizationAttribute )
+    {
+        setAttribute( ObjectType.VISUALIZATION, visualizationAttribute );
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isMapAttribute()
+    {
+        return isAttribute( ObjectType.MAP );
+    }
+
+    public void setMapAttribute( boolean mapAttribute )
+    {
+        setAttribute( ObjectType.MAP, mapAttribute );
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isEventReportAttribute()
+    {
+        return isAttribute( ObjectType.EVENT_REPORT );
+    }
+
+    public void setEventReportAttribute( boolean eventReportAttribute )
+    {
+        setAttribute( ObjectType.EVENT_REPORT, eventReportAttribute );
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isEventChartAttribute()
+    {
+        return isAttribute( ObjectType.EVENT_CHART );
+    }
+
+    public void setEventChartAttribute( boolean eventChartAttribute )
+    {
+        setAttribute( ObjectType.EVENT_CHART, eventChartAttribute );
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.attribute;
 
-import java.util.ArrayList;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -69,9 +72,11 @@ import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.validation.ValidationRule;
 import org.hisp.dhis.validation.ValidationRuleGroup;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.google.common.base.CaseFormat;
 import com.google.common.base.MoreObjects;
 
 /**
@@ -81,67 +86,98 @@ import com.google.common.base.MoreObjects;
 public class Attribute
     extends BaseNameableObject implements MetadataObject
 {
+    /**
+     * The types of {@link IdentifiableObject}s that can have attributes
+     */
+    public enum ObjectType
+    {
+        DATA_ELEMENT( DataElement.class ),
+
+        DATA_ELEMENT_GROUP( DataElementGroup.class ),
+
+        INDICATOR( Indicator.class ),
+
+        INDICATOR_GROUP( IndicatorGroup.class ),
+
+        DATA_SET( DataSet.class ),
+
+        ORGANISATION_UNIT( OrganisationUnit.class ),
+
+        ORGANISATION_UNIT_GROUP( OrganisationUnitGroup.class ),
+
+        ORGANISATION_UNIT_GROUP_SET( OrganisationUnitGroupSet.class ),
+
+        USER( User.class ),
+
+        USER_GROUP( UserGroup.class ),
+
+        PROGRAM( Program.class ),
+
+        PROGRAM_STAGE( ProgramStage.class ),
+
+        TRACKED_ENTITY_TYPE( TrackedEntityType.class ),
+
+        TRACKED_ENTITY_ATTRIBUTE( TrackedEntityAttribute.class ),
+
+        CATEGORY_OPTION( CategoryOption.class ),
+
+        CATEGORY_OPTION_GROUP( CategoryOptionGroup.class ),
+
+        DOCUMENT( Document.class ),
+
+        OPTION( Option.class ),
+
+        OPTION_SET( OptionSet.class ),
+
+        CONSTANT( Constant.class ),
+
+        LEGEND_SET( LegendSet.class ),
+
+        PROGRAM_INDICATOR( ProgramIndicator.class ),
+
+        SQL_VIEW( SqlView.class ),
+
+        SECTION( Section.class ),
+
+        CATEGORY_OPTION_COMBO( CategoryOptionCombo.class ),
+
+        CATEGORY_OPTION_GROUP_SET( CategoryOptionGroupSet.class ),
+
+        DATA_ELEMENT_GROUP_SET( DataElementGroupSet.class ),
+
+        VALIDATION_RULE( ValidationRule.class ),
+
+        VALIDATION_RULE_GROUP( ValidationRuleGroup.class ),
+
+        CATEGORY( Category.class );
+
+        final Class<? extends IdentifiableObject> type;
+
+        ObjectType( Class<? extends IdentifiableObject> type )
+        {
+            this.type = type;
+        }
+
+        public Class<? extends IdentifiableObject> getType()
+        {
+            return type;
+        }
+
+        public static ObjectType valueOf( Class<?> type )
+        {
+            return stream( values() ).filter( t -> t.type == type ).findFirst().orElse( null );
+        }
+
+        public String getPropertyName()
+        {
+            return CaseFormat.UPPER_UNDERSCORE.converterTo( CaseFormat.LOWER_CAMEL )
+                .convert( name() ) + "Attribute";
+        }
+    }
+
     private ValueType valueType;
 
-    private boolean dataElementAttribute;
-
-    private boolean dataElementGroupAttribute;
-
-    private boolean indicatorAttribute;
-
-    private boolean indicatorGroupAttribute;
-
-    private boolean dataSetAttribute;
-
-    private boolean organisationUnitAttribute;
-
-    private boolean organisationUnitGroupAttribute;
-
-    private boolean organisationUnitGroupSetAttribute;
-
-    private boolean userAttribute;
-
-    private boolean userGroupAttribute;
-
-    private boolean programAttribute;
-
-    private boolean programStageAttribute;
-
-    private boolean trackedEntityTypeAttribute;
-
-    private boolean trackedEntityAttributeAttribute;
-
-    private boolean categoryOptionAttribute;
-
-    private boolean categoryOptionGroupAttribute;
-
-    private boolean documentAttribute;
-
-    private boolean optionAttribute;
-
-    private boolean optionSetAttribute;
-
-    private boolean constantAttribute;
-
-    private boolean legendSetAttribute;
-
-    private boolean programIndicatorAttribute;
-
-    private boolean sqlViewAttribute;
-
-    private boolean sectionAttribute;
-
-    private boolean categoryOptionComboAttribute;
-
-    private boolean categoryOptionGroupSetAttribute;
-
-    private boolean dataElementGroupSetAttribute;
-
-    private boolean validationRuleAttribute;
-
-    private boolean validationRuleGroupAttribute;
-
-    private boolean categoryAttribute;
+    private final EnumSet<ObjectType> objectTypes = EnumSet.noneOf( ObjectType.class );
 
     private boolean mandatory;
 
@@ -165,16 +201,8 @@ public class Attribute
     @Override
     public int hashCode()
     {
-        return 31 * super.hashCode() + Objects.hash( valueType, dataElementAttribute, dataElementGroupAttribute,
-            indicatorAttribute, indicatorGroupAttribute,
-            dataSetAttribute, organisationUnitAttribute, organisationUnitGroupAttribute,
-            organisationUnitGroupSetAttribute, userAttribute, userGroupAttribute,
-            programAttribute, programStageAttribute, trackedEntityTypeAttribute, trackedEntityAttributeAttribute,
-            categoryOptionAttribute, categoryOptionGroupAttribute,
-            mandatory, unique, optionSet, optionAttribute, constantAttribute, legendSetAttribute,
-            programIndicatorAttribute, sqlViewAttribute, sectionAttribute, categoryOptionComboAttribute,
-            categoryOptionGroupAttribute, dataElementGroupSetAttribute, validationRuleAttribute,
-            validationRuleGroupAttribute, categoryAttribute );
+        return 31 * super.hashCode() + Objects.hash( valueType, objectTypes,
+            mandatory, unique, optionSet );
     }
 
     @Override
@@ -198,37 +226,28 @@ public class Attribute
         final Attribute other = (Attribute) obj;
 
         return Objects.equals( this.valueType, other.valueType )
-            && Objects.equals( this.dataElementAttribute, other.dataElementAttribute )
-            && Objects.equals( this.dataElementGroupAttribute, other.dataElementGroupAttribute )
-            && Objects.equals( this.indicatorAttribute, other.indicatorAttribute )
-            && Objects.equals( this.indicatorGroupAttribute, other.indicatorGroupAttribute )
-            && Objects.equals( this.dataSetAttribute, other.dataSetAttribute )
-            && Objects.equals( this.organisationUnitAttribute, other.organisationUnitAttribute )
-            && Objects.equals( this.organisationUnitGroupAttribute, other.organisationUnitGroupAttribute )
-            && Objects.equals( this.organisationUnitGroupSetAttribute, other.organisationUnitGroupSetAttribute )
-            && Objects.equals( this.userAttribute, other.userAttribute )
-            && Objects.equals( this.userGroupAttribute, other.userGroupAttribute )
-            && Objects.equals( this.programAttribute, other.programAttribute )
-            && Objects.equals( this.programStageAttribute, other.programStageAttribute )
-            && Objects.equals( this.trackedEntityTypeAttribute, other.trackedEntityTypeAttribute )
-            && Objects.equals( this.trackedEntityAttributeAttribute, other.trackedEntityAttributeAttribute )
-            && Objects.equals( this.categoryOptionAttribute, other.categoryOptionAttribute )
-            && Objects.equals( this.categoryOptionGroupAttribute, other.categoryOptionGroupAttribute )
-            && Objects.equals( this.optionAttribute, other.optionAttribute )
-            && Objects.equals( this.constantAttribute, other.constantAttribute )
-            && Objects.equals( this.legendSetAttribute, other.legendSetAttribute )
-            && Objects.equals( this.programIndicatorAttribute, other.programIndicatorAttribute )
-            && Objects.equals( this.sqlViewAttribute, other.sqlViewAttribute )
-            && Objects.equals( this.sectionAttribute, other.sectionAttribute )
-            && Objects.equals( this.categoryOptionComboAttribute, other.categoryOptionComboAttribute )
-            && Objects.equals( this.categoryOptionGroupSetAttribute, other.categoryOptionGroupSetAttribute )
-            && Objects.equals( this.dataElementGroupSetAttribute, other.dataElementGroupSetAttribute )
-            && Objects.equals( this.validationRuleAttribute, other.validationRuleAttribute )
-            && Objects.equals( this.validationRuleGroupAttribute, other.validationRuleGroupAttribute )
-            && Objects.equals( this.categoryAttribute, other.categoryAttribute )
+            && Objects.equals( this.objectTypes, other.objectTypes )
             && Objects.equals( this.mandatory, other.mandatory )
             && Objects.equals( this.unique, other.unique )
             && Objects.equals( this.optionSet, other.optionSet );
+    }
+
+    @JsonIgnore
+    public boolean isAttribute( ObjectType type )
+    {
+        return objectTypes.contains( type );
+    }
+
+    public void setAttribute( ObjectType type, boolean isAttribute )
+    {
+        if ( isAttribute )
+        {
+            objectTypes.add( type );
+        }
+        else
+        {
+            objectTypes.remove( type );
+        }
     }
 
     @JsonProperty
@@ -273,24 +292,24 @@ public class Attribute
     @Property( value = PropertyType.BOOLEAN, required = Property.Value.FALSE )
     public boolean isDataElementAttribute()
     {
-        return dataElementAttribute;
+        return isAttribute( ObjectType.DATA_ELEMENT );
     }
 
     public void setDataElementAttribute( boolean dataElementAttribute )
     {
-        this.dataElementAttribute = dataElementAttribute;
+        setAttribute( ObjectType.DATA_ELEMENT, dataElementAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isDataElementGroupAttribute()
     {
-        return dataElementGroupAttribute;
+        return isAttribute( ObjectType.DATA_ELEMENT_GROUP );
     }
 
     public void setDataElementGroupAttribute( Boolean dataElementGroupAttribute )
     {
-        this.dataElementGroupAttribute = dataElementGroupAttribute;
+        setAttribute( ObjectType.DATA_ELEMENT_GROUP, dataElementGroupAttribute );
     }
 
     @JsonProperty
@@ -298,36 +317,36 @@ public class Attribute
     @Property( value = PropertyType.BOOLEAN, required = Property.Value.FALSE )
     public boolean isIndicatorAttribute()
     {
-        return indicatorAttribute;
+        return isAttribute( ObjectType.INDICATOR );
     }
 
     public void setIndicatorAttribute( boolean indicatorAttribute )
     {
-        this.indicatorAttribute = indicatorAttribute;
+        setAttribute( ObjectType.INDICATOR, indicatorAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isIndicatorGroupAttribute()
     {
-        return indicatorGroupAttribute;
+        return isAttribute( ObjectType.INDICATOR_GROUP );
     }
 
     public void setIndicatorGroupAttribute( Boolean indicatorGroupAttribute )
     {
-        this.indicatorGroupAttribute = indicatorGroupAttribute;
+        setAttribute( ObjectType.INDICATOR_GROUP, indicatorGroupAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isDataSetAttribute()
     {
-        return dataSetAttribute;
+        return isAttribute( ObjectType.DATA_SET );
     }
 
     public void setDataSetAttribute( Boolean dataSetAttribute )
     {
-        this.dataSetAttribute = dataSetAttribute;
+        setAttribute( ObjectType.DATA_SET, dataSetAttribute );
     }
 
     @JsonProperty
@@ -335,36 +354,36 @@ public class Attribute
     @Property( value = PropertyType.BOOLEAN, required = Property.Value.FALSE )
     public boolean isOrganisationUnitAttribute()
     {
-        return organisationUnitAttribute;
+        return isAttribute( ObjectType.ORGANISATION_UNIT );
     }
 
     public void setOrganisationUnitAttribute( boolean organisationUnitAttribute )
     {
-        this.organisationUnitAttribute = organisationUnitAttribute;
+        setAttribute( ObjectType.ORGANISATION_UNIT, organisationUnitAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isOrganisationUnitGroupAttribute()
     {
-        return organisationUnitGroupAttribute;
+        return isAttribute( ObjectType.ORGANISATION_UNIT_GROUP );
     }
 
     public void setOrganisationUnitGroupAttribute( Boolean organisationUnitGroupAttribute )
     {
-        this.organisationUnitGroupAttribute = organisationUnitGroupAttribute;
+        setAttribute( ObjectType.ORGANISATION_UNIT_GROUP, organisationUnitGroupAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isOrganisationUnitGroupSetAttribute()
     {
-        return organisationUnitGroupSetAttribute;
+        return isAttribute( ObjectType.ORGANISATION_UNIT_GROUP_SET );
     }
 
     public void setOrganisationUnitGroupSetAttribute( Boolean organisationUnitGroupSetAttribute )
     {
-        this.organisationUnitGroupSetAttribute = organisationUnitGroupSetAttribute;
+        setAttribute( ObjectType.ORGANISATION_UNIT_GROUP_SET, organisationUnitGroupSetAttribute );
     }
 
     @JsonProperty
@@ -372,204 +391,204 @@ public class Attribute
     @Property( value = PropertyType.BOOLEAN, required = Property.Value.FALSE )
     public boolean isUserAttribute()
     {
-        return userAttribute;
+        return isAttribute( ObjectType.USER );
     }
 
     public void setUserAttribute( boolean userAttribute )
     {
-        this.userAttribute = userAttribute;
+        setAttribute( ObjectType.USER, userAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isUserGroupAttribute()
     {
-        return userGroupAttribute;
+        return isAttribute( ObjectType.USER_GROUP );
     }
 
     public void setUserGroupAttribute( Boolean userGroupAttribute )
     {
-        this.userGroupAttribute = userGroupAttribute;
+        setAttribute( ObjectType.USER_GROUP, userGroupAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isProgramAttribute()
     {
-        return programAttribute;
+        return isAttribute( ObjectType.PROGRAM );
     }
 
     public void setProgramAttribute( boolean programAttribute )
     {
-        this.programAttribute = programAttribute;
+        setAttribute( ObjectType.PROGRAM, programAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isProgramStageAttribute()
     {
-        return programStageAttribute;
+        return isAttribute( ObjectType.PROGRAM_STAGE );
     }
 
     public void setProgramStageAttribute( boolean programStageAttribute )
     {
-        this.programStageAttribute = programStageAttribute;
+        setAttribute( ObjectType.PROGRAM_STAGE, programStageAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isTrackedEntityTypeAttribute()
     {
-        return trackedEntityTypeAttribute;
+        return isAttribute( ObjectType.TRACKED_ENTITY_TYPE );
     }
 
     public void setTrackedEntityTypeAttribute( boolean trackedEntityTypeAttribute )
     {
-        this.trackedEntityTypeAttribute = trackedEntityTypeAttribute;
+        setAttribute( ObjectType.TRACKED_ENTITY_TYPE, trackedEntityTypeAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isTrackedEntityAttributeAttribute()
     {
-        return trackedEntityAttributeAttribute;
+        return isAttribute( ObjectType.TRACKED_ENTITY_ATTRIBUTE );
     }
 
     public void setTrackedEntityAttributeAttribute( boolean trackedEntityAttributeAttribute )
     {
-        this.trackedEntityAttributeAttribute = trackedEntityAttributeAttribute;
+        setAttribute( ObjectType.TRACKED_ENTITY_ATTRIBUTE, trackedEntityAttributeAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCategoryOptionAttribute()
     {
-        return categoryOptionAttribute;
+        return isAttribute( ObjectType.CATEGORY_OPTION );
     }
 
     public void setCategoryOptionAttribute( boolean categoryOptionAttribute )
     {
-        this.categoryOptionAttribute = categoryOptionAttribute;
+        setAttribute( ObjectType.CATEGORY_OPTION, categoryOptionAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCategoryOptionGroupAttribute()
     {
-        return categoryOptionGroupAttribute;
+        return isAttribute( ObjectType.CATEGORY_OPTION_GROUP );
     }
 
     public void setCategoryOptionGroupAttribute( boolean categoryOptionGroupAttribute )
     {
-        this.categoryOptionGroupAttribute = categoryOptionGroupAttribute;
+        setAttribute( ObjectType.CATEGORY_OPTION_GROUP, categoryOptionGroupAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isDocumentAttribute()
     {
-        return documentAttribute;
+        return isAttribute( ObjectType.DOCUMENT );
     }
 
     public void setDocumentAttribute( boolean documentAttribute )
     {
-        this.documentAttribute = documentAttribute;
+        setAttribute( ObjectType.DOCUMENT, documentAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isOptionAttribute()
     {
-        return optionAttribute;
+        return isAttribute( ObjectType.OPTION );
     }
 
     public void setOptionAttribute( boolean optionAttribute )
     {
-        this.optionAttribute = optionAttribute;
+        setAttribute( ObjectType.OPTION, optionAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isOptionSetAttribute()
     {
-        return optionSetAttribute;
+        return isAttribute( ObjectType.OPTION_SET );
     }
 
     public void setOptionSetAttribute( boolean optionSetAttribute )
     {
-        this.optionSetAttribute = optionSetAttribute;
+        setAttribute( ObjectType.OPTION_SET, optionSetAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isLegendSetAttribute()
     {
-        return legendSetAttribute;
+        return isAttribute( ObjectType.LEGEND_SET );
     }
 
     public void setLegendSetAttribute( boolean legendSetAttribute )
     {
-        this.legendSetAttribute = legendSetAttribute;
+        setAttribute( ObjectType.LEGEND_SET, legendSetAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isConstantAttribute()
     {
-        return constantAttribute;
+        return isAttribute( ObjectType.CONSTANT );
     }
 
     public void setConstantAttribute( boolean constantAttribute )
     {
-        this.constantAttribute = constantAttribute;
+        setAttribute( ObjectType.CONSTANT, constantAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isProgramIndicatorAttribute()
     {
-        return programIndicatorAttribute;
+        return isAttribute( ObjectType.PROGRAM_INDICATOR );
     }
 
     public void setProgramIndicatorAttribute( boolean programIndicatorAttribute )
     {
-        this.programIndicatorAttribute = programIndicatorAttribute;
+        setAttribute( ObjectType.PROGRAM_INDICATOR, programIndicatorAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isSqlViewAttribute()
     {
-        return sqlViewAttribute;
+        return isAttribute( ObjectType.SQL_VIEW );
     }
 
     public void setSqlViewAttribute( boolean sqlViewAttribute )
     {
-        this.sqlViewAttribute = sqlViewAttribute;
+        setAttribute( ObjectType.SQL_VIEW, sqlViewAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCategoryOptionComboAttribute()
     {
-        return categoryOptionComboAttribute;
+        return isAttribute( ObjectType.CATEGORY_OPTION_COMBO );
     }
 
     public void setCategoryOptionComboAttribute( boolean categoryOptionComboAttribute )
     {
-        this.categoryOptionComboAttribute = categoryOptionComboAttribute;
+        setAttribute( ObjectType.CATEGORY_OPTION_COMBO, categoryOptionComboAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isSectionAttribute()
     {
-        return sectionAttribute;
+        return isAttribute( ObjectType.SECTION );
     }
 
     public void setSectionAttribute( boolean sectionAttribute )
     {
-        this.sectionAttribute = sectionAttribute;
+        setAttribute( ObjectType.SECTION, sectionAttribute );
     }
 
     @JsonProperty
@@ -588,60 +607,60 @@ public class Attribute
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCategoryOptionGroupSetAttribute()
     {
-        return this.categoryOptionGroupSetAttribute;
+        return isAttribute( ObjectType.CATEGORY_OPTION_GROUP_SET );
     }
 
     public void setCategoryOptionGroupSetAttribute( boolean categoryOptionGroupSetAttribute )
     {
-        this.categoryOptionGroupSetAttribute = categoryOptionGroupSetAttribute;
+        setAttribute( ObjectType.CATEGORY_OPTION_GROUP_SET, categoryOptionGroupSetAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isDataElementGroupSetAttribute()
     {
-        return this.dataElementGroupSetAttribute;
+        return isAttribute( ObjectType.DATA_ELEMENT_GROUP_SET );
     }
 
     public void setDataElementGroupSetAttribute( boolean dataElementGroupSetAttribute )
     {
-        this.dataElementGroupSetAttribute = dataElementGroupSetAttribute;
+        setAttribute( ObjectType.DATA_ELEMENT_GROUP_SET, dataElementGroupSetAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isValidationRuleAttribute()
     {
-        return this.validationRuleAttribute;
+        return isAttribute( ObjectType.VALIDATION_RULE );
     }
 
     public void setValidationRuleAttribute( boolean validationRuleAttribute )
     {
-        this.validationRuleAttribute = validationRuleAttribute;
+        setAttribute( ObjectType.VALIDATION_RULE, validationRuleAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isValidationRuleGroupAttribute()
     {
-        return this.validationRuleGroupAttribute;
+        return isAttribute( ObjectType.VALIDATION_RULE_GROUP );
     }
 
     public void setValidationRuleGroupAttribute( boolean validationRuleGroupAttribute )
     {
-        this.validationRuleGroupAttribute = validationRuleGroupAttribute;
+        setAttribute( ObjectType.VALIDATION_RULE_GROUP, validationRuleGroupAttribute );
     }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCategoryAttribute()
     {
-        return this.categoryAttribute;
+        return isAttribute( ObjectType.CATEGORY );
     }
 
     public void setCategoryAttribute( boolean categoryAttribute )
     {
-        this.categoryAttribute = categoryAttribute;
+        setAttribute( ObjectType.CATEGORY, categoryAttribute );
     }
 
     @JsonProperty
@@ -658,70 +677,7 @@ public class Attribute
 
     public List<Class<? extends IdentifiableObject>> getSupportedClasses()
     {
-        List<Class<? extends IdentifiableObject>> klasses = new ArrayList<>();
-
-        if ( dataElementAttribute )
-            klasses.add( DataElement.class );
-        if ( dataElementGroupAttribute )
-            klasses.add( DataElementGroup.class );
-        if ( categoryOptionAttribute )
-            klasses.add( CategoryOption.class );
-        if ( categoryOptionGroupAttribute )
-            klasses.add( CategoryOptionGroup.class );
-        if ( indicatorAttribute )
-            klasses.add( Indicator.class );
-        if ( indicatorGroupAttribute )
-            klasses.add( IndicatorGroup.class );
-        if ( dataSetAttribute )
-            klasses.add( DataSet.class );
-        if ( organisationUnitAttribute )
-            klasses.add( OrganisationUnit.class );
-        if ( organisationUnitGroupAttribute )
-            klasses.add( OrganisationUnitGroup.class );
-        if ( organisationUnitGroupSetAttribute )
-            klasses.add( OrganisationUnitGroupSet.class );
-        if ( userAttribute )
-            klasses.add( User.class );
-        if ( userGroupAttribute )
-            klasses.add( UserGroup.class );
-        if ( programAttribute )
-            klasses.add( Program.class );
-        if ( programStageAttribute )
-            klasses.add( ProgramStage.class );
-        if ( trackedEntityTypeAttribute )
-            klasses.add( TrackedEntityType.class );
-        if ( trackedEntityAttributeAttribute )
-            klasses.add( TrackedEntityAttribute.class );
-        if ( documentAttribute )
-            klasses.add( Document.class );
-        if ( optionAttribute )
-            klasses.add( Option.class );
-        if ( optionSetAttribute )
-            klasses.add( OptionSet.class );
-        if ( legendSetAttribute )
-            klasses.add( LegendSet.class );
-        if ( constantAttribute )
-            klasses.add( Constant.class );
-        if ( programIndicatorAttribute )
-            klasses.add( ProgramIndicator.class );
-        if ( sqlViewAttribute )
-            klasses.add( SqlView.class );
-        if ( sectionAttribute )
-            klasses.add( Section.class );
-        if ( categoryOptionComboAttribute )
-            klasses.add( CategoryOptionCombo.class );
-        if ( categoryOptionGroupSetAttribute )
-            klasses.add( CategoryOptionGroupSet.class );
-        if ( dataElementGroupSetAttribute )
-            klasses.add( DataElementGroupSet.class );
-        if ( validationRuleAttribute )
-            klasses.add( ValidationRule.class );
-        if ( validationRuleGroupAttribute )
-            klasses.add( ValidationRuleGroup.class );
-        if ( categoryAttribute )
-            klasses.add( Category.class );
-
-        return klasses;
+        return objectTypes.stream().map( ObjectType::getType ).collect( toList() );
     }
 
     @Override
@@ -730,33 +686,7 @@ public class Attribute
         return MoreObjects.toStringHelper( this )
             .add( "sortOrder", sortOrder )
             .add( "valueType", valueType )
-            .add( "dataElementAttribute", dataElementAttribute )
-            .add( "dataElementGroupAttribute", dataElementGroupAttribute )
-            .add( "indicatorAttribute", indicatorAttribute )
-            .add( "indicatorGroupAttribute", indicatorGroupAttribute )
-            .add( "dataSetAttribute", dataSetAttribute )
-            .add( "organisationUnitAttribute", organisationUnitAttribute )
-            .add( "organisationUnitGroupAttribute", organisationUnitGroupAttribute )
-            .add( "organisationUnitGroupSetAttribute", organisationUnitGroupSetAttribute )
-            .add( "userAttribute", userAttribute )
-            .add( "userGroupAttribute", userGroupAttribute )
-            .add( "programAttribute", programAttribute )
-            .add( "programStageAttribute", programStageAttribute )
-            .add( "trackedEntityTypeAttribute", trackedEntityTypeAttribute )
-            .add( "trackedEntityAttributeAttribute", trackedEntityAttributeAttribute )
-            .add( "categoryOptionAttribute", categoryOptionAttribute )
-            .add( "categoryOptionGroupAttribute", categoryOptionGroupAttribute )
-            .add( "constantAttribute", constantAttribute )
-            .add( "legendSetAttribute", legendSetAttribute )
-            .add( "programIndicatorAttribute", programIndicatorAttribute )
-            .add( "sqlViewAttribute", sqlViewAttribute )
-            .add( "sectionAttribute", sectionAttribute )
-            .add( "categoryOptionComboAttribute", categoryOptionComboAttribute )
-            .add( "categoryOptionGroupSetAttribute", categoryOptionGroupSetAttribute )
-            .add( "dataElementGroupSetAttribute", dataElementGroupSetAttribute )
-            .add( "validationRuleAttribute", validationRuleAttribute )
-            .add( "validationRuleGroupAttribute", validationRuleGroupAttribute )
-            .add( "categoryAttribute", categoryAttribute )
+            .add( "objectTypes", objectTypes )
             .add( "mandatory", mandatory )
             .toString();
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeStore.java
@@ -27,39 +27,12 @@
  */
 package org.hisp.dhis.attribute;
 
+import static java.util.Arrays.stream;
+
 import java.util.List;
 
-import org.hisp.dhis.category.Category;
-import org.hisp.dhis.category.CategoryOption;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.category.CategoryOptionGroup;
-import org.hisp.dhis.category.CategoryOptionGroupSet;
+import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.constant.Constant;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementGroup;
-import org.hisp.dhis.dataelement.DataElementGroupSet;
-import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.dataset.Section;
-import org.hisp.dhis.document.Document;
-import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.indicator.IndicatorGroup;
-import org.hisp.dhis.legend.LegendSet;
-import org.hisp.dhis.option.Option;
-import org.hisp.dhis.option.OptionSet;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramIndicator;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.sqlview.SqlView;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserGroup;
-import org.hisp.dhis.validation.ValidationRule;
-import org.hisp.dhis.validation.ValidationRuleGroup;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -71,38 +44,8 @@ public interface AttributeStore
 {
     String ID = AttributeStore.class.getName();
 
-    ImmutableMap<Class<?>, String> CLASS_ATTRIBUTE_MAP = ImmutableMap.<Class<?>, String> builder()
-        .put( DataElement.class, "dataElementAttribute" )
-        .put( DataElementGroup.class, "dataElementGroupAttribute" )
-        .put( Indicator.class, "indicatorAttribute" )
-        .put( IndicatorGroup.class, "indicatorGroupAttribute" )
-        .put( DataSet.class, "dataSetAttribute" )
-        .put( OrganisationUnit.class, "organisationUnitAttribute" )
-        .put( OrganisationUnitGroup.class, "organisationUnitGroupAttribute" )
-        .put( OrganisationUnitGroupSet.class, "organisationUnitGroupSetAttribute" )
-        .put( User.class, "userAttribute" )
-        .put( UserGroup.class, "userGroupAttribute" )
-        .put( Program.class, "programAttribute" )
-        .put( ProgramStage.class, "programStageAttribute" )
-        .put( TrackedEntityType.class, "trackedEntityTypeAttribute" )
-        .put( TrackedEntityAttribute.class, "trackedEntityAttributeAttribute" )
-        .put( CategoryOption.class, "categoryOptionAttribute" )
-        .put( CategoryOptionGroup.class, "categoryOptionGroupAttribute" )
-        .put( Document.class, "documentAttribute" )
-        .put( Option.class, "optionAttribute" )
-        .put( OptionSet.class, "optionSetAttribute" )
-        .put( Constant.class, "constantAttribute" )
-        .put( LegendSet.class, "legendSetAttribute" )
-        .put( ProgramIndicator.class, "programIndicatorAttribute" )
-        .put( SqlView.class, "sqlViewAttribute" )
-        .put( Section.class, "sectionAttribute" )
-        .put( CategoryOptionCombo.class, "categoryOptionComboAttribute" )
-        .put( CategoryOptionGroupSet.class, "categoryOptionGroupSetAttribute" )
-        .put( DataElementGroupSet.class, "dataElementGroupSetAttribute" )
-        .put( ValidationRule.class, "validationRuleAttribute" )
-        .put( ValidationRuleGroup.class, "validationRuleGroupAttribute" )
-        .put( Category.class, "categoryAttribute" )
-        .build();
+    ImmutableMap<Class<?>, String> CLASS_ATTRIBUTE_MAP = stream( ObjectType.values() )
+        .collect( ImmutableMap.toImmutableMap( ObjectType::getType, ObjectType::getPropertyName ) );
 
     /**
      * Get all metadata attributes for a given class, returns empty list for

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
@@ -93,13 +93,13 @@
 
     <property name="categoryAttribute" not-null="false"/>
 
-    <property name="visualizationAttribute" not-null="false"/>
+    <property name="visualizationAttribute" not-null="true"/>
 
-    <property name="mapAttribute" not-null="false"/>
+    <property name="mapAttribute" not-null="true"/>
 
-    <property name="eventReportAttribute" not-null="false"/>
+    <property name="eventReportAttribute" not-null="true"/>
 
-    <property name="eventChartAttribute" not-null="false"/>
+    <property name="eventChartAttribute" not-null="true"/>
 
     <property name="sortOrder"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
@@ -83,24 +83,34 @@
 
     <property name="categoryOptionComboAttribute" not-null="false" />
 
-    <property name="categoryOptionGroupSetAttribute" not-null="false" />
+    <property name="categoryOptionGroupSetAttribute" not-null="false"/>
 
-    <property name="dataElementGroupSetAttribute" not-null="false" />
+    <property name="dataElementGroupSetAttribute" not-null="false"/>
 
-    <property name="validationRuleAttribute" not-null="false" />
+    <property name="validationRuleAttribute" not-null="false"/>
 
-    <property name="validationRuleGroupAttribute" not-null="false" />
+    <property name="validationRuleGroupAttribute" not-null="false"/>
 
-    <property name="categoryAttribute" not-null="false" />
+    <property name="categoryAttribute" not-null="false"/>
 
-    <property name="sortOrder" />
+    <property name="visualizationAttribute" not-null="false"/>
+
+    <property name="mapAttribute" not-null="false"/>
+
+    <property name="eventReportAttribute" not-null="false"/>
+
+    <property name="eventChartAttribute" not-null="false"/>
+
+    <property name="sortOrder"/>
 
     <property name="translations" type="jblTranslations"/>
 
-    <many-to-one name="optionSet" class="org.hisp.dhis.option.OptionSet" column="optionsetid"
-      foreign-key="fk_attribute_optionsetid" />
+    <many-to-one name="optionSet" class="org.hisp.dhis.option.OptionSet"
+                 column="optionsetid"
+                 foreign-key="fk_attribute_optionsetid"/>
 
-    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_attribute_userid" />
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User"
+                 column="userid" foreign-key="fk_attribute_userid"/>
 
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
@@ -45,7 +45,7 @@
       <many-to-many column="categorydimensionid" class="org.hisp.dhis.category.CategoryDimension"
         foreign-key="fk_eventchart_categorydimensions_categorydimensionid" />
     </list>
-    
+
     <list name="organisationUnitGroupSetDimensions" table="eventchart_orgunitgroupsetdimensions" cascade="all-delete-orphan">
       <cache usage="read-write" />
       <key column="eventchartid" foreign-key="fk_eventchart_orgunitgroupsetdimensions_eventchartid" />
@@ -53,7 +53,7 @@
       <many-to-many column="orgunitgroupsetdimensionid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension"
         foreign-key="fk_eventchart_dimensions_ogunitgroupsetdimensionid" />
     </list>
-    
+
     <list name="categoryOptionGroupSetDimensions" table="eventchart_categoryoptiongroupsetdimensions" cascade="all-delete-orphan">
       <cache usage="read-write" />
       <key column="eventchartid" foreign-key="fk_eventchart_catoptiongroupsetdimensions_eventchartid" />
@@ -61,7 +61,7 @@
       <many-to-many column="categoryoptiongroupsetdimensionid" class="org.hisp.dhis.category.CategoryOptionGroupSetDimension"
         foreign-key="fk_eventchart_dimensions_catoptiongroupsetdimensionid" />
     </list>
-    
+
     <list name="organisationUnitLevels" table="eventchart_orgunitlevels">
       <cache usage="read-write" />
       <key column="eventchartid" foreign-key="fk_eventchart_orgunitlevels_eventchartid" />
@@ -134,11 +134,11 @@
     <property name="completedOnly" column="completedonly" />
 
     <property name="timeField" column="timefield" />
-    
+
     <property name="orgUnitField" column="orgunitfield" />
-    
+
     <property name="title" />
-    
+
     <property name="subtitle" />
 
     <property name="hideTitle" />
@@ -188,9 +188,9 @@
         <param name="type">12</param>
       </type>
     </property>
-    
+
     <property name="hideNaData" />
-    
+
     <property name="programStatus" length="40">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.program.ProgramStatus</param>
@@ -198,7 +198,7 @@
         <param name="type">12</param>
       </type>
     </property>
-    
+
     <property name="eventStatus" length="40">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.event.EventStatus</param>
@@ -206,9 +206,9 @@
         <param name="type">12</param>
       </type>
     </property>
-    
+
     <property name="percentStackedValues" />
-    
+
     <property name="cumulativeValues" />
 
     <property name="rangeAxisMaxValue" />
@@ -264,15 +264,18 @@
 
     <property name="favorites" type="jbSet" />
 
-    <property name="subscribers" type="jbSet" />
+    <property name="subscribers" type="jbSet"/>
 
-    <property name="userOrgUnitType" length="12" >
+    <property name="userOrgUnitType" length="12">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.analytics.UserOrgUnitType</param>
         <param name="useNamed">true</param>
         <param name="type">12</param>
       </type>
     </property>
+
+    <!-- Dynamic attribute values -->
+    <property name="attributeValues" type="jsbAttributeValues"/>
 
   </class>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
@@ -53,7 +53,7 @@
       <many-to-many column="orgunitgroupsetdimensionid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension"
         foreign-key="fk_eventreport_dimensions_ogunitgroupsetdimensionid" />
     </list>
-    
+
     <list name="categoryOptionGroupSetDimensions" table="eventreport_categoryoptiongroupsetdimensions" cascade="all-delete-orphan">
       <cache usage="read-write" />
       <key column="eventreportid" foreign-key="fk_eventreport_catoptiongroupsetdimensions_eventreportid" />
@@ -61,7 +61,7 @@
       <many-to-many column="categoryoptiongroupsetdimensionid" class="org.hisp.dhis.category.CategoryOptionGroupSetDimension"
         foreign-key="fk_eventreport_dimensions_catoptiongroupsetdimensionid" />
     </list>
-    
+
     <list name="organisationUnitLevels" table="eventreport_orgunitlevels">
       <cache usage="read-write" />
       <key column="eventreportid" foreign-key="fk_eventreport_orgunitlevels_eventreportid" />
@@ -132,13 +132,13 @@
     </property>
 
     <property name="completedOnly" column="completedonly" />
-    
+
     <property name="timeField" column="timefield" />
 
     <property name="orgUnitField" column="orgunitfield" />
-    
+
     <property name="title" />
-    
+
     <property name="subtitle" />
 
     <property name="hideTitle" />
@@ -236,7 +236,7 @@
         <param name="type">12</param>
       </type>
     </property>
-    
+
     <property name="eventStatus" length="40">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.event.EventStatus</param>
@@ -244,7 +244,7 @@
         <param name="type">12</param>
       </type>
     </property>
-    
+
     <property name="sortOrder" />
 
     <property name="topLimit" />
@@ -258,15 +258,18 @@
 
     <property name="favorites" type="jbSet" />
 
-    <property name="subscribers" type="jbSet" />
+    <property name="subscribers" type="jbSet"/>
 
-    <property name="userOrgUnitType" length="12" >
+    <property name="userOrgUnitType" length="12">
       <type name="org.hibernate.type.EnumType">
         <param name="enumClass">org.hisp.dhis.analytics.UserOrgUnitType</param>
         <param name="useNamed">true</param>
         <param name="type">12</param>
       </type>
     </property>
+
+    <!-- Dynamic attribute values -->
+    <property name="attributeValues" type="jsbAttributeValues"/>
 
   </class>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/Map.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/Map.hbm.xml
@@ -44,15 +44,18 @@
       <one-to-many class="org.hisp.dhis.interpretation.Interpretation" />
     </set>
 
-    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_mapview_userid" />
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User"
+                 column="userid" foreign-key="fk_mapview_userid"/>
 
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 
-    <property name="favorites" type="jbSet" />
+    <property name="favorites" type="jbSet"/>
 
-    <property name="subscribers" type="jbSet" />
+    <property name="subscribers" type="jbSet"/>
 
+    <!-- Dynamic attribute values -->
+    <property name="attributeValues" type="jsbAttributeValues"/>
   </class>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
@@ -115,7 +115,7 @@
         <param name="type">12</param>
       </type>
     </property>
-    
+
     <property name="series" type="jbSeries"/>
 
     <list name="dataDimensionItems" table="visualization_datadimensionitems" cascade="all, delete-orphan">
@@ -319,10 +319,13 @@
 
     <property name="translations" type="jblTranslations"/>
 
-    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_visualization_userid"/>
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User"
+                 column="userid" foreign-key="fk_visualization_userid"/>
 
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
 
+    <!-- Dynamic attribute values -->
+    <property name="attributeValues" type="jsbAttributeValues"/>
   </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
@@ -179,6 +179,7 @@ public class HibernatePropertyIntrospector implements PropertyIntrospector
         Type type = hibernateProperty.getType();
 
         property.setName( hibernateProperty.getName() );
+        property.setFieldName( hibernateProperty.getName() );
         property.setCascade( hibernateProperty.getCascade() );
         property.setCollection( type.isCollectionType() );
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
@@ -235,6 +235,7 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector
     {
         property.setPersisted( true );
         property.setWritable( true );
+        property.setFieldName( persisted.getFieldName() );
         property.setUnique( persisted.isUnique() );
         property.setRequired( persisted.isRequired() );
         property.setLength( persisted.getLength() );

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_6__Add_attributes_for_analytical_objects.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_6__Add_attributes_for_analytical_objects.sql
@@ -1,0 +1,9 @@
+alter table visualization add column if not exists attributevalues jsonb default '{}'::jsonb;
+alter table map add column if not exists attributevalues jsonb default '{}'::jsonb;
+alter table eventreport add column if not exists attributevalues jsonb default '{}'::jsonb;
+alter table eventchart add column if not exists attributevalues jsonb default '{}'::jsonb;
+
+alter table attribute add column if not exists visualizationAttribute boolean;
+alter table attribute add column if not exists mapAttribute boolean;
+alter table attribute add column if not exists eventReportAttribute boolean;
+alter table attribute add column if not exists eventChartAttribute boolean;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_6__Add_attributes_for_analytical_objects.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_6__Add_attributes_for_analytical_objects.sql
@@ -3,7 +3,7 @@ alter table map add column if not exists attributevalues jsonb default '{}'::jso
 alter table eventreport add column if not exists attributevalues jsonb default '{}'::jsonb;
 alter table eventchart add column if not exists attributevalues jsonb default '{}'::jsonb;
 
-alter table attribute add column if not exists visualizationAttribute boolean;
-alter table attribute add column if not exists mapAttribute boolean;
-alter table attribute add column if not exists eventReportAttribute boolean;
-alter table attribute add column if not exists eventChartAttribute boolean;
+alter table attribute add column if not exists visualizationAttribute boolean not null default false;
+alter table attribute add column if not exists mapAttribute boolean not null default false;
+alter table attribute add column if not exists eventReportAttribute boolean not null default false;
+alter table attribute add column if not exists eventChartAttribute boolean not null default false;

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonAttributeValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonAttributeValue.java
@@ -27,87 +27,22 @@
  */
 package org.hisp.dhis.webapi.json.domain;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.hisp.dhis.webapi.json.JsonDate;
-import org.hisp.dhis.webapi.json.JsonList;
 import org.hisp.dhis.webapi.json.JsonObject;
 
 /**
- * Web API equivalent of a {@link org.hisp.dhis.common.BaseIdentifiableObject}.
+ * Web API equivalent of a {@link org.hisp.dhis.attribute.AttributeValue}.
  *
  * @author Jan Bernitt
  */
-public interface JsonIdentifiableObject extends JsonObject
+public interface JsonAttributeValue extends JsonObject
 {
-    default String getId()
+    default String getValue()
     {
-        return getString( "id" ).string();
+        return getString( "value" ).string();
     }
 
-    default String getName()
+    default JsonIdentifiableObject getAttribute()
     {
-        return getString( "name" ).string();
-    }
-
-    default String getDisplayName()
-    {
-        return getString( "displayName" ).string();
-    }
-
-    default String getHref()
-    {
-        return getString( "href" ).string();
-    }
-
-    default String getCode()
-    {
-        return getString( "code" ).string();
-    }
-
-    default JsonUser getLastUpdatedBy()
-    {
-        return get( "lastUpdatedBy", JsonUser.class );
-    }
-
-    default LocalDateTime getLastUpdated()
-    {
-        return get( "lastUpdated", JsonDate.class ).date();
-    }
-
-    default JsonUser getCreatedBy()
-    {
-        return get( "createdBy", JsonUser.class );
-    }
-
-    default LocalDateTime getCreated()
-    {
-        return get( "created", JsonDate.class ).date();
-    }
-
-    default boolean getExternalAccess()
-    {
-        return getBoolean( "externalAccess" ).booleanValue();
-    }
-
-    default List<String> getFavorites()
-    {
-        return getArray( "favorites" ).stringValues();
-    }
-
-    default boolean isFavorite()
-    {
-        return getBoolean( "favorite" ).booleanValue();
-    }
-
-    default JsonSharing getSharing()
-    {
-        return get( "sharing", JsonSharing.class );
-    }
-
-    default JsonList<JsonAttributeValue> getAttributeValues()
-    {
-        return getList( "attributeValues", JsonAttributeValue.class );
+        return get( "attribute", JsonIdentifiableObject.class );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AttributeControllerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+
+import org.hisp.dhis.attribute.Attribute.ObjectType;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the {@link AttributeController}.
+ */
+public class AttributeControllerTest extends DhisControllerConvenienceTest
+{
+
+    /**
+     * Tests that each type only sets the property the type relates to
+     */
+    @Test
+    public void testObjectTypes()
+    {
+        for ( ObjectType testedType : ObjectType.values() )
+        {
+            String propertyName = testedType.getPropertyName();
+            String uid = assertStatus( HttpStatus.CREATED, POST( "/attributes", "{" +
+                "'name':'" + testedType + "', " +
+                "'valueType':'INTEGER', " +
+                "'" + propertyName + "':true}" ) );
+            JsonObject attr = GET( "/attributes/{uid}", uid ).content();
+
+            for ( ObjectType otherType : ObjectType.values() )
+            {
+                assertEquals( testedType == otherType,
+                    attr.getBoolean( otherType.getPropertyName() ).booleanValue() );
+            }
+        }
+    }
+
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -177,11 +177,12 @@ public class SchemaBasedControllerTest extends DhisControllerConvenienceTest
     private void testCanHaveAttributes( JsonSchema schema, String uid )
     {
         ObjectType type = ObjectType.valueOf( schema.getKlass() );
-        if ( type == null )
+        if ( type == null || type == ObjectType.MAP )
         {
             return;
         }
 
+        System.out.println( schema.getRelativeApiEndpoint() );
         String attrId = assertStatus( HttpStatus.CREATED, POST( "/attributes",
             "{'name':'" + type + "', 'valueType':'INTEGER','" + type.getPropertyName() + "':true}" ) );
 


### PR DESCRIPTION
### Summary
Adds 4 further object types that can have attributes:

- Visualization
- Map
- EventReport
- EventChart

The added columns in `Attribute` table are initialised with `not null default false`.


### Refactoring of the `Attribute` Object Types
Instead of using numerous `boolean` fields, one for each table, to indicate whether or not an object type can have a certain attribute a new `enum` `ObjectType` is introduced. The set of object types is then stored as a single `EnumSet` within the `Attribute`. All getter/setters read/write the set instead of individual fields.

There is a convention that the enum constant name can be converted from its upper case to lower camel case and append `"Attribute"` to get the property name of the getter/setter responsible for the object type (and the name used in JSON etcetera).

This would fail the audit listener when it composes the audit entry using `Schema` properties since now lots of `Property`s do exist which had no field name associated (since the field was removed). Still these are mapped to a table column so I modified the property introspection to consider the hibernate members that are mapped columns as having that field name (of the getter property). Should the field name be different to that according to existing logic the existing logic would later override the field name as extracted from the hibernate properties. So makes me fairly confident this change does not break field name based mapping.

The only scenario we do have to think about is that there now might be a field name available from hibernate where there previously was none affecting the result of logic that iterates all properties and uses the field name for something.


### Automatic Testing
Adds a controller based test that check each object type is mapped correctly from/to enum constant in the getter/setter by creating a new attribute that only has a single object type set. Loading the created attribute and check that only that type is `true` (allowed) while all others are `false` (not allowed).

Another test was added to the schema based testing where a new attribute is created for a single object type and an attribute value is assigned to an object making sure we can store attribute values of each type. `MAP` here had to be excluded for unrelated reasons. 