### PR TITLE
build: Enable surefire XML reports archiving on Jenkins

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -27,7 +27,7 @@ pipeline {
             steps {
                 echo 'Building DHIS2 ...'
                 script {
-                    withMaven {
+                    withMaven(options: [artifactsPublisher(disabled: true)]) {
                         sh 'mvn -X -T 4 clean install -f dhis-2/pom-full.xml -Pjdk8 --update-snapshots'
                     }
                 }
@@ -56,6 +56,10 @@ pipeline {
     }
 
     post {
+        success {
+            archiveArtifacts artifacts: '**/target/surefire-reports/TEST-*.xml'
+        }
+
         failure {
             script {
                 slack.sendFailureMessage()


### PR DESCRIPTION
Related to #9149 

The previous PR (#9161) was incorrect and the Surefire XML reports weren't archived.

This PR enables archiving only for Surefire XML reports, instead of all maven artifacts. ✅ 