### PR TITLE
feat: adds filter groups to Gist API [DHIS2-12030]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -209,6 +209,16 @@ public final class GistQuery
         return isAbsoluteUrls() ? getContextRoot() : "";
     }
 
+    public boolean hasFilterGroups()
+    {
+        if ( filters.size() <= 1 )
+        {
+            return false;
+        }
+        int group0 = filters.get( 0 ).group;
+        return filters.stream().anyMatch( f -> f.group != group0 );
+    }
+
     public GistQuery with( NamedParams params )
     {
         int page = abs( params.getInt( "page", 1 ) );
@@ -531,6 +541,9 @@ public final class GistQuery
     public static final class Filter
     {
         @JsonProperty
+        private final int group;
+
+        @JsonProperty
         private final String propertyPath;
 
         @JsonProperty
@@ -544,7 +557,7 @@ public final class GistQuery
 
         public Filter( String propertyPath, Comparison operator, String... value )
         {
-            this( propertyPath, operator, value, false );
+            this( 0, propertyPath, operator, value, false );
         }
 
         public Filter withPropertyPath( String path )
@@ -559,25 +572,41 @@ public final class GistQuery
 
         public Filter asAttribute()
         {
-            return new Filter( propertyPath, operator, value, true );
+            return new Filter( group, propertyPath, operator, value, true );
+        }
+
+        public Filter inGroup( int group )
+        {
+            return group == this.group ? this : new Filter( group, propertyPath, operator, value, attribute );
         }
 
         public static Filter parse( String filter )
         {
             String[] parts = filter.split( "(?:::|:|~|@)" );
-            if ( parts.length == 2 )
+            int group = 0;
+            int nameIndex = 0;
+            int opIndex = 1;
+            int valueIndex = 2;
+            if ( parts[0].matches( "[0-9]" ) )
             {
-                return new Filter( parts[0], Comparison.parse( parts[1] ) );
+                nameIndex++;
+                opIndex++;
+                valueIndex++;
+                group = Integer.parseInt( parts[0] );
             }
-            if ( parts.length == 3 )
+            if ( parts.length == valueIndex )
             {
-                String value = parts[2];
+                return new Filter( parts[nameIndex], Comparison.parse( parts[opIndex] ) ).inGroup( group );
+            }
+            if ( parts.length == valueIndex + 1 )
+            {
+                String value = parts[valueIndex];
                 if ( value.startsWith( "[" ) && value.endsWith( "]" ) )
                 {
-                    return new Filter( parts[0], Comparison.parse( parts[1] ),
-                        value.substring( 1, value.length() - 1 ).split( "," ) );
+                    return new Filter( parts[nameIndex], Comparison.parse( parts[opIndex] ),
+                        value.substring( 1, value.length() - 1 ).split( "," ) ).inGroup( group );
                 }
-                return new Filter( parts[0], Comparison.parse( parts[1] ), value );
+                return new Filter( parts[nameIndex], Comparison.parse( parts[opIndex] ), value ).inGroup( group );
             }
             throw new IllegalArgumentException( "Not a valid filter expression: " + filter );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.gist;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.hisp.dhis.gist.GistQuery.Comparison;
+import org.hisp.dhis.gist.GistQuery.Filter;
+import org.junit.Test;
+
+/**
+ * Tests the {@link GistQuery} API methods to compose a {@link GistQuery}
+ * object.
+ *
+ * @author Jan Bernitt
+ */
+public class GistQueryTest
+{
+
+    @Test
+    public void testFilterParse()
+    {
+        assertFilterEquals( Filter.parse( "name:eq:2" ), 0, "name", Comparison.EQ, "2" );
+        assertFilterEquals( Filter.parse( "1:name:eq:2" ), 1, "name", Comparison.EQ, "2" );
+    }
+
+    private void assertFilterEquals( Filter actual, int group, String name, Comparison op, String... value )
+    {
+        assertEquals( group, actual.getGroup() );
+        assertEquals( name, actual.getPropertyPath() );
+        assertEquals( op, actual.getOperator() );
+        assertArrayEquals( value, actual.getValue() );
+    }
+}


### PR DESCRIPTION
### Summary
Adds filter grouping to Gist API.

Before this feature was added all filters where either combined with `and` (`rootJunction=AND`; default) or with `or` (`rootJunction=OR`). To allow to only combine certain selected filters with `or` while filters in general continue to be combined with `and` the more general feature of filter groups was added.

Filter groups allow to assign each filter to a group. The group is represented by a number 0-9 which can optionally be added before the property name of the filter. Valid filter patterns now are:

    <propert>:<op> 
    <propert>:<op>:<value>

    <group>:<propert>:<op>
    <group>:<propert>:<op>:<value>

Where `:` could also be `::`, `~` or `@`.
When the `<group>` is omitted this implicitly assigns the filter to group `0`.

### Compatibility

As the additional `<group>` is auto-detected and optional this addition is fully backwards compatible. 
It also does not require new parameters or additional syntax elements.

### Example
The feature is explained easiest with some exampls:

    ?filter=age:eq:50&filter=2:firstName:eq:foo&filter=2:surname:eq:foo
    ?filter=0:age:eq:50&filter=2:firstName:eq:foo&filter=2:surname:eq:foo

The above URL parameters are equivalent since group `0` is implicitly assumed when group is omitted. 
This translates to SQL equivalent to:

    e.age = 50 and (e.firstName = 'foo' or e.surname = 'foo')

When using the `rootJunction` to combine filter with `OR`

    ?filter=age:eq:50&filter=2:firstName:eq:foo&filter=2:surname:eq:foo&rootJunction=OR

The corresponding SQL now becomes:

    e.age = 50 or (e.firstName = 'foo' and e.surname = 'foo')

### Outlook
The main reason to add this feature is to have it as a foundation which allows to build search term filters as given in the example which is one of the missing feature of the Gist API that is contained in the normal metadata API as a special search feature.

### Automatic Testing
New controller tests were added, one for a scenario where a group uses `AND` and one scenario where a group uses `OR` combination.