### PR TITLE
refactor: New predictor orgUnit ArrayList

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -357,8 +357,8 @@ public class DefaultPredictionService
 
         for ( OrganisationUnitLevel orgUnitLevel : predictor.getOrganisationUnitLevels() )
         {
-            List<OrganisationUnit> orgUnits = organisationUnitService.getOrganisationUnitsAtOrgUnitLevels(
-                Lists.newArrayList( orgUnitLevel ), currentUserOrgUnits );
+            List<OrganisationUnit> orgUnits = new ArrayList<>( organisationUnitService
+                .getOrganisationUnitsAtOrgUnitLevels( Lists.newArrayList( orgUnitLevel ), currentUserOrgUnits ) );
 
             orgUnits.sort( Comparator.comparing( OrganisationUnit::getPath ) );
 


### PR DESCRIPTION
On play/dev, predictor runs are now reliably failing for the (only) defined predictor Malaria Outbreak Threshold. The error message is:

_getDataValues ready for /ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/DiszpKrYNg8 but called with {..."Karina MCHP"...}_


This error is from an unexpected internal condition here: https://github.com/dhis2/dhis2-core/blob/d01e204421b447a35f62868af417e32a1f1b1f13/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java#L251-L252 What's going on is this: `DefaultPredictionService` fetches a list of orgUnits to predict for and sorts them in path order. It initializes `PredictionDataValueFetcher` to fetch any aggregate data values needed for predictions from the same list of orgUnits, to be fetched in orgUnit path order. It then calls `fetcherInstance.getDataValues()` for each of the orgUnits, in path order. It's fine if it calls for an orgUnit with a later path than data is found for, because not every orgUnit may have data. But it should not call for an orgUnit with a path that is earlier than the path of the next orgUnit for which data was found, because it should have made that call earlier. This is an internal error, which generates the exception.

The orgUnits in the reported error message are:

```
Data is ready for (producerOrgUnitPath):
/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/DiszpKrYNg8  Sierra Leone - Bo - Badjia - Ngelehun CHC

But is being requested for (consumerOrgUnitPath, later in path order):
/ImspTQPwCqd/fdc6uOvgoji/fwH9ipvXde9/ObV5AR1NECl  Sierra Leone - Bombali - Biriwa - Karina MCHP
```

The way the code should work (and the way it works on my machine) is that Ngelehun CHC should be requested before Karina MCHP, because it is earlier in path order. Once Ngelehun CHC data has been delivered, `PredictionDataValueFetcher` will move on to the next orgUnit in path order (if any). For some reason the later orgUnit in path order is being requested while `PredictionDataValueFetcher` still has data ready for an earlier orgUnit.

I've been unable to reproduce this error on my machine, therefore I've been unable to debug it, even with loading the latest source code from Github and the latest SL Demo database from dhis2.org. Stepping through the debugger, the list of orgUnits in `DefaultPredictionService` is in path-sorted order, and `fetcherInstance.getDataValues()` is called with the correct sequence of orgUnits. Test even succeed for a user who has a subset of the orgUnit tree, like the SL Demo user 'donor'.

I've found nothing so far reading the source code that looks like the problem. The only questionable code I've found is that `DefaultPredictionService` fetches the list of orgUnits from Hibernate, and then sorts that list. In stepping through the code on my machine, this is clearly a new `ArrayList` that Hibernate allocates, but it might not be safest to sort the list that Hibernate returns.

This refactor is to put the returned list of orgUnits from Hibernate into a new `ArrayList<OrganisationUnit>` before sorting it. This is likely safer code. With luck, it might also solve the problem.