### PR TITLE
feat: DE type Number displaying zero instead of null value [2.38-DHIS2-9477]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -287,10 +287,15 @@ public abstract class AbstractJdbcEventAnalyticsManager
                     columns.add( getColumn( queryItem, OU_NAME_COL_SUFFIX ) );
                 }
             }
+            else if ( queryItem.getValueType() == ValueType.NUMBER )
+            {
+                columns.add( "coalesce(" + getColumn( queryItem ) + ", 'NaN')" );
+            }
             else
             {
                 columns.add( getColumn( queryItem ) );
             }
+
         }
 
         return columns;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -287,9 +287,9 @@ public abstract class AbstractJdbcEventAnalyticsManager
                     columns.add( getColumn( queryItem, OU_NAME_COL_SUFFIX ) );
                 }
             }
-            else if ( queryItem.getValueType() == ValueType.NUMBER )
+            else if ( queryItem.getValueType() == ValueType.NUMBER && !isGroupByClause )
             {
-                columns.add( "coalesce(" + getColumn( queryItem ) + ", 'NaN')" );
+                columns.add( "coalesce(" + getColumn( queryItem ) + ", 'NaN') as " + queryItem.getItemName() );
             }
             else
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -295,7 +295,6 @@ public abstract class AbstractJdbcEventAnalyticsManager
             {
                 columns.add( getColumn( queryItem ) );
             }
-
         }
 
         return columns;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -163,6 +163,10 @@ public class EnrollmentAnalyticsManagerTest
             + " where analytics_event_" + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid() + "' order by executiondate desc limit 1 )";
 
+        if ( valueType == ValueType.NUMBER )
+        {
+            subSelect = "coalesce(" + subSelect + ", 'NaN') as fWIAEtYVEGk";
+        }
         String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect + "  from " + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) " + "and ps = '"
             + programStage.getUid() + "' limit 101";
@@ -207,7 +211,8 @@ public class EnrollmentAnalyticsManagerTest
             + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid() + "' order by executiondate desc limit 1 )";
 
-        String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect + "  from " + getTable( programA.getUid() )
+        String expected = "ax.\"monthly\",ax.\"ou\"," + "coalesce(" + subSelect + ", 'NaN') as fWIAEtYVEGk" + "  from "
+            + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) "
             + "and ps = '" + programStage.getUid() + "' and " + subSelect + " > '10' limit 10001";
 


### PR DESCRIPTION
Instead of 0.0 (null in database, data type double precision) the NaN is displayed.

The idea is wrapping the numbers (double precision) into coalesce method. If the number is not set (null), 'NaN' (valid expression for numbers) will be used:

- For event table style:

SELECT count(ax."psi") AS value,
       ax."uidlevel1",
       **coalesce(ax."a3kGcGDCuk6", 'NaN') AS a3kGcGDCuk6**
FROM analytics_event_iphinat79uw AS ax
WHERE ax."executiondate" >= '2021-01-09'
  AND ax."executiondate" <= '2021-01-10'
  AND (ax."uidlevel1" = 'ImspTQPwCqd')
  AND ax."ps" = 'A03MvHHogjR'
  AND ax."yearly" in ('2021')
GROUP BY ax."uidlevel1",
         ax."a3kGcGDCuk6"
LIMIT 200001

- For linelist table style:

SELECT psi,
       ps,
       executiondate,
       storedby,
       lastupdated,
       enrollmentdate,
       incidentdate,
       tei,
       pi,
       ST_AsGeoJSON(psigeometry, 6) AS geometry,
       longitude,
       latitude,
       ouname,
       oucode,
       ax."ou",
       **coalesce(ax."a3kGcGDCuk6", 'NaN') AS a3kGcGDCuk6**
FROM analytics_event_iphinat79uw AS ax
WHERE ax."executiondate" >= '2021-01-09'
  AND ax."executiondate" <= '2021-01-10'
  AND (ax."uidlevel1" = 'ImspTQPwCqd')
  AND ax."ps" = 'A03MvHHogjR'
  AND ax."yearly" in ('2021')
ORDER BY ax."executiondate" DESC
LIMIT 100
OFFSET 0

