### PR TITLE
refactor: jdbc event store replaced some strings with constants/enums [TECH-463]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -895,7 +895,7 @@ public class JdbcEventStore implements EventStore
 
         StringBuilder sqlBuilder = new StringBuilder().append( "select " )
             .append( COLUMNS_ALIAS_MAP.entrySet().stream()
-                .map( columnAliasEntry -> columnAliasEntry.getKey() + " as " + columnAliasEntry.getValue() )
+                .map( col -> col.getKey() + " as " + col.getValue() )
                 .collect( Collectors.joining( ", " ) ) )
             .append( " , " );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/query/EventQuery.java
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.dxf2.events.trackedentity.store.query;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,8 @@ import org.hisp.dhis.dxf2.events.trackedentity.store.Function;
 import org.hisp.dhis.dxf2.events.trackedentity.store.QueryElement;
 import org.hisp.dhis.dxf2.events.trackedentity.store.Subselect;
 import org.hisp.dhis.dxf2.events.trackedentity.store.TableColumn;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * @author Luciano Fiandesio
@@ -96,7 +100,7 @@ public class EventQuery
 
     private static final Collection<QueryElement> QUERY_ELEMENTS = Arrays.stream( COLUMNS.values() )
         .map( COLUMNS::getQueryElement )
-        .collect( Collectors.toList() );
+        .collect( collectingAndThen( toList(), ImmutableList::copyOf ) );
 
     public static String getQuery()
     {


### PR DESCRIPTION
I tried to replace, where possible, all hard-coded strings which referenced column names/aliases, with respective enums/constants.