### PR TITLE
fix: allow JSON response for XML metadata import [DHIS2-12026]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -159,4 +159,12 @@ public class MetadataImportExportControllerTest extends DhisControllerConvenienc
         assertEquals( HttpStatus.OK, response.status() );
         assertTrue( response.content( MediaType.APPLICATION_XML ).startsWith( "<importReport" ) );
     }
+
+    @Test
+    public void testPostXmlMetadata_JsonResponse()
+    {
+        assertWebMessage( "OK", 200, "OK", null,
+            POST( "/38/metadata", Body( "<metadata></metadata>" ),
+                ContentType( "application/xml" ), Accept( "application/json" ) ).content( HttpStatus.OK ) );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -189,7 +189,7 @@ public class MetadataImportExportController
         return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
-    @PostMapping( value = "", consumes = APPLICATION_XML_VALUE, produces = APPLICATION_XML_VALUE )
+    @PostMapping( value = "", consumes = APPLICATION_XML_VALUE )
     @ResponseBody
     public WebMessage postXmlMetadata( HttpServletRequest request )
         throws IOException


### PR DESCRIPTION
In #8460 I wrongly assumed that import would always use input-output pairs of same mime type, like JSON => JSON or XML => XML. This is not correct. One should be able to import an XML file and get the report in JSON.