### PR TITLE
fix: don't log audits to stdout, only file by default

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -124,7 +124,7 @@ public enum ConfigurationKey
     AUDIT_USE_INMEMORY_QUEUE_ENABLED( "audit.inmemory-queue.enabled", Constants.OFF ),
     AUDIT_USE_IN_MEMORY_QUEUE_ENABLED( "audit.in_memory_queue.enabled", Constants.OFF ),
     AUDIT_LOGGER( "audit.logger", Constants.ON, false ),
-    AUDIT_DATABASE( "audit.database", Constants.ON, false ),
+    AUDIT_DATABASE( "audit.database", Constants.OFF, false ),
     AUDIT_METADATA_MATRIX( "audit.metadata", "", false ),
     AUDIT_TRACKER_MATRIX( "audit.tracker", "", false ),
     AUDIT_AGGREGATE_MATRIX( "audit.aggregate", "", false ),

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
@@ -176,7 +176,7 @@ public class Log4JLogConfigInitializer
 
         for ( String loggerName : packages )
         {
-            LoggerConfig loggerConfig = LoggerConfig.createLogger( true, Level.INFO, loggerName, "true", refs, null,
+            LoggerConfig loggerConfig = LoggerConfig.createLogger( false, Level.INFO, loggerName, "true", refs, null,
                 getLogConfiguration(), null );
 
             loggerConfig.addAppender( appender, null, null );


### PR DESCRIPTION
### Summary

* Turns off `additive` logging for audits, only log to `dhis-audit.log`
* Turn off `audit.database` by default