### PR TITLE
chore: Lower logger levels on authentication messages

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultUserDetailsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultUserDetailsService.java
@@ -89,7 +89,7 @@ public class DefaultUserDetailsService
 
         if ( ObjectUtils.anyIsFalse( enabled, credentialsNonExpired, accountNonLocked, accountNonExpired ) )
         {
-            log.info( String.format(
+            log.debug( String.format(
                 "Login attempt for disabled/locked user: '%s', enabled: %b, account non-expired: %b, credentials non-expired: %b, account non-locked: %b",
                 username, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked ) );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -115,14 +115,14 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider
 
             if ( securityService.isLocked( username ) )
             {
-                log.info( String.format( "Temporary lockout for user: %s and IP: %s", username, ip ) );
+                log.debug( String.format( "Temporary lockout for user: %s and IP: %s", username, ip ) );
 
                 throw new LockedException( String.format( "IP is temporarily locked: %s", ip ) );
             }
 
             if ( !LongValidator.getInstance().isValid( code ) || !SecurityUtils.verify( userCredentials, code ) )
             {
-                log.info(
+                log.debug(
                     String.format( "Two-factor authentication failure for user: %s", userCredentials.getUsername() ) );
 
                 throw new BadCredentialsException( "Invalid verification code" );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationListener.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationListener.java
@@ -76,7 +76,7 @@ public class AuthenticationListener
         {
             TwoFactorWebAuthenticationDetails authDetails = (TwoFactorWebAuthenticationDetails) details;
 
-            log.info( String.format( "Login attempt failed for remote IP: %s", authDetails.getIp() ) );
+            log.debug( String.format( "Login attempt failed for remote IP: %s", authDetails.getIp() ) );
         }
 
         if ( OAuth2LoginAuthenticationToken.class.isAssignableFrom( auth.getClass() ) )
@@ -93,7 +93,7 @@ public class AuthenticationListener
             WebAuthenticationDetails tokenDetails = (WebAuthenticationDetails) authenticationToken.getDetails();
             String remoteAddress = tokenDetails.getRemoteAddress();
 
-            log.info( String.format( "OIDC login attempt failed for remote IP: %s", remoteAddress ) );
+            log.debug( String.format( "OIDC login attempt failed for remote IP: %s", remoteAddress ) );
         }
 
         securityService.registerFailedLogin( username );


### PR DESCRIPTION
#### Summary:
Remove redundant logging of authentication events.
Lower log levels from info to debug in all other authentication logging classes than AuthenticationLoggerListener.
Let AuthenticationLoggerListener the main authentication logging class.