### PR TITLE
chore: Move lambdas initializations into static blocks [TECH-774]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -270,14 +270,7 @@ public class JdbcEventStore implements EventStore
         "eventdatavalues" );            // 22
     // @formatter:on
 
-    private final static String INSERT_EVENT_SQL = "insert into programstageinstance (" +
-        String.join( ",", INSERT_COLUMNS ) + ") " +
-        "values ( nextval('programstageinstance_sequence'), " +
-        INSERT_COLUMNS.stream()
-            .skip( 1L )
-            .map( column -> "?" )
-            .collect( Collectors.joining( "," ) )
-        + ")";
+    private final static String INSERT_EVENT_SQL;
 
     private final static List<String> UPDATE_COLUMNS = ImmutableList.of(
     // @formatter:off
@@ -303,12 +296,7 @@ public class JdbcEventStore implements EventStore
         UID.getColumnName() );          // 20
     // @formatter:on
 
-    private final static String UPDATE_EVENT_SQL = "update programstageinstance set " +
-        UPDATE_COLUMNS.stream()
-            .map( column -> column + " = ?" )
-            .limit( UPDATE_COLUMNS.size() - 1 )
-            .collect( Collectors.joining( "," ) )
-        + " where uid = ?;";
+    private final static String UPDATE_EVENT_SQL;
 
     /**
      * Updates Tracked Entity Instance after an event update. In order to
@@ -320,6 +308,25 @@ public class JdbcEventStore implements EventStore
         + "update trackedentityinstance set lastupdated = %s, lastupdatedby = %s where uid in (%s)";
 
     private static final String NULL = "null";
+
+    static
+    {
+        INSERT_EVENT_SQL = "insert into programstageinstance (" +
+            String.join( ",", INSERT_COLUMNS ) + ") " +
+            "values ( nextval('programstageinstance_sequence'), " +
+            INSERT_COLUMNS.stream()
+                .skip( 1L )
+                .map( column -> "?" )
+                .collect( Collectors.joining( "," ) )
+            + ")";
+
+        UPDATE_EVENT_SQL = "update programstageinstance set " +
+            UPDATE_COLUMNS.stream()
+                .map( column -> column + " = ?" )
+                .limit( UPDATE_COLUMNS.size() - 1 )
+                .collect( Collectors.joining( "," ) )
+            + " where uid = ?;";
+    }
 
     // -------------------------------------------------------------------------
     // Dependencies

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/query/EventQuery.java
@@ -98,9 +98,14 @@ public class EventQuery
         }
     }
 
-    private static final Collection<QueryElement> QUERY_ELEMENTS = Arrays.stream( COLUMNS.values() )
-        .map( COLUMNS::getQueryElement )
-        .collect( collectingAndThen( toList(), ImmutableList::copyOf ) );
+    private static final Collection<QueryElement> QUERY_ELEMENTS;
+
+    static
+    {
+        QUERY_ELEMENTS = Arrays.stream( COLUMNS.values() )
+            .map( COLUMNS::getQueryElement )
+            .collect( collectingAndThen( toList(), ImmutableList::copyOf ) );
+    }
 
     public static String getQuery()
     {


### PR DESCRIPTION
In master (2.38), I realized that initializing constants with lambdas is causing problems in some JDK versions (including mine 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10).

After investigating this issue, it seems to be caused by a bug in some JDK versions, which makes the build of DHIS2 impossible for those JDKs.

https://bugs.openjdk.java.net/browse/JDK-8166672

This ticket will be used to initialize those constants in "static" blocks, so this bug can be avoided for users/clients using older JDK versions.

**_Feel free to suggest other solutions you don't like this one._**