### PR TITLE
fix: JpaQueryUtils groups_access args DHIS2-11921

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -395,7 +395,7 @@ public class JpaQueryUtils
             + " and " + JsonbFunctions.CHECK_USER_ACCESS + "( %1$s, '%2$s', '%4$s' ) = true )  "
             + (StringUtils.isEmpty( groupsIds ) ? ""
                 : " or ( " + JsonbFunctions.HAS_USER_GROUP_IDS + "( %1$s, '%3$s') = true "
-                    + " and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( %1$s, '%3$s', '%4$s') = true )");
+                    + " and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( %1$s, '%4$s', '%3$s') = true )");
         return String.format( sql, sharingColumn, userId, groupsIds, access );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
@@ -31,13 +31,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.google.common.collect.Lists;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 /**


### PR DESCRIPTION
See [DHIS2-11921](https://jira.dhis2.org/browse/DHIS2-11921). DataValueSet values are not returned if data has an AttributeOptionCombo with a CategoryOption that is shared by a UserGroup.

`JpaQueryUtils` generates a `jsonb_check_user_groups_access` function reference with args:
1-sharing column
2-list of userGroupIds
3-access pattern

However, the `jsonb_check_user_groups_access` function expects args:
1-sharing column
2-access pattern
3-list of userGroupIds

The fix is to change the order of args 2 and 3 in `JpaQueryUtils` to match the order expected by `jsonb_check_user_groups_access`.