### PR TITLE
fix: change default fields on EventController

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -56,9 +56,6 @@ import java.util.zip.GZIPOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
@@ -137,6 +134,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -248,7 +248,8 @@ public class EventController
 
         if ( fields.isEmpty() )
         {
-            fields.addAll( Preset.ALL.getFields() );
+            fields.add( "*" );
+            fields.add( "dataValues" );
         }
 
         CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo( attributeCc, attributeCos,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -56,6 +56,9 @@ import java.util.zip.GZIPOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
@@ -134,9 +137,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
-
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>


### PR DESCRIPTION
Since we have removed the old Squiggly library for field filtering (and now relying on node services), some fields are not included when you field filter on `*`, this PR changes that to explicitely using `*,dataValues` if no field filter is present.