### PR TITLE
fix: Change i18nJavaScript.action to dynamic permitAll ant matcher

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -179,7 +179,6 @@ public class DhisWebCommonsWebSecurityConfig
                 .antMatchers( "/dhis-web-commons/css/**" )
                 .antMatchers( "/dhis-web-commons/flags/**" )
                 .antMatchers( "/dhis-web-commons/fonts/**" )
-                .antMatchers( "/dhis-web-commons/i18nJavaScript.action" )
                 .antMatchers( "/api/files/style/external" )
                 .antMatchers( "/external-static/**" )
                 .antMatchers( "/favicon.ico" );
@@ -195,7 +194,7 @@ public class DhisWebCommonsWebSecurityConfig
                 .accessDecisionManager( accessDecisionManager() )
 
                 .requestMatchers( analyticsPluginResources() ).permitAll()
-
+                .antMatchers( "/dhis-web-commons/i18nJavaScript.action" ).permitAll()
                 .antMatchers( "/oauth2/**" ).permitAll()
                 .antMatchers( "/dhis-web-commons/security/login.action" ).permitAll()
                 .antMatchers( "/dhis-web-commons/security/logout.action" ).permitAll()


### PR DESCRIPTION
⋅ Change i18nJavaScript.action to use the dynamic permitAll antMatcher instead of ignoring(). Ignoring() is for static resources and not Struts actions.