### PR TITLE
chore: only run mvn test to run integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run integration tests
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
+        run: mvn clean test -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
 
       - name: Archive surefire reports
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
when analyzing #9162 I find that only half of the integration step duration is actually
spent running tests. However, most of the time is spent with the Surefire test plugin. Most likely setting up the DB, cache, the app. See https://github.com/dhis2/dhis2-core/runs/4081450916\?check_suite_focus\=true
The maven reactor summary shows the total time spent on the maven build.

We use mvn install which includes phases package, verify, install. These phases do not take up "a lot" of time but we are repeating ourselves. We do not have to `install` in every job. When running tests we should use the test phase. 