### PR TITLE
fix: ignore non-writable properties when checking owner references

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/NotOwnerReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/NotOwnerReferencesCheck.java
@@ -100,7 +100,7 @@ public class NotOwnerReferencesCheck implements ValidationCheck
 
         Schema schema = ctx.getSchemaService().getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
 
-        schema.getProperties().stream().filter( p -> !p.isOwner()
+        schema.getProperties().stream().filter( p -> !p.isOwner() && p.isWritable()
             && (PropertyType.REFERENCE == p.getPropertyType() || PropertyType.REFERENCE == p.getItemPropertyType()) )
             .forEach( p -> {
                 if ( !p.isCollection() )


### PR DESCRIPTION
Updating OUs with JSON patch would fail since the `ancestors` property wrongly would be checked by the references check.
This check should have ignore the property as it is not `writable`. This PR add the condition to the filter of checked properties so only `writable` properties are checked.