### PR TITLE
fix: do not reference v37 branches in master

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -1,5 +1,5 @@
 [
-    "https://github.com/d2-ci/approval-app#master",
+    "https://github.com/d2-ci/approval-app",
     "https://github.com/d2-ci/app-management-app",
     "https://github.com/d2-ci/cache-cleaner-app",
     "https://github.com/d2-ci/capture-app",
@@ -23,6 +23,6 @@
     "https://github.com/d2-ci/tracker-capture-app",
     "https://github.com/d2-ci/translations-app",
     "https://github.com/d2-ci/usage-analytics-app",
-    "https://github.com/d2-ci/user-app#v37",
-    "https://github.com/d2-ci/user-profile-app#v37"
+    "https://github.com/d2-ci/user-app",
+    "https://github.com/d2-ci/user-profile-app"
 ]


### PR DESCRIPTION
When work was merged, the changes to `apps-to-bundle.json` that are only for `2.37` were partially merged to `master`: https://github.com/dhis2/dhis2-core/blame/master/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json#L26-L27

This fixes the bundled application versions for apps: `user` and `user-profile`.