### PR TITLE
fix: Revert query to check lastupdated in events/enrollments [ DHIS2-11761 ] [ 2.35 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -129,6 +129,8 @@ public class HibernateTrackedEntityInstanceStore
 
     private static final String TEI_LASTUPDATED = " tei.lastUpdated";
 
+    private static final String GT_EQUAL = " >= ";
+
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -353,12 +355,12 @@ public class HibernateTrackedEntityInstanceStore
 
         if ( params.hasLastUpdatedDuration() )
         {
-            hql += hlp.whereAnd() + TEI_LASTUPDATED + " >= '" +
+            hql += hlp.whereAnd() + TEI_LASTUPDATED + GT_EQUAL + " '" +
                 getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
         }
         else
         {
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> TEI_LASTUPDATED + " >= '" +
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> TEI_LASTUPDATED + GT_EQUAL + " '" +
                 getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
 
             hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> TEI_LASTUPDATED + " < '" +
@@ -373,7 +375,7 @@ public class HibernateTrackedEntityInstanceStore
         if ( params.getSkipChangedBefore() != null && params.getSkipChangedBefore().getTime() > 0 )
         {
             String skipChangedBefore = DateUtils.getLongDateString( params.getSkipChangedBefore() );
-            hql += hlp.whereAnd() + TEI_LASTUPDATED + " >= '" + skipChangedBefore + "'";
+            hql += hlp.whereAnd() + TEI_LASTUPDATED + GT_EQUAL + " '" + skipChangedBefore + "'";
         }
 
         params.handleOrganisationUnits();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -127,6 +127,8 @@ public class HibernateTrackedEntityInstanceStore
 
     private static final String PSI_STATUS = "PSI.status";
 
+    private static final String TEI_LASTUPDATED = " tei.lastUpdated";
+
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -351,27 +353,27 @@ public class HibernateTrackedEntityInstanceStore
 
         if ( params.hasLastUpdatedDuration() )
         {
-            hql += hlp.whereAnd() + " tei.lastUpdated >= '" +
+            hql += hlp.whereAnd() + TEI_LASTUPDATED + " >= '" +
                 getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
         }
         else
         {
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> " tei.lastUpdated >= '" +
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> TEI_LASTUPDATED + " >= '" +
                 getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
 
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> " tei.lastUpdated < '" +
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> TEI_LASTUPDATED + " < '" +
                 getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );
         }
 
         hql += addWhereConditionally( hlp, params.isSynchronizationQuery(),
-            () -> "tei.lastUpdated > tei.lastSynchronized" );
+            () -> TEI_LASTUPDATED + " > tei.lastSynchronized" );
 
         // Comparing milliseconds instead of always creating new Date( 0 )
 
         if ( params.getSkipChangedBefore() != null && params.getSkipChangedBefore().getTime() > 0 )
         {
             String skipChangedBefore = DateUtils.getLongDateString( params.getSkipChangedBefore() );
-            hql += hlp.whereAnd() + " tei.lastUpdated >= '" + skipChangedBefore + "'";
+            hql += hlp.whereAnd() + TEI_LASTUPDATED + " >= '" + skipChangedBefore + "'";
         }
 
         params.handleOrganisationUnits();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -360,8 +360,9 @@ public class HibernateTrackedEntityInstanceStore
         }
         else
         {
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> TEI_LASTUPDATED + GT_EQUAL + " '" +
-                getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(),
+                () -> TEI_LASTUPDATED + GT_EQUAL + " '" +
+                    getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
 
             hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> TEI_LASTUPDATED + " < '" +
                 getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -331,32 +331,6 @@ public class HibernateTrackedEntityInstanceStore
 
         String hql = "select " + (idOnly ? "tei.id" : "tei") + " from TrackedEntityInstance tei ";
 
-        final String lastUpdated = " tei.lastUpdated";
-
-        if ( !params.hasLastUpdatedDuration() )
-        {
-            if ( params.hasLastUpdatedStartDate() )
-            {
-                hql += ", ProgramStageInstance psi, ProgramInstance pi";
-                String lastUpdatedDateString = getMediumDateString( params.getLastUpdatedStartDate() );
-
-                hql += hlp.whereAnd() + " ( " + hlp.or() + lastUpdated + "  >= '" + lastUpdatedDateString + "' "
-                    + hlp.andOr()
-                    + " pi.lastUpdated >= '" + lastUpdatedDateString
-                    + "' " + hlp.or() + " psi.lastUpdated >= '" + lastUpdatedDateString
-                    + "')";
-            }
-
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> lastUpdated + "  < '" +
-                getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );
-
-        }
-        else
-        {
-            hql += hlp.whereAnd() + lastUpdated + " >= '" +
-                getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
-        }
-
         // Used for switching between registration org unit or ownership org
         // unit. Default source is registration ou.
         String teiOuSource = params.hasProgram() ? "po.organisationUnit" : "tei.organisationUnit";
@@ -374,6 +348,20 @@ public class HibernateTrackedEntityInstanceStore
 
         hql += addWhereConditionally( hlp, params.hasTrackedEntityInstances(),
             () -> " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" );
+
+        if ( params.hasLastUpdatedDuration() )
+        {
+            hql += hlp.whereAnd() + " tei.lastUpdated >= '" +
+                getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
+        }
+        else
+        {
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> " tei.lastUpdated >= '" +
+                getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
+
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> " tei.lastUpdated < '" +
+                getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );
+        }
 
         hql += addWhereConditionally( hlp, params.isSynchronizationQuery(),
             () -> "tei.lastUpdated > tei.lastSynchronized" );
@@ -1079,8 +1067,6 @@ public class HibernateTrackedEntityInstanceStore
     private String getFromSubQueryProgramInstanceConditions( SqlHelper whereAnd,
         TrackedEntityInstanceQueryParams params )
     {
-        SqlHelper hlp = new SqlHelper( true );
-
         StringBuilder program = new StringBuilder();
 
         if ( !params.hasProgram() )
@@ -1094,23 +1080,6 @@ public class HibernateTrackedEntityInstanceStore
             .append( "SELECT PI.trackedentityinstanceid " )
             .append( "FROM programinstance PI " );
 
-        if ( !params.hasLastUpdatedDuration() )
-        {
-            if ( params.hasLastUpdatedStartDate() )
-            {
-                program.append( ", ProgramStageInstance psi" );
-                String lastUpdatedDateString = getMediumDateString( params.getLastUpdatedStartDate() );
-
-                program.append( hlp.whereAnd() ).append( "(" ).append(
-                    hlp.or() ).append( "pi.lastUpdated >= '" )
-                    .append( lastUpdatedDateString ).append( "' " ).append( hlp.or() ).append( " psi.lastUpdated >= '" )
-                    .append( lastUpdatedDateString ).append( "')" );
-            }
-
-            program.append( addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> " tei.lastUpdated < '" +
-                getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" ) );
-        }
-
         /*
          * Events depends on program, so we do the event filtering within the
          * enrollment clause.
@@ -1120,7 +1089,8 @@ public class HibernateTrackedEntityInstanceStore
             program.append( getFromSubQueryProgramStageInstance( params ) );
         }
 
-        program.append( hlp.whereAnd() ).append( " PI.trackedentityinstanceid = TEI.trackedentityinstanceid " )
+        program
+            .append( "WHERE PI.trackedentityinstanceid = TEI.trackedentityinstanceid " )
             .append( "AND PI.programid = " )
             .append( params.getProgram().getId() )
             .append( SPACE );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -48,18 +47,11 @@ import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import com.google.common.collect.Sets;
 
 /**
  * @author Lars Helge Overland
@@ -88,15 +80,6 @@ public class TrackedEntityInstanceStoreTest
 
     @Autowired
     private ProgramInstanceService programInstanceService;
-
-    @Autowired
-    private ProgramStageService programStageService;
-
-    @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
-
-    @Autowired
-    private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
     private TrackedEntityInstance teiA;
 
@@ -344,117 +327,5 @@ public class TrackedEntityInstanceStoreTest
         assertThat( grid.get( 0 ).keySet(), hasSize( 8 ) );
         assertThat( grid.get( 0 ).get( atC.getUid() ), is( "OrganisationUnitC" ) );
 
-    }
-
-    @Test
-    public void shouldGNotGetTeiPreviousQueryDate()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, +1 );
-
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 0, teiStore.getTrackedEntityInstances( params ).size() );
-    }
-
-    @Test
-    public void shouldGetTeiNextQueryDate()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, -1 );
-
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstances( params ).size() );
-    }
-
-    @Test
-    public void shouldGNotGetTeiByIdPreviousQueryDate()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, +1 );
-
-        params.setTrackedEntityTypes( Collections.singletonList( trackedEntityType ) );
-        params.setProgram( pr );
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 0, teiStore.getTrackedEntityInstanceIds( params ).size() );
-    }
-
-    @Test
-    public void shouldGetTeiByIdNextQueryDate()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, -1 );
-
-        params.setTrackedEntityTypes( Collections.singletonList( trackedEntityType ) );
-        params.setProgram( pr );
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstanceIds( params ).size() );
-    }
-
-    private void createTeiAndProgramInstances( Program program, TrackedEntityType trackedEntityType )
-    {
-        trackedEntityTypeService.addTrackedEntityType( trackedEntityType );
-
-        TrackedEntityInstance tei = createTrackedEntityInstance( ouA );
-        tei.setTrackedEntityType( trackedEntityType );
-
-        teiStore.save( tei );
-
-        idObjectManager.save( program );
-
-        ProgramStage programStage = createProgramStage( 'A', program );
-        programStageService.saveProgramStage( programStage );
-
-        ProgramInstance programInstance = new ProgramInstance( new Date(), new Date(), tei,
-            program );
-
-        programInstance.setUid( "UID-A" );
-        programInstance.setOrganisationUnit( ouA );
-
-        ProgramStageInstance programStageInstance = new ProgramStageInstance( programInstance, programStage );
-        programInstance.setUid( "UID-PSI-A" );
-        programInstance.setOrganisationUnit( ouA );
-
-        programInstanceService.addProgramInstance( programInstance );
-        programStageInstanceService.addProgramStageInstance( programStageInstance );
-
-        programInstance.setProgramStageInstances( Sets.newHashSet( programStageInstance ) );
-        tei.setProgramInstances( Sets.newHashSet( programInstance ) );
-
-        programInstanceService.updateProgramInstance( programInstance );
-
-        trackedEntityProgramOwnerService.createTrackedEntityProgramOwner( tei.getUid(), program.getUid(),
-            ouA.getUid() );
     }
 }


### PR DESCRIPTION
Revert lastupdated check in events/enrollments when getting teis list, due to performance issues