### PR TITLE
fix: Add potentialDuplicate parameter in tei/query endpoint (2.37.0) 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -88,6 +88,8 @@ public class TrackedEntityInstanceQueryParams
 
     public static final String PAGER_META_KEY = "pager";
 
+    public static final String POTENTIAL_DUPLICATE = "potentialduplicate";
+
     public static final int DEFAULT_PAGE = 1;
 
     public static final int DEFAULT_PAGE_SIZE = 50;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityInstanceService.java
@@ -42,6 +42,7 @@ import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.META_
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.ORG_UNIT_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.ORG_UNIT_NAME;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.PAGER_META_KEY;
+import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.POTENTIAL_DUPLICATE;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.TRACKED_ENTITY_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.TRACKED_ENTITY_INSTANCE_ID;
 
@@ -328,6 +329,7 @@ public class DefaultTrackedEntityInstanceService
         grid.addHeader( new GridHeader( ORG_UNIT_NAME, "Organisation unit name" ) );
         grid.addHeader( new GridHeader( TRACKED_ENTITY_ID, "Tracked entity type" ) );
         grid.addHeader( new GridHeader( INACTIVE_ID, "Inactive" ) );
+        grid.addHeader( new GridHeader( POTENTIAL_DUPLICATE, "Potential duplicate" ) );
 
         if ( params.isIncludeDeleted() )
         {
@@ -385,6 +387,7 @@ public class DefaultTrackedEntityInstanceService
             grid.addValue( entity.get( ORG_UNIT_NAME ) );
             grid.addValue( entity.get( TRACKED_ENTITY_ID ) );
             grid.addValue( entity.get( INACTIVE_ID ) );
+            grid.addValue( entity.get( POTENTIAL_DUPLICATE ) );
 
             if ( params.isIncludeDeleted() )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -33,16 +33,9 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getTokens;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.CREATED_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.DELETED;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.INACTIVE_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.LAST_UPDATED_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.ORG_UNIT_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.ORG_UNIT_NAME;
+import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.*;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.getColumn;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.isStaticColumn;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.TRACKED_ENTITY_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.TRACKED_ENTITY_INSTANCE_ID;
 import static org.hisp.dhis.util.DateUtils.getDateAfterAddition;
 import static org.hisp.dhis.util.DateUtils.getLongGmtDateString;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
@@ -432,6 +425,7 @@ public class HibernateTrackedEntityInstanceStore
             map.put( ORG_UNIT_NAME, rowSet.getString( ORG_UNIT_NAME ) );
             map.put( TRACKED_ENTITY_ID, rowSet.getString( TRACKED_ENTITY_ID ) );
             map.put( INACTIVE_ID, rowSet.getString( INACTIVE_ID ) );
+            map.put( POTENTIAL_DUPLICATE, rowSet.getString( POTENTIAL_DUPLICATE ) );
 
             if ( params.isIncludeDeleted() )
             {
@@ -624,7 +618,8 @@ public class HibernateTrackedEntityInstanceStore
             .append( "TEI.ou AS " + ORG_UNIT_ID + ", " )
             .append( "TEI.ouname AS " + ORG_UNIT_NAME + ", " )
             .append( "TET.uid AS " + TRACKED_ENTITY_ID + ", " )
-            .append( "TEI.inactive AS " + INACTIVE_ID )
+            .append( "TEI.inactive AS " + INACTIVE_ID + ", " )
+            .append( "TEI.potentialduplicate AS " + POTENTIAL_DUPLICATE )
             .append( (params.isIncludeDeleted() ? ", TEI.deleted AS " + DELETED : "") )
             .append( (params.hasAttributes() ? ", string_agg(TEA.uid || ':' || TEAV.value, ';') AS tea_values" : "") );
 
@@ -710,6 +705,7 @@ public class HibernateTrackedEntityInstanceStore
             .append( "TEI.lastupdated, " )
             .append( "TEI.inactive, " )
             .append( "TEI.trackedentitytypeid, " )
+            .append( "TEI.potentialduplicate, " )
             .append( "TEI.deleted, " )
             .append( "OU.uid as ou, " )
             .append( "OU.name as ouname " )
@@ -1370,6 +1366,7 @@ public class HibernateTrackedEntityInstanceStore
             .append( "TEI.ou, " )
             .append( "TEI.ouname, " )
             .append( "TET.uid, " )
+            .append( "TEI.potentialduplicate, " )
             .append( "TEI.inactive " )
             .append( (params.isIncludeDeleted() ? ", TEI.deleted " : "") );
 


### PR DESCRIPTION
Added potentialduplicate column into the result of api/trackedEntityInstances/query API.
Added tests to verify the column is returned when accessing HibernateTrackedEntityInstanceStore.getGrid()


(cherry picked from commit bf3551090352aa2aba8dd4b5c714f9b2f1e6d03b)