### PR TITLE
fix: Id schema not respected for data elements if operands are absent  [DHIS2-11769]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -610,29 +610,6 @@ public class DimensionalObjectUtils
     }
 
     /**
-     * Returns a mapping between the base dimension item identifier and the
-     * dimension item identifier defined by the given identifier scheme. This
-     * mapping is specific for data elements.
-     *
-     * @param itemObjects the dimensional items.
-     * @param idScheme the identifier scheme.
-     * @return a mapping between dimension item identifiers.
-     */
-    public static Map<String, String> getDataElementIdSchemeMap(
-        Collection<DimensionalItemObject> itemObjects, IdScheme idScheme )
-    {
-        Map<String, String> map = Maps.newHashMap();
-
-        for ( DimensionalItemObject itemObject : itemObjects )
-        {
-            map.put( itemObject.getDimensionItem(),
-                itemObject.getDimensionItem( IdScheme.from( idScheme ) ) );
-        }
-
-        return map;
-    }
-
-    /**
      * Returns a dimension item identifier for the given data set identifier and
      * reporting date metric.
      *

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -57,7 +57,6 @@ package org.hisp.dhis.analytics.data.handler;
 
 import static org.hisp.dhis.analytics.OutputFormat.DATA_VALUE_SET;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
-import static org.hisp.dhis.common.DimensionalObjectUtils.getDataElementIdSchemeMap;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDataElementOperandIdSchemeMap;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionItemIdSchemeMap;
 
@@ -160,7 +159,7 @@ public class SchemaIdResponseMapper
 
     private void applyDataElementsIdSchemaMapping( final DataQueryParams params, final Map<String, String> map )
     {
-        map.putAll( getDataElementIdSchemeMap( asTypedList( params.getDataElements() ),
+        map.putAll( getDimensionItemIdSchemeMap( asTypedList( params.getDataElements() ),
             params.getOutputDataElementIdScheme() ) );
     }
 


### PR DESCRIPTION
This fix is needed to cover the output id schema for data elements within data set calls.
The data element schema was being ignored when there are no data element operands in the response.