### PR TITLE
fix: Id schema not respected for data elements if operands are absent [DHIS2-11769]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -105,14 +105,25 @@ public class SchemaIdResponseMapper
         }
 
         // This section overrides the general schema, so it can be fine-grained.
-        if ( params.isOutputFormat( DATA_VALUE_SET ) && !params.getDataElementOperands().isEmpty() )
+        if ( params.isOutputFormat( DATA_VALUE_SET ) )
         {
             // If "outputDataElementIdScheme" is set, we replace all data
             // elements values
             // respecting it's definition.
             if ( params.isOutputDataElementIdSchemeSet() )
             {
-                applyDataElementOperandsIdSchemaMapping( params, responseMap );
+                if ( !params.getDataElementOperands().isEmpty() )
+                {
+                    // Replace all data elements operands respecting it's
+                    // schema definition.
+                    applyDataElementOperandsIdSchemaMapping( params, responseMap );
+                }
+                else if ( !params.getDataElements().isEmpty() )
+                {
+                    // Replace all data elements respecting it's schema
+                    // definition.
+                    applyDataElementsIdSchemaMapping( params, responseMap );
+                }
             }
         }
 
@@ -136,6 +147,12 @@ public class SchemaIdResponseMapper
     private void applyDataElementOperandsIdSchemaMapping( final DataQueryParams params, final Map<String, String> map )
     {
         map.putAll( getDataElementOperandIdSchemeMap( asTypedList( params.getDataElementOperands() ),
+            params.getOutputDataElementIdScheme() ) );
+    }
+
+    private void applyDataElementsIdSchemaMapping( final DataQueryParams params, final Map<String, String> map )
+    {
+        map.putAll( getDimensionItemIdSchemeMap( asTypedList( params.getDataElements() ),
             params.getOutputDataElementIdScheme() ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapperTest.java
@@ -197,10 +197,10 @@ public class SchemaIdResponseMapperTest
     public void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToNameForDataValueSet()
     {
         // Given
-        final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
+        final List<DataElement> dataElementsStub = stubDataElements();
         final OrganisationUnit orUnitStub = stubOrgUnit();
         final Period periodStub = stubPeriod();
-        final DataQueryParams theDataQueryParams = stubQueryParams( dataElementOperandsStub, orUnitStub, periodStub,
+        final DataQueryParams theDataQueryParams = stubDataElementQueryParams( dataElementsStub, orUnitStub, periodStub,
             DATA_VALUE_SET );
         theDataQueryParams.setOutputDataElementIdScheme( NAME );
 
@@ -210,16 +210,13 @@ public class SchemaIdResponseMapperTest
         // Then
         final String orgUnitUid = orUnitStub.getUid();
         final String periodIsoDate = periodStub.getIsoDate();
-        final DataElement dataElementA = dataElementOperandsStub.get( 0 ).getDataElement();
-        final DataElement dataElementB = dataElementOperandsStub.get( 1 ).getDataElement();
-        final CategoryOptionCombo categoryOptionComboC = dataElementOperandsStub.get( 0 ).getCategoryOptionCombo();
+        final DataElement dataElementA = dataElementsStub.get( 0 );
+        final DataElement dataElementB = dataElementsStub.get( 1 );
 
         assertThat( responseMap.get( orgUnitUid ), is( equalTo( orUnitStub.getUid() ) ) );
         assertThat( responseMap.get( periodIsoDate ), is( equalTo( periodStub.getUid() ) ) );
         assertThat( responseMap.get( dataElementA.getUid() ), is( equalTo( dataElementA.getName() ) ) );
         assertThat( responseMap.get( dataElementB.getUid() ), is( equalTo( dataElementB.getName() ) ) );
-        assertThat( responseMap.get( categoryOptionComboC.getUid() ), is( equalTo( categoryOptionComboC.getName() ) ) );
-        assertThat( responseMap.get( categoryOptionComboC.getUid() ), is( equalTo( categoryOptionComboC.getName() ) ) );
     }
 
     @Test
@@ -545,6 +542,19 @@ public class SchemaIdResponseMapperTest
             .build();
     }
 
+    private DataQueryParams stubDataElementQueryParams( final List<DataElement> dataElements,
+        final OrganisationUnit organisationUnit, final Period period, final OutputFormat outputFormat )
+    {
+        return newBuilder()
+            .addDimension( new BaseDimensionalObject( DATA_X_DIM_ID, DATA_X, dataElements ) )
+            .addDimension(
+                new BaseDimensionalObject( ORGUNIT_DIM_ID, ORGANISATION_UNIT, newArrayList( organisationUnit ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD,
+                newArrayList( period ) ) )
+            .withOutputFormat( outputFormat )
+            .build();
+    }
+
     private Period stubPeriod()
     {
         final Period period = getPeriodFromIsoString( "202010" );
@@ -573,6 +583,19 @@ public class SchemaIdResponseMapperTest
         final DataElementOperand dataElementOperandB = new DataElementOperand( dataElementB, categoryOptionCombo );
 
         return newArrayList( dataElementOperandA, dataElementOperandB );
+    }
+
+    private List<DataElement> stubDataElements()
+    {
+        final DataElement dataElementA = new DataElement( "NameA" );
+        dataElementA.setUid( "uid1234567A" );
+        dataElementA.setCode( "CodeA" );
+
+        final DataElement dataElementB = new DataElement( "NameB" );
+        dataElementB.setUid( "uid1234567B" );
+        dataElementB.setCode( "CodeB" );
+
+        return newArrayList( dataElementA, dataElementB );
     }
 
     private OrganisationUnit stubOrgUnit()


### PR DESCRIPTION
This fix is needed to cover the output id schema for data elements within data set calls.
The data element schema was being ignored when there are no data element operands in the response.

**_This is a backport from the master branch (2.38)._**