### PR TITLE
fix: Load in preheat all attributes and dataElements linked to program rules [DHIS2-11762]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleService.java
@@ -93,7 +93,7 @@ public interface ProgramRuleService
      */
     List<ProgramRule> getAllProgramRule();
 
-    List<ProgramRule> getProgramRuleByProgramStage( Set<String> programStages );
+    List<ProgramRule> getProgramRulesLinkedToTeaOrDe();
 
     List<ProgramRule> getProgramRulesByActionTypes( Program program, Set<ProgramRuleActionType> types );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleStore.java
@@ -62,7 +62,7 @@ public interface ProgramRuleStore
      * @param programStageIds
      * @return ProgramRule list
      */
-    List<ProgramRule> getByProgramStage( Set<String> programStageIds );
+    List<ProgramRule> getProgramRulesLinkedToTeaOrDe();
 
     /**
      * Get validation by {@link Program}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
@@ -105,9 +105,9 @@ public class DefaultProgramRuleService
 
     @Override
     @Transactional( readOnly = true )
-    public List<ProgramRule> getProgramRuleByProgramStage( Set<String> programStages )
+    public List<ProgramRule> getProgramRulesLinkedToTeaOrDe()
     {
-        return programRuleStore.getByProgramStage( programStages );
+        return programRuleStore.getProgramRulesLinkedToTeaOrDe();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
@@ -57,7 +57,7 @@ public class HibernateProgramRuleStore
     public HibernateProgramRuleStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
         ApplicationEventPublisher publisher, CurrentUserService currentUserService, AclService aclService )
     {
-        super( sessionFactory, jdbcTemplate, publisher, ProgramRule.class, currentUserService, aclService, true );
+        super( sessionFactory, jdbcTemplate, publisher, ProgramRule.class, currentUserService, aclService, false );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
@@ -80,16 +80,15 @@ public class HibernateProgramRuleStore
     }
 
     @Override
-    public List<ProgramRule> getByProgramStage( Set<String> programStageIds )
+    public List<ProgramRule> getProgramRulesLinkedToTeaOrDe()
     {
-        final String jql = "SELECT distinct pr FROM ProgramRule pr, ProgramStage ps, Program p " +
-            "JOIN FETCH pr.programRuleActions pra " +
-            "WHERE p = ps.program AND p.uid = pr.program.uid " +
-            "AND ps.uid in (:ids)";
 
+        String jql = "SELECT distinct pr FROM ProgramRule pr, Program p " +
+            "JOIN FETCH pr.programRuleActions pra " +
+            "WHERE p.uid = pr.program.uid AND " +
+            "(pra.dataElement IS NOT NULL OR pra.attribute IS NOT NULL)";
         Session session = getSession();
         return session.createQuery( jql, ProgramRule.class )
-            .setParameterList( "ids", programStageIds )
             .getResultList();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -98,29 +98,25 @@ public class TrackerIdentifierCollector
     private void collectProgramRulesFields( Map<Class<?>, Set<String>> map,
         TrackerIdentifierParams params )
     {
-        Set<String> programStages = map.get( ProgramStage.class );
-        if ( programStages != null )
-        {
-            List<ProgramRule> programRules = programRuleService.getProgramRuleByProgramStage( programStages );
-            Set<String> dataElements = programRules.stream()
-                .flatMap( pr -> pr.getProgramRuleActions().stream() )
-                .filter( a -> Objects.nonNull( a.getDataElement() ) )
-                .map( a -> a.getDataElement().getUid() )
-                .collect( Collectors.toSet() );
+        List<ProgramRule> programRules = programRuleService.getProgramRulesLinkedToTeaOrDe();
+        Set<String> dataElements = programRules.stream()
+            .flatMap( pr -> pr.getProgramRuleActions().stream() )
+            .filter( a -> Objects.nonNull( a.getDataElement() ) )
+            .map( a -> a.getDataElement().getUid() )
+            .collect( Collectors.toSet() );
 
-            dataElements
-                .forEach(
-                    de -> addIdentifier( map, DataElement.class, params.getDataElementIdScheme().getIdScheme(), de ) );
+        dataElements
+            .forEach(
+                de -> addIdentifier( map, DataElement.class, params.getDataElementIdScheme().getIdScheme(), de ) );
 
-            Set<String> attributes = programRules.stream()
-                .flatMap( pr -> pr.getProgramRuleActions().stream() )
-                .filter( a -> Objects.nonNull( a.getAttribute() ) )
-                .map( a -> a.getAttribute().getUid() )
-                .collect( Collectors.toSet() );
+        Set<String> attributes = programRules.stream()
+            .flatMap( pr -> pr.getProgramRuleActions().stream() )
+            .filter( a -> Objects.nonNull( a.getAttribute() ) )
+            .map( a -> a.getAttribute().getUid() )
+            .collect( Collectors.toSet() );
 
-            attributes.forEach(
-                attribute -> addIdentifier( map, TrackedEntityAttribute.class, TrackerIdScheme.UID, attribute ) );
-        }
+        attributes.forEach(
+            attribute -> addIdentifier( map, TrackedEntityAttribute.class, TrackerIdScheme.UID, attribute ) );
     }
 
     private void collectDefaults( Map<Class<?>, Set<String>> map,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -331,7 +331,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
             TrackedEntityAttribute attribute = preheat.get( TrackedEntityAttribute.class, at.getAttribute() );
 
             checkNotNull( attribute,
-                "Attribute should never be NULL here if validation is enforced before commit." );
+                "Attribute " + at.getAttribute()
+                    + " should never be NULL here if validation is enforced before commit." );
 
             TrackedEntityAttributeValue attributeValue = attributeValueDBMap.get( at.getAttribute() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -63,7 +63,6 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
         TrackedEntityAttribute teAttr )
     {
         checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
-        checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
         checkNotNull( teAttr, TRACKED_ENTITY_ATTRIBUTE_CANT_BE_NULL );
 
         ValueType valueType = teAttr.getValueType();


### PR DESCRIPTION
Attributes or a data elements linked to program rules must be loaded in the preheat because they could be assigned to a tracker entity in the payload and at the moment of validation they need to be found in the preheat.
All the attributes and data elements linked to program rules are loaded even though they could not be used. Filter more in depth in the collector phase in NTI would me to expensive, so it is better to load some more data and be sure they are in the context