### PR TITLE
fix: (2.37) Event collection endpoint does not fetch relationships

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/RelationshipTypeActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/RelationshipTypeActions.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.actions.metadata;
+
+import com.google.gson.JsonObject;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.helpers.JsonObjectBuilder;
+import org.hisp.dhis.utils.DataGenerator;
+
+/**
+ * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
+ */
+public class RelationshipTypeActions
+    extends RestApiActions
+{
+    public RelationshipTypeActions()
+    {
+        super( "relationshipTypes" );
+    }
+
+    public String createRelationshipType( String fromEntityType, String fromConstraintId, String toEntityType,
+        String toConstraintId,
+        boolean bidirectional )
+    {
+        JsonObject object = new JsonObjectBuilder()
+            .addProperty( "publicAccess", "rwrw----" )
+            .addProperty( "name", "TA_RELATIONSHIP_TYPE " + DataGenerator.randomString() )
+            .addProperty( "fromToName", "Test to" )
+            .addProperty( "toFromName", "Test from" )
+            .addObject( "fromConstraint", createRelationshipConstraint( fromEntityType, fromConstraintId ) )
+            .addObject( "toConstraint", createRelationshipConstraint( toEntityType, toConstraintId ) )
+            .addProperty( "bidirectional", String.valueOf( bidirectional ) )
+            .addUserGroupAccess()
+            .build();
+
+        return this.create( object );
+    }
+
+    private JsonObject createRelationshipConstraint( String type, String id )
+    {
+        JsonObjectBuilder builder = new JsonObjectBuilder().addProperty( "relationshipEntity", type );
+        switch ( type )
+        {
+        case "PROGRAM_STAGE_INSTANCE":
+            builder
+                .addObject( "program", new JsonObjectBuilder().addProperty( "id", id ) );
+            break;
+
+        case "TRACKED_ENTITY_INSTANCE":
+            builder.addObject( "trackedEntityType", new JsonObjectBuilder().addProperty( "id", id ) );
+            break;
+
+        }
+
+        return builder.build();
+    }
+}

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/importer/TrackerActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/importer/TrackerActions.java
@@ -306,13 +306,7 @@ public class TrackerActions
     public JsonObject buildTrackedEntityRelationship( String trackedEntity_1, String trackedEntity_2,
         String relationshipType )
     {
-        return new JsonObjectBuilder()
-            .addProperty( "relationshipType", relationshipType )
-            .addObject( "from", new JsonObjectBuilder()
-                .addProperty( "trackedEntity", trackedEntity_1 ) )
-            .addObject( "to", new JsonObjectBuilder()
-                .addProperty( "trackedEntity", trackedEntity_2 ) )
-            .build();
+        return buildRelationship( "trackedEntity", trackedEntity_1, "trackedEntity", trackedEntity_2, relationshipType );
     }
 
     public JsonObject buildRelationship( String fromEntityName, String fromEntityId, String toEntityName, String toEntityId,

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/events/EventExportTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/events/EventExportTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.tracker.events;
+
+import com.google.gson.JsonObject;
+import org.hamcrest.Matchers;
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.Constants;
+import org.hisp.dhis.actions.LoginActions;
+import org.hisp.dhis.actions.metadata.RelationshipTypeActions;
+import org.hisp.dhis.actions.tracker.EventActions;
+import org.hisp.dhis.actions.tracker.importer.TrackerActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.JsonObjectBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+/**
+ * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
+ */
+public class EventExportTests
+    extends ApiTest
+{
+    private String eventId;
+
+    private String relationshipId;
+
+    private TrackerActions trackerActions;
+
+    private EventActions eventActions;
+
+    private String eventProgramId = Constants.EVENT_PROGRAM_ID;
+
+    private String eventProgramStageID = Constants.EVENT_PROGRAM_STAGE_ID;
+
+    private RelationshipTypeActions relationshipTypeActions;
+
+    @BeforeAll
+    public void beforeAll()
+    {
+        relationshipTypeActions = new RelationshipTypeActions();
+        trackerActions = new TrackerActions();
+        eventActions = new EventActions();
+
+        new LoginActions().loginAsAdmin();
+
+        String relationshipTypeId = relationshipTypeActions
+            .createRelationshipType( "PROGRAM_STAGE_INSTANCE", eventProgramId, "PROGRAM_STAGE_INSTANCE", eventProgramId, true );
+
+        eventId = createEvent();
+        relationshipId = createRelationship( eventId, createEvent(), relationshipTypeId );
+    }
+
+    @ValueSource( strings = {
+        "?event=eventId&fields=*",
+        "?event=eventId&fields=relationships",
+        "?program=programId&fields=*",
+        "?program=programId&fields=relationships"
+    } )
+    @ParameterizedTest
+    public void shouldFetchRelationships( String queryParams )
+    {
+        ApiResponse response = eventActions.get( queryParams.replace( "eventId", eventId ).replace( "programId", eventProgramId ) );
+        String body = "relationships";
+
+        if ( response.extractList( "events" ) != null )
+        {
+            body = "events[0].relationships";
+        }
+
+        response
+            .validate()
+            .body( body, hasSize( Matchers.greaterThanOrEqualTo( 1 ) ) )
+            .body( body + ".relationship", hasItems( relationshipId ) );
+    }
+
+    @ValueSource( strings = {
+        "?event=eventId",
+        "?event=eventId&fields=*,!relationships",
+        "?program=programId&fields=*,!relationships"
+    } )
+    @ParameterizedTest
+    public void shouldSkipRelationshipsForEventId( String queryParams )
+    {
+        ApiResponse response = eventActions.get( queryParams.replace( "eventId", eventId ).replace( "programId", eventProgramId ) );
+        String body = "relationships";
+
+        if ( response.extractList( "events" ) != null )
+        {
+            body = "events[0].relationships";
+        }
+
+        response
+            .validate()
+            .body( body, anyOf( nullValue(), hasSize( 0 ) ) );
+    }
+
+    private String createEvent()
+    {
+        return trackerActions
+            .postAndGetJobReport( trackerActions.buildEvent( Constants.ORG_UNIT_IDS[0], eventProgramId, eventProgramStageID ) )
+            .validateSuccessfulImport()
+            .extractImportedEvents().get( 0 );
+    }
+
+    private String createRelationship( String eventId, String event2Id, String relationshipTypeId )
+    {
+        JsonObject relationships = new JsonObjectBuilder( trackerActions
+            .buildRelationship( "event", eventId, "event", event2Id, relationshipTypeId ) )
+            .wrapIntoArray( "relationships" );
+
+        return trackerActions.postAndGetJobReport( relationships )
+            .validateSuccessfulImport().extractImportedRelationships().get( 0 );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/Event.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/Event.java
@@ -78,7 +78,7 @@ public class Event
 
     private String trackedEntityInstance;
 
-    private Set<Relationship> relationships;
+    private Set<Relationship> relationships = new HashSet<>();
 
     private String eventDate;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -153,6 +153,8 @@ public class EventSearchParams
 
     private boolean skipPaging;
 
+    private boolean includeRelationships;
+
     private List<OrderParam> orders;
 
     private List<OrderParam> gridOrders;
@@ -758,5 +760,16 @@ public class EventSearchParams
     public boolean isIncludeOnlyAssignedEvents()
     {
         return AssignedUserSelectionMode.ANY.equals( this.assignedUserSelectionMode );
+    }
+
+    public boolean isIncludeRelationships()
+    {
+        return includeRelationships;
+    }
+
+    public EventSearchParams setIncludeRelationships( boolean includeRelationships )
+    {
+        this.includeRelationships = includeRelationships;
+        return this;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -100,6 +100,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.events.enrollment.EnrollmentStatus;
 import org.hisp.dhis.dxf2.events.report.EventRow;
 import org.hisp.dhis.dxf2.events.trackedentity.Attribute;
+import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.hibernate.jsonb.type.JsonEventDataValueSetBinaryType;
@@ -123,6 +124,7 @@ import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import org.postgresql.util.PGobject;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
 import org.springframework.dao.DataAccessException;
@@ -137,6 +139,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.gson.Gson;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -145,6 +150,8 @@ import com.google.common.collect.ImmutableMap;
 @Repository( "org.hisp.dhis.dxf2.events.event.EventStore" )
 public class JdbcEventStore implements EventStore
 {
+    private static final String RELATIONSHIP_IDS_QUERY = " left join (select ri.programstageinstanceid as ri_psi_id, json_agg(ri.relationshipid) as psi_rl FROM relationshipitem ri"
+        + " GROUP by ri_psi_id)  as fgh on fgh.ri_psi_id=event.psi_id ";
 
     private static final String PSI_EVENT_COMMENT_QUERY = "select psic.programstageinstanceid    as psic_id," +
         " psinote.trackedentitycommentid as psinote_id," +
@@ -270,9 +277,12 @@ public class JdbcEventStore implements EventStore
 
     private final Environment env;
 
+    private final org.hisp.dhis.dxf2.events.trackedentity.store.EventStore eventStore;
+
     public JdbcEventStore( StatementBuilder statementBuilder, JdbcTemplate jdbcTemplate,
         @Qualifier( "dataValueJsonMapper" ) ObjectMapper jsonMapper,
-        CurrentUserService currentUserService, IdentifiableObjectManager identifiableObjectManager, Environment env )
+        CurrentUserService currentUserService, IdentifiableObjectManager identifiableObjectManager, Environment env,
+        org.hisp.dhis.dxf2.events.trackedentity.store.EventStore eventStore )
     {
         checkNotNull( statementBuilder );
         checkNotNull( jdbcTemplate );
@@ -280,6 +290,7 @@ public class JdbcEventStore implements EventStore
         checkNotNull( identifiableObjectManager );
         checkNotNull( jsonMapper );
         checkNotNull( env );
+        checkNotNull( eventStore );
 
         this.statementBuilder = statementBuilder;
         this.jdbcTemplate = jdbcTemplate;
@@ -287,6 +298,7 @@ public class JdbcEventStore implements EventStore
         this.manager = identifiableObjectManager;
         this.jsonMapper = jsonMapper;
         this.env = env;
+        this.eventStore = eventStore;
 
     }
 
@@ -304,6 +316,9 @@ public class JdbcEventStore implements EventStore
 
         Map<String, Event> eventUidToEventMap = new HashMap<>( params.getPageSizeWithDefault() );
         List<Event> events = new ArrayList<>();
+        List<Long> relationshipIds = new ArrayList<>();
+
+        final Gson gson = new Gson();
 
         String sql = buildSql( params, organisationUnits, user );
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
@@ -466,6 +481,29 @@ public class JdbcEventStore implements EventStore
                 event.getNotes().add( note );
                 notes.add( rowSet.getString( "psinote_id" ) );
             }
+
+            if ( params.isIncludeRelationships() )
+            {
+                if ( rowSet.getObject( "psi_rl" ) != null )
+                {
+                    PGobject pGobject = (PGobject) rowSet.getObject( "psi_rl" );
+
+                    if ( pGobject != null )
+                    {
+                        String value = pGobject.getValue();
+
+                        relationshipIds.addAll( Lists.newArrayList( gson.fromJson( value, Long[].class ) ) );
+                    }
+                }
+
+                final Multimap<String, Relationship> map = eventStore
+                    .getRelationshipsByIds( relationshipIds );
+
+                if ( !map.isEmpty() )
+                {
+                    events.forEach( e -> e.getRelationships().addAll( map.get( e.getEvent() ) ) );
+                }
+            }
         }
 
         IdSchemes idSchemes = ObjectUtils.firstNonNull( params.getIdSchemes(), new IdSchemes() );
@@ -573,6 +611,7 @@ public class JdbcEventStore implements EventStore
         List<EventRow> eventRows = new ArrayList<>();
 
         String sql = buildSql( params, organisationUnits, user );
+
         SqlRowSet rowSet = jdbcTemplate.queryForRowSet( sql );
 
         log.debug( "Event query SQL: " + sql );
@@ -891,6 +930,11 @@ public class JdbcEventStore implements EventStore
 
         sqlBuilder.append( ") as cm on event.psi_id=cm.psic_id " );
 
+        if ( params.isIncludeRelationships() )
+        {
+            sqlBuilder.append( RELATIONSHIP_IDS_QUERY );
+        }
+
         sqlBuilder.append( getOrderQuery( params ) );
 
         return sqlBuilder.toString();
@@ -903,7 +947,8 @@ public class JdbcEventStore implements EventStore
         SqlHelper hlp = new SqlHelper();
 
         StringBuilder sqlBuilder = new StringBuilder().append( "select "
-            + getEventSelectIdentifiersByIdScheme( params.getIdSchemes() ) + " psi.uid as psi_uid, "
+            + getEventSelectIdentifiersByIdScheme( params.getIdSchemes() )
+            + " psi.uid as psi_uid, "
             + "ou.uid as ou_uid, p.uid as p_uid, ps.uid as ps_uid, coc.uid as coc_uid, "
             + "psi.programstageinstanceid as psi_id, psi.status as psi_status, psi.executiondate as psi_executiondate, "
             + "psi.eventdatavalues as psi_eventdatavalues, psi.duedate as psi_duedate, psi.completedby as psi_completedby, psi.storedby as psi_storedby, "

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/RelationshipItem.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/RelationshipItem.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.events.trackedentity;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
 import org.hisp.dhis.dxf2.events.event.Event;
@@ -94,9 +95,10 @@ public class RelationshipItem
     public String toString()
     {
         return "RelationshipItem{" +
-            "trackedEntityInstance=" + trackedEntityInstance.getTrackedEntityInstance() +
-            ", enrollment=" + enrollment.getEnrollment() +
-            ", event=" + event.getEvent() +
+            "trackedEntityInstance="
+            + StringUtils.defaultIfBlank( trackedEntityInstance.getTrackedEntityInstance(), "" ) +
+            ", enrollment=" + StringUtils.defaultIfBlank( enrollment.getEnrollment(), "" ) +
+            ", event=" + StringUtils.defaultIfBlank( event.getEvent(), "" ) +
             '}';
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AbstractStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AbstractStore.java
@@ -50,11 +50,11 @@ public abstract class AbstractStore
 {
     protected final NamedParameterJdbcTemplate jdbcTemplate;
 
-    private final static String GET_RELATIONSHIP_ID_BY_ENTITYTYPE_SQL = "select ri.%s as id, r.relationshipid "
+    private final static String GET_RELATIONSHIP_ID_BY_ENTITY_ID_SQL = "select ri.%s as id, r.relationshipid "
         + "FROM relationshipitem ri left join relationship r on ri.relationshipid = r.relationshipid "
         + "where ri.%s in (:ids)";
 
-    private final static String GET_RELATIONSHIP_SQL = "select "
+    private final static String GET_RELATIONSHIP_BY_RELATIONSHIP_ID = "select "
         + "r.uid as rel_uid, r.created, r.lastupdated, rst.name as reltype_name, rst.uid as reltype_uid, rst.bidirectional as reltype_bi, "
         + "coalesce((select 'tei|' || tei.uid from trackedentityinstance tei "
         + "join relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid "
@@ -99,26 +99,30 @@ public abstract class AbstractStore
 
     public Multimap<String, Relationship> getRelationships( List<Long> ids )
     {
-        String getRelationshipsHavingIdSQL = String.format( GET_RELATIONSHIP_ID_BY_ENTITYTYPE_SQL,
+        String getRelationshipsHavingIdSQL = String.format( GET_RELATIONSHIP_ID_BY_ENTITY_ID_SQL,
             getRelationshipEntityColumn(), getRelationshipEntityColumn() );
 
         // Get all the relationship ids that have at least one relationship item
         // having
         // the ids in the tei|pi|psi column (depending on the subclass)
 
-        List<Map<String, Object>> relationshipIdsList = jdbcTemplate.queryForList( getRelationshipsHavingIdSQL,
-            createIdsParam( ids ) );
-
-        List<Long> relationshipIds = new ArrayList<>();
-        for ( Map<String, Object> relationshipIdsMap : relationshipIdsList )
-        {
-            relationshipIds.add( (Long) relationshipIdsMap.get( "relationshipid" ) );
-        }
+        List<Long> relationshipIds = getRelationshipIds( getRelationshipsHavingIdSQL, createIdsParam( ids ) );
 
         if ( !relationshipIds.isEmpty() )
         {
             RelationshipRowCallbackHandler handler = new RelationshipRowCallbackHandler();
-            jdbcTemplate.query( GET_RELATIONSHIP_SQL, createIdsParam( relationshipIds ), handler );
+            jdbcTemplate.query( GET_RELATIONSHIP_BY_RELATIONSHIP_ID, createIdsParam( relationshipIds ), handler );
+            return handler.getItems();
+        }
+        return ArrayListMultimap.create();
+    }
+
+    public Multimap<String, Relationship> getRelationshipsByIds( List<Long> ids )
+    {
+        if ( !ids.isEmpty() )
+        {
+            RelationshipRowCallbackHandler handler = new RelationshipRowCallbackHandler();
+            jdbcTemplate.query( GET_RELATIONSHIP_BY_RELATIONSHIP_ID, createIdsParam( ids ), handler );
             return handler.getItems();
         }
         return ArrayListMultimap.create();
@@ -178,5 +182,19 @@ public abstract class AbstractStore
     {
         return "SELECT "
             + columnMap.values().stream().map( TableColumn::useInSelect ).collect( Collectors.joining( ", " ) ) + " ";
+    }
+
+    private List<Long> getRelationshipIds( String sql, MapSqlParameterSource parameterSource )
+    {
+        List<Map<String, Object>> relationshipIdsList = jdbcTemplate.queryForList( sql,
+            parameterSource );
+
+        List<Long> relationshipIds = new ArrayList<>();
+        for ( Map<String, Object> relationshipIdsMap : relationshipIdsList )
+        {
+            relationshipIds.add( (Long) relationshipIdsMap.get( "relationshipid" ) );
+        }
+
+        return relationshipIds;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EventStore.java
@@ -69,10 +69,20 @@ public interface EventStore
      * specified in the arg as "left" or "right" relationship
      *
      * @param ids a list of {@see Enrollment} Primary Keys
-     * @return a MultiMap where key is a {@see Enrollment} uid and the key a
+     * @return a MultiMap where key is a {@see Enrollment} uid and the value a
      *         List of {@see Relationship} objects
      */
     Multimap<String, Relationship> getRelationships( List<Long> ids );
+
+    /**
+     * Fetch all the relationships based on provided relationship ids and return
+     * the response as Map of entity as key and List of Relationships as value
+     *
+     * @param ids Relationship ids
+     * @return Multimap containing entity uid as key and its associated list of
+     *         Relationships as value.
+     */
+    Multimap<String, Relationship> getRelationshipsByIds( List<Long> ids );
 
     Multimap<String, Note> getNotes( List<Long> eventIds );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -39,6 +39,7 @@ import javax.sql.DataSource;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.events.report.EventRow;
+import org.hisp.dhis.dxf2.events.trackedentity.store.EventStore;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
 import org.hisp.dhis.user.CurrentUserService;
 import org.junit.Before;
@@ -75,6 +76,9 @@ public class JdbcEventStoreTest
     @Mock
     private Environment env;
 
+    @Mock
+    private EventStore eventStore;
+
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
@@ -87,7 +91,7 @@ public class JdbcEventStoreTest
 
         ObjectMapper objectMapper = new ObjectMapper();
         subject = new JdbcEventStore( new PostgreSQLStatementBuilder(), jdbcTemplate, objectMapper, currentUserService,
-            manager, env );
+            manager, env, eventStore );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -134,6 +134,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
@@ -509,17 +510,19 @@ public class EventController
         EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
         HttpServletResponse response,
         HttpServletRequest request )
-        throws WebMessageException
     {
         WebOptions options = new WebOptions( parameters );
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
 
         if ( fields.isEmpty() )
         {
-            fields.addAll( Preset.ALL.getFields() );
+            fields.add(
+                "event,uid,program,programType,status,assignedUser,orgUnit,orgUnitName,eventDate,orgUnit,orgUnitName,created,lastUpdated,followup" );
         }
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+
+        setParamBasedOnFieldParameters( params, fields );
 
         Events events = eventService.getEvents( params );
 
@@ -1099,5 +1102,22 @@ public class EventController
     private String getParamValue( Map<String, List<String>> params, String key )
     {
         return params.get( key ) != null ? params.get( key ).get( 0 ) : null;
+    }
+
+    private void setParamBasedOnFieldParameters( EventSearchParams params, List<String> fields )
+    {
+        String joined = Joiner.on( "" ).join( fields );
+
+        if ( joined.contains( "*" ) )
+        {
+            params.setIncludeAllDataElements( true );
+            params.setIncludeAttributes( true );
+            params.setIncludeRelationships( true );
+        }
+
+        if ( joined.contains( "relationships" ) )
+        {
+            params.setIncludeRelationships( true );
+        }
     }
 }


### PR DESCRIPTION
[DHIS2-11541] (#8540)

* initialize with empty set to avoid NPE

* fix: Event collection endpoint does not fetch relationships

* minor refactor

* handle list of relationships

* fix compilation error

* use date utils instead of toString

* update sql

* use already created eventstore instead of new sql

* remove unused code

* relationship by event id

* minor

* get sql row set

* aggregate Relationships

* java docs

* java doc

* refactor

* minor

* refactor

* reduce number of sql queries

* sonar cloud review fix

* resolve PR reviews

* fix code reviews

* change the flag from skipRelationships to includeRelationships

* minor refactor

* test: adds tests

* fix: remove tests for single event endpoint

* remove includeRelationship flag

* remove flag from event controller

* minor

* fix compilation issues in e2e test

* chore: remove duplicate tests

Co-authored-by: Gintare Vilkelyte <vilkelyte.gintare@gmail.com>