### PR TITLE
fix: only remind users about account disable on specific days [DHIS2-11589]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -475,20 +475,15 @@ public interface UserService
     int disableUsersInactiveSince( Date inactiveSince );
 
     /**
-     * Selects all users where the {@link UserCredentials#getLastLogin()} is
-     * before or equal to the provided pivot {@link Date}.
+     * Selects all not disabled users where the
+     * {@link UserCredentials#getLastLogin()} is within the given time-frame and
+     * which have an email address.
      *
-     * Does a comparable query to {@link #disableUsersInactiveSince(Date)} but
-     * instead of disabling the found uses it returns them (without making a
-     * change).
-     *
-     * @see #disableUsersInactiveSince(Date)
-     *
-     * @param inactiveSince the most recent point in time that is considered *
-     *        inactive together with accounts only active further in the past.
-     * @return user emails that were inactive since the provided date
+     * @param from start of the selected time-frame (inclusive)
+     * @param to end of the selected time-frame (exclusive)
+     * @return user emails having a last login within the given time-frame.
      */
-    Set<String> findUsersInactiveSince( Date inactiveSince );
+    Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 
     /**
      * Get user display name by concat( firstname,' ', surname ) Return null if

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -124,20 +124,15 @@ public interface UserStore
     int disableUsersInactiveSince( Date inactiveSince );
 
     /**
-     * Selects all users where the {@link UserCredentials#getLastLogin()} is
-     * before or equal to the provided pivot {@link Date}.
+     * Selects all not disabled users where the
+     * {@link UserCredentials#getLastLogin()} is within the given time-frame and
+     * which have an email address.
      *
-     * Does a comparable query to {@link #disableUsersInactiveSince(Date)} but
-     * instead of disabling the found uses it returns them (without making a
-     * change).
-     *
-     * @see #disableUsersInactiveSince(Date)
-     *
-     * @param inactiveSince the most recent point in time that is considered *
-     *        inactive together with accounts only active further in the past.
-     * @return user emails that were inactive at least since the provided date
+     * @param from start of the selected time-frame (inclusive)
+     * @param to end of the selected time-frame (exclusive)
+     * @return user emails having a last login within the given time-frame.
      */
-    Set<String> findUsersInactiveSince( Date inactiveSince );
+    Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 
     String getDisplayName( String userUid );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -825,9 +825,9 @@ public class DefaultUserService
 
     @Override
     @Transactional( readOnly = true )
-    public Set<String> findUsersInactiveSince( Date inactiveSince )
+    public Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to )
     {
-        return userStore.findUsersInactiveSince( inactiveSince );
+        return userStore.findNotifiableUsersWithLastLoginBetween( from, to );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -588,14 +588,15 @@ public class HibernateUserStore
     }
 
     @Override
-    public Set<String> findUsersInactiveSince( Date inactiveSince )
+    public Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to )
     {
         String hql = "select u.email " +
             "from User u inner join u.userCredentials uc " +
-            "where u.email is not null and uc.disabled = false and uc.lastLogin <= :since";
+            "where u.email is not null and uc.disabled = false and uc.lastLogin >= :from and uc.lastLogin < :to";
         return getSession().createQuery( hql, String.class )
-            .setParameter( "since", inactiveSince ).stream()
-            .collect( toSet() );
+            .setParameter( "from", from )
+            .setParameter( "to", to )
+            .stream().collect( toSet() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -655,9 +655,10 @@ public class UserServiceTest
     }
 
     @Test
-    public void testFindUsersInactiveSince()
+    public void testFindNotifiableUsersWithLastLoginBetween()
     {
         ZonedDateTime now = ZonedDateTime.now();
+        Date oneMonthsAgo = Date.from( now.minusMonths( 1 ).toInstant() );
         Date twoMonthsAgo = Date.from( now.minusMonths( 2 ).toInstant() );
         Date threeMonthAgo = Date.from( now.minusMonths( 3 ).toInstant() );
         Date fourMonthAgo = Date.from( now.minusMonths( 4 ).toInstant() );
@@ -666,14 +667,17 @@ public class UserServiceTest
         User userA = addUser( 'A', UserCredentials::setLastLogin, threeMonthAgo );
         User userB = addUser( 'B', credentials -> {
             credentials.setDisabled( true );
-            credentials.setLastLogin( fourMonthAgo );
+            credentials.setLastLogin( Date.from( now.minusMonths( 4 ).plusDays( 2 ).toInstant() ) );
         } );
 
         addUser( 'C', UserCredentials::setLastLogin, twentyTwoDaysAgo );
         addUser( 'D' );
 
-        assertEquals( singleton( "EmailA" ), userService.findUsersInactiveSince( twoMonthsAgo ) );
+        assertEquals( singleton( "EmailA" ),
+            userService.findNotifiableUsersWithLastLoginBetween( threeMonthAgo, twoMonthsAgo ) );
+        assertEquals( singleton( "EmailA" ),
+            userService.findNotifiableUsersWithLastLoginBetween( fourMonthAgo, oneMonthsAgo ) );
         assertEquals( new HashSet<>( asList( "EmailA", "EmailC" ) ),
-            userService.findUsersInactiveSince( Date.from( now.minusDays( 10 ).toInstant() ) ) );
+            userService.findNotifiableUsersWithLastLoginBetween( fourMonthAgo, Date.from( now.toInstant() ) ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/mock/MockUserService.java
@@ -406,7 +406,7 @@ public class MockUserService
     }
 
     @Override
-    public Set<String> findUsersInactiveSince( Date inactiveSince )
+    public Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to )
     {
         return null;
     }


### PR DESCRIPTION
As discussed the issue with the current implementation of the reminder email was, that it would send an email to the user daily in case the user would not log in. This is now changed. We only select users with a last login being on a single specific day dependent on the job configuration. Those users get an email. Then the number is divided by two and users being that number of days away from being disabled also get an email. This continues until (and including) 1 days to being disabled. 

As now only users being a single particular number of days away from being disabled are selected a reminded the number of days stated in the email is correct when it states the same number for all of them.

Existing unit tests were adopted and extended.