### PR TITLE
fix: Moving out org unit logic [DHIS2-11769]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -113,14 +113,14 @@ public class SchemaIdResponseMapper
             {
                 applyDataElementOperandsIdSchemaMapping( params, responseMap );
             }
+        }
 
-            // If "outputOrgUnitIdScheme" is set, we replace all org units
-            // values respecting
-            // it's definition.
-            if ( params.isOutputOrgUnitIdSchemeSet() )
-            {
-                applyOrgUnitIdSchemaMapping( params, responseMap );
-            }
+        // If "outputOrgUnitIdScheme" is set, we replace all org units
+        // values respecting
+        // it's definition.
+        if ( params.isOutputOrgUnitIdSchemeSet() )
+        {
+            applyOrgUnitIdSchemaMapping( params, responseMap );
         }
 
         return responseMap;


### PR DESCRIPTION
The logic to org unit output schema was being only applied when we had element operands in the params. This is being fixed as the org unit schema does not depend on operands.