### PR TITLE
chore: extra enforcer rules are not used

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -226,7 +226,6 @@
         <dependency-check-maven.version>6.0.3</dependency-check-maven.version>
         <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
         <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
-        <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <jrebel-x-maven-plugin.version>1.1.6</jrebel-x-maven-plugin.version>
         <dhis-antlr-expression-parser.version>1.0.18</dhis-antlr-expression-parser.version>
@@ -703,13 +702,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>${maven-enforcer-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>extra-enforcer-rules</artifactId>
-                        <version>${extra-enforcer-rules.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>


### PR DESCRIPTION
we only rely on the standard rules provided by the maven enforcer plugin
https://maven.apache.org/enforcer/enforcer-rules/index.html

so we do not need the extra-enforcer-rules plugin