### PR TITLE
build: Enable dev pipeline maven artifact archiving

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -27,7 +27,7 @@ pipeline {
             steps {
                 echo 'Building DHIS2 ...'
                 script {
-                    withMaven(options: [artifactsPublisher(disabled: true)]) {
+                    withMaven {
                         sh 'mvn -X -T 4 clean install -f dhis-2/pom-full.xml -Pjdk8 --update-snapshots'
                     }
                 }


### PR DESCRIPTION
Related to #9149

Temporarily enable Maven artifacts archiving for dev pipeline, to allow for comparison between Jenkins and GitHub Actions surefire XML reports.