### PR TITLE
chore: allow calling run-api.sh from root

### DIFF
--- a/dhis-2/run-api.sh
+++ b/dhis-2/run-api.sh
@@ -39,9 +39,20 @@ echo -e "Port: $DHIS2_PORT\n"
 read -p "Do you want to skip compile? (if yes press y/Y) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  java -Ddhis2.home=$DHIS2_HOME -Djetty.host=$DHIS2_HOSTNAME -Djetty.http.port=$DHIS2_PORT -jar ./dhis-web-embedded-jetty/target/dhis-web-embedded-jetty.jar
+  java \
+    -Ddhis2.home=$DHIS2_HOME \
+    -Djetty.host=$DHIS2_HOSTNAME \
+    -Djetty.http.port=$DHIS2_PORT \
+    -jar "$(dirname "$0")/dhis-web-embedded-jetty/target/dhis-web-embedded-jetty.jar"
   exit 0;
 fi
 
-mvn clean install -Pdev -Pjdk11 -T 100C -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.javadoc.skip=true
-java -Ddhis2.home=$DHIS2_HOME -Djetty.host=$DHIS2_HOSTNAME -Djetty.http.port=$DHIS2_PORT -jar ./dhis-web-embedded-jetty/target/dhis-web-embedded-jetty.jar
+mvn clean install \
+    -f "$(dirname "$0")/pom.xml" \
+    -Pdev -Pjdk11 -T 100C \
+    -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.javadoc.skip=true
+java \
+    -Ddhis2.home=$DHIS2_HOME \
+    -Djetty.host=$DHIS2_HOSTNAME \
+    -Djetty.http.port=$DHIS2_PORT \
+    -jar "$(dirname "$0")/dhis-web-embedded-jetty/target/dhis-web-embedded-jetty.jar"


### PR DESCRIPTION
I constantly forget that I have to switch to ./dhis-2 before running
run-api.sh

if I do I am reminded of it by maven ;)

[ERROR] The goal you specified requires a project to execute but there is no POM in this directory (/home/ivo/code/dhis2/dhis2-core). Please verify you invoked Maven from the correct directory.

Constract absolute paths so anyone can run the script from the root of
the repo or from within ./dhis-2