### PR TITLE
fix: super user cant read private dashboard

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -1039,7 +1039,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, UserInfo userInfo,
         CurrentUserGroupInfo groupInfo, String access )
     {
-        if ( !sharingEnabled( userInfo ) || userInfo == null || groupInfo == null )
+        if ( !sharingEnabled( userInfo ) || userInfo == null || groupInfo == null || userInfo.isSuper() )
         {
             return new ArrayList<>();
         }
@@ -1050,7 +1050,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     @Override
     public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user, String access )
     {
-        if ( !sharingEnabled( user ) || user == null )
+        if ( !sharingEnabled( user ) || user == null || user.isSuper() )
         {
             return new ArrayList<>();
         }
@@ -1066,7 +1066,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     {
         List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
 
-        if ( !dataSharingEnabled( userInfo ) || userInfo == null || groupInfo == null )
+        if ( !dataSharingEnabled( userInfo ) || userInfo == null || groupInfo == null || userInfo.isSuper() )
         {
             return predicates;
         }
@@ -1080,7 +1080,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     {
         List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
 
-        if ( !dataSharingEnabled( user ) || user == null )
+        if ( !dataSharingEnabled( user ) || user == null || user.isSuper() )
         {
             return predicates;
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -1039,7 +1039,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, UserInfo userInfo,
         CurrentUserGroupInfo groupInfo, String access )
     {
-        if ( !sharingEnabled( userInfo ) || userInfo == null || groupInfo == null || userInfo.isSuper() )
+        if ( !sharingEnabled( userInfo ) || userInfo == null || userInfo.isSuper() )
         {
             return new ArrayList<>();
         }
@@ -1066,7 +1066,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     {
         List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
 
-        if ( !dataSharingEnabled( userInfo ) || userInfo == null || groupInfo == null || userInfo.isSuper() )
+        if ( !dataSharingEnabled( userInfo ) || userInfo == null || userInfo.isSuper() )
         {
             return predicates;
         }
@@ -1120,8 +1120,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
      * @return Predicate
      */
     private List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, String userUid,
-        Set<String> userGroupUids,
-        String access )
+        Set<String> userGroupUids, String access )
     {
         List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.Event;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/EventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/EventCriteria.java
@@ -125,8 +125,8 @@ public class EventCriteria extends PagingAndSortingCriteriaAdapter
     public Set<String> getEvents()
     {
         return CollectionUtils.emptyIfNull( TextUtils.splitToArray( event, TextUtils.SEMICOLON ) )
-                .stream()
-                .filter( CodeGenerator::isValidUid )
-                .collect( Collectors.toSet() );
+            .stream()
+            .filter( CodeGenerator::isValidUid )
+            .collect( Collectors.toSet() );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12008

### Issue
- Currently when you call the method `getByUid()`  the query has sharing check but doesn't check if current user is SuperUser. Therefore, if an object has `publicAccess=--------` and is not shared to superUser, then `getByUid()` will return null.
- This will cause issue in some controllers where the code looks like this
```java
object = store.getByUid( uid );

if ( object == null ) 
{
   return notFound( "Object of type " + type + " with ID " + id + " was not found." );
}

User user = currentUserService.getCurrentUser();

if ( !aclService.canManage( user, object ) )
{
    throw new AccessDeniedException( "You do not have manage access to this object." );
}
...
store.update( object );
```
With the above code, a superUser should be able to update the object, but currently it can't. The code will throw "object not found" exception.

- Note that currently in `AbtractCrudController#getEntity()` we use `getNoAcl()`,  it might be reason this issue has not been reported until now.

### Fix
- Add code to bypass sharing check if `user.isSuper()` in hibernate store layer.
- I also remove the redundant null check for `userGroupInfo` as 
### Test
- Added unit test for both read and update function.