### PR TITLE
chore: add regression test for DHIS2-11655

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
@@ -27,7 +27,13 @@
  */
 package org.hisp.dhis.tracker.importer;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +44,7 @@ import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.dto.TrackerApiResponse;
 import org.hisp.dhis.tracker.TrackerNtiApiTest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -131,5 +138,27 @@ public class TrackerExportTests
         } );
 
         return split;
+    }
+
+    @Test
+    public void shouldReturnSingleTeiGivenFilter()
+    {
+
+        trackerActions.get("trackedEntities?orgUnit=O6uvpzGd5pu&program=f1AyMswryyQ&filter=kZeSYCgaHTk:in:Bravo")
+                .validate()
+                .statusCode(200)
+                .body("instances.findAll { it.trackedEntity == 'Kj6vYde4LHh' }.size()", is(1))
+                .body("instances.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value", everyItem(is("Bravo")));
+    }
+
+    @Test
+    public void shouldReturnSingleTeiGivenFilterWhileSkippingPaging()
+    {
+
+        trackerActions.get("trackedEntities?skipPaging=true&orgUnit=O6uvpzGd5pu&program=f1AyMswryyQ&filter=kZeSYCgaHTk:in:Bravo")
+                .validate()
+                .statusCode(200)
+                .body("instances.findAll { it.trackedEntity == 'Kj6vYde4LHh' }.size()", is(1))
+                .body("instances.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value", everyItem(is("Bravo")));
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11655

is already fixed by https://github.com/dhis2/dhis2-core/pull/9022

However, there was no test preventing the bug/ensuring the above PRs refactoring/removal actually works.

This change adds a regression test for it.

This is how it looks like when for example `shouldReturnSingleTeiGivenFilterWhileSkippingPaging` fails because the same TEI is returned twice

```
java.lang.AssertionError: 1 expectation failed.
JSON path instances.findAll { it.trackedEntity == 'JQJFJJUXQNB' }.size() doesn't match.
Expected: is <1>
  Actual: 2
```

I provoked the failure with a sample payload recorded after replicating the issue.

This is how it looks like when for example `shouldReturnSingleTeiGivenFilterWhileSkippingPaging` fails because there is a TEI in the result that does not have the expected name (attribute == 'kZeSYCgaHTk') 'Bravo'. The request to DHIS2 was made with a filter expecting every TEI to have the name 'Bravo'.

```
java.lang.AssertionError: 1 expectation failed.
JSON path instances.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value doesn't match.
Expected: every item is is "Bravo"
  Actual: [Bravo, Test]
```