### PR TITLE
fix: JpaQueryUtils groups_access args DHIS2-11921 (#8902)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -395,7 +395,7 @@ public class JpaQueryUtils
             + " and " + JsonbFunctions.CHECK_USER_ACCESS + "( %1$s, '%2$s', '%4$s' ) = true )  "
             + (StringUtils.isEmpty( groupsIds ) ? ""
                 : " or ( " + JsonbFunctions.HAS_USER_GROUP_IDS + "( %1$s, '%3$s') = true "
-                    + " and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( %1$s, '%3$s', '%4$s') = true )");
+                    + " and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( %1$s, '%4$s', '%3$s') = true )");
         return String.format( sql, sharingColumn, userId, groupsIds, access );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/JpaQueryUtilsTest.java
@@ -32,8 +32,13 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserGroup;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * Unit tests for {@link JpaQueryUtils}.
@@ -208,5 +213,30 @@ public class JpaQueryUtilsTest
 
         Assert.assertEquals( "lower(x.value1)", JpaQueryUtils.createSelectOrderExpression(
             Collections.singletonList( new Order( property1, Direction.ASCENDING ).ignoreCase() ), "x" ) );
+    }
+
+    @Test
+    public void testGenerateSQlQueryForSharingCheck()
+    {
+        UserGroup groupA = new UserGroup();
+        groupA.setUid( "aUserGroupA" );
+
+        UserGroup groupB = new UserGroup();
+        groupB.setUid( "aUserGroupB" );
+
+        User userA = new User();
+        userA.setUid( "randomUserA" );
+        userA.setGroups( Sets.newLinkedHashSet( Lists.newArrayList( groupA, groupB ) ) );
+
+        String expected = " ( x.sharing->>'owner' is null or x.sharing->>'owner' = 'randomUserA')  "
+            + "or x.sharing->>'public' like '__r_____' or x.sharing->>'public' is null  "
+            + "or (jsonb_has_user_id( x.sharing, 'randomUserA') = true  "
+            + "and jsonb_check_user_access( x.sharing, 'randomUserA', '__r_____' ) = true )   "
+            + "or ( jsonb_has_user_group_ids( x.sharing, '{aUserGroupA,aUserGroupB}') = true  "
+            + "and jsonb_check_user_groups_access( x.sharing, '__r_____', '{aUserGroupA,aUserGroupB}') = true )";
+
+        String actual = JpaQueryUtils.generateSQlQueryForSharingCheck( "x.sharing", userA, "__r_____" );
+
+        Assert.assertEquals( expected, actual );
     }
 }


### PR DESCRIPTION
* fix: JpaQueryUtils groups_access args DHIS2-11921

* fix: import order

(cherry picked from commit 26676e0a3f3b0e7383aca8851f86e5d28ff2bfb8)