### PR TITLE
fix: do not show file transfer progress in CI builds

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn speedy-spotless:check -Pdefault -Pjdk11 --update-snapshots -q -f ./dhis-2/pom.xml $MAVEN_BUILD_OPTS
+        run: mvn speedy-spotless:check -Pdefault -Pjdk11 --no-transfer-progress --update-snapshots -q -f ./dhis-2/pom.xml $MAVEN_BUILD_OPTS
 
       - name: Check formatting in web
         env:
           # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn speedy-spotless:check -Pdefault -Pjdk11 --update-snapshots -q -f ./dhis-2/dhis-web/pom.xml $MAVEN_BUILD_OPTS
+        run: mvn speedy-spotless:check -Pdefault -Pjdk11 --no-transfer-progress --update-snapshots -q -f ./dhis-2/dhis-web/pom.xml $MAVEN_BUILD_OPTS

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,12 +61,12 @@ jobs:
         env:
           # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -f ./dhis-2/pom.xml -Pdev -Pjdk11 -DskipTests=true -Dmaven.javadoc.skip=true -B -V $MAVEN_BUILD_OPTS
+        run: mvn clean install -f ./dhis-2/pom.xml -Pdev -Pjdk11 --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true -B -V $MAVEN_BUILD_OPTS
       - name: Build web
         env:
           # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -f ./dhis-2/dhis-web/pom.xml -Pdev -Pjdk11 -DskipTests=true -Dmaven.javadoc.skip=true -B -V $MAVEN_BUILD_OPTS
+        run: mvn clean install -f ./dhis-2/dhis-web/pom.xml -Pdev -Pjdk11 --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true -B -V $MAVEN_BUILD_OPTS
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Test core
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pdefault -Pjdk11 --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
+        run: mvn clean install -Pdefault -Pjdk11 --no-transfer-progress --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
 
       - name: Test dhis-web
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pdefault -Pjdk11 --update-snapshots -f ./dhis-2/dhis-web/pom.xml $MAVEN_BUILD_OPTS
+        run: mvn clean install -Pdefault -Pjdk11 --no-transfer-progress --update-snapshots -f ./dhis-2/dhis-web/pom.xml $MAVEN_BUILD_OPTS
 
   integration-test:
     runs-on: ubuntu-latest
@@ -50,4 +50,4 @@ jobs:
       - name: Run integration tests
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pintegration -Pjdk11 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
+        run: mvn clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS


### PR DESCRIPTION
Uses `--no-transfer-progress` (requires maven >= 3.6.1) to suppress logging of downloads like this

```
Downloading: some.jar
4/2122 KB   
8/2122 KB   
12/2122 KB   
...
```

Had a look at the raw logs and can't find any of the above so I assume this did work.