### PR TITLE
chore: quiet down integration test logs TECH-784

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2.xml
@@ -4,6 +4,16 @@
 
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout  pattern="* %-5p %d{ABSOLUTE} %m (%F [%t])%n" />
+            <Filters>
+                <!-- Only log warn, error, fatal during testing-->
+                <!-- Log4JLogConfigInitializer creates loggers with level INFO for org.hisp.dhis.dxf2, org.hisp.dhis.analytics.table, ...-->
+                <!-- There can only be one logger per name, declaring it here competes with the former, one of which will win.-->
+                <!-- I chose a filter as I did not know if someone is still interested in the log files created by Log4JLogConfigInitializer -->
+                <!-- INFO logs create noise in the build, hide warnings/errors and have a performance cost attached to them-->
+                <!-- Surefire by default forks a JVM for every module this sub-process communicates back to the main maven process-->
+                <!-- via pipes which can be a bottleneck -->
+                <ThresholdFilter level="warn" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
         </Console>
     </Appenders>
     <Loggers>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/simplelogger.properties
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/simplelogger.properties
@@ -1,0 +1,22 @@
+#THIS FILE IS NEEDED UNTIL WE FIX FOLLOWING WARNING
+#
+#SLF4J: Class path contains multiple SLF4J bindings.
+#SLF4J: Found binding in [jar:file:/home/ivo/.m2/repository/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+#SLF4J: Found binding in [jar:file:/home/ivo/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.14.1/log4j-slf4j-impl-2.14.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+#SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+#SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]
+#
+#This shows that we are actually using slf4j simplelogger in these
+#modules instead of log4j2. This means  our log4j2 configuration has no
+#effect, not in tests, not in production.
+#
+#We should quiet down the build until we fix the root cause. By default
+#SimpleLogger's level is INFO. The adds noise we have to ignore when
+#looking for warnings/errors. It most likely also adds to the test
+#duration as it puts pressure on Surefire's forks/inter-process
+#communication which uses unix pipes.
+#
+org.slf4j.simpleLogger.defaultLogLevel=warn
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+org.slf4j.simpleLogger.showThreadName=false


### PR DESCRIPTION
all modules running integraiton tests emit following warnings

SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/ivo/.m2/repository/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/ivo/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.14.1/log4j-slf4j-impl-2.14.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]

This shows that we are actually using slf4j simplelogger in these
modules instead of log4j2. This means our log4j2 configuration has no
effect, not in tests, not in production.

We should quiet down the build until we fix the root cause. By default
SimpleLogger's level is INFO. The adds noise we have to ignore when
looking for warnings/errors. It most likely also adds to the test
duration as it puts pressure on Surefire's forks/inter-process
communication which uses unix pipes.