### PR TITLE
chore: use maven parallel builds for integration tests TECH-784

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run integration tests
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
+        run: mvn -T1C clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
 
       - name: Archive surefire reports
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
we are using it on https://github.com/dhis2/dhis2-core/blob/e4f16962bfcca2ec564c08787faa382c2d58d577/jenkinsfiles/dev\#L31
Jenkins where all tests (unit + integration) finish in ~10min

the specs of the machines are different
GitHub action runners
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners\#supported-runners-and-hardware-resources

for Linux have
2-core CPU, 7 GB of RAM memory, 14 GB of SSD disk space

as opposed to the EC2 instances - m6i.xlarge type - 4 vCPUs, 16GB RAM we run Jenkins on

Check the build logs to see a line like
`[INFO] Using the MultiThreadedBuilder implementation with a thread count of 2`
which tells us the actual number of threads used by maven