### PR TITLE
fix: Revert query to check lastupdated in events/enrollments [ DHIS2-11761 ] [ 2.37 ] 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -130,6 +130,10 @@ public class HibernateTrackedEntityInstanceStore
 
     private static final String PSI_STATUS = "PSI.status";
 
+    private static final String TEI_LASTUPDATED = " tei.lastUpdated";
+
+    private static final String GT_EQUAL = " >= ";
+
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -361,15 +365,16 @@ public class HibernateTrackedEntityInstanceStore
 
         if ( params.hasLastUpdatedDuration() )
         {
-            hql += hlp.whereAnd() + " tei.lastUpdated >= '" +
+            hql += hlp.whereAnd() + TEI_LASTUPDATED + GT_EQUAL + "  '" +
                 getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
         }
         else
         {
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> " tei.lastUpdated >= '" +
-                getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(),
+                () -> TEI_LASTUPDATED + GT_EQUAL + " '" +
+                    getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
 
-            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> " tei.lastUpdated < '" +
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> TEI_LASTUPDATED + " < '" +
                 getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );
         }
 
@@ -381,7 +386,7 @@ public class HibernateTrackedEntityInstanceStore
         if ( params.getSkipChangedBefore() != null && params.getSkipChangedBefore().getTime() > 0 )
         {
             String skipChangedBefore = DateUtils.getLongDateString( params.getSkipChangedBefore() );
-            hql += hlp.whereAnd() + " tei.lastUpdated >= '" + skipChangedBefore + "'";
+            hql += hlp.whereAnd() + TEI_LASTUPDATED + GT_EQUAL + " '" + skipChangedBefore + "'";
         }
 
         params.handleOrganisationUnits();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -130,18 +130,6 @@ public class HibernateTrackedEntityInstanceStore
 
     private static final String PSI_STATUS = "PSI.status";
 
-    private static final String EXISTS = "EXISTS";
-
-    private static final String EQ = "=";
-
-    private static final String GT_EQ = ">=";
-
-    private static final String LT_EQ = "<=";
-
-    private static final String GT = ">";
-
-    private static final String LT = "<";
-
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -250,6 +238,7 @@ public class HibernateTrackedEntityInstanceStore
                 hql += addConditionally( params.hasAssignedUsers(), () -> "inner join fetch psi.assignedUser au" );
 
                 hql += hlp.whereAnd() + getEventWhereClauseHql( params );
+
             }
 
             hql += hlp.whereAnd() + " po.program.uid = '" + params.getProgram().getUid() + "'";
@@ -353,8 +342,6 @@ public class HibernateTrackedEntityInstanceStore
 
         hql += withProgram( params, hlp );
 
-        hql += getFromSubQueryLastUpdatedCondition( hlp, params, true );
-
         if ( params.hasAttributeAsOrder() )
         {
             hql += hlp.whereAnd() + " attr2.uid='" + params.getFirstAttributeOrder() + "'  ";
@@ -371,6 +358,20 @@ public class HibernateTrackedEntityInstanceStore
 
         hql += addWhereConditionally( hlp, params.hasTrackedEntityInstances(),
             () -> " tei.uid in (" + getQuotedCommaDelimitedString( params.getTrackedEntityInstanceUids() ) + ")" );
+
+        if ( params.hasLastUpdatedDuration() )
+        {
+            hql += hlp.whereAnd() + " tei.lastUpdated >= '" +
+                getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) + "'";
+        }
+        else
+        {
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedStartDate(), () -> " tei.lastUpdated >= '" +
+                getMediumDateString( params.getLastUpdatedStartDate() ) + "'" );
+
+            hql += addWhereConditionally( hlp, params.hasLastUpdatedEndDate(), () -> " tei.lastUpdated < '" +
+                getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) + "'" );
+        }
 
         hql += addWhereConditionally( hlp, params.isSynchronizationQuery(),
             () -> " tei.lastUpdated > tei.lastSynchronized" );
@@ -673,12 +674,10 @@ public class HibernateTrackedEntityInstanceStore
 
             // LEFT JOIN attributes we need to sort on.
             .append( getFromSubQueryJoinOrderByAttributes( params ) )
-            .append( getFromSubQueryProgramInstanceConditions( whereAnd, params ) )
-            // lastUpdated Conditions
-            .append( getFromSubQueryLastUpdatedCondition( whereAnd, params, false ) )
 
             // WHERE
-            .append( getFromSubQueryTrackedEntityConditions( whereAnd, params ) );
+            .append( getFromSubQueryTrackedEntityConditions( whereAnd, params ) )
+            .append( getFromSubQueryProgramInstanceConditions( whereAnd, params ) );
 
         if ( !isCountQuery )
         {
@@ -780,31 +779,25 @@ public class HibernateTrackedEntityInstanceStore
                 .append( ") " );
         }
 
-        // If we have a where condition on program, we'll check lastupdated
-        // later on program in OR condition, same as here but enrollments and
-        // event check
-        if ( !params.hasProgram() )
+        if ( params.hasLastUpdatedDuration() )
         {
-            if ( params.hasLastUpdatedDuration() )
+            trackedEntity.append( whereAnd.whereAnd() )
+                .append( " TEI.lastupdated >= '" )
+                .append( getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) )
+                .append( SINGLE_QUOTE );
+        }
+        else
+        {
+            if ( params.hasLastUpdatedStartDate() )
             {
-                trackedEntity.append( whereAnd.whereAnd() )
-                    .append( " TEI.lastupdated >= '" )
-                    .append( getLongGmtDateString( DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) ) )
-                    .append( SINGLE_QUOTE );
+                trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated >= '" )
+                    .append( getMediumDateString( params.getLastUpdatedStartDate() ) ).append( SINGLE_QUOTE );
             }
-            else
+            if ( params.hasLastUpdatedEndDate() )
             {
-                if ( params.hasLastUpdatedStartDate() )
-                {
-                    trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated >= '" )
-                        .append( getMediumDateString( params.getLastUpdatedStartDate() ) ).append( SINGLE_QUOTE );
-                }
-                if ( params.hasLastUpdatedEndDate() )
-                {
-                    trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated < '" )
-                        .append( getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) )
-                        .append( SINGLE_QUOTE );
-                }
+                trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated < '" )
+                    .append( getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) )
+                    .append( SINGLE_QUOTE );
             }
         }
 
@@ -1072,8 +1065,6 @@ public class HibernateTrackedEntityInstanceStore
     private String getFromSubQueryProgramInstanceConditions( SqlHelper whereAnd,
         TrackedEntityInstanceQueryParams params )
     {
-        SqlHelper hlp = new SqlHelper( true );
-
         StringBuilder program = new StringBuilder();
 
         if ( !params.hasProgram() )
@@ -1083,7 +1074,7 @@ public class HibernateTrackedEntityInstanceStore
 
         program
             .append( whereAnd.whereAnd() )
-            .append( EXISTS + " (" )
+            .append( "EXISTS (" )
             .append( "SELECT PI.trackedentityinstanceid " )
             .append( "FROM programinstance PI " );
 
@@ -1092,7 +1083,8 @@ public class HibernateTrackedEntityInstanceStore
             program.append( getFromSubQueryProgramStageInstance( params ) );
         }
 
-        program.append( hlp.whereAnd() ).append( " PI.trackedentityinstanceid = TEI.trackedentityinstanceid " )
+        program
+            .append( "WHERE PI.trackedentityinstanceid = TEI.trackedentityinstanceid " )
             .append( "AND PI.programid = " )
             .append( params.getProgram().getId() )
             .append( SPACE );
@@ -1153,153 +1145,6 @@ public class HibernateTrackedEntityInstanceStore
         program.append( ") " );
 
         return program.toString();
-    }
-
-    /**
-     * This method create lastUpdated query condition in case query params have
-     * one of lastUpdated fields. If params also have a program, it will append
-     * enrollments and events an exists query, otherwise it will only check it
-     * for tei
-     *
-     * @param whereAnd
-     * @param params
-     * @param hql
-     * @return
-     */
-    private String getFromSubQueryLastUpdatedCondition( SqlHelper whereAnd, TrackedEntityInstanceQueryParams params,
-        boolean hql )
-    {
-        StringBuilder lastUpdatedCondition = new StringBuilder();
-
-        boolean lastUpdatedCheckInProgram = params.hasProgram()
-            && (params.hasLastUpdatedDuration() || params.hasLastUpdatedStartDate() || params.hasLastUpdatedEndDate());
-
-        if ( lastUpdatedCheckInProgram )
-        {
-            if ( !hql )
-            {
-                lastUpdatedCondition
-                    .append( whereAnd.whereAnd() );
-                lastUpdatedCondition.append( EXISTS + " (" )
-                    .append( "SELECT PI.trackedentityinstanceid " )
-                    .append( "FROM ProgramInstance pi " );
-                lastUpdatedCondition
-                    .append( "INNER JOIN programstageinstance psi ON PSI.programinstanceid = pi.programinstanceid" );
-
-                lastUpdatedCondition.append( whereAnd.whereAnd() )
-                    .append( " pi.trackedentityinstanceid = tei.trackedentityinstanceid " )
-                    .append( "AND pi.programid = " )
-                    .append( params.getProgram().getId() )
-                    .append( SPACE );
-            }
-            else
-            {
-                lastUpdatedCondition
-                    .append( whereAnd.whereAnd() );
-                lastUpdatedCondition.append( EXISTS + " (" )
-                    .append( "FROM ProgramInstance as pi " );
-                lastUpdatedCondition
-                    .append( "INNER JOIN pi.programStageInstances as psi " );
-                lastUpdatedCondition
-                    .append( "WHERE pi.entityInstance.id = tei.id " )
-                    .append( "AND pi.program.id = " )
-                    .append( params.getProgram().getId() )
-                    .append( SPACE );
-            }
-        }
-
-        final String teiLastUpdated = " tei.lastUpdated";
-        final String piLastUpdated = " pi.lastUpdated";
-        final String psiLastUpdated = " psi.lastUpdated";
-
-        final SqlHelper hlp;
-
-        if ( params.hasLastUpdatedDuration() )
-        {
-            hlp = new SqlHelper( true );
-
-            String lastUpdatedDateDuration = getLongGmtDateString(
-                DateUtils.nowMinusDuration( params.getLastUpdatedDuration() ) );
-
-            return getConditionFrom( whereAnd, lastUpdatedCondition, lastUpdatedCheckInProgram, teiLastUpdated,
-                piLastUpdated, psiLastUpdated, hlp, lastUpdatedDateDuration, GT_EQ );
-        }
-        else
-        {
-            hlp = new SqlHelper( true );
-
-            if ( params.hasLastUpdatedStartDate() && params.hasLastUpdatedEndDate() )
-            {
-                String lastUpdatedDateString = getMediumDateString( params.getLastUpdatedStartDate() );
-
-                String lastUpdatedEndString = getMediumDateString(
-                    getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) );
-
-                return lastUpdatedCondition.append( whereAnd.whereAnd() ).append( "(" )
-                    .append( "(" )
-                    .append( hlp.or() )
-                    .append( " " + teiLastUpdated + " " + GT_EQ + " " ).append( SINGLE_QUOTE )
-                    .append( lastUpdatedDateString ).append( SINGLE_QUOTE )
-                    .append( whereAnd.whereAnd() )
-                    .append( " " + teiLastUpdated + " " + LT + " " ).append( SINGLE_QUOTE )
-                    .append( lastUpdatedEndString ).append( SINGLE_QUOTE )
-                    .append( ")" )
-                    .append( addConditionally( lastUpdatedCheckInProgram, () -> hlp.or() + "(" +
-                        " " + piLastUpdated + " " + GT_EQ + " " + SINGLE_QUOTE +
-                        lastUpdatedDateString + SINGLE_QUOTE +
-                        whereAnd.whereAnd() +
-                        " " + piLastUpdated + " " + LT + " " + SINGLE_QUOTE +
-                        lastUpdatedEndString + SINGLE_QUOTE +
-                        ")" ) )
-                    .append( addConditionally( lastUpdatedCheckInProgram, () -> hlp.or() + "(" +
-                        " " + psiLastUpdated + " " + GT_EQ + " " + SINGLE_QUOTE +
-                        lastUpdatedDateString + SINGLE_QUOTE +
-                        whereAnd.whereAnd() +
-                        " " + psiLastUpdated + " " + LT + " " + SINGLE_QUOTE +
-                        lastUpdatedEndString + SINGLE_QUOTE +
-                        ")" ) )
-                    .append( ")" )
-                    .append( addConditionally( lastUpdatedCheckInProgram, () -> ") " ) ).toString();
-            }
-
-            if ( params.hasLastUpdatedStartDate() )
-            {
-                String lastUpdatedDateString = getMediumDateString( params.getLastUpdatedStartDate() );
-
-                return getConditionFrom( whereAnd, lastUpdatedCondition, lastUpdatedCheckInProgram, teiLastUpdated,
-                    piLastUpdated, psiLastUpdated, hlp, lastUpdatedDateString, GT_EQ );
-            }
-
-            if ( params.hasLastUpdatedEndDate() )
-            {
-                String lastUpdatedEndString = getMediumDateString(
-                    getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) );
-
-                return getConditionFrom( whereAnd, lastUpdatedCondition, lastUpdatedCheckInProgram, teiLastUpdated,
-                    piLastUpdated, psiLastUpdated, hlp, lastUpdatedEndString, LT );
-            }
-        }
-
-        return lastUpdatedCondition.toString();
-    }
-
-    private String getConditionFrom( SqlHelper whereAnd, StringBuilder lastUpdatedCondition,
-        boolean lastUpdatedCheckInProgram,
-        String teiLastUpdated, String piLastUpdated, String psiLastUpdated, SqlHelper hlp, String lastUpdatedDateString,
-        String operator )
-    {
-        return lastUpdatedCondition.append( whereAnd.whereAnd() ).append( "(" ).append( hlp.or() )
-            .append( " " + teiLastUpdated + " " + operator + " " ).append( SINGLE_QUOTE )
-            .append( lastUpdatedDateString )
-            .append( SINGLE_QUOTE )
-            .append( addConditionally( lastUpdatedCheckInProgram, () -> hlp.or() +
-                " " + piLastUpdated + " " + operator + " " + SINGLE_QUOTE + lastUpdatedDateString
-                + SINGLE_QUOTE ) )
-            .append( addConditionally( lastUpdatedCheckInProgram, () -> hlp.or()
-                + " " + psiLastUpdated + " " + operator + " " + SINGLE_QUOTE + lastUpdatedDateString
-                + SINGLE_QUOTE ) )
-            .append( ")" )
-            .append( addConditionally( lastUpdatedCheckInProgram, () -> ") " ) ).toString();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -53,18 +52,11 @@ import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import com.google.common.collect.Sets;
 
 /**
  * @author Lars Helge Overland
@@ -93,15 +85,6 @@ public class TrackedEntityInstanceStoreTest
 
     @Autowired
     private ProgramInstanceService programInstanceService;
-
-    @Autowired
-    private ProgramStageService programStageService;
-
-    @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
-
-    @Autowired
-    private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
     private TrackedEntityInstance teiA;
 
@@ -349,146 +332,5 @@ public class TrackedEntityInstanceStoreTest
         assertThat( grid.get( 0 ).keySet(), hasSize( 8 ) );
         assertThat( grid.get( 0 ).get( atC.getUid() ), is( "OrganisationUnitC" ) );
 
-    }
-
-    @Test
-    public void shouldGNotGetTeis()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, +1 );
-
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 0, teiStore.getTrackedEntityInstances( params ).size() );
-    }
-
-    @Test
-    public void shouldGetTeis()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-        params.setProgram( pr );
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, -1 );
-
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstances( params ).size() );
-
-        cal = Calendar.getInstance();
-
-        params.setLastUpdatedEndDate( cal.getTime() );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstances( params ).size() );
-
-        cal = Calendar.getInstance();
-
-        params.setLastUpdatedStartDate( null );
-        params.setLastUpdatedEndDate( cal.getTime() );
-        cal.add( Calendar.DATE, +1 );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstances( params ).size() );
-    }
-
-    @Test
-    public void shouldGNotGetTeiIds()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-        params.setProgram( pr );
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, +1 );
-
-        params.setTrackedEntityTypes( Collections.singletonList( trackedEntityType ) );
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 0, teiStore.getTrackedEntityInstanceIds( params ).size() );
-    }
-
-    @Test
-    public void shouldGetTeiIds()
-    {
-        Program pr = createProgram( 'X', null, null );
-        TrackedEntityType trackedEntityType = createTrackedEntityType( 'X' );
-
-        createTeiAndProgramInstances( pr, trackedEntityType );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-        params.setProgram( pr );
-
-        Calendar cal = Calendar.getInstance();
-        cal.add( Calendar.DATE, -1 );
-
-        params.setTrackedEntityTypes( Collections.singletonList( trackedEntityType ) );
-        params.setLastUpdatedStartDate( cal.getTime() );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstanceIds( params ).size() );
-
-        cal = Calendar.getInstance();
-
-        params.setLastUpdatedEndDate( cal.getTime() );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstanceIds( params ).size() );
-
-        cal = Calendar.getInstance();
-
-        params.setLastUpdatedStartDate( null );
-        params.setLastUpdatedEndDate( cal.getTime() );
-        cal.add( Calendar.DATE, +1 );
-
-        assertEquals( 1, teiStore.getTrackedEntityInstanceIds( params ).size() );
-    }
-
-    private void createTeiAndProgramInstances( Program program, TrackedEntityType trackedEntityType )
-    {
-        trackedEntityTypeService.addTrackedEntityType( trackedEntityType );
-
-        TrackedEntityInstance tei = createTrackedEntityInstance( ouA );
-        tei.setTrackedEntityType( trackedEntityType );
-
-        teiStore.save( tei );
-
-        idObjectManager.save( program );
-
-        ProgramStage programStage = createProgramStage( 'A', program );
-        programStageService.saveProgramStage( programStage );
-
-        ProgramInstance programInstance = new ProgramInstance( new Date(), new Date(), tei,
-            program );
-
-        programInstance.setUid( "UID-A" );
-        programInstance.setOrganisationUnit( ouA );
-
-        ProgramStageInstance programStageInstance = new ProgramStageInstance( programInstance, programStage );
-        programInstance.setUid( "UID-PSI-A" );
-        programInstance.setOrganisationUnit( ouA );
-
-        programInstanceService.addProgramInstance( programInstance );
-        programStageInstanceService.addProgramStageInstance( programStageInstance );
-
-        programInstance.setProgramStageInstances( Sets.newHashSet( programStageInstance ) );
-        tei.setProgramInstances( Sets.newHashSet( programInstance ) );
-
-        programInstanceService.updateProgramInstance( programInstance );
-
-        trackedEntityProgramOwnerService.createTrackedEntityProgramOwner( tei.getUid(), program.getUid(),
-            ouA.getUid() );
     }
 }


### PR DESCRIPTION
Revert lastupdated check in events/enrollments when getting teis list, due to performance issues
