### PR TITLE
fix: event endpoint should account for ouMode when validating params

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -973,11 +973,11 @@ public abstract class AbstractEventService
         }
 
         if ( params.getProgram() == null && params.getOrgUnit() == null && params.getTrackedEntityInstance() == null
-            && params.getEvents().isEmpty() && params.getOrgUnitSelectionMode() != null &&
-            !params.getOrgUnitSelectionMode().equals( OrganisationUnitSelectionMode.ACCESSIBLE ) &&
-            !params.getOrgUnitSelectionMode().equals( OrganisationUnitSelectionMode.ALL ) )
+            && params.getEvents().isEmpty()
+            && !OrganisationUnitSelectionMode.ACCESSIBLE.equals( params.getOrgUnitSelectionMode() )
+            && !OrganisationUnitSelectionMode.ALL.equals( params.getOrgUnitSelectionMode() ) )
         {
-            violation = "At least one of the following query parameters are required: orgUnit, program, trackedEntityInstance or event";
+            violation = "At least one of the following query parameters are required when ouMode is not ACCESSIBLE or ALL: orgUnit, program, trackedEntityInstance or event";
         }
 
         if ( params.hasLastUpdatedDuration() && (params.hasLastUpdatedStartDate() || params.hasLastUpdatedEndDate()) )


### PR DESCRIPTION
The initial problem here was that the event endpoint would require orgUnit to be specified, even when ouModes like ACCESSIBLE and ALL are being used. These ouModes have orgUnits implied, and should not require additional orgUnit, as it would be unnecessary.

The correct validation here, is to either have:
- Event
- OrgUnit
- Program
- TrackedEntityInstance
- ouMode=ACCESSIBLE
- ouMode=ALL

ouMode=ALL requires a specific authority which is validated elsewhere.
