### PR TITLE
fix: Reverting org. units logic in events [DHIS2-11800]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -370,6 +370,7 @@ public class AbstractJdbcEventAnalyticsManagerTest
 
         // Then
         assertThat( whereClause,
-            containsString( "and ax.\"uidlevel1\" in ('ouabcdefghA', 'ouabcdefghB', 'ouabcdefghC')" ) );
+            containsString(
+                "and (ax.\"uidlevel0\" = 'ouabcdefghA' or ax.\"uidlevel0\" = 'ouabcdefghB' or ax.\"uidlevel0\" = 'ouabcdefghC' )" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -139,7 +139,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
         String expected = "select psi,ps,executiondate,storedby,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,oucode,ax.\"monthly\",ax.\"ou\"  from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') limit 101";
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertThat( sql.getValue(), is( expected ) );
     }
@@ -162,7 +162,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
             "as geometry,longitude,latitude,ouname,oucode,ax.\"monthly\",ax.\"ou\",\"" + dataElement.getUid() + "_name"
             + "\"  " +
             "from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') limit 101";
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertThat( sql.getValue(), is( expected ) );
     }
@@ -177,7 +177,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') limit 101";
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( expected, sql.getValue() );
     }
@@ -193,7 +193,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -210,7 +210,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -227,7 +227,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid() + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -306,7 +306,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -322,7 +322,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid() + "' and lower(ax.\"fWIAEtYVEGk\") > '10' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -350,7 +350,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
         String expected = "select count(ax.\"psi\") as value,ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid() + "' group by ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" limit 200001";
 
         assertThat( sql.getValue(), is( expected ) );
@@ -378,7 +378,7 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
         String expected = "select count(ax.\"psi\") as value,ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"ou\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and lower(ax.\"fWIAEtYVEGk\") > '10' group by ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" limit 200001";
         assertThat( sql.getValue(), is( expected ) );
@@ -487,11 +487,9 @@ public class EventsAnalyticsManagerTest extends EventAnalyticsTest
         when( rowSet.getInt( "value" ) ).thenReturn( 100 );
     }
 
-    private void assertSql( String expected, String actual )
+    private void assertSql( String actual, String expected )
     {
-        expected = "select " + DEFAULT_COLUMNS_WITH_REGISTRATION + "," + expected;
-
-        assertThat( actual, is( expected ) );
+        assertThat( "select " + DEFAULT_COLUMNS_WITH_REGISTRATION + "," + actual, is( expected ) );
     }
 
     @Override


### PR DESCRIPTION
This fix reverts the latest changes we applied, with the intent of improving the org. units logic for performance gains.

Unfortunately, it changed the output expected by the underline flow.
To play on the safe side and avoid a new problem, I'm reverting the logic from the 2.36 release.
We can play around it in 2.38 if needed.

**_Technical notes_**
This query used to work in 2.36, but fails in 2.37. That's how QA found it.
`api/37/analytics/events/query/VBqh0ynB2wv.json?dimension=ou:at6UHUQatSo&stage=pTo4uMt3xur&coordinatesOnly=true&startDate=2020-01-01T01:00:00.000&endDate=2021-10-01T02:00:00.000&pageSize=100000`

After firing that query, at some point the org. units SQL condition differs between 2.36 and 2.37:
**2.36)**
where ax."executiondate" >= '2020-01-01' and ax."executiondate" <= '2021-10-01' and (ax."uidlevel2" = 'at6UHUQatSo' )

**2.37)**
where ax."executiondate" >= '2020-01-01' and ax."executiondate" <= '2021-10-01' and ax."ou" in ('at6UHUQatSo') 

The issue is that in 2.37 we compare using ax."ou", instead of ax."uidlevel2", so no results are found.


**This PR needs to be approved by the changing control board.**

cc @Philip-Larsen-Donnelly 