### PR TITLE
fix: npm complaint about uncommitted lock file

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/.gitignore
+++ b/dhis-2/dhis-web/dhis-web-apps/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 node/
-package-lock.json

--- a/dhis-2/dhis-web/dhis-web-apps/package-lock.json
+++ b/dhis-2/dhis-web/dhis-web-apps/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "dhis-web-apps",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
frontend-maven-plugin is running npm install which then outputs
[ERROR] npm notice created a lockfile as package-lock.json. You should commit this file.
in the build