### PR TITLE
fix: allow non ASCII letters in token in memory restriction [DHIS2-10323]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotTokenOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotTokenOperator.java
@@ -40,8 +40,7 @@ import org.hisp.dhis.query.planner.QueryPath;
 /**
  * @author Henning Håkonsen
  */
-public class NotTokenOperator<T extends Comparable<? super T>>
-    extends Operator<T>
+public class NotTokenOperator<T extends Comparable<? super T>> extends Operator<T>
 {
     private final boolean caseSensitive;
 
@@ -74,10 +73,8 @@ public class NotTokenOperator<T extends Comparable<? super T>>
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public boolean test( Object value )
     {
-        String targetValue = caseSensitive ? getValue( String.class ) : getValue( String.class ).toLowerCase();
-        return !TokenUtils.test( args, (T) value, targetValue, caseSensitive, matchMode );
+        return !TokenUtils.test( value, getValue( String.class ), caseSensitive, matchMode );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/Operator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/Operator.java
@@ -171,7 +171,7 @@ public abstract class Operator<T extends Comparable<? super T>>
 
     public abstract boolean test( Object value );
 
-    org.hibernate.criterion.MatchMode getMatchMode( org.hisp.dhis.query.operators.MatchMode matchMode )
+    org.hibernate.criterion.MatchMode getMatchMode( MatchMode matchMode )
     {
         switch ( matchMode )
         {
@@ -188,7 +188,7 @@ public abstract class Operator<T extends Comparable<? super T>>
         }
     }
 
-    protected JpaQueryUtils.StringSearchMode getJpaMatchMode( org.hisp.dhis.query.operators.MatchMode matchMode )
+    protected JpaQueryUtils.StringSearchMode getJpaMatchMode( MatchMode matchMode )
     {
         switch ( matchMode )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
@@ -40,14 +40,13 @@ import org.hisp.dhis.query.planner.QueryPath;
 /**
  * @author Henning Håkonsen
  */
-public class TokenOperator<T extends Comparable<? super T>>
-    extends Operator<T>
+public class TokenOperator<T extends Comparable<? super T>> extends Operator<T>
 {
     private final boolean caseSensitive;
 
     private final org.hibernate.criterion.MatchMode matchMode;
 
-    public TokenOperator( T arg, boolean caseSensitive, org.hisp.dhis.query.operators.MatchMode matchMode )
+    public TokenOperator( T arg, boolean caseSensitive, MatchMode matchMode )
     {
         super( "token", Typed.from( String.class ), arg );
         this.caseSensitive = caseSensitive;
@@ -74,10 +73,8 @@ public class TokenOperator<T extends Comparable<? super T>>
     }
 
     @Override
-    @SuppressWarnings( "unchecked" )
     public boolean test( Object value )
     {
-        String targetValue = caseSensitive ? getValue( String.class ) : getValue( String.class ).toLowerCase();
-        return TokenUtils.test( args, (T) value, targetValue, caseSensitive, matchMode );
+        return TokenUtils.test( value, getValue( String.class ), caseSensitive, matchMode );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenUtils.java
@@ -27,97 +27,71 @@
  */
 package org.hisp.dhis.query.operators;
 
-import java.util.Arrays;
+import static java.util.Arrays.asList;
+
 import java.util.List;
 
 import org.hibernate.criterion.MatchMode;
-import org.hisp.dhis.query.Type;
 
 /**
  * @author Henning Håkonsen
  */
 public class TokenUtils
 {
+    private TokenUtils()
+    {
+        throw new UnsupportedOperationException( "util" );
+    }
+
     public static List<String> getTokens( String value )
     {
-        return Arrays.asList( value.replaceAll( "[^\\p{L}0-9]", " " ).split( "[\\s@&.?$+-]+" ) );
+        return asList( value.replaceAll( "[^\\p{L}0-9]", " " ).split( "[\\s@&.?$+-]+" ) );
     }
 
     public static StringBuilder createRegex( String value )
     {
         StringBuilder regex = new StringBuilder();
 
-        List<String> tokens = TokenUtils.getTokens( value );
+        List<String> tokens = getTokens( value );
 
-        if ( tokens == null || tokens.isEmpty() )
+        if ( tokens.isEmpty() )
         {
             return regex;
         }
 
-        TokenUtils.getTokens( value ).forEach( token -> regex.append( "(?=.*" ).append( token ).append( ")" ) );
-
+        for ( String token : getTokens( value ) )
+        {
+            regex.append( "(?=.*" ).append( token ).append( ")" );
+        }
         return regex;
     }
 
-    public static <T> boolean test( List<T> args, T testValue, String targetValue, boolean caseSensitive,
-        MatchMode matchMode )
+    public static <T> boolean test( T value, String searchTerm, boolean caseSensitive, MatchMode mode )
     {
-        if ( args.isEmpty() || testValue == null )
+        if ( value == null )
         {
             return false;
         }
+        String searchString = caseSensitive ? searchTerm : searchTerm.toLowerCase();
+        String valueString = caseSensitive ? value.toString() : value.toString().toLowerCase();
+        List<String> searchTokens = getTokens( searchString );
+        List<String> valueTokens = getTokens( valueString );
+        return searchTokens.stream().allMatch( searchToken -> testToken( searchToken, valueTokens, mode ) );
+    }
 
-        Type type = new Type( testValue );
-
-        if ( type.isString() )
+    private static boolean testToken( String searchToken, List<String> valueTokens, MatchMode mode )
+    {
+        switch ( mode )
         {
-            String s2 = caseSensitive ? (String) testValue : ((String) testValue).toLowerCase();
-
-            List<String> s1_tokens = getTokens( targetValue );
-            List<String> s2_tokens = Arrays.asList( s2.replaceAll( "[^a-zA-Z0-9]", " " ).split( "[\\s@&.?$+-]+" ) );
-
-            if ( s1_tokens.size() == 1 )
-            {
-                return s2.contains( targetValue );
-            }
-            else
-            {
-                for ( String s : s1_tokens )
-                {
-                    boolean found = false;
-
-                    for ( String s3 : s2_tokens )
-                    {
-                        switch ( matchMode )
-                        {
-                        case EXACT:
-                            found = s3.equals( s );
-                            break;
-                        case START:
-                            found = s3.startsWith( s );
-                            break;
-                        case END:
-                            found = s3.endsWith( s );
-                            break;
-                        case ANYWHERE:
-                            found = s3.contains( s );
-                            break;
-                        }
-
-                        if ( found )
-                        {
-                            break;
-                        }
-                    }
-
-                    if ( !found )
-                    {
-                        return false;
-                    }
-                }
-            }
+        case EXACT:
+            return valueTokens.stream().anyMatch( token -> token.equals( searchToken ) );
+        case START:
+            return valueTokens.stream().anyMatch( token -> token.startsWith( searchToken ) );
+        case END:
+            return valueTokens.stream().anyMatch( token -> token.endsWith( searchToken ) );
+        default:
+        case ANYWHERE:
+            return valueTokens.stream().anyMatch( token -> token.contains( searchToken ) );
         }
-
-        return true;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/TokenOperatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/TokenOperatorTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.query;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.query.operators.MatchMode;
+import org.hisp.dhis.query.operators.NotTokenOperator;
+import org.hisp.dhis.query.operators.TokenOperator;
+import org.junit.Test;
+
+/**
+ * Tests the {@link org.hisp.dhis.query.operators.TokenOperator} and
+ * {@link org.hisp.dhis.query.operators.NotTokenOperator} implementation.
+ *
+ * @author Jan Bernitt
+ */
+public class TokenOperatorTest
+{
+    @Test
+    public void nullValue()
+    {
+        for ( MatchMode mode : MatchMode.values() )
+        {
+            assertFalse( new TokenOperator<>( "any", true, mode ).test( null ) );
+            assertFalse( new TokenOperator<>( "any", false, mode ).test( null ) );
+            assertTrue( new NotTokenOperator<>( "any", true, mode ).test( null ) );
+            assertTrue( new NotTokenOperator<>( "any", false, mode ).test( null ) );
+        }
+    }
+
+    @Test
+    public void exactMatchOneWordOneTerm()
+    {
+        assertMatch( MatchMode.EXACT, "Hello!", "Hello" );
+        assertMatch( MatchMode.EXACT, "Hello!", "Hello!" );
+    }
+
+    @Test
+    public void exactMatchOneWordManyTerms()
+    {
+        assertMatch( MatchMode.EXACT, "Hello!", "Hello Hello" );
+        assertMatch( MatchMode.EXACT, "Hello!", "Hello! Hello!" );
+    }
+
+    @Test
+    public void exactMatchManyWordsOneTerm()
+    {
+        assertMatch( MatchMode.EXACT, "Hello World!", "Hello" );
+        assertMatch( MatchMode.EXACT, "Hello World!", "World" );
+    }
+
+    @Test
+    public void exactMatchManyWordsManyTerms()
+    {
+        assertMatch( MatchMode.EXACT, "Hello World!", "Hello World" );
+        assertMatch( MatchMode.EXACT, "Hello World!", "Hello, World!" );
+        assertMatch( MatchMode.EXACT, "Hello there World!", "Hello, World!" );
+    }
+
+    @Test
+    public void startsWithMatchOneWordOneTerm()
+    {
+        assertMatch( MatchMode.START, "Hello!", "Hello" );
+        assertMatch( MatchMode.START, "Hello!", "Hello!" );
+        assertMatch( MatchMode.START, "Hello!", "Hel" );
+    }
+
+    @Test
+    public void startsWithMatchOneWordManyTerms()
+    {
+        assertMatch( MatchMode.START, "Hello!", "Hello Hello" );
+        assertMatch( MatchMode.START, "Hello!", "Hello! Hello!" );
+        assertMatch( MatchMode.START, "Hello!", "He! Hell" );
+    }
+
+    @Test
+    public void startsWithMatchManyWordsOneTerm()
+    {
+        assertMatch( MatchMode.START, "Hello World!", "Hello" );
+        assertMatch( MatchMode.START, "Hello World!", "World" );
+        assertMatch( MatchMode.START, "Hello World!", "Hel" );
+        assertMatch( MatchMode.START, "Hello World!", "Wo" );
+    }
+
+    @Test
+    public void startsWithMatchManyWordsManyTerms()
+    {
+        assertMatch( MatchMode.START, "Hello World!", "Hello World" );
+        assertMatch( MatchMode.START, "Hello World!", "Hello, World!" );
+        assertMatch( MatchMode.START, "Hello there World!", "Hello, World!" );
+        assertMatch( MatchMode.START, "Hello there World!", "Hel, Wor" );
+    }
+
+    @Test
+    public void endsWithMatchOneWordOneTerm()
+    {
+        assertMatch( MatchMode.END, "Hello!", "Hello" );
+        assertMatch( MatchMode.END, "Hello!", "Hello!" );
+        assertMatch( MatchMode.END, "Hello!", "lo!" );
+    }
+
+    @Test
+    public void endsWithMatchOneWordManyTerms()
+    {
+        assertMatch( MatchMode.END, "Hello!", "Hello Hello" );
+        assertMatch( MatchMode.END, "Hello!", "Hello! Hello!" );
+        assertMatch( MatchMode.END, "Hello!", "lo ello" );
+    }
+
+    @Test
+    public void endsWithMatchManyWordsOneTerm()
+    {
+        assertMatch( MatchMode.END, "Hello World!", "Hello" );
+        assertMatch( MatchMode.END, "Hello World!", "World" );
+        assertMatch( MatchMode.END, "Hello World!", "lo" );
+        assertMatch( MatchMode.END, "Hello World!", "rld" );
+    }
+
+    @Test
+    public void endsWithMatchManyWordsManyTerms()
+    {
+        assertMatch( MatchMode.END, "Hello World!", "Hello World" );
+        assertMatch( MatchMode.END, "Hello World!", "Hello, World!" );
+        assertMatch( MatchMode.END, "Hello there World!", "Hello, World!" );
+        assertMatch( MatchMode.END, "Hello there World!", "ello orld" );
+    }
+
+    @Test
+    public void anywhereMatchOneWordOneTerm()
+    {
+        assertMatch( MatchMode.ANYWHERE, "Hello!", "Hello" );
+        assertMatch( MatchMode.ANYWHERE, "Hello!", "Hello!" );
+        assertMatch( MatchMode.ANYWHERE, "Hello!", "ell" );
+    }
+
+    @Test
+    public void anywhereMatchOneWordManyTerms()
+    {
+        assertMatch( MatchMode.ANYWHERE, "Hello!", "Hello Hello" );
+        assertMatch( MatchMode.ANYWHERE, "Hello!", "Hello! Hello!" );
+        assertMatch( MatchMode.ANYWHERE, "Hello!", "el ll" );
+    }
+
+    @Test
+    public void anywhereMatchManyWordsOneTerm()
+    {
+        assertMatch( MatchMode.ANYWHERE, "Hello World!", "Hello" );
+        assertMatch( MatchMode.ANYWHERE, "Hello World!", "World" );
+        assertMatch( MatchMode.ANYWHERE, "Hello World!", "ll" );
+        assertMatch( MatchMode.ANYWHERE, "Hello World!", "or" );
+    }
+
+    @Test
+    public void anywhereMatchManyWordsManyTerms()
+    {
+        assertMatch( MatchMode.ANYWHERE, "Hello World!", "Hello World" );
+        assertMatch( MatchMode.ANYWHERE, "Hello World!", "Hello, World!" );
+        assertMatch( MatchMode.ANYWHERE, "Hello there World!", "Hello, World!" );
+        assertMatch( MatchMode.ANYWHERE, "Hello there World!", "el er or" );
+    }
+
+    private static void assertMatch( MatchMode mode, String value, String term )
+    {
+        String upperValue = value.toUpperCase();
+        String lowerValue = value.toLowerCase();
+
+        TokenOperator<String> caseSensitive = new TokenOperator<>( term, true, mode );
+        TokenOperator<String> caseInsensitive = new TokenOperator<>( term, false, mode );
+
+        assertTrue( caseSensitive.test( value ) );
+        assertTrue( caseInsensitive.test( value ) );
+        assertTrue( caseInsensitive.test( upperValue ) );
+        assertTrue( caseInsensitive.test( lowerValue ) );
+        if ( !upperValue.equals( lowerValue ) )
+        {
+            assertFalse( caseSensitive.test( upperValue ) && caseSensitive.test( lowerValue ) );
+        }
+
+        // make it mismatch by searching for something not in value
+        String zzzTerm = "zzz" + term + "zzz";
+        TokenOperator<String> zzzCaseSensitive = new TokenOperator<>( zzzTerm, true, mode );
+        TokenOperator<String> zzzCaseInsensitive = new TokenOperator<>( zzzTerm, false, mode );
+        assertFalse( zzzCaseSensitive.test( value ) );
+        assertFalse( zzzCaseInsensitive.test( value ) );
+        assertFalse( zzzCaseInsensitive.test( upperValue ) );
+        assertFalse( zzzCaseInsensitive.test( lowerValue ) );
+
+        NotTokenOperator<String> notCaseSensitive = new NotTokenOperator<>( term, true, mode );
+        NotTokenOperator<String> notCaseInsensitive = new NotTokenOperator<>( term, false, mode );
+        assertFalse( notCaseSensitive.test( value ) );
+        assertFalse( notCaseInsensitive.test( value ) );
+        assertFalse( notCaseInsensitive.test( upperValue ) );
+        assertFalse( notCaseInsensitive.test( lowerValue ) );
+        if ( !upperValue.equals( lowerValue ) )
+        {
+            assertTrue( notCaseSensitive.test( upperValue ) || notCaseSensitive.test( lowerValue ) );
+        }
+    }
+}


### PR DESCRIPTION
### Summary
In  #8830 @vietnguyen pointed out that the in memory token operators were using the same regex pattern that would only allow ASCII letters for token based search restrictions.

Looking into the issue I found that there were more problems with the implementation which was confirmed by added tests.
I fixed the implementation and cleaned up some bits around it

### Automatic Tests
The added unit tests now cover all combinations of left and right operand, case sensitivity and match mode.