### PR TITLE
fix: remove updatedAt from note object TECH-590

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Note.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Note.java
@@ -55,9 +55,6 @@ public class Note
     private Instant storedAt;
 
     @JsonProperty
-    private Instant updatedAt;
-
-    @JsonProperty
     private String storedBy;
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/mapper/NoteMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/mapper/NoteMapper.java
@@ -35,6 +35,5 @@ import org.mapstruct.Mapping;
 public interface NoteMapper extends DomainMapper<org.hisp.dhis.dxf2.events.event.Note, Note>
 {
     @Mapping( target = "storedAt", source = "storedDate" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
     Note from( org.hisp.dhis.dxf2.events.event.Note note );
 }


### PR DESCRIPTION
Note object in the NTI can't be updated, so it should be removed to avoid confusing users.

Additional work that I still need to do:
* remove the field from the docs https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/new-tracker.html#changes-in-the-api 
* fix any failing tests I missed. I first ran unit tests locally as I am not 100% familiar with all the tests.
* maybe move that fix to another branch? PR currently would be merged to master. Affects Version/s: 2.36, 2.37
* potentially other places I do not yet know about as it's my first DHIS2 PR 😁 

For more information see TECH-590