### PR TITLE
fix: Fix the way attribute value are updated by hibernate session [DHIS2-11852]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -130,11 +130,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
                     session.persist( convertedDto );
                     typeReport.getStats().incCreated();
                     typeReport.addObjectReport( objectReport );
+                    updateAttributes( session, bundle.getPreheat(), trackerDto, convertedDto );
                 }
                 else
                 {
                     if ( isUpdatable() )
                     {
+                        updateAttributes( session, bundle.getPreheat(), trackerDto, convertedDto );
                         session.merge( convertedDto );
                         typeReport.getStats().incUpdated();
                         typeReport.addObjectReport( objectReport );
@@ -144,8 +146,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
                         typeReport.getStats().incIgnored();
                     }
                 }
-
-                updateAttributes( session, bundle.getPreheat(), trackerDto, convertedDto );
 
                 //
                 // Add the entity to the Preheat
@@ -338,13 +338,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends B
 
             if ( attributeValue == null )
             {
-                attributeValue = new TrackedEntityAttributeValue()
-                    .setAttribute( attribute )
-                    .setEntityInstance( trackedEntityInstance );
+                attributeValue = new TrackedEntityAttributeValue();
                 isNew = true;
             }
 
             attributeValue
+                .setAttribute( attribute )
+                .setEntityInstance( trackedEntityInstance )
                 .setValue( at.getValue() )
                 .setStoredBy( at.getStoredBy() );
 


### PR DESCRIPTION
I couldn't really understand the root cause of the problem but I managed to fix it updating the attributes before persisting the TEI when it is a CREATE and after persisting when it is an UPDATE.