### PR TITLE
fix: NPE when Dispatcher.getInstance() is not available [DHIS2-11990]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/DetectingSystemAuthoritiesProvider.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/DetectingSystemAuthoritiesProvider.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.security.authority;
 
+import static java.util.Collections.emptyList;
+
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -63,9 +65,14 @@ public class DetectingSystemAuthoritiesProvider
     @Override
     public Collection<String> getSystemAuthorities()
     {
-        HashSet<String> authorities = new HashSet<>();
+        Dispatcher instance = Dispatcher.getInstance();
+        if ( instance == null )
+        {
+            return emptyList();
+        }
 
-        Configuration configuration = Dispatcher.getInstance().getConfigurationManager().getConfiguration();
+        HashSet<String> authorities = new HashSet<>();
+        Configuration configuration = instance.getConfigurationManager().getConfiguration();
 
         for ( PackageConfig packageConfig : configuration.getPackageConfigs().values() )
         {


### PR DESCRIPTION
### Summary
The issue is that `/api/authorities` ends up with a 500 due to an NPE.
This isn't an error with the particular endpoint but in the composed `SystemAuthoritiesProvider`, more specifically the `DetectingSystemAuthoritiesProvider`. For some reason `Dispatcher.getInstance()` is `null` now.

The fix here is to add a null check and just don't add authorities if that is the case.
However, this might be the wrong fix entirely.
There might be reasons causing this to not be present when it should be I am not aware of.

### Automatic Testing
There already was a test but I guess since we use some _mock_ `SystemAuthoritiesProvider` during tests it could not catch this.

### Manual Testing
http://localhost:8080/api/authorities should work