### PR TITLE
chore: metadata workflow - rename targetUid to targetId [DHIS2-4828]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
@@ -110,12 +110,12 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
     @Transactional
     public MetadataProposal propose( MetadataProposeParams params )
     {
-        validateConsistency( params.getType(), params.getTargetUid(), params.getChange() );
+        validateConsistency( params.getType(), params.getTargetId(), params.getChange() );
         MetadataProposal proposal = MetadataProposal.builder()
             .createdBy( currentUserService.getCurrentUser() )
             .type( params.getType() )
             .target( params.getTarget() )
-            .targetUid( params.getTargetUid() )
+            .targetId( params.getTargetId() )
             .comment( params.getComment() )
             .change( params.getChange() )
             .build();
@@ -130,14 +130,14 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
     {
         MetadataProposal proposal = getByUid( uid );
         checkHasStatus( proposal, MetadataProposalStatus.NEEDS_UPDATE );
-        if ( params != null && (params.getTargetUid() != null || params.getChange() != null) )
+        if ( params != null && (params.getTargetId() != null || params.getChange() != null) )
         {
             validateSameUser( proposal );
-            proposal.setTargetUid( params.getTargetUid() );
+            proposal.setTargetId( params.getTargetId() );
             proposal.setChange( params.getChange() );
             proposal.setAutoFields();
         }
-        validateConsistency( proposal.getType(), proposal.getTargetUid(), proposal.getChange() );
+        validateConsistency( proposal.getType(), proposal.getTargetId(), proposal.getChange() );
         proposal.setStatus( MetadataProposalStatus.PROPOSED );
         validationDryRun( proposal );
         store.update( proposal );
@@ -168,10 +168,10 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
     {
         MetadataProposalType type = proposal.getType();
         if ( type != MetadataProposalType.ADD
-            && objectManager.get( proposal.getTarget().getType(), proposal.getTargetUid() ) == null )
+            && objectManager.get( proposal.getTarget().getType(), proposal.getTargetId() ) == null )
         {
-            return createImportReportWithError( proposal, ErrorCode.E4015, "targetUid", "targetUid",
-                proposal.getTargetUid() );
+            return createImportReportWithError( proposal, ErrorCode.E4015, "targetId", "targetId",
+                proposal.getTargetId() );
         }
         switch ( type )
         {
@@ -238,7 +238,7 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
         try
         {
             patched = patchManager.apply( patch,
-                objectManager.get( objType, proposal.getTargetUid() ) );
+                objectManager.get( objType, proposal.getTargetId() ) );
         }
         catch ( JsonPatchException ex )
         {
@@ -251,7 +251,7 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
     private ImportReport acceptRemove( MetadataProposal proposal, ObjectBundleMode mode )
     {
         return importService.importMetadata(
-            createImportParams( mode, ImportStrategy.DELETE, objectManager.get( proposal.getTargetUid() ) ) );
+            createImportParams( mode, ImportStrategy.DELETE, objectManager.get( proposal.getTargetId() ) ) );
     }
 
     private MetadataImportParams createImportParams( ObjectBundleMode mode, ImportStrategy strategy,
@@ -315,11 +315,11 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
         return reason.toString();
     }
 
-    private void validateConsistency( MetadataProposalType type, String targetUid, JsonNode change )
+    private void validateConsistency( MetadataProposalType type, String targetId, JsonNode change )
     {
-        if ( type != MetadataProposalType.ADD && targetUid == null )
+        if ( type != MetadataProposalType.ADD && targetId == null )
         {
-            throw new IllegalStateException( "`targetUid` is required for type " + type );
+            throw new IllegalStateException( "`targetId` is required for type " + type );
         }
         if ( type != MetadataProposalType.REMOVE && (change == null || change.isNull()) )
         {

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/MetadataAdjustParams.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/MetadataAdjustParams.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class MetadataAdjustParams
 {
     @JsonProperty
-    private String targetUid;
+    private String targetId;
 
     @JsonProperty
     private JsonNode change;

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/MetadataProposal.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/MetadataProposal.java
@@ -84,7 +84,7 @@ public class MetadataProposal implements PrimaryKeyObject
     private MetadataProposalTarget target;
 
     @Immutable
-    private String targetUid;
+    private String targetId;
 
     @Immutable
     private User createdBy;
@@ -144,9 +144,9 @@ public class MetadataProposal implements PrimaryKeyObject
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getTargetUid()
+    public String getTargetId()
     {
-        return targetUid;
+        return targetId;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/MetadataProposeParams.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/MetadataProposeParams.java
@@ -48,7 +48,7 @@ public class MetadataProposeParams
     private final MetadataProposalTarget target;
 
     @JsonProperty
-    private String targetUid;
+    private String targetId;
 
     @JsonProperty
     private JsonNode change;

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/resources/org/hisp/dhis/metadata/hibernate/MetadataProposal.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/resources/org/hisp/dhis/metadata/hibernate/MetadataProposal.hbm.xml
@@ -37,7 +37,7 @@
             </type>
         </property>
 
-        <property name="targetUid" column="targetuid" length="11"
+        <property name="targetId" column="targetuid" length="11"
                   not-null="false"/>
 
         <many-to-one name="createdBy" class="org.hisp.dhis.user.User"

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/json/JsonMetadataProposal.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/json/JsonMetadataProposal.java
@@ -68,9 +68,9 @@ public interface JsonMetadataProposal extends JsonObject
         return getString( "target" ).parsed( MetadataProposalTarget::valueOf );
     }
 
-    default String getTargetUid()
+    default String getTargetId()
     {
-        return getString( "targetUid" ).string();
+        return getString( "targetId" ).string();
     }
 
     default JsonObject getChange()


### PR DESCRIPTION
Renames `targetUid` to `targetId` in the API as IDs in the API always should be understood as UIDs.