### PR TITLE
fix: Caching inconsistency in analytics [DHIS2-11820]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -70,6 +70,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DimensionItemObjectValue;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalKeywords;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.DisplayProperty;
@@ -598,8 +599,10 @@ public class DataQueryParams
     {
         QueryKey key = new QueryKey();
 
-        dimensions.forEach( e -> key.add( "dimension", "[" + e.getKey() + "]" ) );
-        filters.forEach( e -> key.add( "filter", "[" + e.getKey() + "]" ) );
+        dimensions.forEach( e -> key.add( "dimension",
+            "[" + e.getKey() + "]" + getDimensionalItemKeywords( e.getDimensionalKeywords() ) ) );
+        filters.forEach( e -> key.add( "filter",
+            "[" + e.getKey() + "]" + getDimensionalItemKeywords( e.getDimensionalKeywords() ) ) );
 
         measureCriteria.forEach( ( k, v ) -> key.add( "measureCriteria", (String.valueOf( k ) + v) ) );
         preAggregateMeasureCriteria
@@ -639,6 +642,18 @@ public class DataQueryParams
     // -------------------------------------------------------------------------
     // Logic read methods
     // -------------------------------------------------------------------------
+
+    private String getDimensionalItemKeywords( final DimensionalKeywords keywords )
+    {
+        if ( keywords != null )
+        {
+            return keywords.getGroupBy().stream()
+                .map( DimensionalKeywords.Keyword::getKey )
+                .collect( Collectors.joining( ":" ) );
+        }
+
+        return StringUtils.EMPTY;
+    }
 
     /**
      * Returns a key representing a group of queries which should be run in


### PR DESCRIPTION
The org. unit levels were not being considered as part of the cache key.
This was causing one issue: returning invalid results when similar requests with different org. unit levels set.

In other short words, different analytics requests were giving the same results. This PR aims to fix it.
More details in the ticket https://jira.dhis2.org/browse/DHIS2-11820

**_NEEDS TO BE APPROVED BY THE CHANGE CONTROL COMMITTEE._**