### PR TITLE
fix: dimensions for data sets not modifiable [DHIS2-12031]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DimensionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DimensionControllerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonArray;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the
+ * {@link org.hisp.dhis.webapi.controller.dimension.DimensionController} using
+ * (mocked) REST requests.
+ *
+ * @author Jan Bernitt
+ */
+public class DimensionControllerTest extends DhisControllerConvenienceTest
+{
+    @Autowired
+    private CategoryService categoryService;
+
+    private String ccId;
+
+    @Before
+    public void setUp()
+    {
+        CategoryOption categoryOptionA = new CategoryOption( "Male" );
+        CategoryOption categoryOptionB = new CategoryOption( "Female" );
+
+        categoryService.addCategoryOption( categoryOptionA );
+        categoryService.addCategoryOption( categoryOptionB );
+
+        Category categoryA = new Category( "Gender", DataDimensionType.DISAGGREGATION );
+        categoryA.setShortName( categoryA.getName() );
+
+        categoryA.addCategoryOption( categoryOptionA );
+        categoryA.addCategoryOption( categoryOptionB );
+
+        categoryService.addCategory( categoryA );
+
+        CategoryCombo categoryComboA = new CategoryCombo( "Gender", DataDimensionType.DISAGGREGATION );
+
+        categoryComboA.addCategory( categoryA );
+
+        categoryService.addCategoryCombo( categoryComboA );
+        ccId = categoryComboA.getUid();
+    }
+
+    @Test
+    public void testGetDimensionsForDataSet()
+    {
+        String dsId = assertStatus( HttpStatus.CREATED,
+            POST( "/dataSets/",
+                "{'name':'My data set', 'periodType':'Monthly', 'categoryCombo':{'id':'" + ccId + "'}}" ) );
+
+        JsonObject response = GET( "/dimensions/dataSet/{ds}", dsId ).content();
+        JsonArray dimensions = response.getArray( "dimensions" );
+        assertEquals( 1, dimensions.size() );
+        JsonObject gender = dimensions.getObject( 0 );
+        assertEquals( "Gender", gender.getString( "name" ).string() );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller.dimension;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hisp.dhis.common.CodeGenerator.isValidUid;
@@ -38,7 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -245,15 +245,14 @@ public class DimensionController
         List<DimensionalObject> dimensions = new ArrayList<>();
         dimensions.addAll( dataSet.getCategoryCombo().getCategories().stream()
             .filter( ca -> !ca.isDefault() )
-            .collect( Collectors.toList() ) );
+            .collect( toList() ) );
         dimensions.addAll( dataSet.getCategoryOptionGroupSets() );
 
         dimensions = dimensionService.getCanReadObjects( dimensions );
 
-        for ( DimensionalObject dim : dimensions )
-        {
-            metadata.getDimensions().add( dimensionService.getDimensionalObjectCopy( dim.getUid(), true ) );
-        }
+        metadata.setDimensions( dimensions.stream()
+            .map( dim -> dimensionService.getDimensionalObjectCopy( dim.getUid(), true ) )
+            .collect( toList() ) );
 
         if ( links )
         {


### PR DESCRIPTION
### Summary
In #8345 we introduced a more generic way to internally represent the `Metadata`.
What was missed is that `WebMetadata` inherits from `Metadata` and that the `DimensionController#getDimensionsForDataSet` uses `matadata.getDimensions().add(...)`. This attempt to modify the returned "read-only" internal state of the metadata is no longer valid. Instead changed values always must use the setter to change the `Metadata` state. In this case use `setDimensions(...)` to replace the dimensions with a computed list.

### Automatic Testing
Added a spring controller test first that failed when trying to modify the metadata collection. Then fixed the code to do the operation using the setter and made some asserts to make sure we actually get the dimension that was created in test setup.