### PR TITLE
refactor: JavaDoc typo in CategoryOptionCombo

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
@@ -310,7 +310,7 @@ public class CategoryOptionCombo
      * extensions to the category end dates for aggregate data entry in data
      * sets with openPeriodsAfterCoEndDate.
      *
-     * @return the latest option start date for this combo.
+     * @return the earliest option end date for this combo.
      */
     public Date getEarliestEndDate()
     {


### PR DESCRIPTION
Fix copy/paste typo in JavaDoc for `CategoryOptionCombo.getEarliestEndDate()`. Was copied from `getLatestStartDate()` but not changed.