### PR TITLE
fix: Improve SQL in EnrollmentTimeFieldSqlRenderer [2.38-DHIS2-11927]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -145,7 +145,7 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
             Set<AnalyticsPeriodBoundary> boundaries = map.get( programStage );
 
             String eventTableName = "analytics_event_" + programIndicator.getProgram().getUid();
-            sql += " (select count(*) from " + eventTableName + " where " + eventTableName +
+            sql += " exists(select 1 from " + eventTableName + " where " + eventTableName +
                 ".pi = " + ANALYTICS_TBL_ALIAS + ".pi and executiondate is not null ";
 
             for ( AnalyticsPeriodBoundary boundary : boundaries )
@@ -156,7 +156,7 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
                     + "' as date )";
             }
 
-            sql += ") > 0";
+            sql += " limit 1)";
         }
 
         return sql;


### PR DESCRIPTION
The analytics queries for analytics type enrollment, custom boundaries with PS_EVENTDATE used aggregation count(*) and "> 0" condition. It was replaced by "exists (count 1 ... limit 1)"

https://jira.dhis2.org/browse/DHIS2-11927