### PR TITLE
fix: Use join fetch when getting enrollments by program type

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -381,7 +381,7 @@ public class HibernateProgramInstanceStore
     @Override
     public List<ProgramInstance> getByType( ProgramType type )
     {
-        String hql = "from ProgramInstance pi where pi.program.programType = :type";
+        String hql = "select pi from ProgramInstance pi join fetch pi.program p where p.programType = :type";
 
         Query<ProgramInstance> query = getQuery( hql );
         query.setParameter( "type", type );


### PR DESCRIPTION
Use join fetch when getting the enrollments by program type to avoid a CROSS JOIN that will take a substantial amount of time.