### PR TITLE
fix: NPE when loading custom form for dataSet report

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -651,6 +651,11 @@ public class GridUtils
      */
     public static String getValue( TagNode cell )
     {
+        if ( cell.getChildren() == null || cell.getChildren().size() == 0 )
+        {
+            return EMPTY;
+        }
+
         StringBuilder builder = new StringBuilder();
 
         for ( Node child : cell.getChildren().toNodeArray() )


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11858

## Before applying the fix there was a NPE thrown

<img width="727" alt="Screen Shot 2021-10-07 at 9 02 56 PM" src="https://user-images.githubusercontent.com/766102/136400783-ad14c0a6-7ff1-4c57-a9fe-da4a648f1d86.png">


```
Caused by: java.lang.NullPointerException
	at org.hisp.dhis.system.grid.GridUtils.getValue(GridUtils.java:656)
	at org.hisp.dhis.system.grid.GridUtils.fromHtml(GridUtils.java:609)
	at org.hisp.dhis.datasetreport.impl.DefaultDataSetReportService.getCustomDataSetReportAsGrid(DefaultDataSetReportService.java:170)
	... 141 more
```



## After applying the fix

<img width="750" alt="Screen Shot 2021-10-07 at 9 03 15 PM" src="https://user-images.githubusercontent.com/766102/136400834-0435a113-5888-4b44-9b72-c66c5be3016a.png">
