### PR TITLE
fix: Event import catOption start/end DHIS2-12061

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoader.java
@@ -333,7 +333,8 @@ public class AttributeOptionComboLoader
     private CategoryOption loadCategoryOption( IdScheme idScheme, String id )
     {
         String key = "categoryoptionid";
-        final String sql = "select " + key + ", uid, code, name, sharing from dataelementcategoryoption "
+        final String sql = "select " + key
+            + ", uid, code, name, startdate, enddate, sharing from dataelementcategoryoption "
             + "where " + resolveId( idScheme, key, id );
 
         try
@@ -344,6 +345,8 @@ public class AttributeOptionComboLoader
                 categoryOption.setUid( rs.getString( "uid" ) );
                 categoryOption.setCode( rs.getString( "code" ) );
                 categoryOption.setName( rs.getString( "name" ) );
+                categoryOption.setStartDate( rs.getDate( "startdate" ) );
+                categoryOption.setEndDate( rs.getDate( "enddate" ) );
                 categoryOption.setSharing( getSharing( rs.getString( "sharing" ) ) );
                 return categoryOption;
             } );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
@@ -137,7 +137,7 @@ public class AttributeOptionComboLoaderTest
         categoryOption.setId( 100L );
 
         when( jdbcTemplate.queryForObject(
-            eq( "select categoryoptionid, uid, code, name, sharing from dataelementcategoryoption where uid = 'abcdef'" ),
+            eq( "select categoryoptionid, uid, code, name, startdate, enddate, sharing from dataelementcategoryoption where uid = 'abcdef'" ),
             any( RowMapper.class ) ) ).thenReturn( categoryOption );
 
         when( jdbcTemplate.query( anyString(), any( RowMapper.class ) ) )


### PR DESCRIPTION
See [DHIS2-12061](https://jira.dhis2.org/browse/DHIS2-12061).

Importing an event should fail if the event date is not within the bounds (if any) of a CategoryOption that is part of the Attribute Option Combo for the event. The check that should do this is [here in AttributeOptionComboDateCheck](https://github.com/dhis2/dhis2-core/blob/ea76fa86409613c9766d4508d65c88ac55c413c3/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/AttributeOptionComboDateCheck.java#L77).

However, the check was always failing because the start and end dates were not fetched by SQL for category options associated with an Attribute Option Combo for event import. This fix fetches these fields, so the check is successful as intended.

This fix passes the test described in [DHIS2-12061](https://jira.dhis2.org/browse/DHIS2-12061).