### PR TITLE
feat: New system key 'startModuleEnableLightweight' [DHIS2-11993]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -74,6 +74,7 @@ public enum SettingKey
     FLAG( "keyFlag", "dhis2", String.class ),
     FLAG_IMAGE( "keyFlagImage" ),
     START_MODULE( "startModule", "dhis-web-dashboard", String.class ),
+    START_MODULE_ENABLE_LIGHT_WEIGHT( "startModuleEnableLightweight", Boolean.FALSE, Boolean.class ),
     FACTOR_OF_DEVIATION( "factorDeviation", 2d, Double.class ),
     EMAIL_HOST_NAME( "keyEmailHostName" ),
     EMAIL_PORT( "keyEmailPort", 587, Integer.class ),


### PR DESCRIPTION
Adding a new boolean flag to support a new feature in the front-end. This will allow the front-end to enable or disable this flag using the existing `/systemSettings` endpoint.

For more details see the ticket: https://jira.dhis2.org/browse/DHIS2-11993
