### PR TITLE
refactor: replaceAll -> replace in SqlUtils

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/SqlViewUtils.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/SqlViewUtils.java
@@ -99,24 +99,22 @@ public class SqlViewUtils
      */
     public static String substituteSqlVariable( String sql, String name, String value )
     {
-        final String regex = "\\$\\{(" + name + ")\\}";
-
         if ( value != null && SqlView.isValidQueryValue( value ) )
         {
-            return sql.replaceAll( regex, value );
+            return sql.replace( "${" + name + "}", value );
         }
 
         return sql;
     }
 
     /**
-     * Replaces all query separators ";" with whitespaces in the given SQL.
+     * Removes all query separators ";" in the given SQL.
      *
      * @param sql the SQL.
      * @return the replaced SQL.
      */
     public static String removeQuerySeparator( String sql )
     {
-        return sql.replaceAll( ";", "" );
+        return sql.replace( ";", "" );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewUtilsTest.java
@@ -59,9 +59,9 @@ public class SqlViewUtilsTest
         variables.put( "level", "4" );
         variables.put( "id", "abc" );
 
-        String sql = "select * from datavalue where level=${level} and id='${id}'";
+        String sql = "select ${level},* from datavalue where level=${level} and id='${id}'";
 
-        String expected = "select * from datavalue where level=4 and id='abc'";
+        String expected = "select 4,* from datavalue where level=4 and id='abc'";
 
         String actual = SqlViewUtils.substituteSqlVariables( sql, variables );
 
@@ -86,11 +86,23 @@ public class SqlViewUtilsTest
     @Test
     public void testSubsituteSqlVariable()
     {
-        String sql = "select * from datavalue where level=${level} and id='${id}'";
+        String sql = "select ${level},* from datavalue where level=${level} and id='${id}'";
 
-        String expected = "select * from datavalue where level=4 and id='${id}'";
+        String expected = "select 4,* from datavalue where level=4 and id='${id}'";
 
         String actual = SqlViewUtils.substituteSqlVariable( sql, "level", "4" );
+
+        assertEquals( expected, actual );
+    }
+
+    @Test
+    public void testRemoveQuerySeparator()
+    {
+        String sql = "select * from datavalue; delete from datavalue;";
+
+        String expected = "select * from datavalue delete from datavalue";
+
+        String actual = SqlViewUtils.removeQuerySeparator( sql );
 
         assertEquals( expected, actual );
     }


### PR DESCRIPTION
SonarCloud reported a blocker vulnerability in `SqlViewUtils.substituteSqlVariable`: "Change this code to not construct the regular expression from user-controlled data." The danger is that "a small carefully-crafted input ... can trigger catastrophic backtracking" as part of a DOS attack.

The change is to use `String.replace()` instead of `replaceAll()`. The only difference between these methods is that replaceAll takes a regular expression as the first argument whereas replace just takes a String. Both methods replace all instances. In this case, a regular expression argument was not needed.

`SqlViewUtils.removeQuerySeparator` was also changed to use replace instead of replaceAll, since the first argument was not a regular expression.