### PR TITLE
fix: UnapproveData incorrectly allowed DHIS2-11981 (#9052) (#9060)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -325,6 +325,9 @@ public class HibernateDataApprovalStore
         // Get other information
         // ---------------------------------------------------------------------
 
+        boolean acceptanceRequiredForApproval = (Boolean) systemSettingManager
+            .getSystemSetting( SettingKey.ACCEPTANCE_REQUIRED_FOR_APPROVAL );
+
         final boolean isSuperUser = currentUserService.currentUserIsSuper();
 
         final String startDate = DateUtils.getMediumDateString( period.getStartDate() );
@@ -464,9 +467,6 @@ public class HibernateDataApprovalStore
 
         if ( approvalLevelBelowOrgUnit != null )
         {
-            boolean acceptanceRequiredForApproval = (Boolean) systemSettingManager
-                .getSystemSetting( SettingKey.ACCEPTANCE_REQUIRED_FOR_APPROVAL );
-
             readyBelowSubquery = "not exists ( " + // Ready if nothing expected
                                                    // below is
                                                    // unapproved(/unaccepted)
@@ -645,7 +645,8 @@ public class HibernateDataApprovalStore
                                                                                            // approved
             DataApprovalLevel actionLevel = (approvedLevel == null ? lowestApprovalLevelForOrgUnit : approvedLevel);
 
-            if ( approvedAbove && accepted && approvedAboveLevel == approvalLevelAboveUser )
+            if ( approvedAbove && accepted && acceptanceRequiredForApproval
+                && approvedAboveLevel == approvalLevelAboveUser )
             {
                 approvedAbove = false; // Hide higher-level approval from user.
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -72,7 +72,6 @@ import org.hisp.dhis.user.UserGroupAccessService;
 import org.hisp.dhis.user.UserGroupService;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -81,7 +80,6 @@ import com.google.common.collect.Sets;
 /**
  * @author Jim Grace
  */
-@Ignore
 public class DataApprovalServiceCategoryOptionGroupTest
     extends IntegrationTestBase
 {
@@ -304,10 +302,11 @@ public class DataApprovalServiceCategoryOptionGroupTest
 
         userGroupService.addUserGroup( userGroup );
 
-        users.forEach( user -> {
+        for ( User user : users )
+        {
             user.getGroups().add( userGroup );
             userService.updateUser( user );
-        } );
+        }
 
         return userGroup;
     }
@@ -327,8 +326,8 @@ public class DataApprovalServiceCategoryOptionGroupTest
     private void setPrivateAccess( BaseIdentifiableObject object, UserGroup... userGroups )
     {
         object.getSharing().setPublicAccess( ACCESS_NONE );
-        // object.getSharing().setOwner( userA ); // Needed for sharing to work
-        // object.setUser( userA );
+        object.getSharing().setOwner( userA ); // Needed for sharing to work
+        object.setUser( userA );
         object.getSharing().resetUserGroupAccesses();
         object.getSharing().resetUserAccesses();
         for ( UserGroup group : userGroups )


### PR DESCRIPTION
(cherry picked from commit 8441b921dff2f89c027028e258ca04c28ac48b7a)
(cherry picked from commit 7db3d1b27c9e3481b5e4e95ce7fdc371d0ec388a)

I'm not sure whether or not we will be backporting this fix to 2.37.0, so I submitted this PR and will let Lars decide. I've backported the fix to 2.37, 2.36, 2.35, and 2.34.