### PR TITLE
fix: Change default value for import csv events with header [DHIS2-10837]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/events/EventsTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/events/EventsTests.java
@@ -113,7 +113,7 @@ public class EventsTests
 
         ApiResponse response = trackerActions
             .post( "", contentType, obj, new QueryParamsBuilder()
-                .addAll( "dryRun=false", "eventIdScheme=UID", "orgUnitIdScheme=UID", "skipFirst=true" ) );
+                .addAll( "dryRun=false", "eventIdScheme=UID", "orgUnitIdScheme=UID" ) );
         response
             .validate()
             .statusCode( 200 );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -179,7 +179,7 @@ public class TrackerImportController
         "text/csv" }, produces = APPLICATION_JSON_VALUE, params = { "async=false" } )
     public ResponseEntity<TrackerImportReport> syncPostCsvTracker(
         HttpServletRequest request,
-        @RequestParam( required = false, defaultValue = "false" ) boolean skipFirst,
+        @RequestParam( required = false, defaultValue = "true" ) boolean skipFirst,
         @RequestParam( defaultValue = "errors", required = false ) String reportMode, User currentUser )
         throws IOException,
         ParseException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -146,7 +146,7 @@ public class TrackerImportController
     @ResponseBody
     public WebMessage asyncPostCsvTracker( HttpServletRequest request,
         User currentUser,
-        @RequestParam( required = false, defaultValue = "false" ) boolean skipFirst )
+        @RequestParam( required = false, defaultValue = "true" ) boolean skipFirst )
         throws IOException,
         ParseException
     {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -145,7 +145,7 @@ public class TrackerImportControllerTest
             .andExpect( jsonPath( "$.message" ).value( TRACKER_JOB_ADDED ) )
             .andExpect( content().contentType( "application/json" ) );
 
-        verify( csvEventService ).readEvents( any(), eq( false ) );
+        verify( csvEventService ).readEvents( any(), eq( true ) );
         verify( importStrategy ).importReport( any() );
     }
 


### PR DESCRIPTION
Change the default value for import csv events to be `skipFirst=true` to be compatible with the default value in the export endpoint