### PR TITLE
feat: Gist API extract bean properties from persistent fields [DHIS2-12038]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/annotation/Gist.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/annotation/Gist.java
@@ -157,7 +157,7 @@ public @interface Gist
 
         /**
          * Provides a non-persistent property based on one or more persisted
-         * ones. For example {@code name~from[firstName,surname]}.
+         * ones. For example {@code name~from(firstName,surname)}.
          */
         FROM;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/annotation/Gist.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/annotation/Gist.java
@@ -153,7 +153,13 @@ public @interface Gist
          * Without argument same as {@link #IDS}, argument can be used to
          * extract any other {@link String} field.
          */
-        PLUCK;
+        PLUCK,
+
+        /**
+         * Provides a non-persistent property based on one or more persisted
+         * ones. For example {@code name~from[firstName,surname]}.
+         */
+        FROM;
 
         public static Transform parse( String transform )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -41,6 +41,7 @@ import static org.hisp.dhis.gist.GistLogic.isStringLengthFilter;
 import static org.hisp.dhis.gist.GistLogic.parentPath;
 import static org.hisp.dhis.gist.GistLogic.pathOnSameParent;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +58,7 @@ import java.util.function.Function;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -97,6 +99,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @author Jan Bernitt
  */
+@Slf4j
 @RequiredArgsConstructor
 final class GistBuilder
 {
@@ -194,6 +197,22 @@ final class GistBuilder
         if ( isAccessProperty( p ) && !existsSameParentField( query, f, SHARING_PROPERTY ) )
         {
             return query.withField( pathOnSameParent( f.getPropertyPath(), SHARING_PROPERTY ) );
+        }
+
+        return addFromTransformationSupportFields( query, f );
+    }
+
+    private static GistQuery addFromTransformationSupportFields( GistQuery query, Field f )
+    {
+        if ( f.getTransformation() == Transform.FROM )
+        {
+            for ( String propertyName : f.getTransformationArgument().split( "," ) )
+            {
+                if ( !existsSameParentField( query, f, propertyName ) )
+                {
+                    query = query.withField( pathOnSameParent( f.getPropertyPath(), propertyName ) );
+                }
+            }
         }
         return query;
     }
@@ -407,6 +426,10 @@ final class GistBuilder
             addTransformer( row -> row[index] = access.asAccess( objType, (Sharing) row[sharingFieldIndex] ) );
             return HQL_NULL;
         }
+        if ( field.getTransformation() == Transform.FROM )
+        {
+            return createFromTransformedFieldHQL( index, field, path, property );
+        }
         if ( isPersistentReferenceField( property ) )
         {
             return createReferenceFieldHQL( index, field );
@@ -421,6 +444,36 @@ final class GistBuilder
         }
         String memberPath = getMemberPath( path );
         return "e." + memberPath;
+    }
+
+    private String createFromTransformedFieldHQL( int index, Field field, String path, Property property )
+    {
+        Object bean = newQueryElementInstance();
+        if ( bean == null )
+        {
+            return HQL_NULL;
+        }
+        String[] sources = field.getTransformationArgument().split( "," );
+        List<Method> setters = stream( sources ).map( context::resolveMandatory ).map( Property::getSetterMethod )
+            .collect( toList() );
+        int[] indexes = stream( sources ).mapToInt( srcProperty -> getSameParentFieldIndex( path, srcProperty ) )
+            .toArray();
+        Method getter = property.getGetterMethod();
+        addTransformer( row -> {
+            try
+            {
+                for ( int i = 0; i < indexes.length; i++ )
+                {
+                    setters.get( i ).invoke( bean, row[indexes[i]] );
+                }
+                row[index] = getter.invoke( bean );
+            }
+            catch ( Exception ex )
+            {
+                log.debug( "Failed to perform from transformation", ex );
+            }
+        } );
+        return HQL_NULL;
     }
 
     private String createReferenceFieldHQL( int index, Field field )
@@ -887,7 +940,9 @@ final class GistBuilder
     {
         for ( Field field : query.getFields() )
         {
-            if ( field.getTransformationArgument() != null && field.getTransformation() != Transform.PLUCK )
+            Transform transformation = field.getTransformation();
+            if ( field.getTransformationArgument() != null && transformation != Transform.PLUCK
+                && transformation != Transform.FROM )
             {
                 dest.accept( "p_" + field.getPropertyPath(), field.getTransformationArgument() );
             }
@@ -993,5 +1048,18 @@ final class GistBuilder
         return value != null && (value.contains( "*" ) || value.contains( "?" ))
             ? value.replace( "*", "%" ).replace( "?", "_" )
             : "%" + value + "%";
+    }
+
+    private Object newQueryElementInstance()
+    {
+        try
+        {
+            return context.getHome().getKlass().getConstructor().newInstance();
+        }
+        catch ( Exception ex )
+        {
+            log.warn( "Failed to construct from transformation transfer bean instance" );
+            return null;
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.RelativePropertyContext;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.annotation.Gist.Transform;
+import org.hisp.dhis.user.User;
 
 /**
  * The {@link GistPlanner} is responsible to expand the list of {@link Field}s
@@ -99,6 +100,7 @@ class GistPlanner
         fields = withPresetFields( fields ); // 1:n
         fields = withAttributeFields( fields ); // 1:1
         fields = withDisplayAsTranslatedFields( fields ); // 1:1
+        fields = withUserNameAsFromTransformedField( fields ); // 1:1
         fields = withInnerAsSeparateFields( fields ); // 1:n
         fields = withCollectionItemPropertyAsTransformation( fields ); // 1:1
         fields = withEffectiveTransformation( fields ); // 1:1
@@ -293,6 +295,16 @@ class GistPlanner
             f -> isDisplayShortName( f.getPropertyPath() ),
             f -> f.withAlias( f.getName() ).withTranslate()
                 .withPropertyPath( pathOnSameParent( f.getPropertyPath(), "shortName" ) ) );
+    }
+
+    private List<Field> withUserNameAsFromTransformedField( List<Field> fields )
+    {
+        return query.getElementType() != User.class
+            ? fields
+            : map1to1( fields,
+                f -> f.getPropertyPath().equals( "name" ),
+                f -> f.toBuilder().transformation( Transform.FROM ).transformationArgument( "firstName,surname" )
+                    .build() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.gist;
 
+import static java.util.Arrays.stream;
 import static org.hisp.dhis.gist.GistLogic.getBaseType;
 import static org.hisp.dhis.gist.GistLogic.isNonNestedPath;
 
@@ -141,6 +142,11 @@ final class GistValidator
 
     private void validateFromTransformation( RelativePropertyContext context, Property field, String transArgs )
     {
+        if ( stream( query.getElementType().getConstructors() ).noneMatch( c -> c.getParameterCount() == 0 ) )
+        {
+            throw createIllegalProperty( field,
+                "Property `%s` cannot use from transformation as bean has no default constructor." );
+        }
         if ( field.isPersisted() )
         {
             throw createIllegalProperty( field,
@@ -165,7 +171,6 @@ final class GistValidator
                     "Property `%s` must be persistent to be used as source for from transformation." );
             }
         }
-        // TODO make sure the bean has a no-args constructor
     }
 
     /**

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -240,4 +240,11 @@ public class GistFieldsControllerTest extends AbstractGistControllerTest
         assertEquals( 1, dataElements.size() );
         assertEquals( "extra-value", dataElements.getObject( 0 ).getString( "extra" ).string() );
     }
+
+    @Test
+    public void testField_UserNameAutomaticFromTransformation()
+    {
+        JsonArray users = GET( "/users/gist?fields=id,name&headless=true" ).content();
+        assertEquals( "admin admin", users.getObject( 0 ).getString( "name" ).string() );
+    }
 }


### PR DESCRIPTION
### Background
Reason for this new feature is the lack of non-persistent fields in the Gist API. 

This is especially problematic with popular fields such as the `User.getName()` which is build from the persistent fields `firstName` and `surname`. Until now such fields simply could not be extracted using the Gist API as we directly extract properties from the database as individual values. This has led to workarounds being uses such as composing the user name on client side from first name and surname. However, this de-facto duplicates the composition logic for the user name making it a somewhat unsatisfactory solution.

Thinking about a better solution to this particular problem gave me an idea for a more general feature for the Gist API that might be useful in more situation as just the user name.

### Solution
The solution is a general feature that allows to read non-persistent "bean" properties while explicitly stating as part of a transformation argument what persistent properties are needed in order for the non-persistent property to produce a proper value.

This means we add a new transformer `FROM` that takes one or more property names as parameter.
These persistent properties are fetched from database and set in a bean instance during result transformation. The actual value for the non-persistent field is then resolved by reading the getter from the bean that has been partly initialized.

This makes sure the result for the non-persistent property is based on the same code that would be used in the normal metadata API without paying the overhead of creating actual beans (except one instance).
The transformation process can be (and is) done using a single bean instance so the overhead is very small.

### Example
This is best explained using the user name property as an example.
To read with gist API we use `from` transformation.

    ?fields=id,name~from(firstName,surname)

As this is such a common thing to do in case of the user name I added a special handling to the planner stage
that will translate plain `name` for `User` lists to the equivalent of `name~from(firstName,surname)`. 
So in case of user name one actually can write

    ?fields=id,name

The difference to the normal metadata API is that this is a special field that by default is not included and needs to be requested explicitly in the `fields` list.

### Automatic Testing
Added a controller based unit test that tests the user name special case with indirectly tests most of the new feature.