### PR TITLE
chore: build api-test image using buildkit on GitHub

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -25,11 +25,21 @@ jobs:
         run: |
           bash ./dhis-2/build-dev.sh
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build test image
+        uses: docker/build-push-action@v2
+        with:
+          context: dhis-2/dhis-e2e-test
+          push: false
+          load: true # https://github.com/docker/build-push-action/blob/5e11b373bfed0d8024ef33d1586c675819690e95/docs/advanced/export-docker.md
+          tags: ${{ env.TEST_IMAGE_NAME }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Run tests
         run: |
           cd dhis-2/dhis-e2e-test
           IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up -d
-          docker build -t $TEST_IMAGE_NAME .
           IMAGE_NAME=$TEST_IMAGE_NAME docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
 
       - name: Upload logs


### PR DESCRIPTION
seperate it out into its own step so it can be built using
https://docs.docker.com/develop/develop-images/build_enhancements/

so we can take advantage of it building the image faster and enable
caching as well
https://github.com/docker/build-push-action/blob/5e11b373bfed0d8024ef33d1586c675819690e95/docs/advanced/cache.md#github-cache