### PR TITLE
chore(apps): bump usage-analytics release

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -22,7 +22,7 @@
     "https://github.com/d2-ci/settings-app#patch/2.37.0",
     "https://github.com/d2-ci/tracker-capture-app#patch/2.37.0",
     "https://github.com/d2-ci/translations-app#patch/2.37.0",
-    "https://github.com/d2-ci/usage-analytics-app#v101.0.4",
+    "https://github.com/d2-ci/usage-analytics-app#v101.0.5",
     "https://github.com/d2-ci/user-app#patch/2.37.0",
     "https://github.com/d2-ci/user-profile-app#patch/2.37.0"
 ]


### PR DESCRIPTION
Use release v101.0.5 to include fix for report table endpoint being
removed in 2.37.0.

Jira-key: DHIS2-11751
Jira-url: https://jira.dhis2.org/browse/DHIS2-11751
