### PR TITLE
fix: Support visualization in missing endpoints [DHIS2-11693] (2.36)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/AggregatedStatistics.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/AggregatedStatistics.java
@@ -51,6 +51,8 @@ public class AggregatedStatistics
 
     private Integer pivotTableViews;
 
+    private Integer visualizationViews;
+
     private Integer eventReportViews;
 
     private Integer eventChartViews;
@@ -71,6 +73,8 @@ public class AggregatedStatistics
 
     private Integer averagePivotTableViews;
 
+    private Integer averageVisualizationViews;
+
     private Integer averageEventReportViews;
 
     private Integer averageEventChartViews;
@@ -84,6 +88,8 @@ public class AggregatedStatistics
     private Integer savedCharts;
 
     private Integer savedPivotTables;
+
+    private Integer savedVisualizations;
 
     private Integer savedEventReports;
 
@@ -189,6 +195,17 @@ public class AggregatedStatistics
     public void setPivotTableViews( Integer pivotTableViews )
     {
         this.pivotTableViews = pivotTableViews;
+    }
+
+    @JsonProperty
+    public Integer getVisualizationViews()
+    {
+        return visualizationViews;
+    }
+
+    public void setVisualizationViews( Integer visualizationViews )
+    {
+        this.visualizationViews = visualizationViews;
     }
 
     @JsonProperty
@@ -324,6 +341,17 @@ public class AggregatedStatistics
     }
 
     @JsonProperty
+    public Integer getAverageVisualizationViews()
+    {
+        return averageVisualizationViews;
+    }
+
+    public void setAverageVisualizationViews( Integer averageVisualizationViews )
+    {
+        this.averageVisualizationViews = averageVisualizationViews;
+    }
+
+    @JsonProperty
     public Integer getAverageEventReportViews()
     {
         return averageEventReportViews;
@@ -376,6 +404,17 @@ public class AggregatedStatistics
     public void setSavedPivotTables( Integer savedPivotTables )
     {
         this.savedPivotTables = savedPivotTables;
+    }
+
+    @JsonProperty
+    public Integer getSavedVisualizations()
+    {
+        return savedVisualizations;
+    }
+
+    public void setSavedVisualizations( Integer savedVisualizations )
+    {
+        this.savedVisualizations = savedVisualizations;
     }
 
     @JsonProperty
@@ -455,6 +494,7 @@ public class AggregatedStatistics
             ", mapViews=" + mapViews +
             ", chartViews=" + chartViews +
             ", pivotTableViews=" + pivotTableViews +
+            ", visualizationViews=" + visualizationViews +
             ", eventReportViews=" + eventReportViews +
             ", eventChartViews=" + eventChartViews +
             ", dashboardViews=" + dashboardViews +
@@ -465,6 +505,7 @@ public class AggregatedStatistics
             ", averageMapViews=" + averageMapViews +
             ", averageChartViews=" + averageChartViews +
             ", averagePivotTableViews=" + averagePivotTableViews +
+            ", averageVisualizationViews=" + averageVisualizationViews +
             ", averageEventReportViews=" + averageEventReportViews +
             ", averageEventChartViews=" + averageEventChartViews +
             ", averageDashboardViews=" + averageDashboardViews +
@@ -472,6 +513,7 @@ public class AggregatedStatistics
             ", savedMaps=" + savedMaps +
             ", savedCharts=" + savedCharts +
             ", savedPivotTables=" + savedPivotTables +
+            ", savedVisualizations=" + savedVisualizations +
             ", savedEventReports=" + savedEventReports +
             ", savedEventCharts=" + savedEventCharts +
             ", savedDashboards=" + savedDashboards +

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/PlotData.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/PlotData.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static java.util.Collections.emptyList;
+
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.AnalyticsType;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.i18n.I18nFormat;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.user.User;
+
+/**
+ * A simple wrapper that holds "plotable" objects and expose useful methods that
+ * are required during the creation of a chart.
+ *
+ * @author maikel arabori
+ */
+public class PlotData
+{
+    private EventChart eventChart;
+
+    private Visualization visualization;
+
+    public PlotData( final EventChart eventChart )
+    {
+        this.eventChart = eventChart;
+    }
+
+    public PlotData( final Visualization visualization )
+    {
+        this.visualization = visualization;
+    }
+
+    public EventChart getEventChart()
+    {
+        return eventChart;
+    }
+
+    public Visualization getVisualization()
+    {
+        return visualization;
+    }
+
+    public boolean hasOrganisationUnitLevels()
+    {
+        if ( eventChart != null )
+        {
+            return eventChart.hasOrganisationUnitLevels();
+        }
+        else if ( visualization != null )
+        {
+            return visualization.hasOrganisationUnitLevels();
+        }
+
+        return false;
+    }
+
+    public boolean hasItemOrganisationUnitGroups()
+    {
+        if ( eventChart != null )
+        {
+            return eventChart.hasItemOrganisationUnitGroups();
+        }
+        else if ( visualization != null )
+        {
+            return visualization.hasItemOrganisationUnitGroups();
+        }
+
+        return false;
+    }
+
+    public void init( User user, Date date, OrganisationUnit organisationUnit, List<OrganisationUnit> atLevels,
+        List<OrganisationUnit> inGroups, I18nFormat format )
+    {
+        if ( eventChart != null )
+        {
+            eventChart.init( user, date, organisationUnit, atLevels, inGroups, format );
+        }
+        else if ( visualization != null )
+        {
+            visualization.init( user, date, organisationUnit, atLevels, inGroups, format );
+        }
+    }
+
+    public void clearTransientState()
+    {
+        if ( eventChart != null )
+        {
+            eventChart.clearTransientState();
+        }
+        else if ( visualization != null )
+        {
+            visualization.clearTransientState();
+        }
+    }
+
+    public List<Integer> getOrganisationUnitLevels()
+    {
+        if ( eventChart != null )
+        {
+            return eventChart.getOrganisationUnitLevels();
+        }
+        else if ( visualization != null )
+        {
+            return visualization.getOrganisationUnitLevels();
+        }
+
+        return emptyList();
+    }
+
+    public List<OrganisationUnit> getOrganisationUnits()
+    {
+        if ( eventChart != null )
+        {
+            return eventChart.getOrganisationUnits();
+        }
+        else if ( visualization != null )
+        {
+            return visualization.getOrganisationUnits();
+        }
+
+        return emptyList();
+    }
+
+    public List<OrganisationUnitGroup> getItemOrganisationUnitGroups()
+    {
+        if ( eventChart != null )
+        {
+            return eventChart.getItemOrganisationUnitGroups();
+        }
+        else if ( visualization != null )
+        {
+            return visualization.getItemOrganisationUnitGroups();
+        }
+
+        return emptyList();
+    }
+
+    public boolean isAggregate()
+    {
+        if ( visualization != null )
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public void setGrid( final Grid grid )
+    {
+        if ( eventChart != null )
+        {
+            eventChart.setDataItemGrid( grid );
+        }
+    }
+
+    public AnalyticsType getAnalyticsType()
+    {
+        if ( visualization != null )
+        {
+            return AnalyticsType.AGGREGATE;
+        }
+
+        return AnalyticsType.EVENT;
+    }
+
+    public boolean isRegression()
+    {
+        if ( visualization != null )
+        {
+            return visualization.isRegression();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.isRegression();
+        }
+
+        return false;
+    }
+
+    public boolean hasSortOrder()
+    {
+        if ( visualization != null )
+        {
+            return visualization.hasSortOrder();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.hasSortOrder();
+        }
+
+        return false;
+    }
+
+    public List<DimensionalItemObject> category()
+    {
+        if ( visualization != null )
+        {
+            return visualization.chartCategory();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.category();
+        }
+
+        return emptyList();
+    }
+
+    public List<DimensionalItemObject> series()
+    {
+        if ( visualization != null )
+        {
+            return visualization.chartSeries();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.series();
+        }
+
+        return emptyList();
+    }
+
+    public boolean isType( String type )
+    {
+        if ( visualization != null )
+        {
+            return StringUtils.trimToEmpty( type ).equals( visualization.getType().name() );
+        }
+        else if ( eventChart != null )
+        {
+            return StringUtils.trimToEmpty( type ).equals( eventChart.getType().name() );
+        }
+
+        return false;
+    }
+
+    public String getType()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getType().name();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getType().name();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public boolean hasTitle()
+    {
+        if ( visualization != null )
+        {
+            return visualization.hasTitle();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.hasTitle();
+        }
+
+        return false;
+    }
+
+    public String getDisplayTitle()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getDisplayTitle();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getDisplayTitle();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public String generateTitle()
+    {
+        if ( visualization != null )
+        {
+            return visualization.generateTitle();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.generateTitle();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public boolean isHideTitle()
+    {
+        if ( visualization != null )
+        {
+            return visualization.isHideTitle();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.isHideTitle();
+        }
+
+        return false;
+    }
+
+    public String getName()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getName();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getName();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public boolean isHideLegend()
+    {
+        if ( visualization != null )
+        {
+            return visualization.isHideLegend();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.isHideLegend();
+        }
+
+        return false;
+    }
+
+    public String getDomainAxisLabel()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getDomainAxisLabel();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getDomainAxisLabel();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public String getRangeAxisLabel()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getRangeAxisLabel();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getRangeAxisLabel();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public boolean isTargetLine()
+    {
+        if ( visualization != null )
+        {
+            return visualization.isTargetLine();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.isTargetLine();
+        }
+
+        return false;
+    }
+
+    public boolean isBaseLine()
+    {
+        if ( visualization != null )
+        {
+            return visualization.isBaseLine();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.isBaseLine();
+        }
+
+        return false;
+    }
+
+    public boolean isHideSubtitle()
+    {
+        if ( visualization != null )
+        {
+            return visualization.isHideSubtitle();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.isHideSubtitle();
+        }
+
+        return false;
+    }
+
+    public int getSortOrder()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getSortOrder();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getSortOrder();
+        }
+
+        return 0;
+    }
+
+    public Double getTargetLineValue()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getTargetLineValue();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getTargetLineValue();
+        }
+
+        return 0d;
+    }
+
+    public Double getBaseLineValue()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getBaseLineValue();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getBaseLineValue();
+        }
+
+        return 0d;
+    }
+
+    public String getTargetLineLabel()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getTargetLineLabel();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getTargetLineLabel();
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    public String getBaseLineLabel()
+    {
+        if ( visualization != null )
+        {
+            return visualization.getBaseLineLabel();
+        }
+        else if ( eventChart != null )
+        {
+            return eventChart.getBaseLineLabel();
+        }
+
+        return StringUtils.EMPTY;
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -1841,4 +1841,22 @@ public class Visualization
 
         return join( titleItems, DimensionalObjectUtils.TITLE_ITEM_SEP );
     }
+
+    public boolean isChart()
+    {
+        return type == VisualizationType.LINE ||
+            type == VisualizationType.COLUMN ||
+            type == VisualizationType.BAR ||
+            type == VisualizationType.AREA ||
+            type == VisualizationType.PIE ||
+            type == VisualizationType.STACKED_COLUMN ||
+            type == VisualizationType.STACKED_BAR ||
+            type == VisualizationType.STACKED_AREA ||
+            type == VisualizationType.RADAR ||
+            type == VisualizationType.GAUGE ||
+            type == VisualizationType.SCATTER ||
+            type == VisualizationType.BUBBLE ||
+            type == VisualizationType.YEAR_OVER_YEAR_LINE ||
+            type == VisualizationType.YEAR_OVER_YEAR_COLUMN;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/VisualizationPlotService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/VisualizationPlotService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import java.util.Date;
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.i18n.I18nFormat;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.user.User;
+import org.jfree.chart.JFreeChart;
+
+/**
+ * This service is used to wrap and support the rendering of different type of
+ * charts based on different visualization types. This code of this class is not
+ * new, it was just sightly re-adapted from the old ChartService in order to to
+ * support Visualization charts.
+ *
+ * This is mainly needed because of the deprecation process of charts and report
+ * tables.
+ *
+ * @author maikel arabori
+ */
+public interface VisualizationPlotService
+{
+    JFreeChart getJFreeChart( PlotData plotData, Date date, OrganisationUnit organisationUnit, I18nFormat format,
+        User currentUser );
+
+    JFreeChart getJFreePeriodChart( Indicator indicator, OrganisationUnit organisationUnit, boolean title,
+        I18nFormat format );
+
+    JFreeChart getJFreeOrganisationUnitChart( Indicator indicator, OrganisationUnit parent, boolean title,
+        I18nFormat format );
+
+    JFreeChart getJFreeChartHistory( DataElement dataElement, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, Period lastPeriod, OrganisationUnit organisationUnit,
+        int historyLength, I18nFormat format );
+}

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsStore.java
@@ -96,28 +96,34 @@ public class HibernateDataStatisticsStore
             ads.setMapViews( resultSet.getInt( "mapViews" ) );
             ads.setChartViews( resultSet.getInt( "chartViews" ) );
             ads.setPivotTableViews( resultSet.getInt( "reportTableViews" ) );
+            ads.setVisualizationViews( resultSet.getInt( "visualizationViews" ) );
             ads.setEventReportViews( resultSet.getInt( "eventReportViews" ) );
             ads.setEventChartViews( resultSet.getInt( "eventChartViews" ) );
             ads.setDashboardViews( resultSet.getInt( "dashboardViews" ) );
             ads.setPassiveDashboardViews( resultSet.getInt( "passiveDashboardViews" ) );
             ads.setDataSetReportViews( resultSet.getInt( "dataSetReportViews" ) );
             ads.setTotalViews( resultSet.getInt( "totalViews" ) );
+
             ads.setAverageViews( resultSet.getInt( "averageViews" ) );
             ads.setAverageMapViews( resultSet.getInt( "averageMapViews" ) );
             ads.setAverageChartViews( resultSet.getInt( "averageChartViews" ) );
             ads.setAveragePivotTableViews( resultSet.getInt( "averageReportTableViews" ) );
+            ads.setAverageVisualizationViews( resultSet.getInt( "averageVisualizationViews" ) );
             ads.setAverageEventReportViews( resultSet.getInt( "averageEventReportViews" ) );
             ads.setAverageEventChartViews( resultSet.getInt( "averageEventChartViews" ) );
             ads.setAverageDashboardViews( resultSet.getInt( "averageDashboardViews" ) );
             ads.setAveragePassiveDashboardViews( resultSet.getInt( "averagePassiveDashboardViews" ) );
+
             ads.setSavedMaps( resultSet.getInt( "savedMaps" ) );
             ads.setSavedCharts( resultSet.getInt( "savedCharts" ) );
             ads.setSavedPivotTables( resultSet.getInt( "savedReportTables" ) );
+            ads.setSavedVisualizations( resultSet.getInt( "savedVisualizations" ) );
             ads.setSavedEventReports( resultSet.getInt( "savedEventReports" ) );
             ads.setSavedEventCharts( resultSet.getInt( "savedEventCharts" ) );
             ads.setSavedDashboards( resultSet.getInt( "savedDashboards" ) );
             ads.setSavedIndicators( resultSet.getInt( "savedIndicators" ) );
             ads.setSavedDataValues( resultSet.getInt( "savedDataValues" ) );
+
             ads.setActiveUsers( resultSet.getInt( "activeUsers" ) );
             ads.setUsers( resultSet.getInt( "users" ) );
 
@@ -228,6 +234,7 @@ public class HibernateDataStatisticsStore
         return "cast(round(cast(sum(mapviews) as numeric),0) as int) as mapViews," +
             "cast(round(cast(sum(chartviews) as numeric),0) as int) as chartViews," +
             "cast(round(cast(sum(reporttableviews) as numeric),0) as int) as reportTableViews, " +
+            "cast(round(cast(sum(visualizationviews) as numeric),0) as int) as visualizationViews," +
             "cast(round(cast(sum(eventreportviews) as numeric),0) as int) as eventReportViews, " +
             "cast(round(cast(sum(eventchartviews) as numeric),0) as int) as eventChartViews," +
             "cast(round(cast(sum(dashboardviews) as numeric),0) as int) as dashboardViews, " +
@@ -238,6 +245,7 @@ public class HibernateDataStatisticsStore
             "coalesce(sum(mapviews)/nullif(max(active_users), 0), 0) as averageMapViews, " +
             "coalesce(sum(chartviews)/nullif(max(active_users), 0), 0) as averageChartViews, " +
             "coalesce(sum(reporttableviews)/nullif(max(active_users), 0), 0) as averageReportTableViews, " +
+            "coalesce(sum(visualizationviews)/nullif(max(active_users), 0), 0) as averageVisualizationViews, " +
             "coalesce(sum(eventreportviews)/nullif(max(active_users), 0), 0) as averageEventReportViews, " +
             "coalesce(sum(eventchartviews)/nullif(max(active_users), 0), 0) as averageEventChartViews, " +
             "coalesce(sum(dashboardviews)/nullif(max(active_users), 0), 0) as averageDashboardViews, " +
@@ -246,6 +254,7 @@ public class HibernateDataStatisticsStore
             "cast(round(cast(sum(maps) as numeric),0) as int) as savedMaps," +
             "cast(round(cast(sum(charts) as numeric),0) as int) as savedCharts," +
             "cast(round(cast(sum(reporttables) as numeric),0) as int) as savedReportTables," +
+            "cast(round(cast(sum(visualizations) as numeric),0) as int) as savedVisualizations," +
             "cast(round(cast(sum(eventreports) as numeric),0) as int) as savedEventReports," +
             "cast(round(cast(sum(eventcharts) as numeric),0) as int) as savedEventCharts," +
             "cast(round(cast(sum(dashboards) as numeric),0) as int) as savedDashboards, " +

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/visualization/DefaultVisualizationPlotService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/visualization/DefaultVisualizationPlotService.java
@@ -1,0 +1,875 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
+import static org.hisp.dhis.commons.collection.ListUtils.getArray;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.math3.analysis.UnivariateFunction;
+import org.apache.commons.math3.analysis.interpolation.SplineInterpolator;
+import org.apache.commons.math3.analysis.interpolation.UnivariateInterpolator;
+import org.apache.commons.math3.exception.MathRuntimeException;
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.hisp.dhis.analytics.AnalyticsService;
+import org.hisp.dhis.analytics.event.EventAnalyticsService;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.AnalyticsType;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.DimensionalObjectUtils;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.NameableObject;
+import org.hisp.dhis.common.NumericSortWrapper;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.i18n.I18nFormat;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.minmax.MinMaxDataElement;
+import org.hisp.dhis.minmax.MinMaxDataElementService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.RelativePeriods;
+import org.hisp.dhis.system.grid.GridUtils;
+import org.hisp.dhis.system.util.MathUtils;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.CategoryAxis;
+import org.jfree.chart.axis.CategoryLabelPositions;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.labels.StandardPieSectionLabelGenerator;
+import org.jfree.chart.plot.CategoryPlot;
+import org.jfree.chart.plot.DatasetRenderingOrder;
+import org.jfree.chart.plot.DialShape;
+import org.jfree.chart.plot.Marker;
+import org.jfree.chart.plot.MeterInterval;
+import org.jfree.chart.plot.MeterPlot;
+import org.jfree.chart.plot.MultiplePiePlot;
+import org.jfree.chart.plot.PiePlot;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.SpiderWebPlot;
+import org.jfree.chart.plot.ValueMarker;
+import org.jfree.chart.renderer.category.AreaRenderer;
+import org.jfree.chart.renderer.category.BarRenderer;
+import org.jfree.chart.renderer.category.CategoryItemRenderer;
+import org.jfree.chart.renderer.category.LineAndShapeRenderer;
+import org.jfree.chart.renderer.category.StackedAreaRenderer;
+import org.jfree.chart.renderer.category.StackedBarRenderer;
+import org.jfree.chart.title.TextTitle;
+import org.jfree.chart.ui.RectangleInsets;
+import org.jfree.chart.util.TableOrder;
+import org.jfree.data.Range;
+import org.jfree.data.category.CategoryDataset;
+import org.jfree.data.category.DefaultCategoryDataset;
+import org.jfree.data.general.DefaultValueDataset;
+import org.jfree.data.general.ValueDataset;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @see VisualizationPlotService
+ *
+ * @author maikel arabori
+ */
+@Service( "org.hisp.dhis.visualization.VisualizationPlotService" )
+public class DefaultVisualizationPlotService implements VisualizationPlotService
+{
+    private static final Font TITLE_FONT = new Font( Font.SANS_SERIF, Font.BOLD, 12 );
+
+    private static final Font SUB_TITLE_FONT = new Font( Font.SANS_SERIF, Font.PLAIN, 11 );
+
+    private static final Font LABEL_FONT = new Font( Font.SANS_SERIF, Font.PLAIN, 10 );
+
+    private static final String TREND_PREFIX = "Trend - ";
+
+    private static final Color[] COLORS = { Color.decode( "#88be3b" ), Color.decode( "#3b6286" ),
+        Color.decode( "#b7404c" ), Color.decode( "#ff9f3a" ), Color.decode( "#968f8f" ), Color.decode( "#b7409f" ),
+        Color.decode( "#ffda64" ), Color.decode( "#4fbdae" ), Color.decode( "#b78040" ), Color.decode( "#676767" ),
+        Color.decode( "#6a33cf" ), Color.decode( "#4a7833" ) };
+
+    private static final Color COLOR_LIGHT_GRAY = Color.decode( "#dddddd" );
+
+    private static final Color COLOR_LIGHTER_GRAY = Color.decode( "#eeeeee" );
+
+    private static final Color DEFAULT_BACKGROUND_COLOR = Color.WHITE;
+
+    // -------------------------------------------------------------------------
+    // Dependencies
+    // -------------------------------------------------------------------------
+
+    private final PeriodService periodService;
+
+    private final DataValueService dataValueService;
+
+    private final MinMaxDataElementService minMaxDataElementService;
+
+    private final CurrentUserService currentUserService;
+
+    private final OrganisationUnitService organisationUnitService;
+
+    private final AnalyticsService analyticsService;
+
+    private final EventAnalyticsService eventAnalyticsService;
+
+    public DefaultVisualizationPlotService( PeriodService periodService, DataValueService dataValueService,
+        MinMaxDataElementService minMaxDataElementService, CurrentUserService currentUserService,
+        OrganisationUnitService organisationUnitService, AnalyticsService analyticsService,
+        EventAnalyticsService eventAnalyticsService )
+    {
+        checkNotNull( periodService );
+        checkNotNull( dataValueService );
+        checkNotNull( minMaxDataElementService );
+        checkNotNull( currentUserService );
+        checkNotNull( organisationUnitService );
+        checkNotNull( analyticsService );
+        checkNotNull( eventAnalyticsService );
+
+        this.periodService = periodService;
+        this.dataValueService = dataValueService;
+        this.minMaxDataElementService = minMaxDataElementService;
+        this.currentUserService = currentUserService;
+        this.organisationUnitService = organisationUnitService;
+        this.analyticsService = analyticsService;
+        this.eventAnalyticsService = eventAnalyticsService;
+    }
+
+    // -------------------------------------------------------------------------
+    // Main implementation
+    // -------------------------------------------------------------------------
+
+    @Override
+    @Transactional( readOnly = true )
+    public JFreeChart getJFreeChart( PlotData plotData, Date date, OrganisationUnit organisationUnit, I18nFormat format,
+        User currentUser )
+    {
+        User user = (currentUser != null ? currentUser : currentUserService.getCurrentUser());
+
+        if ( organisationUnit == null && user != null )
+        {
+            organisationUnit = user.getOrganisationUnit();
+        }
+
+        List<OrganisationUnit> atLevels = new ArrayList<>();
+        List<OrganisationUnit> inGroups = new ArrayList<>();
+
+        if ( plotData.hasOrganisationUnitLevels() )
+        {
+            atLevels.addAll( organisationUnitService.getOrganisationUnitsAtLevels( plotData.getOrganisationUnitLevels(),
+                plotData.getOrganisationUnits() ) );
+        }
+
+        if ( plotData.hasItemOrganisationUnitGroups() )
+        {
+            inGroups.addAll( organisationUnitService.getOrganisationUnits( plotData.getItemOrganisationUnitGroups(),
+                plotData.getOrganisationUnits() ) );
+        }
+
+        plotData.init( user, date, organisationUnit, atLevels, inGroups, format );
+
+        JFreeChart resultChart = getJFreeChart( plotData );
+
+        plotData.clearTransientState();
+
+        return resultChart;
+    }
+
+    // -------------------------------------------------------------------------
+    // Specific chart methods
+    // -------------------------------------------------------------------------
+
+    @Override
+    @Transactional( readOnly = true )
+    public JFreeChart getJFreePeriodChart( Indicator indicator, OrganisationUnit unit, boolean title,
+        I18nFormat format )
+    {
+        List<Period> periods = periodService.reloadPeriods(
+            new RelativePeriods().setLast12Months( true ).getRelativePeriods( format, true ) );
+
+        Visualization visualization = new Visualization();
+
+        if ( title )
+        {
+            visualization.setName( indicator.getName() );
+        }
+
+        visualization.setType( VisualizationType.LINE );
+        visualization.setColumnDimensions( Arrays.asList( DimensionalObject.DATA_X_DIM_ID ) );
+        visualization.setRowDimensions( Arrays.asList( DimensionalObject.PERIOD_DIM_ID ) );
+        visualization.setFilterDimensions( Arrays.asList( DimensionalObject.ORGUNIT_DIM_ID ) );
+        visualization.setHideLegend( true );
+        visualization.addDataDimensionItem( indicator );
+        visualization.setPeriods( periods );
+        visualization.getOrganisationUnits().add( unit );
+        visualization.setHideSubtitle( title );
+        visualization.setFormat( format );
+
+        return getJFreeChart( new PlotData( visualization ) );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public JFreeChart getJFreeOrganisationUnitChart( Indicator indicator, OrganisationUnit parent, boolean title,
+        I18nFormat format )
+    {
+        List<Period> periods = periodService.reloadPeriods(
+            new RelativePeriods().setThisYear( true ).getRelativePeriods( format, true ) );
+
+        Visualization visualization = new Visualization();
+
+        if ( title )
+        {
+            visualization.setName( indicator.getName() );
+        }
+
+        visualization.setType( VisualizationType.COLUMN );
+        visualization.setColumnDimensions( Arrays.asList( DimensionalObject.DATA_X_DIM_ID ) );
+        visualization.setRowDimensions( Arrays.asList( DimensionalObject.ORGUNIT_DIM_ID ) );
+        visualization.setFilterDimensions( Arrays.asList( DimensionalObject.PERIOD_DIM_ID ) );
+        visualization.setHideLegend( true );
+        visualization.addDataDimensionItem( indicator );
+        visualization.setPeriods( periods );
+        visualization.setOrganisationUnits( parent.getSortedChildren() );
+        visualization.setHideSubtitle( title );
+        visualization.setFormat( format );
+
+        return getJFreeChart( new PlotData( visualization ) );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public JFreeChart getJFreeChartHistory( DataElement dataElement, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, Period lastPeriod, OrganisationUnit organisationUnit,
+        int historyLength, I18nFormat format )
+    {
+        lastPeriod = periodService.reloadPeriod( lastPeriod );
+
+        List<Period> periods = periodService.getPeriods( lastPeriod, historyLength );
+
+        MinMaxDataElement minMax = minMaxDataElementService.getMinMaxDataElement( organisationUnit, dataElement,
+            categoryOptionCombo );
+
+        UnivariateInterpolator interpolator = new SplineInterpolator();
+
+        int periodCount = 0;
+        List<Double> x = new ArrayList<>();
+        List<Double> y = new ArrayList<>();
+
+        // ---------------------------------------------------------------------
+        // DataValue, MinValue and MaxValue DataSets
+        // ---------------------------------------------------------------------
+
+        DefaultCategoryDataset dataValueDataSet = new DefaultCategoryDataset();
+        DefaultCategoryDataset metaDataSet = new DefaultCategoryDataset();
+
+        for ( Period period : periods )
+        {
+            ++periodCount;
+
+            period.setName( format.formatPeriod( period ) );
+
+            DataValue dataValue = dataValueService.getDataValue( dataElement, period, organisationUnit,
+                categoryOptionCombo, attributeOptionCombo );
+
+            double value = 0;
+
+            if ( dataValue != null && dataValue.getValue() != null && MathUtils.isNumeric( dataValue.getValue() ) )
+            {
+                value = Double.parseDouble( dataValue.getValue() );
+
+                x.add( (double) periodCount );
+                y.add( value );
+            }
+
+            dataValueDataSet.addValue( value, dataElement.getShortName(), period.getName() );
+
+            if ( minMax != null )
+            {
+                metaDataSet.addValue( minMax.getMin(), "Min value", period.getName() );
+                metaDataSet.addValue( minMax.getMax(), "Max value", period.getName() );
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Interpolation DataSet
+        // ---------------------------------------------------------------------
+
+        if ( x.size() >= 3 ) // minimum 3 points required for interpolation
+        {
+            periodCount = 0;
+
+            double[] xa = getArray( x );
+
+            int min = MathUtils.getMin( xa ).intValue();
+            int max = MathUtils.getMax( xa ).intValue();
+
+            try
+            {
+                UnivariateFunction function = interpolator.interpolate( xa, getArray( y ) );
+
+                for ( Period period : periods )
+                {
+                    if ( ++periodCount >= min && periodCount <= max )
+                    {
+                        metaDataSet.addValue( function.value( periodCount ), "Regression value", period.getName() );
+                    }
+                }
+            }
+            catch ( MathRuntimeException ex )
+            {
+                throw new RuntimeException( "Failed to interpolate", ex );
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Plots
+        // ---------------------------------------------------------------------
+
+        CategoryPlot plot = getCategoryPlot( dataValueDataSet, getBarRenderer(), PlotOrientation.VERTICAL,
+            CategoryLabelPositions.UP_45 );
+
+        plot.setDataset( 1, metaDataSet );
+        plot.setRenderer( 1, getLineRenderer() );
+
+        return getBasicJFreeChart( plot );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a basic JFreeChart.
+     */
+    private JFreeChart getBasicJFreeChart( CategoryPlot plot )
+    {
+        JFreeChart jFreeChart = new JFreeChart( null, TITLE_FONT, plot, false );
+
+        jFreeChart.setBackgroundPaint( Color.WHITE );
+        jFreeChart.setAntiAlias( true );
+
+        return jFreeChart;
+    }
+
+    /**
+     * Returns a CategoryPlot.
+     */
+    private CategoryPlot getCategoryPlot( CategoryDataset dataSet, CategoryItemRenderer renderer,
+        PlotOrientation orientation, CategoryLabelPositions labelPositions )
+    {
+        CategoryPlot plot = new CategoryPlot( dataSet, new CategoryAxis(), new NumberAxis(), renderer );
+
+        plot.setDatasetRenderingOrder( DatasetRenderingOrder.FORWARD );
+        plot.setOrientation( orientation );
+
+        CategoryAxis xAxis = plot.getDomainAxis();
+        xAxis.setCategoryLabelPositions( labelPositions );
+
+        return plot;
+    }
+
+    /**
+     * Returns a bar renderer.
+     */
+    private BarRenderer getBarRenderer()
+    {
+        BarRenderer renderer = new BarRenderer();
+
+        renderer.setMaximumBarWidth( 0.07 );
+
+        for ( int i = 0; i < COLORS.length; i++ )
+        {
+            renderer.setSeriesPaint( i, COLORS[i] );
+            renderer.setShadowVisible( false );
+        }
+
+        return renderer;
+    }
+
+    /**
+     * Returns a line and shape renderer.
+     */
+    private LineAndShapeRenderer getLineRenderer()
+    {
+        LineAndShapeRenderer renderer = new LineAndShapeRenderer();
+
+        for ( int i = 0; i < COLORS.length; i++ )
+        {
+            renderer.setSeriesPaint( i, COLORS[i] );
+        }
+
+        return renderer;
+    }
+
+    /**
+     * Returns a stacked bar renderer.
+     */
+    private StackedBarRenderer getStackedBarRenderer()
+    {
+        StackedBarRenderer renderer = new StackedBarRenderer();
+
+        for ( int i = 0; i < COLORS.length; i++ )
+        {
+            renderer.setSeriesPaint( i, COLORS[i] );
+            renderer.setShadowVisible( false );
+        }
+
+        return renderer;
+    }
+
+    /**
+     * Returns a stacked area renderer.
+     */
+    private AreaRenderer getStackedAreaRenderer()
+    {
+        StackedAreaRenderer renderer = new StackedAreaRenderer();
+
+        for ( int i = 0; i < COLORS.length; i++ )
+        {
+            renderer.setSeriesPaint( i, COLORS[i] );
+        }
+
+        return renderer;
+    }
+
+    /**
+     * Returns a horizontal line marker for the given x value and label.
+     */
+    private Marker getMarker( Double value, String label )
+    {
+        Marker marker = new ValueMarker( value );
+        marker.setPaint( Color.BLACK );
+        marker.setStroke( new BasicStroke( 1.1f ) );
+        marker.setLabel( label );
+        marker.setLabelOffset( new RectangleInsets( -10, 50, 0, 0 ) );
+        marker.setLabelFont( SUB_TITLE_FONT );
+
+        return marker;
+    }
+
+    /**
+     * Returns a JFreeChart of type defined in the chart argument.
+     */
+    private JFreeChart getJFreeChart( PlotData plotData )
+    {
+        final CategoryDataset[] dataSets = getCategoryDataSet( plotData );
+        final CategoryDataset dataSet = dataSets[0];
+
+        final BarRenderer barRenderer = getBarRenderer();
+        final LineAndShapeRenderer lineRenderer = getLineRenderer();
+
+        // ---------------------------------------------------------------------
+        // Plot
+        // ---------------------------------------------------------------------
+
+        CategoryPlot plot;
+
+        if ( plotData.isType( VisualizationType.LINE.name() ) )
+        {
+            plot = new CategoryPlot( dataSet, new CategoryAxis(), new NumberAxis(), lineRenderer );
+            plot.setOrientation( PlotOrientation.VERTICAL );
+        }
+        else if ( plotData.isType( VisualizationType.COLUMN.name() ) )
+        {
+            plot = new CategoryPlot( dataSet, new CategoryAxis(), new NumberAxis(), barRenderer );
+            plot.setOrientation( PlotOrientation.VERTICAL );
+        }
+        else if ( plotData.isType( VisualizationType.BAR.name() ) )
+        {
+            plot = new CategoryPlot( dataSet, new CategoryAxis(), new NumberAxis(), barRenderer );
+            plot.setOrientation( PlotOrientation.HORIZONTAL );
+        }
+        else if ( plotData.isType( VisualizationType.AREA.name() ) )
+        {
+            return getStackedAreaChart( plotData, dataSet );
+        }
+        else if ( plotData.isType( VisualizationType.PIE.name() ) )
+        {
+            return getMultiplePieChart( plotData, dataSets );
+        }
+        else if ( plotData.isType( VisualizationType.STACKED_COLUMN.name() ) )
+        {
+            return getStackedBarChart( plotData, dataSet, false );
+        }
+        else if ( plotData.isType( VisualizationType.STACKED_BAR.name() ) )
+        {
+            return getStackedBarChart( plotData, dataSet, true );
+        }
+        else if ( plotData.isType( VisualizationType.RADAR.name() ) )
+        {
+            return getRadarChart( plotData, dataSet );
+        }
+        else if ( plotData.isType( VisualizationType.GAUGE.name() ) )
+        {
+            Number number = dataSet.getValue( 0, 0 );
+            ValueDataset valueDataSet = new DefaultValueDataset( number );
+
+            return getGaugeChart( plotData, valueDataSet );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Illegal or no chart type: " + plotData.getType() );
+        }
+
+        if ( plotData.isRegression() )
+        {
+            plot.setDataset( 1, dataSets[1] );
+            plot.setRenderer( 1, lineRenderer );
+        }
+
+        JFreeChart jFreeChart = new JFreeChart( plotData.getName(), TITLE_FONT, plot, !plotData.isHideLegend() );
+
+        setBasicConfig( jFreeChart, plotData );
+
+        if ( plotData.isTargetLine() )
+        {
+            plot.addRangeMarker( getMarker( plotData.getTargetLineValue(), plotData.getTargetLineLabel() ) );
+        }
+
+        if ( plotData.isBaseLine() )
+        {
+            plot.addRangeMarker( getMarker( plotData.getBaseLineValue(), plotData.getBaseLineLabel() ) );
+        }
+
+        if ( plotData.isHideSubtitle() )
+        {
+            jFreeChart.addSubtitle( getSubTitle( plotData ) );
+        }
+
+        plot.setDatasetRenderingOrder( DatasetRenderingOrder.FORWARD );
+
+        // ---------------------------------------------------------------------
+        // Category label positions
+        // ---------------------------------------------------------------------
+
+        CategoryAxis domainAxis = plot.getDomainAxis();
+        domainAxis.setCategoryLabelPositions( CategoryLabelPositions.UP_45 );
+        domainAxis.setLabel( plotData.getDomainAxisLabel() );
+
+        ValueAxis rangeAxis = plot.getRangeAxis();
+        rangeAxis.setLabel( plotData.getRangeAxisLabel() );
+
+        return jFreeChart;
+    }
+
+    private JFreeChart getStackedAreaChart( PlotData plotData, CategoryDataset dataSet )
+    {
+        JFreeChart stackedAreaChart = ChartFactory.createStackedAreaChart( plotData.getName(),
+            plotData.getDomainAxisLabel(), plotData.getRangeAxisLabel(), dataSet, PlotOrientation.VERTICAL,
+            !plotData.isHideLegend(), false, false );
+
+        setBasicConfig( stackedAreaChart, plotData );
+
+        CategoryPlot plot = (CategoryPlot) stackedAreaChart.getPlot();
+        plot.setOrientation( PlotOrientation.VERTICAL );
+        plot.setRenderer( getStackedAreaRenderer() );
+
+        CategoryAxis xAxis = plot.getDomainAxis();
+        xAxis.setCategoryLabelPositions( CategoryLabelPositions.UP_45 );
+        xAxis.setLabelFont( LABEL_FONT );
+
+        return stackedAreaChart;
+    }
+
+    private JFreeChart getRadarChart( PlotData plotData, CategoryDataset dataSet )
+    {
+        SpiderWebPlot plot = new SpiderWebPlot( dataSet, TableOrder.BY_ROW );
+        plot.setLabelFont( LABEL_FONT );
+
+        JFreeChart radarChart = new JFreeChart( plotData.getName(), TITLE_FONT, plot, !plotData.isHideLegend() );
+
+        setBasicConfig( radarChart, plotData );
+
+        return radarChart;
+    }
+
+    private JFreeChart getStackedBarChart( PlotData plotData, CategoryDataset dataSet, boolean horizontal )
+    {
+        JFreeChart stackedBarChart = ChartFactory.createStackedBarChart( plotData.getName(),
+            plotData.getDomainAxisLabel(), plotData.getRangeAxisLabel(), dataSet, PlotOrientation.VERTICAL,
+            !plotData.isHideLegend(), false, false );
+
+        setBasicConfig( stackedBarChart, plotData );
+
+        CategoryPlot plot = (CategoryPlot) stackedBarChart.getPlot();
+        plot.setOrientation( horizontal ? PlotOrientation.HORIZONTAL : PlotOrientation.VERTICAL );
+        plot.setRenderer( getStackedBarRenderer() );
+
+        CategoryAxis xAxis = plot.getDomainAxis();
+        xAxis.setCategoryLabelPositions( CategoryLabelPositions.UP_45 );
+
+        return stackedBarChart;
+    }
+
+    private JFreeChart getMultiplePieChart( PlotData plotData, CategoryDataset[] dataSets )
+    {
+        JFreeChart multiplePieChart = ChartFactory.createMultiplePieChart( plotData.getName(), dataSets[0],
+            TableOrder.BY_ROW, !plotData.isHideLegend(), false, false );
+
+        setBasicConfig( multiplePieChart, plotData );
+
+        if ( multiplePieChart.getLegend() != null )
+        {
+            multiplePieChart.getLegend().setItemFont( SUB_TITLE_FONT );
+        }
+
+        MultiplePiePlot multiplePiePlot = (MultiplePiePlot) multiplePieChart.getPlot();
+        JFreeChart pieChart = multiplePiePlot.getPieChart();
+        pieChart.setBackgroundPaint( DEFAULT_BACKGROUND_COLOR );
+        pieChart.getTitle().setFont( SUB_TITLE_FONT );
+
+        PiePlot piePlot = (PiePlot) pieChart.getPlot();
+        piePlot.setBackgroundPaint( DEFAULT_BACKGROUND_COLOR );
+        piePlot.setOutlinePaint( DEFAULT_BACKGROUND_COLOR );
+        piePlot.setLabelFont( LABEL_FONT );
+        piePlot.setLabelGenerator( new StandardPieSectionLabelGenerator( "{2}" ) );
+        piePlot.setSimpleLabels( true );
+        piePlot.setIgnoreZeroValues( true );
+        piePlot.setIgnoreNullValues( true );
+        piePlot.setShadowXOffset( 0d );
+        piePlot.setShadowYOffset( 0d );
+
+        for ( int i = 0; i < dataSets[0].getColumnCount(); i++ )
+        {
+            piePlot.setSectionPaint( dataSets[0].getColumnKey( i ), COLORS[(i % COLORS.length)] );
+        }
+
+        return multiplePieChart;
+    }
+
+    private JFreeChart getGaugeChart( PlotData plotData, ValueDataset dataSet )
+    {
+        MeterPlot meterPlot = new MeterPlot( dataSet );
+
+        meterPlot.setUnits( "" );
+        meterPlot.setRange( new Range( 0.0d, 100d ) );
+
+        for ( int i = 0; i < 10; i++ )
+        {
+            double start = i * 10d;
+            double end = start + 10d;
+            String label = String.valueOf( start );
+
+            meterPlot.addInterval(
+                new MeterInterval( label, new Range( start, end ), COLOR_LIGHT_GRAY, null, COLOR_LIGHT_GRAY ) );
+        }
+
+        meterPlot.setMeterAngle( 180 );
+        meterPlot.setDialBackgroundPaint( COLOR_LIGHT_GRAY );
+        meterPlot.setDialShape( DialShape.CHORD );
+        meterPlot.setNeedlePaint( COLORS[0] );
+        meterPlot.setTickLabelsVisible( true );
+        meterPlot.setTickLabelFont( LABEL_FONT );
+        meterPlot.setTickLabelPaint( Color.BLACK );
+        meterPlot.setTickPaint( COLOR_LIGHTER_GRAY );
+        meterPlot.setValueFont( TITLE_FONT );
+        meterPlot.setValuePaint( Color.BLACK );
+
+        JFreeChart meterChart = new JFreeChart( plotData.getName(), meterPlot );
+        setBasicConfig( meterChart, plotData );
+        meterChart.removeLegend();
+
+        return meterChart;
+    }
+
+    /**
+     * Sets basic configuration including title font, subtitle, background paint
+     * and anti-alias on the given JFreeChart.
+     */
+    private void setBasicConfig( JFreeChart jFreeChart, PlotData plotData )
+    {
+        jFreeChart.getTitle().setFont( TITLE_FONT );
+
+        jFreeChart.setBackgroundPaint( DEFAULT_BACKGROUND_COLOR );
+        jFreeChart.setAntiAlias( true );
+
+        if ( !plotData.isHideTitle() )
+        {
+            jFreeChart.addSubtitle( getSubTitle( plotData ) );
+        }
+
+        Plot plot = jFreeChart.getPlot();
+        plot.setBackgroundPaint( DEFAULT_BACKGROUND_COLOR );
+        plot.setOutlinePaint( DEFAULT_BACKGROUND_COLOR );
+    }
+
+    private TextTitle getSubTitle( PlotData plotData )
+    {
+        TextTitle textTitle = new TextTitle();
+
+        String title = plotData.hasTitle() ? plotData.getDisplayTitle() : plotData.generateTitle();
+
+        textTitle.setFont( SUB_TITLE_FONT );
+        textTitle.setText( title );
+
+        return textTitle;
+    }
+
+    private CategoryDataset[] getCategoryDataSet( PlotData plotData )
+    {
+        Map<String, Object> valueMap = new HashMap<>();
+
+        if ( plotData.isAggregate() )
+        {
+            valueMap = analyticsService.getAggregatedDataValueMapping( plotData.getVisualization() );
+        }
+        else
+        {
+            Grid grid = eventAnalyticsService.getAggregatedEventData( plotData.getEventChart() );
+
+            plotData.getEventChart().setDataItemGrid( grid );
+
+            valueMap = GridUtils.getMetaValueMapping( grid, (grid.getWidth() - 1) );
+        }
+
+        DefaultCategoryDataset regularDataSet = new DefaultCategoryDataset();
+        DefaultCategoryDataset regressionDataSet = new DefaultCategoryDataset();
+
+        SimpleRegression regression = new SimpleRegression();
+
+        valueMap = DimensionalObjectUtils.getSortedKeysMap( valueMap );
+
+        List<NameableObject> seriez = new ArrayList<>( plotData.series() );
+        List<NameableObject> categories = new ArrayList<>( defaultIfNull( plotData.category(), emptyList() ) );
+
+        if ( plotData.hasSortOrder() )
+        {
+            categories = getSortedCategories( categories, plotData, valueMap );
+        }
+
+        for ( NameableObject series : seriez )
+        {
+            double categoryIndex = 0;
+
+            for ( NameableObject category : categories )
+            {
+                categoryIndex++;
+
+                String key = getKey( series, category, plotData.getAnalyticsType() );
+
+                Object object = valueMap.get( key );
+
+                Number value = object != null && object instanceof Number ? (Number) object : null;
+
+                regularDataSet.addValue( value, series.getShortName(), category.getShortName() );
+
+                if ( plotData.isRegression() && value != null && value instanceof Double
+                    && !MathUtils.isEqual( (Double) value, MathUtils.ZERO ) )
+                {
+                    regression.addData( categoryIndex, (Double) value );
+                }
+            }
+
+            if ( plotData.isRegression() ) // Period must be category
+            {
+                categoryIndex = 0;
+
+                for ( NameableObject category : plotData.category() )
+                {
+                    final double value = regression.predict( categoryIndex++ );
+
+                    // Enough values must exist for regression
+
+                    if ( !Double.isNaN( value ) )
+                    {
+                        regressionDataSet.addValue( value, TREND_PREFIX + series.getShortName(),
+                            category.getShortName() );
+                    }
+                }
+            }
+        }
+
+        return new CategoryDataset[] { regularDataSet, regressionDataSet };
+    }
+
+    /**
+     * Creates a key based on the given input. Sorts the key on its components
+     * to remove significance of column order.
+     */
+    private String getKey( NameableObject series, NameableObject category, AnalyticsType analyticsType )
+    {
+        String key = series.getUid() + DIMENSION_SEP + category.getUid();
+
+        // Replace potential operand separator with dimension separator
+
+        key = AnalyticsType.AGGREGATE.equals( analyticsType )
+            ? key.replace( DataElementOperand.SEPARATOR, DIMENSION_SEP )
+            : key;
+
+        // TODO fix issue with keys including -.
+
+        return DimensionalObjectUtils.sortKey( key );
+    }
+
+    /**
+     * Returns a list of sorted nameable objects. Sorting is defined per the
+     * corresponding value in the given value map.
+     */
+    private List<NameableObject> getSortedCategories( List<NameableObject> categories, PlotData plotData,
+        Map<String, Object> valueMap )
+    {
+        NameableObject series = plotData.series().get( 0 );
+
+        int sortOrder = plotData.getSortOrder();
+
+        List<NumericSortWrapper<NameableObject>> list = new ArrayList<>();
+
+        for ( NameableObject category : categories )
+        {
+            String key = getKey( series, category, plotData.getAnalyticsType() );
+
+            Object value = valueMap.get( key );
+
+            if ( value instanceof Number )
+            {
+                list.add( new NumericSortWrapper<>( category, (Double) value, sortOrder ) );
+            }
+        }
+
+        Collections.sort( list );
+
+        return NumericSortWrapper.getObjectList( list );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_46__SumUp_DataStatisticsEvent_Chart_ReportTable_Into_Visualization.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.36/V2_36_46__SumUp_DataStatisticsEvent_Chart_ReportTable_Into_Visualization.sql
@@ -1,0 +1,9 @@
+-- This will sum-up CHART_VIEW and REPORT_TABLE_VIEW into VISUALIZATION_VIEW.
+-- See JIRA DHIS2-11693
+
+-- Populate the visualizationviews based on existing metrics for report table and charts.
+UPDATE datastatistics
+SET visualizationviews = reporttableviews + chartviews WHERE visualizationviews IS NULL;
+
+UPDATE datastatistics
+SET visualizations = reporttables + charts WHERE visualizations IS NULL;

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationDataController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationDataController.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
+
+import java.io.IOException;
+import java.util.Date;
+
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.render.RenderService;
+import org.hisp.dhis.system.grid.GridUtils;
+import org.hisp.dhis.system.util.CodecUtils;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.visualization.PlotData;
+import org.hisp.dhis.visualization.Visualization;
+import org.hisp.dhis.visualization.VisualizationGridService;
+import org.hisp.dhis.visualization.VisualizationPlotService;
+import org.hisp.dhis.visualization.VisualizationService;
+import org.hisp.dhis.visualization.VisualizationType;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.jfree.chart.ChartUtils;
+import org.jfree.chart.JFreeChart;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller responsible to expose endpoints related to data export/extraction.
+ * They are fully based on Visualizations and are able to extract data from
+ * different visualization types (charts and pivot tables at this state).
+ *
+ * The code is not new. It was moved in and re-adapted to support visualizations
+ * and unify chart and pivot tables. This is mainly needed because of the
+ * deprecation process of charts and pivot tables.
+ *
+ * @author maikel arabori
+ */
+@RestController
+@AllArgsConstructor
+@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+public class VisualizationDataController
+{
+    @NonNull
+    private OrganisationUnitService organisationUnitService;
+
+    @NonNull
+    private final ContextUtils contextUtils;
+
+    @NonNull
+    private final VisualizationService visualizationService;
+
+    @NonNull
+    private final VisualizationGridService visualizationGridService;
+
+    @NonNull
+    private final VisualizationPlotService visualizationPlotService;
+
+    @NonNull
+    private final DataElementService dataElementService;
+
+    @NonNull
+    private final CategoryService categoryService;
+
+    @NonNull
+    private final IndicatorService indicatorService;
+
+    @NonNull
+    private final I18nManager i18nManager;
+
+    @NonNull
+    private final CurrentUserService currentUserService;
+
+    @NonNull
+    private final RenderService renderService;
+
+    @GetMapping( value = "/visualizations/{uid}/data.html" )
+    public @ResponseBody Grid getVisualizationDataHtml( @PathVariable( "uid" ) String uid, Model model,
+        @RequestParam( value = "ou", required = false ) String organisationUnitUid,
+        @RequestParam( value = "date", required = false ) Date date )
+    {
+        return getReportTableGrid( uid, organisationUnitUid, date );
+    }
+
+    @GetMapping( value = "/visualizations/{uid}/data.html+css" )
+    public void getVisualizationDataHtmlCss( @PathVariable( "uid" ) String uid,
+        @RequestParam( value = "ou", required = false ) String organisationUnitUid,
+        @RequestParam( value = "date", required = false ) Date date,
+        HttpServletResponse response )
+        throws Exception
+    {
+        Grid grid = getReportTableGrid( uid, organisationUnitUid, date );
+
+        String filename = filenameEncode( grid.getTitle() ) + ".html";
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            filename, false );
+
+        GridUtils.toHtmlCss( grid, response.getWriter() );
+    }
+
+    @GetMapping( value = "/visualizations/{uid}/data.xml" )
+    public void getVisualizationDataXml( @PathVariable( "uid" ) String uid,
+        @RequestParam( value = "ou", required = false ) String organisationUnitUid,
+        @RequestParam( value = "date", required = false ) Date date,
+        HttpServletResponse response )
+        throws Exception
+    {
+        Grid grid = getReportTableGrid( uid, organisationUnitUid, date );
+
+        String filename = filenameEncode( grid.getTitle() ) + ".xml";
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            filename, false );
+
+        GridUtils.toXml( grid, response.getOutputStream() );
+    }
+
+    @GetMapping( value = "/visualizations/{uid}/data.pdf" )
+    public void getVisualizationDataPdf( @PathVariable( "uid" ) String uid,
+        @RequestParam( value = "ou", required = false ) String organisationUnitUid,
+        @RequestParam( value = "date", required = false ) Date date,
+        HttpServletResponse response )
+        throws Exception
+    {
+        Grid grid = getReportTableGrid( uid, organisationUnitUid, date );
+
+        String filename = filenameEncode( grid.getTitle() ) + ".pdf";
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_PDF, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            filename, false );
+
+        GridUtils.toPdf( grid, response.getOutputStream() );
+    }
+
+    @GetMapping( value = "/visualizations/{uid}/data.xls" )
+    public void getVisualizationDataXls( @PathVariable( "uid" ) String uid,
+        @RequestParam( value = "ou", required = false ) String organisationUnitUid,
+        @RequestParam( value = "date", required = false ) Date date,
+        HttpServletResponse response )
+        throws Exception
+    {
+        Grid grid = getReportTableGrid( uid, organisationUnitUid, date );
+
+        String filename = filenameEncode( grid.getTitle() ) + ".xls";
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_EXCEL, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            filename, true );
+
+        GridUtils.toXls( grid, response.getOutputStream() );
+    }
+
+    @GetMapping( value = "/visualizations/{uid}/data.csv" )
+    public void getVisualizationDataCsv( @PathVariable( "uid" ) String uid,
+        @RequestParam( value = "ou", required = false ) String organisationUnitUid,
+        @RequestParam( value = "date", required = false ) Date date,
+        HttpServletResponse response )
+        throws Exception
+    {
+        Grid grid = getReportTableGrid( uid, organisationUnitUid, date );
+
+        String filename = filenameEncode( grid.getTitle() ) + ".csv";
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            filename, true );
+
+        GridUtils.toCsv( grid, response.getWriter() );
+    }
+
+    @GetMapping( value = { "/visualizations/{uid}/data", "/visualizations/{uid}/data.png" } )
+    public void getVisualizationData(
+        @PathVariable( "uid" ) String uid,
+        @RequestParam( value = "date", required = false ) Date date,
+        @RequestParam( value = "ou", required = false ) String ou,
+        @RequestParam( value = "width", defaultValue = "800", required = false ) int width,
+        @RequestParam( value = "height", defaultValue = "500", required = false ) int height,
+        @RequestParam( value = "attachment", required = false ) boolean attachment,
+        HttpServletResponse response )
+        throws IOException,
+        WebMessageException
+    {
+        final Visualization visualization = visualizationService.getVisualizationNoAcl( uid );
+
+        if ( visualization == null )
+        {
+            throw new WebMessageException( notFound( "Visualization does not exist: " + uid ) );
+        }
+
+        if ( visualization.isChart() && isChartSupported( visualization.getType() ) )
+        {
+            OrganisationUnit unit = ou != null ? organisationUnitService.getOrganisationUnit( ou ) : null;
+
+            JFreeChart jFreeChart = visualizationPlotService.getJFreeChart( new PlotData( visualization ), date, unit,
+                i18nManager.getI18nFormat(), currentUserService.getCurrentUser() );
+
+            String filename = CodecUtils.filenameEncode( visualization.getName() ) + ".png";
+
+            contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_PNG,
+                CacheStrategy.RESPECT_SYSTEM_SETTING,
+                filename, attachment );
+
+            ChartUtils.writeChartAsPNG( response.getOutputStream(), jFreeChart, width, height );
+        }
+        else
+        {
+            response.setContentType( CONTENT_TYPE_JSON );
+            renderService.toJson( response.getOutputStream(), getReportTableGrid( uid, ou, date ) );
+        }
+    }
+
+    @GetMapping( value = { "/visualizations/data", "/visualizations/data.png" } )
+    public void getVisualizationChartData(
+        @RequestParam( value = "in" ) String indicatorUid,
+        @RequestParam( value = "ou" ) String organisationUnitUid,
+        @RequestParam( value = "periods", required = false ) boolean periods,
+        @RequestParam( value = "width", defaultValue = "800", required = false ) int width,
+        @RequestParam( value = "height", defaultValue = "500", required = false ) int height,
+        @RequestParam( value = "skipTitle", required = false ) boolean skipTitle,
+        @RequestParam( value = "attachment", required = false ) boolean attachment,
+        HttpServletResponse response )
+        throws IOException
+    {
+        Indicator indicator = indicatorService.getIndicator( indicatorUid );
+        OrganisationUnit unit = organisationUnitService.getOrganisationUnit( organisationUnitUid );
+
+        JFreeChart chart;
+
+        if ( periods )
+        {
+            chart = visualizationPlotService.getJFreePeriodChart( indicator, unit, !skipTitle,
+                i18nManager.getI18nFormat() );
+        }
+        else
+        {
+            chart = visualizationPlotService.getJFreeOrganisationUnitChart( indicator, unit, !skipTitle,
+                i18nManager.getI18nFormat() );
+        }
+
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_PNG, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            "chart.png", attachment );
+
+        ChartUtils.writeChartAsPNG( response.getOutputStream(), chart, width, height );
+    }
+
+    @GetMapping( value = { "/visualizations/history/data", "/visualizations/history/data.png" } )
+    public void getVisualizationChartHistory(
+        @RequestParam String de,
+        @RequestParam String co,
+        @RequestParam String cp,
+        @RequestParam String pe,
+        @RequestParam String ou,
+        @RequestParam( defaultValue = "525", required = false ) int width,
+        @RequestParam( defaultValue = "300", required = false ) int height,
+        HttpServletResponse response )
+        throws IOException,
+        WebMessageException
+    {
+        DataElement dataElement = dataElementService.getDataElement( de );
+
+        if ( dataElement == null )
+        {
+            throw new WebMessageException( conflict( "Data element does not exist: " + de ) );
+        }
+
+        CategoryOptionCombo categoryOptionCombo = categoryService.getCategoryOptionCombo( co );
+
+        if ( categoryOptionCombo == null )
+        {
+            throw new WebMessageException( conflict( "Category option combo does not exist: " + co ) );
+        }
+
+        CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( cp );
+
+        if ( attributeOptionCombo == null )
+        {
+            throw new WebMessageException( conflict( "Category option combo does not exist: " + cp ) );
+        }
+
+        Period period = PeriodType.getPeriodFromIsoString( pe );
+
+        if ( period == null )
+        {
+            throw new WebMessageException( conflict( "Period does not exist: " + pe ) );
+        }
+
+        OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( ou );
+
+        if ( organisationUnit == null )
+        {
+            throw new WebMessageException( conflict( "Organisation unit does not exist: " + ou ) );
+        }
+
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_PNG, CacheStrategy.RESPECT_SYSTEM_SETTING,
+            "chart.png", false );
+
+        JFreeChart chart = visualizationPlotService.getJFreeChartHistory( dataElement, categoryOptionCombo,
+            attributeOptionCombo, period, organisationUnit, 13, i18nManager.getI18nFormat() );
+
+        ChartUtils.writeChartAsPNG( response.getOutputStream(), chart, width, height );
+    }
+
+    private Grid getReportTableGrid( String uid, String organisationUnitUid, Date date )
+    {
+        Visualization visualization = visualizationService.getVisualizationNoAcl( uid );
+
+        if ( organisationUnitUid == null && visualization.hasReportingParams()
+            && visualization.getReportingParams().isOrganisationUnitSet() )
+        {
+            organisationUnitUid = organisationUnitService.getRootOrganisationUnits().iterator().next().getUid();
+        }
+
+        date = date != null ? date : new Date();
+
+        return visualizationGridService.getVisualizationGrid( uid, date, organisationUnitUid );
+    }
+
+    private boolean isChartSupported( final VisualizationType type )
+    {
+        return type == VisualizationType.LINE ||
+            type == VisualizationType.COLUMN ||
+            type == VisualizationType.BAR ||
+            type == VisualizationType.AREA ||
+            type == VisualizationType.PIE ||
+            type == VisualizationType.STACKED_COLUMN ||
+            type == VisualizationType.STACKED_BAR ||
+            type == VisualizationType.RADAR ||
+            type == VisualizationType.GAUGE;
+    }
+}

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -29,6 +29,9 @@ package org.hisp.dhis.webapi.controller.datastatistics;
 
 import static java.util.Calendar.DATE;
 import static java.util.Calendar.MILLISECOND;
+import static org.hisp.dhis.datastatistics.DataStatisticsEventType.CHART_VIEW;
+import static org.hisp.dhis.datastatistics.DataStatisticsEventType.REPORT_TABLE_VIEW;
+import static org.hisp.dhis.datastatistics.DataStatisticsEventType.VISUALIZATION_VIEW;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 
 import java.util.Date;
@@ -88,6 +91,17 @@ public class DataStatisticsController
 
         DataStatisticsEvent event = new DataStatisticsEvent( eventType, timestamp, username, favorite );
         dataStatisticsService.addEvent( event );
+
+        // Logic needed to assist the deprecation process of charts and
+        // report tables.
+        if ( eventType == CHART_VIEW || eventType == REPORT_TABLE_VIEW )
+        {
+            // For each CHART_VIEW or REPORT_TABLE_VIEW we also add a
+            // VISUALIZATION_VIEW event.
+            DataStatisticsEvent visualizationEvent = new DataStatisticsEvent( VISUALIZATION_VIEW, timestamp, username,
+                favorite );
+            dataStatisticsService.addEvent( visualizationEvent );
+        }
     }
 
     @GetMapping

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/vote/ExternalAccessVoter.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/vote/ExternalAccessVoter.java
@@ -69,6 +69,7 @@ public class ExternalAccessVoter implements AccessDecisionVoter<FilterInvocation
         // clean this up when they are
         externalClasses.put( "charts", Visualization.class );
         externalClasses.put( "reportTables", Visualization.class );
+        externalClasses.put( "visualizations", Visualization.class );
         externalClasses.put( "maps", org.hisp.dhis.mapping.Map.class );
         externalClasses.put( "reports", Report.class );
         externalClasses.put( "documents", Document.class );


### PR DESCRIPTION
This set of fixes are related to missing support for Visualizations in the statistics data endpoint and media/file export endpoints in 2.36.

This PR will give the option to the users to use Visualizations for the respective endpoints, instead of allowing only Charts and Report Tables, which is in line with other endpoints that already have support for Visualizations.

Note
The code duplication pointed by Sonar comes from legacy classes that were renamed and adapted to support the Visualization object. Refactoring those classes is not in scope for this fix.

Also
This is a "forward-port" of the exact same code already reviewed in 2.34 here: #8647