### PR TITLE
feat: Add index on tei and psi table to improve tei querying performance [DHIS2-11767](2.38)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_5__Add_indexes_to_tei_and_psi_table_to_improve_tei_querying.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_5__Add_indexes_to_tei_and_psi_table_to_improve_tei_querying.sql
@@ -1,2 +1,2 @@
-create index if not exists in_tei_created_deleted_tet_ou ON trackedentityinstance using btree (created, deleted, trackedentitytypeid, organisationunitid);
+create index if not exists in_trackedentityinstance_created ON trackedentityinstance using btree (created);
 create index if not exists in_psi_deleted_assigneduserid ON programstageinstance using btree (deleted,assigneduserid);

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_5__Add_indexes_to_tei_and_psi_table_to_improve_tei_querying.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_5__Add_indexes_to_tei_and_psi_table_to_improve_tei_querying.sql
@@ -1,0 +1,2 @@
+create index if not exists in_tei_created_deleted_tet_ou ON trackedentityinstance using btree (created, deleted, trackedentitytypeid, organisationunitid);
+create index if not exists in_psi_deleted_assigneduserid ON programstageinstance using btree (deleted,assigneduserid);


### PR DESCRIPTION
2 indexes have been added.
One index on **trackedentityinstance** table and another one on **programstageinstance** table. These significanly improve tei fetching through the APIs when either sort order is created date or when there are event filter assignments involved.