### PR TITLE
chore: cache maven dependencies on github action api-tests

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: zulu
+          cache: maven
       - name: Build core image
         run: |
           bash ./dhis-2/build-dev.sh


### PR DESCRIPTION
The step 'Building core image' currently takes ~6-8 minutes. Its not
clear from the logs how much time is spent downloading dependencies
using maven. At least for me locally it easily takes 3 minutes. We
should at least help reduce this step using caching. If not build the
artifact in another job and feed it into this one. Since we are also
running similar maven commands in the test workflow (unit/integration
steps).

The v2 of actions/setup-java supports caching out of the box
https://github.com/actions/setup-java\#caching-maven-dependencies

since v1 used the zulu distribution https://github.com/actions/setup-java/blob/main/README.md\#v2-vs-v1
I stuck with it. Providing the distribution is now mandatory