### PR TITLE
fix: superUser can't update sharing of private object

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -128,4 +128,18 @@ public class SharingControllerTest extends DhisControllerConvenienceTest
         assertEquals( 0, matches.getArray( "userGroups" ).size() );
         assertEquals( 0, matches.getArray( "users" ).size() );
     }
+
+    @Test
+    public void testSuperUserGetPrivateObject()
+    {
+        String dataSetId = assertStatus( HttpStatus.CREATED,
+            POST( "/dataSets", "{'name':'test','periodType':'Monthly','sharing':{'public':'--------'}}" ) );
+        GET( "/sharing?type=dataSet&id=" + dataSetId ).content( HttpStatus.OK );
+
+        switchToNewUser( "A", "test" );
+        GET( "/sharing?type=dataSet&id=" + dataSetId ).content( HttpStatus.FORBIDDEN );
+
+        switchToSuperuser();
+        GET( "/sharing?type=dataSet&id=" + dataSetId ).content( HttpStatus.OK );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -128,7 +128,7 @@ public class SharingController
         }
 
         Class<? extends IdentifiableObject> klass = aclService.classForType( type );
-        IdentifiableObject object = manager.get( klass, id );
+        IdentifiableObject object = manager.getNoAcl( klass, id );
 
         if ( object == null )
         {
@@ -242,7 +242,7 @@ public class SharingController
             return conflict( "Type " + type + " is not supported." );
         }
 
-        BaseIdentifiableObject object = (BaseIdentifiableObject) manager.get( sharingClass, id );
+        BaseIdentifiableObject object = (BaseIdentifiableObject) manager.getNoAcl( sharingClass, id );
 
         if ( object == null )
         {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -80,7 +80,7 @@ public class SharingControllerTest
 
         doReturn( OrganisationUnit.class ).when( aclService ).classForType( eq( "organisationUnit" ) );
         when( aclService.isClassShareable( eq( OrganisationUnit.class ) ) ).thenReturn( true );
-        doReturn( organisationUnit ).when( manager ).get( eq( OrganisationUnit.class ), eq( "kkSjhdhks" ) );
+        doReturn( organisationUnit ).when( manager ).getNoAcl( eq( OrganisationUnit.class ), eq( "kkSjhdhks" ) );
 
         sharingController.postSharing( "organisationUnit", "kkSjhdhks", request );
     }
@@ -94,7 +94,7 @@ public class SharingControllerTest
 
         doReturn( Category.class ).when( aclService ).classForType( eq( "category" ) );
         when( aclService.isClassShareable( eq( Category.class ) ) ).thenReturn( true );
-        when( manager.get( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
+        when( manager.getNoAcl( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
 
         sharingController.postSharing( "category", "kkSjhdhks", request );
     }
@@ -108,7 +108,7 @@ public class SharingControllerTest
 
         doReturn( Category.class ).when( aclService ).classForType( eq( "category" ) );
         when( aclService.isClassShareable( eq( Category.class ) ) ).thenReturn( true );
-        when( manager.get( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
+        when( manager.getNoAcl( eq( Category.class ), eq( "kkSjhdhks" ) ) ).thenReturn( category );
 
         WebMessage message = sharingController.postSharing( "category", "kkSjhdhks", request );
         assertThat( message.getMessage(),


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12008

### Issue
- SuperUser can't get or update a private dashboard in `SharingController`
- The cause is we try to get the object by calling  the method `getByUid`, which enforce sharing check for dashboard  in `HibernateIdentifiableObjectStore#forceAcl()` 

### Fix
- Get the object by calling `getNoAcl()` then do the sharing check using aclService

### Test
- Added unit test

