### PR TITLE
fix: return approvedBy for dataApproval with status ACCEPTED_HERE

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalPermissionsEvaluator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalPermissionsEvaluator.java
@@ -264,7 +264,8 @@ class DataApprovalPermissionsEvaluator
         permissions.setApprovedAt( status.getCreated() );
 
         if ( status.getState() == DataApprovalState.APPROVED_HERE
-            || (status.getState() == DataApprovalState.APPROVED_ABOVE && userLevelIndex < dataLevelIndex) )
+            || (status.getState() == DataApprovalState.APPROVED_ABOVE && userLevelIndex < dataLevelIndex)
+            || status.getState() == DataApprovalState.ACCEPTED_HERE )
         {
             permissions.setApprovedBy( status.getCreator() != null ? status.getCreator().getName() : null );
         }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11870

Make `api/dataApprovals` to return the `approvedBy` info if approval has status `ACCEPTED_HERE`