### PR TITLE
fix: class name for Relationship in audit logs (2.37.0) [DHIS2-11802]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
@@ -310,7 +310,8 @@ public class HibernatePotentialDuplicateStore
                     .auditScope( AuditScope.TRACKER )
                     .auditType( AuditType.UPDATE )
                     .createdAt( LocalDateTime.now() )
-                    .object( HibernateProxyUtils.getRealClass( relationship ) )
+                    .object( relationship )
+                    .klass( HibernateProxyUtils.getRealClass( relationship ).getCanonicalName() )
                     .uid( rel )
                     .auditableEntity( new AuditableEntity( Relationship.class, relationship ) )
                     .build() ) );


### PR DESCRIPTION
Class name for Relationship in audit logs when merging potential duplicates is now correct