### PR TITLE
chore: get debug logs of integration test step

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run integration tests
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
+        run: mvn clean install -X -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
 
       - name: Archive surefire reports
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
I suspect half the duration of the integration test step is surefire forking the VM
setting the debug log will allow us to see this together with GitHub's timestamps