### PR TITLE
fix: Lazy init exception when ownership ou already happens to be in c…

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwnerStore.java
@@ -68,7 +68,5 @@ public interface TrackedEntityProgramOwnerStore extends GenericStore<TrackedEnti
 
     List<TrackedEntityProgramOwnerIds> getTrackedEntityProgramOwnersUids( List<Long> teiIds, long programId );
 
-    List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits( Set<Long> teiIds,
-        Set<Long> programIds );
-
+    List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits( Set<Long> teiIds );
 }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
@@ -144,6 +144,7 @@ public class UserActions
     public void grantUserAccessToOrgUnit( String userId, String orgUnitId )
     {
         JsonObject object = this.get( userId ).getBody();
+
         JsonObject orgUnit = new JsonObject();
         orgUnit.addProperty( "id", orgUnitId );
 
@@ -152,6 +153,20 @@ public class UserActions
         object.get( "teiSearchOrganisationUnits" ).getAsJsonArray().add( orgUnit );
 
         ApiResponse response = this.update( userId, object );
+        response.validate().statusCode( 200 )
+            .body( "status", equalTo( "OK" ) );
+    }
+
+    public void grantUserSearchAccessToOrgUnit( String userId, String orgUnitId ) {
+        JsonObject object = this.get( userId ).getBody();
+
+        JsonObject orgUnit = new JsonObject();
+        orgUnit.addProperty( "id", orgUnitId );
+
+        object.get( "teiSearchOrganisationUnits" ).getAsJsonArray().add( orgUnit );
+
+        ApiResponse response = this.update( userId, object );
+
         response.validate().statusCode( 200 )
             .body( "status", equalTo( "OK" ) );
     }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/ProgramActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/metadata/ProgramActions.java
@@ -59,6 +59,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matchers;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.dto.ApiResponse;
@@ -96,16 +97,16 @@ public class ProgramActions
         return post( object );
     }
 
-    public ApiResponse createTrackerProgram( String... orgUnitIds )
+    public ApiResponse createTrackerProgram( String trackedEntityTypeId, String... orgUnitIds )
     {
-        return createProgram( "WITH_REGISTRATION", orgUnitIds );
+        return createProgram( "WITH_REGISTRATION", trackedEntityTypeId, orgUnitIds ).validateStatus( 201 );
     }
 
     public ApiResponse createEventProgram( String... orgUnitsIds )
     {
         String programStageId = createProgramStage( "DEFAULT STAGE" );
 
-        JsonObject body = getDummy( "WITHOUT_REGISTRATION", orgUnitsIds );
+        JsonObject body = getDummy( "WITHOUT_REGISTRATION", null, orgUnitsIds );
 
         JsonArray programStages = new JsonArray();
 
@@ -119,9 +120,9 @@ public class ProgramActions
         return post( body );
     }
 
-    public ApiResponse createProgram( String programType, String... orgUnitIds )
+    public ApiResponse createProgram( String programType, String trackedEntityTypeId, String... orgUnitIds )
     {
-        JsonObject object = getDummy( programType, orgUnitIds );
+        JsonObject object = getDummy( programType, trackedEntityTypeId, orgUnitIds );
 
         return post( object );
     }
@@ -221,7 +222,7 @@ public class ProgramActions
         return program;
     }
 
-    JsonObject getDummy( String programType, String... orgUnitIds )
+    JsonObject getDummy( String programType,String trackedEntityTypeId, String... orgUnitIds )
     {
         JsonObject object = getDummy( programType );
         JsonArray orgUnits = new JsonArray();
@@ -232,6 +233,14 @@ public class ProgramActions
             orgUnit.addProperty( "id", ouid );
 
             orgUnits.add( orgUnit );
+        }
+
+        if ( !StringUtils.isEmpty( trackedEntityTypeId ) )
+        {
+            JsonObject tetype = new JsonObject();
+            tetype.addProperty( "id", trackedEntityTypeId );
+
+            object.add( "trackedEntityType", tetype );
         }
 
         object.add( "organisationUnits", orgUnits );

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/EventActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/EventActions.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.dto.ApiResponse;
 
 import com.google.gson.JsonObject;
+import org.hisp.dhis.helpers.JsonObjectBuilder;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -116,6 +117,5 @@ public class EventActions
         event.addProperty( "eventDate", "2018-12-01T00:00:00.000" );
 
         return event;
-
     }
 }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -32,6 +32,7 @@ import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.helpers.JsonObjectBuilder;

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/CsvFileReader.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/CsvFileReader.java
@@ -132,6 +132,12 @@ public class CsvFileReader
         return this;
     }
 
+    @Override public org.hisp.dhis.helpers.file.FileReader replacePropertyValuesRecursivelyWith( String propertyName,
+        String replacedValue )
+    {
+        return null;
+    }
+
     @Override
     public org.hisp.dhis.helpers.file.FileReader replace( Function<Object, Object> function )
     {

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/FileReader.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/FileReader.java
@@ -70,6 +70,8 @@ public interface FileReader
 
     FileReader replacePropertyValuesWith( String propertyNames, String replacedValues );
 
+    FileReader replacePropertyValuesRecursivelyWith( String propertyName, String replacedValue );
+
     FileReader replace( Function<Object, Object> function );
 
     Object get();

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/JsonFileReader.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/JsonFileReader.java
@@ -59,6 +59,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.hisp.dhis.actions.IdGenerator;
@@ -103,7 +104,6 @@ public class JsonFileReader
     {
         replace( p -> {
             JsonObject object = ((JsonElement) p).getAsJsonObject();
-
             if ( replacedValue.equalsIgnoreCase( "uniqueid" ) )
             {
                 object.addProperty( propertyName, new IdGenerator().generateUniqueId() );
@@ -118,6 +118,28 @@ public class JsonFileReader
 
         return this;
     }
+
+    @Override
+    public FileReader replacePropertyValuesRecursivelyWith( String propertyName, String replacedValue )
+    {
+        replace( obj, jsonObject -> {
+            if ( !jsonObject.has( propertyName ) )
+            {
+                return;
+            }
+            if ( replacedValue.equalsIgnoreCase( "uniqueid" ) )
+            {
+                jsonObject.addProperty( propertyName, new IdGenerator().generateUniqueId() );
+            }
+            else
+            {
+                jsonObject.addProperty( propertyName, replacedValue );
+            }
+        } );
+
+        return this;
+    }
+
 
     public JsonObject get()
     {
@@ -149,5 +171,29 @@ public class JsonFileReader
 
         obj = newObj;
         return this;
+    }
+
+    private void replace( JsonElement root, Consumer<JsonObject> function )
+    {
+        if ( root.isJsonArray() )
+        {
+            for ( JsonElement e : root.getAsJsonArray() )
+            {
+                replace( e,function );
+            }
+        }
+        else if ( root.isJsonObject() )
+        {
+            JsonObject jsonObjRoot = root.getAsJsonObject();
+            function.accept( jsonObjRoot );
+            for ( String key : jsonObjRoot.keySet() )
+            {
+                JsonElement element = jsonObjRoot.get( key );
+                if ( element.isJsonArray() )
+                {
+                    replace( element,function );
+                }
+            }
+        }
     }
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/XmlFileReader.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/file/XmlFileReader.java
@@ -139,6 +139,11 @@ public class XmlFileReader
         return this;
     }
 
+    @Override public FileReader replacePropertyValuesRecursivelyWith( String propertyName, String replacedValue )
+    {
+        return null;
+    }
+
     @Override
     public FileReader replace( Function<Object, Object> function )
     {

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/programs/ProgramStagesTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/programs/ProgramStagesTest.java
@@ -93,7 +93,7 @@ public class ProgramStagesTest
         programStageActions = programActions.programStageActions;
 
         loginActions.loginAsSuperUser();
-        programId = programActions.createTrackerProgram().extractUid();
+        programId = programActions.createTrackerProgram( null ).extractUid();
         programStageId = programActions.createProgramStage( "Tracker program stage 1" );
     }
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/TrackerNtiApiTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/TrackerNtiApiTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.util.List;
 
 import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.Constants;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.MaintenanceActions;
 import org.hisp.dhis.actions.tracker.importer.TrackerActions;
@@ -47,6 +48,10 @@ import com.google.gson.JsonObject;
 public class TrackerNtiApiTest
     extends ApiTest
 {
+    protected String TRACKER_PROGRAM_ID = Constants.TRACKER_PROGRAM_ID;
+
+    protected static final String TRACKER_PROGRAM_STAGE_ID = "nlXNK4b7LVr";
+
     protected TrackerActions trackerActions;
 
     protected LoginActions loginActions;
@@ -104,6 +109,22 @@ public class TrackerNtiApiTest
             .read( new File( "src/test/resources/tracker/importer/teis/teiWithEnrollments.json" ) )
             .replacePropertyValuesWith( "program", programId )
             .replacePropertyValuesWith( "programStage", programStageId )
+            .get( JsonObject.class );
+
+        TrackerApiResponse response = trackerActions.postAndGetJobReport( teiWithEnrollment );
+
+        response.validateSuccessfulImport();
+        return response;
+    }
+
+    protected TrackerApiResponse importTeiWithEnrollmentAndEvent( String orgUnit, String programId, String programStageId )
+        throws Exception
+    {
+        JsonObject teiWithEnrollment = new FileReaderUtils()
+            .read( new File( "src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json" ) )
+            .replacePropertyValuesRecursivelyWith( "orgUnit", orgUnit )
+            .replacePropertyValuesRecursivelyWith( "program", programId )
+            .replacePropertyValuesRecursivelyWith( "programStage", programStageId )
             .get( JsonObject.class );
 
         TrackerApiResponse response = trackerActions.postAndGetJobReport( teiWithEnrollment );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/ImportStrategyTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/ImportStrategyTests.java
@@ -126,7 +126,6 @@ public class ImportStrategyTests
         String teiId = response.extractImportedTeis().get( 0 );
         String enrollmentId = response.extractImportedEnrollments().get( 0 );
         String eventId1 = response.extractImportedEvents().get( 0 );
-        String eventId2 = response.extractImportedEvents().get( 1 );
 
         body.remove( "events" );
 
@@ -136,15 +135,13 @@ public class ImportStrategyTests
 
         // assert
         response.validateSuccessfulImport()
-            .validate().body( "stats.deleted", Matchers.equalTo( 4 ) );
+            .validate().body( "stats.deleted", Matchers.equalTo( 3 ) );
 
         trackerActions.getTrackedEntity( teiId )
             .validate().statusCode( 404 );
         trackerActions.get( "/enrollments/" + enrollmentId )
             .validate().statusCode( 404 );
         trackerActions.get( "/events/" + eventId1 )
-            .validate().statusCode( 404 );
-        trackerActions.get( "/events/" + eventId2 )
             .validate().statusCode( 404 );
     }
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/enrollments/EnrollmentsOwnershipTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/enrollments/EnrollmentsOwnershipTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.tracker.importer.enrollments;
+
+import com.google.gson.JsonObject;
+import org.hisp.dhis.Constants;
+import org.hisp.dhis.actions.UserActions;
+import org.hisp.dhis.actions.metadata.ProgramActions;
+import org.hisp.dhis.helpers.JsonObjectBuilder;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.hisp.dhis.tracker.TrackerNtiApiTest;
+import org.hisp.dhis.utils.DataGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Instant;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
+ */
+public class EnrollmentsOwnershipTests
+    extends TrackerNtiApiTest
+{
+    String userPassword = Constants.USER_PASSWORD;
+
+    String captureOu = "DiszpKrYNg8";
+
+    String searchOu = "g8upMTyEZGZ";
+
+    String trackedEntityType = "Q9GufDoplCL";
+
+    String username;
+
+    String tei;
+
+    private ProgramActions programActions;
+    private UserActions userActions;
+    private JsonObject enrollment;
+    private JsonObject program;
+
+    private String protectedProgram;
+
+    @BeforeAll
+    public void beforeAll()
+        throws Exception
+    {
+        userActions = new UserActions();
+        programActions = new ProgramActions();
+        loginActions.loginAsSuperUser();
+        username = createUserWithAccessToOu();
+
+        protectedProgram = createProtectedProgram();
+
+        program = programActions.get("/" + protectedProgram + "?fields=*").validateStatus( 200 ).getBody();
+
+        String protectedProgramStageId = program.get( "programStages" ).getAsJsonArray().get(0).getAsJsonObject().get( "id" ).getAsString();
+
+        tei = super.importTeiWithEnrollmentAndEvent( captureOu, protectedProgram, protectedProgramStageId )
+                .extractImportedTeis().get( 0 );
+
+        enrollment = trackerActions.getTrackedEntity( tei + "?fields=enrollments" )
+                .validateStatus( 200 )
+                .getBody();
+
+         trackerActions.update( "/ownership/transfer?trackedEntityInstance=" + tei + "&program=" + protectedProgram + "&ou=" + searchOu, new JsonObject()  ).validateStatus( 200 );
+    }
+
+    @BeforeEach
+    public void beforeEach()
+    {
+        loginActions.loginAsAdmin();
+    }
+
+    @Test
+    @Disabled("This test does not make sense. Need to correct the test setup based on what exactly we want to test")
+    public void shouldValidateCaptureScope()
+    {
+        JsonObject object = trackerActions.getTrackedEntity( tei )
+            .validateStatus( 200 )
+            .getBodyAsJsonBuilder()
+            .wrapIntoArray( "trackedEntities" );
+
+        loginActions.loginAsUser( username, userPassword );
+
+        trackerActions.postAndGetJobReport( object )
+            .validateErrorReport()
+            .body( "errorCode", hasItems( "E1000" ) );
+
+        loginActions.loginAsAdmin();
+    }
+
+    @ValueSource( strings = { "CREATE_AND_UPDATE", "UPDATE", "DELETE" })
+    @ParameterizedTest
+    public void shouldValidateEnrollmentOwnership(String importStrategy)
+    {
+        loginActions.loginAsUser( username, userPassword );
+
+        trackerActions.postAndGetJobReport( enrollment, new QueryParamsBuilder().add( "importStrategy="  + importStrategy) )
+            .validateErrorReport()
+            .body( "errorCode", hasItems( "E1102" ) );
+
+        loginActions.loginAsAdmin();
+    }
+
+    @Test
+    public void shouldNotEnroll() {
+        loginActions.loginAsAdmin();
+
+        trackerActions.getTrackedEntity( tei + "?fields=enrollments").validate().statusCode( 200 )
+            .body( "enrollments", hasSize(1) );
+
+
+        loginActions.loginAsUser( username, userPassword );
+
+        trackerActions.getTrackedEntity( tei + "?fields=enrollments").validate().statusCode( 200 )
+            .body( "enrollments", hasSize( 0 ) );
+
+
+        trackerActions.postAndGetJobReport( buildEnrollment( protectedProgram, captureOu, tei ) )
+            .validate().statusCode( 200 );
+
+        loginActions.loginAsUser( username, userPassword );
+
+        trackerActions.getTrackedEntity( tei + "?fields=enrollments").validate().statusCode( 200 )
+            .body( "enrollments", hasSize(0) );
+
+        loginActions.loginAsAdmin();
+
+    }
+
+    protected String createUserWithAccessToOu()
+    {
+        String username = DataGenerator.randomString();
+        String userid = userActions.addUser( username, Constants.USER_PASSWORD );
+
+        //userActions.addRoleToUser( userid, auth );
+        userActions.grantUserAccessToOrgUnit( userid, captureOu );
+        userActions.grantUserSearchAccessToOrgUnit( userid, searchOu );
+        userActions.addUserToUserGroup( userid, Constants.USER_GROUP_ID );
+
+        return username;
+    }
+
+    private JsonObject buildEnrollment( String programId, String ouId, String teiId) {
+        return new JsonObjectBuilder().addProperty( "program", programId )
+            .addProperty( "orgUnit", ouId )
+            .addProperty( "trackedEntity", teiId )
+            .addProperty( "enrolledAt", Instant.now().toString() )
+            .addProperty( "occurredAt", Instant.now().toString() )
+            .wrapIntoArray("enrollments");
+    }
+
+    private String createProtectedProgram() {
+        String programId = programActions.createTrackerProgram( trackedEntityType, captureOu, searchOu ).extractUid();
+
+        JsonObject program = programActions.get( programId )
+            .getBody();
+
+        program.addProperty( "accessLevel", "PROTECTED" );
+        program.addProperty( "publicAccess" , "rwrw----" );
+
+        programActions.update( programId, program ).validateStatus( 200 );
+
+        String programStageID = programActions.createProgramStage( "Program stage " + DataGenerator.randomString() );
+
+        programActions.addProgramStage( programId, programStageID );
+
+        return programId;
+    }
+
+}

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/tei/TeiValidationTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/tei/TeiValidationTests.java
@@ -280,7 +280,7 @@ public class TeiValidationTests
         trackedEntityType = trackedEntityTypeActions.create( trackedEntityTypePayload );
 
         // create a program
-        program = programActions.createTrackerProgram( Constants.ORG_UNIT_IDS ).extractUid();
+        program = programActions.createTrackerProgram( null, Constants.ORG_UNIT_IDS ).extractUid();
         ApiResponse programResponse = programActions.get( program );
 
         JsonObject programPayload = programResponse.getBody();

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json
@@ -22,46 +22,6 @@
             {
               "scheduledAt": "2019-08-19T13:59:13.688",
               "program": "f1AyMswryyQ",
-              "event": "ZwwuwNp6gVd",
-              "programStage": "nlXNK4b7LVr",
-              "orgUnit": "O6uvpzGd5pu",
-              "trackedEntity": "Kj6vYde4LHh",
-              "enrollment": "MNWZ6hnuhSw",
-              "enrollmentStatus": "ACTIVE",
-              "status": "ACTIVE",
-              "occurredAt": "2019-08-01T00:00:00.000",
-              "attributeCategoryOptions": "xYerKDKCefk",
-              "deleted": false,
-              "attributeOptionCombo": "HllvX50cXC0",
-              "dataValues": [
-                {
-                  "updatedAt": "2019-08-19T13:58:37.477",
-                  "storedBy": "admin",
-                  "dataElement": "BuZ5LGNfGEU",
-                  "value": "20",
-                  "providedElsewhere": false
-                },
-                {
-                  "updatedAt": "2019-08-19T13:58:40.031",
-                  "storedBy": "admin",
-                  "dataElement": "ZrqtjjveTFc",
-                  "value": "Male",
-                  "providedElsewhere": false
-                },
-                {
-                  "updatedAt": "2019-08-19T13:59:13.691",
-                  "storedBy": "admin",
-                  "dataElement": "mB2QHw1tU96",
-                  "value": "[-11.566044,9.477801]",
-                  "providedElsewhere": false
-                }
-              ],
-              "notes": [],
-              "relationships": []
-            },
-            {
-              "scheduledAt": "2019-08-19T13:59:13.688",
-              "program": "f1AyMswryyQ",
               "event": "XwwuwNp6gVE",
               "programStage": "PaOOjwLVW23",
               "orgUnit": "O6uvpzGd5pu",

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityProgramOwnerStore.java
@@ -109,23 +109,21 @@ public class HibernateTrackedEntityProgramOwnerStore
     }
 
     @Override
-    public List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits( Set<Long> teiIds,
-        Set<Long> programIds )
+    public List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits( Set<Long> teiIds )
     {
         List<TrackedEntityProgramOwnerOrgUnit> trackedEntityProgramOwnerOrgUnits = new ArrayList<>();
 
-        if ( teiIds == null || programIds == null || teiIds.size() == 0 || programIds.size() == 0 )
+        if ( teiIds == null || teiIds.size() == 0 )
         {
             return trackedEntityProgramOwnerOrgUnits;
         }
 
         Iterable<List<Long>> teiIdsPartitions = Iterables.partition( teiIds, 20000 );
 
-        String hql = "select new org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit( tepo.entityInstance.uid, tepo.program.uid, tepo.organisationUnit) from TrackedEntityProgramOwner tepo where tepo.entityInstance.id in (:teiIds) and tepo.program.id in (:programIds)";
+        String hql = "select new org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit( tepo.entityInstance.uid, tepo.program.uid, tepo.organisationUnit) from TrackedEntityProgramOwner tepo where tepo.entityInstance.id in (:teiIds)";
 
         Query<TrackedEntityProgramOwnerOrgUnit> q = getQuery( hql, TrackedEntityProgramOwnerOrgUnit.class );
 
-        q.setParameter( "programIds", programIds );
         teiIdsPartitions.forEach( partition -> {
             q.setParameterList( "teiIds", partition );
             trackedEntityProgramOwnerOrgUnits.addAll( q.list() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
@@ -67,6 +67,7 @@ public interface ProgramMapper extends PreheatMapper<Program>
     @Mapping( target = "expiryDays" )
     @Mapping( target = "expiryPeriodType" )
     @Mapping( target = "completeEventsExpiryDays" )
+    @Mapping( target = "accessLevel" )
     Program map( Program program );
 
     Set<UserGroupAccess> userGroupAccessesProgram( Set<UserGroupAccess> userGroupAccesses );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
@@ -68,18 +68,11 @@ public class ProgramOwnerSupplier extends AbstractPreheatSupplier
             TrackerIdScheme.UID,
             new HashMap<>() );
         Set<Long> teiIds = new HashSet<>();
-        Set<Long> programIds = new HashSet<>();
         params.getEnrollments().stream().forEach( en -> {
             TrackedEntityInstance tei = preheatedTrackedEntities.get( en.getTrackedEntity() );
             if ( tei != null )
             {
                 teiIds.add( tei.getId() );
-            }
-
-            ProgramInstance pi = preheatedEnrollments.get( en.getEnrollment() );
-            if ( pi != null )
-            {
-                programIds.add( pi.getProgram().getId() );
             }
         } );
 
@@ -88,12 +81,11 @@ public class ProgramOwnerSupplier extends AbstractPreheatSupplier
             if ( pi != null )
             {
                 teiIds.add( pi.getEntityInstance().getId() );
-                programIds.add( pi.getProgram().getId() );
             }
         } );
 
         List<TrackedEntityProgramOwnerOrgUnit> tepos = trackedEntityProgramOwnerStore
-            .getTrackedEntityProgramOwnerOrgUnits( teiIds, programIds );
+            .getTrackedEntityProgramOwnerOrgUnits( teiIds );
 
         tepos = tepos.stream().map(
             tepo -> new TrackedEntityProgramOwnerOrgUnit( tepo.getTrackedEntityInstanceId(), tepo.getProgramId(),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_enrollment.json
@@ -1,0 +1,21 @@
+{
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAt": "2018-01-26T13:48:13.363",
+      "updatedAt": "2018-01-26T17:48:13.363",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntityType": "nEenWmSyUEp",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": "BFcipDERJnf",
+      "status": "ACTIVE",
+      "orgUnit": "uoNW0E3xXUy",
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followup": false,
+      "deleted": false
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
@@ -1,0 +1,22 @@
+{
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "enrollment": "TvctPPhpD8u",
+      "trackedEntity": "IOR1AXXl24H",
+      "storedBy": "admin",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "program": "BFcipDERJnf",
+      "programStage": "NpsdDv6kKSO",
+      "orgUnit": "uoNW0E3xXUy",
+      "status": "COMPLETED",
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAtClient": "2019-01-28T10:10:38.109",
+      "createdAtClient": "2019-01-28T11:10:38.108",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "completedBy": "admin"
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_metadata.json
@@ -1,0 +1,1036 @@
+{
+  "trackedEntityTypes": [
+    {
+      "created": "2020-05-31T08:59:52.758",
+      "lastUpdated": "2020-05-31T11:41:22.419",
+      "name": "Person",
+      "id": "ja8NY4PW7Xm",
+      "publicAccess": "rwrw----",
+      "description": "person",
+      "maxTeiCountToReturn": 0,
+      "allowAuditLog": false,
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "trackedEntityTypeAttributes": [],
+      "translations": [],
+      "userAccesses": []
+    }
+  ],
+  "relationshipTypes": [
+    {
+      "created": "2019-04-23T09:20:41.834",
+      "lastUpdated": "2019-04-23T09:21:18.063",
+      "name": "TA Sibling",
+      "id": "xLmPUYJX8Ks",
+      "bidirectional": true,
+      "publicAccess": "rw------",
+      "toFromName": "Sibling of",
+      "fromToName": "Sibling of",
+      "fromConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "ja8NY4PW7Xm"
+        }
+      },
+      "toConstraint": {
+        "relationshipEntity": "PROGRAM_INSTANCE",
+        "program": {
+          "id": "BFcipDERJnf"
+        }
+      },
+      "userGroupAccesses": [],
+      "translations": [],
+      "userAccesses": []
+    },
+    {
+      "lastUpdated": "2020-11-20T09:06:23.348",
+      "id": "TV9oB9LT3sh",
+      "created": "2020-11-20T09:06:23.348",
+      "name": "TA Parent to Child",
+      "bidirectional": false,
+      "displayName": "TA Parent to Child",
+      "publicAccess": "rw------",
+      "fromToName": "Parent Of",
+      "externalAccess": false,
+      "displayFromToName": "Parent Of",
+      "favorite": false,
+      "fromConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "ja8NY4PW7Xm"
+        }
+      },
+      "toConstraint": {
+        "relationshipEntity": "PROGRAM_STAGE_INSTANCE",
+        "program": {
+          "id": "BFcipDERJnf"
+        }
+      },
+      "userGroupAccesses": []
+    }
+  ],
+  "dataElements": [
+    {
+      "lastUpdated": "2020-05-31T11:41:22.404",
+      "id": "DATAEL00001",
+      "created": "2020-05-31T08:58:48.406",
+      "name": "test-dataelement1",
+      "shortName": "test-dataelement1",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "publicAccess": "rw------",
+      "valueType": "TEXT",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": [],
+      "aggregationLevels": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.404",
+      "id": "DATAEL00002",
+      "created": "2020-05-31T08:58:48.406",
+      "name": "test-dataelement2",
+      "shortName": "test-dataelement2",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "publicAccess": "rw------",
+      "valueType": "TEXT",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": [],
+      "aggregationLevels": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.404",
+      "id": "DATAEL00003",
+      "created": "2020-05-31T08:58:48.406",
+      "name": "test-dataelement3",
+      "shortName": "test-dataelement3",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "publicAccess": "rw------",
+      "valueType": "TEXT",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": [],
+      "aggregationLevels": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.404",
+      "id": "DATAEL00004",
+      "created": "2020-05-31T08:58:48.406",
+      "name": "test-dataelement4",
+      "shortName": "test-dataelement4",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "publicAccess": "rw------",
+      "valueType": "TEXT",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": [],
+      "aggregationLevels": []
+    }
+  ],
+  "userGroups": [
+    {
+      "created": "2020-05-31T09:03:15.823",
+      "lastUpdated": "2020-05-31T11:41:22.375",
+      "name": "test-user-group",
+      "id": "xfHoY6IZSWI",
+      "publicAccess": "rw------",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "users": [
+        {
+          "id": "lPaILkLkgOM"
+        }
+      ],
+      "managedGroups": [],
+      "translations": [],
+      "userAccesses": []
+    }
+  ],
+  "programStages": [
+    {
+      "lastUpdated": "2020-05-31T11:41:22.426",
+      "id": "NpsdDv6kKSO",
+      "created": "2020-05-31T09:02:52.687",
+      "name": "test-program-stage",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "publicAccess": "--------",
+      "description": "test-program-stage",
+      "openAfterEnrollment": false,
+      "repeatable": true,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "BFcipDERJnf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "notificationTemplates": [
+        {
+          "id": "FdIeUL4gyoB"
+        }
+      ],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [
+        {"access": "rwrw----",
+          "uid": "Tu9fv8ezgHl",
+          "user": {
+            "id": "Tu9fv8ezgHl"
+          },
+          "displayName": "UserLevel2"
+        }],
+      "programStageSections": [],
+      "programStageDataElements": [
+        {
+          "lastUpdated": "2019-01-28T11:23:20.855",
+          "id": "PSDE0000001",
+          "created": "2019-01-28T11:23:20.855",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "NpsdDv6kKSO"
+          },
+          "dataElement": {
+            "id": "DATAEL00001"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2019-01-28T11:23:20.855",
+          "id": "PSDE0000002",
+          "created": "2019-01-28T11:23:20.855",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "NpsdDv6kKSO"
+          },
+          "dataElement": {
+            "id": "DATAEL00002"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2019-01-28T11:23:20.855",
+          "id": "PSDE0000003",
+          "created": "2019-01-28T11:23:20.855",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "NpsdDv6kKSO"
+          },
+          "dataElement": {
+            "id": "DATAEL00003"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2019-01-28T11:23:20.855",
+          "id": "PSDE0000004",
+          "created": "2019-01-28T11:23:20.855",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "NpsdDv6kKSO"
+          },
+          "dataElement": {
+            "id": "DATAEL00004"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        }
+      ]
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.426",
+      "id": "NpsdDv6kKSe",
+      "created": "2020-05-31T09:02:52.687",
+      "name": "test-program-stage",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "publicAccess": "--------",
+      "description": "test-program-stage",
+      "openAfterEnrollment": false,
+      "repeatable": true,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "BFcipDERJne"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "notificationTemplates": [
+        {
+          "id": "FdIeUL4gyoB"
+        }
+      ],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "programStageSections": []
+    }
+  ],
+  "users": [
+    {
+      "lastUpdated": "2020-05-31T11:41:22.356",
+      "id": "lPaILkLkgOM",
+      "created": "2020-05-31T08:57:59.048",
+      "surname": "Asghar",
+      "email": "zubair@dhis2.org",
+      "firstName": "Zubair",
+      "phoneNumber": "+4740332255",
+      "userCredentials": {
+        "lastUpdated": "2020-05-31T08:57:58.894",
+        "id": "NDigmwuGPsn",
+        "created": "2020-05-31T08:57:58.894",
+        "name": "Zubair Asghar",
+        "displayName": "Zubair Asghar",
+        "externalAuth": false,
+        "externalAccess": false,
+        "disabled": false,
+        "twoFA": false,
+        "passwordLastUpdated": "2020-05-31T08:57:59.060",
+        "invitation": false,
+        "selfRegistered": false,
+        "favorite": false,
+        "username": "testuser",
+        "userInfo": {
+          "id": "lPaILkLkgOM"
+        },
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": true,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [],
+        "cogsDimensionConstraints": [],
+        "catDimensionConstraints": [],
+        "translations": [],
+        "userGroupAccesses": [],
+        "attributeValues": [],
+        "userRoles": [
+          {
+            "id": "yrB6vc5Ip3r"
+          }
+        ],
+        "userAccesses": []
+      },
+      "teiSearchOrganisationUnits": [],
+      "organisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        }
+      ],
+      "attributeValues": []
+    },
+    {
+      "code": "admin",
+      "lastUpdated": "2020-05-31T11:41:22.356",
+      "id": "M5zQapPyTZI",
+      "created": "2020-05-31T08:55:27.984",
+      "surname": "admin",
+      "firstName": "admin",
+      "userCredentials": {
+        "code": "admin",
+        "lastUpdated": "2020-05-31T08:55:28.230",
+        "id": "KvMx6c1eoYo",
+        "created": "2020-05-31T08:55:28.230",
+        "name": "admin admin",
+        "lastLogin": "2020-05-31T08:55:38.571",
+        "displayName": "admin admin",
+        "externalAuth": false,
+        "externalAccess": false,
+        "disabled": false,
+        "twoFA": false,
+        "passwordLastUpdated": "2020-05-31T08:55:28.232",
+        "invitation": false,
+        "selfRegistered": false,
+        "favorite": false,
+        "username": "admin",
+        "userInfo": {
+          "id": "M5zQapPyTZI"
+        },
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": true,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [],
+        "cogsDimensionConstraints": [],
+        "catDimensionConstraints": [],
+        "translations": [],
+        "userGroupAccesses": [],
+        "attributeValues": [],
+        "userRoles": [
+          {
+            "id": "yrB6vc5Ip3r"
+          }
+        ],
+        "userAccesses": []
+      },
+      "teiSearchOrganisationUnits": [],
+      "organisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        }
+      ],
+      "dataViewOrganisationUnits": [],
+      "attributeValues": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.356",
+      "id": "Tu9fv8ezgHl",
+      "created": "2020-05-31T08:57:59.048",
+      "surname": "user2",
+      "email": "user2@dhis2.org",
+      "firstName": "level2",
+      "phoneNumber": "+474444444",
+      "userCredentials": {
+        "lastUpdated": "2020-05-31T08:57:58.894",
+        "id": "UN7sDmyv94f",
+        "created": "2020-05-31T08:57:58.894",
+        "name": "Level2User",
+        "displayName": "UserLevel2",
+        "externalAuth": false,
+        "externalAccess": false,
+        "disabled": false,
+        "twoFA": false,
+        "passwordLastUpdated": "2020-05-31T08:57:59.060",
+        "invitation": false,
+        "selfRegistered": false,
+        "favorite": false,
+        "username": "level2user",
+        "userInfo": {
+          "id": "Tu9fv8ezgHl"
+        },
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": true,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [],
+        "cogsDimensionConstraints": [],
+        "catDimensionConstraints": [],
+        "translations": [],
+        "userGroupAccesses": [],
+        "attributeValues": [],
+        "userRoles": [
+          {
+            "id": "vymzhFICg4H"
+          }
+        ],
+        "userAccesses": []
+      },
+      "teiSearchOrganisationUnits": [
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        }
+      ],
+      "attributeValues": []
+    }
+  ],
+  "organisationUnits": [
+    {
+      "level": 1,
+      "created": "2020-05-31T08:56:15.922",
+      "lastUpdated": "2020-05-31T11:41:22.384",
+      "name": "test-orgunit",
+      "id": "h4w96yEMlzO",
+      "publicAccess": "rwrw----",
+      "shortName": "test-orgunit",
+      "description": "test-orgunit",
+      "path": "/h4w96yEMlzO",
+      "openingDate": "2020-05-31T00:00:00.000",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "attributeValues": [],
+      "translations": []
+    },
+    {
+      "level": 2,
+      "created": "2020-05-31T09:05:34.570",
+      "lastUpdated": "2020-05-31T11:41:22.385",
+      "name": "test-orgunit-2",
+      "id": "uoNW0E3xXUy",
+      "shortName": "test-program-rule",
+      "path": "/h4w96yEMlzO/uoNW0E3xXUy",
+      "closedDate": "2020-12-27T00:00:00.000",
+      "openingDate": "2020-05-31T00:00:00.000",
+      "parent": {
+        "id": "h4w96yEMlzO"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "attributeValues": [],
+      "translations": []
+    },
+    {
+      "level": 2,
+      "created": "2020-05-31T09:05:34.570",
+      "lastUpdated": "2020-05-31T11:41:22.385",
+      "name": "test-orgunit-3",
+      "id": "B1nCbRV3qtP",
+      "shortName": "test-ownership",
+      "path": "/h4w96yEMlzO/B1nCbRV3qtP",
+      "closedDate": "2020-12-27T00:00:00.000",
+      "openingDate": "2020-05-31T00:00:00.000",
+      "parent": {
+        "id": "h4w96yEMlzO"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "attributeValues": [],
+      "translations": []
+    }
+  ],
+  "programs": [
+    {
+      "lastUpdated": "2020-05-31T11:41:22.438",
+      "id": "BFcipDERJnf",
+      "created": "2020-05-31T09:02:52.718",
+      "name": "test-program",
+      "shortName": "test-program",
+      "publicAccess": "rwrw----",
+      "completeEventsExpiryDays": 0,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "programType": "WITH_REGISTRATION",
+      "accessLevel": "PROTECTED",
+      "version": 2,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "selectEnrollmentDatesInFuture": false,
+      "expiryDays": 0,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "trackedEntityType": {
+        "id": "ja8NY4PW7Xm"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        },
+        {
+          "id": "B1nCbRV3qtP"
+        },
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ],
+      "userGroupAccesses": [],
+      "programSections": [],
+      "attributeValues": [],
+      "programStages": [
+        {
+          "id": "NpsdDv6kKSO"
+        }
+      ],
+      "userAccesses": []
+    },
+    {
+      "lastUpdated": "2019-01-28T11:23:20.906",
+      "id": "BFcipDERJne",
+      "created": "2019-01-28T11:23:20.906",
+      "name": "ProgramA",
+      "shortName": "ProgramA",
+      "publicAccess": "rw------",
+      "completeEventsExpiryDays": 0,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "programType": "WITHOUT_REGISTRATION",
+      "accessLevel": "OPEN",
+      "version": 0,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "selectEnrollmentDatesInFuture": false,
+      "expiryDays": 0,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        }
+      ],
+      "userGroupAccesses": [],
+      "programSections": [],
+      "attributeValues": [],
+      "programStages": [
+        {
+          "id": "NpsdDv6kKSe"
+        }
+      ],
+      "userAccesses": []
+    }
+  ],
+  "userRoles": [
+    {
+      "code": "Superuser",
+      "created": "2020-05-31T08:55:28.141",
+      "lastUpdated": "2020-05-31T11:41:22.347",
+      "name": "Superuser",
+      "id": "yrB6vc5Ip3r",
+      "publicAccess": "--------",
+      "description": "Superuser",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userGroupAccesses": [],
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "F_TRACKER_IMPORTER_EXPERIMENTAL",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_USER_VIEW",
+        "F_GENERATE_MIN_MAX_VALUES",
+        "F_ORGANISATIONUNIT_MOVE",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_PREDICTOR_RUN",
+        "F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION",
+        "F_SKIP_DATA_IMPORT_AUDIT",
+        "F_RUN_VALIDATION",
+        "F_IMPORT_DATA",
+        "F_LOCALE_ADD",
+        "F_REPLICATE_USER",
+        "F_SEND_EMAIL",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_ENROLLMENT_CASCADE_DELETE",
+        "F_METADATA_IMPORT",
+        "F_EXPORT_EVENTS",
+        "F_VIEW_EVENT_ANALYTICS",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_IMPORT_EVENTS",
+        "F_PERFORM_MAINTENANCE",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_METADATA_EXPORT",
+        "F_TEI_CASCADE_DELETE",
+        "F_EXPORT_DATA",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_EDIT_EXPIRED",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_UNCOMPLETE_EVENT"
+      ],
+      "translations": [],
+      "userAccesses": []
+    },
+    {
+      "code": "NonSuperUser",
+      "created": "2020-05-31T08:55:28.141",
+      "lastUpdated": "2020-05-31T11:41:22.347",
+      "name": "nonSuperUser",
+      "id": "vymzhFICg4H",
+      "publicAccess": "--------",
+      "description": "nonSuperUser",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userGroupAccesses": [],
+      "authorities": [
+        "F_APPROVE_DATA",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_PROGRAM_INDICATOR_PUBLIC_ADD",
+        "F_RELATIONSHIP_ADD",
+        "F_SCHEDULING_SEND_MESSAGE",
+        "F_PROGRAM_TRACKING_SEARCH",
+        "F_RELATIONSHIP_MANAGEMENT",
+        "F_ANONYMOUS_DATA_ENTRY",
+        "F_GENERATE_BENEFICIARY_TABULAR_REPORT",
+        "F_SCHEDULING_ADMIN",
+        "F_TRACKED_ENTITY_COMMENT_DELETE",
+        "F_SINGLE_EVENT_DATA_ENTRY",
+        "F_GENERATE_STATISTICAL_PROGRAM_REPORT",
+        "F_TRACKED_ENTITY_COMMENT_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_MANAGEMENT",
+        "F_PROGRAM_INSTANCE_MANAGEMENT",
+        "F_TRACKED_ENTITY_INSTANCE_LIST",
+        "F_PROGRAM_TRACKING_LIST",
+        "F_ACTIVITY_PLAN",
+        "F_PROGRAM_INSTANCE_DELETE",
+        "F_TRACKED_ENTITY_INSTANCE_HISTORY",
+        "F_PROGRAM_STAGE_INSTANCE_DELETE",
+        "F_TRACKED_ENTITY_INSTANCE_CHANGE_LOCATION",
+        "F_PROGRAM_TRACKING_MANAGEMENT",
+        "F_GENERATE_PROGRAM_SUMMARY_REPORT",
+        "F_MOBILE_SENDSMS",
+        "F_NAME_BASED_DATA_ENTRY",
+        "F_RELATIONSHIP_DELETE",
+        "F_TRACKED_ENTITY_INSTANCE_DASHBOARD",
+        "F_PROGRAM_STAGE_INSTANCE_SEARCH"
+      ],
+      "translations": [],
+      "userAccesses": []
+    }
+  ],
+  "trackedEntityAttributes": [
+    {
+      "lastUpdated": "2020-05-31T11:41:22.414",
+      "id": "toUpdate000",
+      "created": "2020-05-31T09:00:51.347",
+      "name": "to-update-tei-attribute",
+      "shortName": "to-update-tei-attribute",
+      "aggregationType": "NONE",
+      "displayInListNoProgram": false,
+      "publicAccess": "rw------",
+      "pattern": "",
+      "skipSynchronization": false,
+      "generated": false,
+      "displayOnVisitSchedule": false,
+      "valueType": "TEXT",
+      "formName": "to-update-tei-attribute",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.414",
+      "id": "toDelete000",
+      "created": "2020-05-31T09:00:51.347",
+      "name": "to-delete-tei-attribute",
+      "shortName": "to-delete-tei-attribute",
+      "aggregationType": "NONE",
+      "displayInListNoProgram": false,
+      "publicAccess": "rw------",
+      "pattern": "",
+      "skipSynchronization": false,
+      "generated": false,
+      "displayOnVisitSchedule": false,
+      "valueType": "TEXT",
+      "formName": "to-delete-tei-attribute",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.414",
+      "id": "notUpdated0",
+      "created": "2020-05-31T09:00:51.347",
+      "name": "not-updated-tei-attribute",
+      "shortName": "not-updated-tei-attribute",
+      "aggregationType": "NONE",
+      "displayInListNoProgram": false,
+      "publicAccess": "rw------",
+      "pattern": "",
+      "skipSynchronization": false,
+      "generated": false,
+      "displayOnVisitSchedule": false,
+      "valueType": "TEXT",
+      "formName": "not-updated-tei-attribute",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    }
+  ],
+  "programNotificationTemplates": [
+    {
+      "lastUpdated": "2020-05-31T11:35:18.355",
+      "id": "FdIeUL4gyoB",
+      "href": "http://localhost:8081/api/programNotificationTemplates/FdIeUL4gyoB",
+      "created": "2020-05-31T11:35:18.355",
+      "name": "test-program-stage-notification",
+      "displayName": "test-program-stage-notification",
+      "externalAccess": false,
+      "notificationTrigger": "PROGRAM_RULE",
+      "subjectTemplate": "test subject",
+      "notificationRecipient": "USER_GROUP",
+      "favorite": false,
+      "messageTemplate": "test message ",
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "recipientUserGroup": {
+        "id": "xfHoY6IZSWI"
+      },
+      "favorites": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "deliveryChannels": [],
+      "attributeValues": [],
+      "userAccesses": []
+    }
+  ]
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_tei.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_tei.json
@@ -1,0 +1,23 @@
+{
+  "trackedEntities": [
+    {
+      "trackedEntityType": "ja8NY4PW7Xm",
+      "trackedEntity": "IOR1AXXl24H",
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "createdAtClient": "2020-02-20T10:09:21.844",
+      "updatedAtClient": "2020-02-20T11:09:21.844",
+      "orgUnit": "uoNW0E3xXUy",
+      "inactive": false,
+      "deleted": false,
+      "featureType": "NONE",
+      "programOwners": [
+        {
+          "ownerOrgUnit": "cNEZTkdAvmg",
+          "program": "hJUBNVQWl4e",
+          "trackedEntity": "EEFkxTWB55Y"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
…ache (#8779)

* test: adds ownership tests

* Added more tests

* revert changes to program hbml xm

* Fixed lazy init issue when checking ownership

* Add explicit classtype parameter to redis value serializer

* Reverted changing to explicit serializer for redistemplate

* Add recursive unproxying and fix some e2e test setup

* Add accessLevel in ProgramMapper. Corrected e2e tests.

* Revert old replaceWith and add sepratet replaceRecursivelyWith in e2e test helper

* Fixed e2e test setup

* fix test setup for EnrollmentsOwnershipTests

* fix e2e test

Co-authored-by: Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
(cherry picked from commit 51059052a5a98239fc198445ed9c561bfa2ed58f)