### PR TITLE
chore: do not compile tests when building for dev

### DIFF
--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -35,11 +35,12 @@ print() {
 
 # Requires maven to be on the classpath
 # Skips clean and test phases
+# Also skips copying test resources and compiling tests
 
 print "Building dhis2-core..."
 
 
-MAVEN_BUILD_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25"
+MAVEN_BUILD_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.test.skip=true"
 
 mvn clean install -T1C -Pdev -Pjdk11 -f $DIR/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
 mvn clean install -T1C -Pdev -Pjdk11 -f $DIR/dhis-web/pom.xml $MAVEN_BUILD_OPTS


### PR DESCRIPTION
Using -DskipTests or setting it in the profile still leads to tests to
be compiled and test resources to be copied. Since we have ~820 tests
that does take some time.

See
https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html

Maven's reported total build time when using the build-dev.sh locally

| project | before | after | reduction [%] |
|--------------|-----------|------------|------------|
| jetty | 02:03 min | 01:37 min | 21%|
| web | 01:33 min | 01:14 min |20%|

(hope I got the percentages right 😂)

We are using the script to build the e2e test image in the api-tests GitHub workflow. I am not sure if the other build scripts could also benefit from this as at least the build.sh also has the skipTests set.
