### PR TITLE
fix: explicitly declare direct dependencies in dhis-api

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>

--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -73,6 +73,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -178,6 +178,10 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.locationtech.jts.io</groupId>
       <artifactId>jts-io-common</artifactId>
     </dependency>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -137,7 +137,7 @@
         <fop.version>2.5</fop.version>
         <mapstruct.version>1.4.1.Final</mapstruct.version>
         <geotools.version>24.0</geotools.version>
-        <jts-io-common.version>1.16.0</jts-io-common.version>
+        <jts.version>1.16.0</jts.version>
 
         <!-- Apache Artemis -->
         <artemis.version>2.17.0</artemis.version>
@@ -2148,9 +2148,14 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.locationtech.jts</groupId>
+                <artifactId>jts-core</artifactId>
+                <version>${jts.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.locationtech.jts.io</groupId>
                 <artifactId>jts-io-common</artifactId>
-                <version>${jts-io-common.version}</version>
+                <version>${jts.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>


### PR DESCRIPTION
There are a few direct dependencies in dhis-api (most likely also in other modules) that are no explicitly declared. The build works since some direct dependencies depend on dependencies we actually need as well (transitive). It's best to be explicit about the dependencies. This ensures we are in charge of their versions and certain they will be there. Transitive dependencies can change (their versions and their existence).

You can run `mvn dependency:analyze` to see what we depend on and do not declare. Also what declare but do not depend on.

Note that after this change it will look like

```
⏵ dhis2-core git:(api-used-undeclared-dependencies) cd dhis-2/dhis-api
⏵ dhis-api git:(api-used-undeclared-dependencies) mvn dependency:analyze
[INFO] Scanning for projects...
[INFO] ...
[WARNING] Used undeclared dependencies found:
[WARNING]    com.google.code.findbugs:jsr305:jar:3.0.2:compile
[WARNING]    org.slf4j:slf4j-api:jar:1.7.32:compile
[WARNING]    commons-lang:commons-lang:jar:2.6:compile
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING]    jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
[WARNING]    javax.persistence:javax.persistence-api:jar:2.2:compile
[WARNING] Unused declared dependencies found:
[WARNING]    net.sf.jasperreports:jasperreports-fonts:jar:4.0.0:compile
[WARNING]    com.fasterxml.jackson.dataformat:jackson-dataformat-csv:jar:2.12.1:compile
[WARNING]    com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.12.1:compile
[WARNING]    com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:jar:2.11.2:compile
[WARNING]    com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.12.1:compile
[WARNING]    org.cache2k:cache2k-api:jar:1.6.0.Final:compile
[WARNING]    org.cache2k:cache2k-core:jar:1.6.0.Final:compile
[WARNING]    org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
[WARNING]    javax.validation:validation-api:jar:2.0.1.Final:compile
[WARNING]    com.fasterxml:classmate:jar:1.3.2:compile
[WARNING]    org.hibernate:hibernate-spatial:jar:5.4.28.Final:compile
[WARNING]    com.graphhopper.external:jackson-datatype-jts:jar:1.0-2.7:compile
[WARNING]    org.geotools:gt-opengis:jar:24.0:compile
[WARNING]    org.apache.logging.log4j:log4j-api:jar:2.14.1:compile
[WARNING]    org.apache.logging.log4j:log4j-core:jar:2.14.1:compile
[WARNING]    org.apache.logging.log4j:log4j-slf4j-impl:jar:2.14.1:compile
[WARNING]    org.mockito:mockito-core:jar:3.4.6:test
[WARNING]    com.cronutils:cron-utils:jar:9.1.3:compile
[WARNING]    org.jboss.aerogear:aerogear-otp-java:jar:1.0.0.CR1:compile
[WARNING]    org.locationtech.jts.io:jts-io-common:jar:1.16.0:compile
[WARNING]    javax.annotation:javax.annotation-api:jar:1.3.2:compile
[WARNING]    com.sun.xml.bind:jaxb-impl:jar:2.4.0-b180830.0438:compile
[WARNING]    jakarta.xml.ws:jakarta.xml.ws-api:jar:2.3.3:compile
[WARNING]    com.sun.xml.ws:jaxws-ri:pom:2.3.2:compile
```

Other undeclared dependencies are a bit more involved to tackle.

In a later PR I might replace usage of `commons-lang` with `commons-lang3` and exclude `commons-lang` from a direct dependency bringing it in. This ensures we have one less undeclared dependency and its easy to do the "right" thing for developers importing from `commons-lang3`.