### PR TITLE
fix: Fix the way attribute value are updated by hibernate session [DHIS2-11852]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -338,13 +338,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
 
             if ( attributeValue == null )
             {
-                attributeValue = new TrackedEntityAttributeValue();
+                attributeValue = new TrackedEntityAttributeValue()
+                    .setAttribute( attribute )
+                    .setEntityInstance( trackedEntityInstance );
                 isNew = true;
             }
 
             attributeValue
-                .setAttribute( attribute )
-                .setEntityInstance( trackedEntityInstance )
                 .setValue( at.getValue() )
                 .setStoredBy( at.getStoredBy() );
 


### PR DESCRIPTION
This is a tricky one.
Removing attribute value was failing (only when importer was used in async mode) because a different attribute object with the same id was assigned to the attribute value throwing a NonUniqueObjectException