### PR TITLE
fix: UnapproveData incorrectly allowed DHIS2-11981

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -323,6 +323,9 @@ public class HibernateDataApprovalStore
         // Get other information
         // ---------------------------------------------------------------------
 
+        boolean acceptanceRequiredForApproval = systemSettingManager
+            .getBoolSetting( SettingKey.ACCEPTANCE_REQUIRED_FOR_APPROVAL );
+
         final boolean isSuperUser = currentUserService.currentUserIsSuper();
 
         final String startDate = DateUtils.getMediumDateString( period.getStartDate() );
@@ -462,9 +465,6 @@ public class HibernateDataApprovalStore
 
         if ( approvalLevelBelowOrgUnit != null )
         {
-            boolean acceptanceRequiredForApproval = systemSettingManager
-                .getBoolSetting( SettingKey.ACCEPTANCE_REQUIRED_FOR_APPROVAL );
-
             readyBelowSubquery = "not exists ( " + // Ready if nothing expected
                                                    // below is
                                                    // unapproved(/unaccepted)
@@ -643,7 +643,8 @@ public class HibernateDataApprovalStore
                                                                                            // approved
             DataApprovalLevel actionLevel = (approvedLevel == null ? lowestApprovalLevelForOrgUnit : approvedLevel);
 
-            if ( approvedAbove && accepted && approvedAboveLevel == approvalLevelAboveUser )
+            if ( approvedAbove && accepted && acceptanceRequiredForApproval
+                && approvedAboveLevel == approvalLevelAboveUser )
             {
                 approvedAbove = false; // Hide higher-level approval from user.
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -73,7 +73,6 @@ import org.hisp.dhis.user.UserGroupAccessService;
 import org.hisp.dhis.user.UserGroupService;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -82,7 +81,6 @@ import com.google.common.collect.Sets;
 /**
  * @author Jim Grace
  */
-@Ignore
 public class DataApprovalServiceCategoryOptionGroupTest
     extends IntegrationTestBase
 {
@@ -305,10 +303,11 @@ public class DataApprovalServiceCategoryOptionGroupTest
 
         userGroupService.addUserGroup( userGroup );
 
-        users.forEach( user -> {
+        for ( User user : users )
+        {
             user.getGroups().add( userGroup );
             userService.updateUser( user );
-        } );
+        }
 
         return userGroup;
     }
@@ -328,8 +327,8 @@ public class DataApprovalServiceCategoryOptionGroupTest
     private void setPrivateAccess( BaseIdentifiableObject object, UserGroup... userGroups )
     {
         object.getSharing().setPublicAccess( ACCESS_NONE );
-        // object.getSharing().setOwner( userA ); // Needed for sharing to work
-        // object.setUser( userA );
+        object.getSharing().setOwner( userA ); // Needed for sharing to work
+        object.setUser( userA );
         object.getSharing().resetUserGroupAccesses();
         object.getSharing().resetUserAccesses();
         for ( UserGroup group : userGroups )


### PR DESCRIPTION
See [DHIS2-11981](https://jira.dhis2.org/browse/DHIS2-11981). This fix passes the test outlined in the ticket.

The code causing the problem was implementing the principle that we hide higher-level actions from the user when the user has no business knowing about them. In instances where two-step approvals are used (approve then accept), the user is entitled to see whether or not their approval has been accepted. This is because it affects their ability to undo their approval with an unapprove. But they are not entitled to see whether the approval was subsequently approved at a higher level. The code in question did this correctly. The user should just see the status `ACCEPTED_HERE`, instead of the status `APPROVED_ABOVE`.

However in an instance for one-step approvals (just approve), the user should be able to see that the approval has been made at the next higher level, because this is what will prevent the user from undoing their approval with an unapprove. This code was incorrectly hiding the higher-level approval. It was testing to see if there was an acceptance flag from the query, but this was returning true on one-step systems.

The fix was to add the test to see if the system setting is for one-step or two-step approvals. In the case of one-step approval, the user should still be given the status `APPROVED_ABOVE`.

`DataApprovalServiceCategoryOptionGroupTest` has been re-enabled (un-ignored), to insure that the fix doesn't break any of those tests. The test was disabled when the sharing objects were converted to JSONB in 2020 [in this commit](https://github.com/dhis2/dhis2-core/commit/3e25b9b834757233501b068c1fd96b5b68cc22f7) but was easily fixed.

A `.forEach` construct in the test was changed back to a regular Java for(), since that is more readable.