### PR TITLE
fix: dhis-e2e-test pom.xml warnings

### DIFF
--- a/dhis-2/dhis-e2e-test/pom.xml
+++ b/dhis-2/dhis-e2e-test/pom.xml
@@ -10,6 +10,7 @@
 
   <properties>
     <rootDir>..</rootDir>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>


### PR DESCRIPTION
when running api tests or compiling the project maven complains about
* file encoding not being set
* com.jayway.jsonpath:json-path dependency being duplicated