### PR TITLE
chore: temporarily archive integration test surefire reports TECH-784

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,3 +41,10 @@ jobs:
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
         run: mvn clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
+
+      - name: Archive surefire reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/TEST-*.xml"
+          retention-days: 10


### PR DESCRIPTION
https://jira.dhis2.org/browse/TECH-784

To investigate how integration test runs that take 22min differ from the ones that run 15min
Surefire gives detailed reports in XML that can automatically be parsed and analyzed

I set the retention days to less than the default of 90 days to not eat
up to much of our quota. We can also remove this once the investigation
is over.

See a successful upload from this PR https://github.com/dhis2/dhis2-core/runs/4045959057?check_suite_focus=true#step:5:10 ~ 1.5MB (compressed); to download see here https://github.com/dhis2/dhis2-core/actions/runs/1398742386 8.5MB (shown as uncompressed)

For more details see https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts