### PR TITLE
fix: Fix active and enrollOnce logic in enrollment validation [DHIS2-11659]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -49,7 +49,7 @@ public enum TrackerErrorCode
     E1014( "Provided Program: `{0}`, is a Program without registration. " +
         "An Enrollment cannot be created into Program without registration." ),
     E1015( "TrackedEntityInstance: `{0}`, already has an active Enrollment in Program `{1}`." ),
-    E1016( "TrackedEntityInstance: `{0}`, already has an active enrollment in Program: `{1}`, and this " +
+    E1016( "TrackedEntityInstance: `{0}`, already has an enrollment in Program: `{1}`, and this " +
         "program only allows enrolling one time." ),
     E1018( "Attribute: `{0}`, is mandatory in program `{1}` but not declared in enrollment `{2}`." ),
     E1019( "Only Program attributes is allowed for enrollment; Non valid attribute: `{0}`." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -104,6 +104,7 @@ public class EnrollmentInExistingValidationHook
         // Priority to payload
         Collection<Enrollment> mergedEnrollments = Stream.of( payloadEnrollment, dbEnrollment )
             .flatMap( Set::stream )
+            .filter( e -> !Objects.equals( e.getEnrollment(), enrollment.getEnrollment() ) )
             .collect( Collectors.toMap( Enrollment::getEnrollment,
                 p -> p,
                 ( Enrollment x, Enrollment y ) -> x ) )
@@ -115,13 +116,13 @@ public class EnrollmentInExistingValidationHook
                 .filter( e -> EnrollmentStatus.ACTIVE == e.getStatus() )
                 .collect( Collectors.toSet() );
 
-            if ( !activeOnly.isEmpty() && !activeOnly.contains( enrollment ) )
+            if ( !activeOnly.isEmpty() )
             {
                 addError( reporter, E1015, tei, program );
             }
         }
 
-        if ( !mergedEnrollments.isEmpty() )
+        if ( Boolean.TRUE.equals( program.getOnlyEnrollOnce() ) && !mergedEnrollments.isEmpty() )
         {
             addError( reporter, E1016, tei, program );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -229,7 +229,7 @@ public class EnrollmentImportValidationTest
     }
 
     @Test
-    public void testEnrollmentInAnotherProgramExists()
+    public void testActiveEnrollmentAlreadyExists()
         throws IOException
     {
         TrackerImportParams trackerImportParams = createBundleFromJson(
@@ -248,13 +248,10 @@ public class EnrollmentImportValidationTest
 
         validationReport = trackerImportReport.getValidationReport();
 
-        assertEquals( 2, validationReport.getErrorReports().size() );
+        assertEquals( 1, validationReport.getErrorReports().size() );
 
         assertThat( validationReport.getErrorReports(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
-
-        assertThat( validationReport.getErrorReports(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
     }
 
     /**


### PR DESCRIPTION
Rules are the following:

- A TEI can only have one active enrollment per Program
- If the program has onlyEnrollOnce flag to false, a TEI can be enrolled multiple times as long as just one is active
- If the program has onlyEnrollOnce flag to true, a TEI can be enrolled only once