### PR TITLE
fix: Gist API allow attribute UIDs without number characters [DHIS2-11867]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -90,7 +90,6 @@ final class GistLogic
     static boolean isAttributePath( String path )
     {
         return path.length() == 11
-            && !path.matches( "[-_a-zA-Z]+" )
             && CodeGenerator.isValidUid( path );
     }
 


### PR DESCRIPTION
Recently #9055 introduced possibility of using attribute UIDs as short handle to include attributes as fields or to filter on attribute values. The logic here wrongly assumed that all UIDs would at least contain a single number character (digit). This could have the consequence that the feature would not work for a specific UID if it did not have digits. There is also a chance that this scenario occurs in a unit tests has it did https://github.com/dhis2/dhis2-core/pull/9068/checks?check_run_id=3905253755#step:4:18522

The fix is simply to loosen the constraint and to remove this line as the method is only called in places where we furthermore check that the name in question indeed is not an existing property name for the schema in question.