### PR TITLE
fix: Newly created Continuous Analytics Job fails [2.37.0-DHIS2-12094]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
@@ -95,9 +95,17 @@ public class ContinuousAnalyticsTableJob implements Job
             DEFAULT_HOUR_OF_DAY );
 
         Date now = new Date();
+
         Date defaultNextFullUpdate = DateUtils.getNextDate( fullUpdateHourOfDay, now );
-        Date nextFullUpdate = (Date) systemSettingManager.getSystemSetting( SettingKey.NEXT_ANALYTICS_TABLE_UPDATE,
-            defaultNextFullUpdate );
+
+        Date nextFullUpdate = (Date) systemSettingManager.getSystemSetting( SettingKey.NEXT_ANALYTICS_TABLE_UPDATE );
+
+        if ( nextFullUpdate == null )
+        {
+            nextFullUpdate = defaultNextFullUpdate;
+        }
+
+        Preconditions.checkNotNull( nextFullUpdate );
 
         log.info(
             "Starting continuous analytics table update, current time: '{}', default next full update: '{}', next full update: '{}'",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.Event;


### PR DESCRIPTION
the local cache return rarely null instead of default value (using lambda for returning the default value). It causes following exception:

```
INFO 2021-11-03T12:46:28,761 Starting continuous analytics table update, current time: '2021-11-03T12:46:28', default next full update: '2021-11-04T00:00:00', next full update: 'null' (ContinuousAnalyticsTableJob.java [taskScheduler-10])
ERROR 2021-11-03T12:46:28,761 Job failed: 'continuous analytics' (AbstractSchedulingManager.java [taskScheduler-10])
java.lang.NullPointerException: null
at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:878) ~[guava-30.1-jre.jar:?]
at org.hisp.dhis.analytics.table.scheduling.ContinuousAnalyticsTableJob.execute(ContinuousAnalyticsTableJob.java:106) ~[dhis-service-analytics-2.37-SNAPSHOT.jar:?]
at org.hisp.dhis.scheduling.AbstractSchedulingManager.execute(AbstractSchedulingManager.java:127) ~[dhis-service-core-2.37-SNAPSHOT.jar:?]
at org.hisp.dhis.scheduling.AbstractSchedulingManager.execute(AbstractSchedulingManager.java:93) ~[dhis-service-core-2.37-SNAPSHOT.jar:?]
at org.hisp.dhis.scheduling.DefaultSchedulingManager.lambda$scheduleTask$3(DefaultSchedulingManager.java:126) ~[dhis-service-core-2.37-SNAPSHOT.jar:?]
at org.hisp.dhis.scheduling.DefaultSchedulingManager.lambda$runIfPossible$5(DefaultSchedulingManager.java:209) ~[dhis-service-core-2.37-SNAPSHOT.jar:?]
at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) [spring-context-5.3.6.jar:5.3.6]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_292]
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_292]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_292]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_292]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_292]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_292]
at java.lang.Thread.run(Thread.java:748) [?:1.8.0_292]
ERROR 2021-11-03T12:46:28,761 java.lang.NullPointerException
at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:878)
at org.hisp.dhis.analytics.table.scheduling.ContinuousAnalyticsTableJob.execute(ContinuousAnalyticsTableJob.java:106)
at org.hisp.dhis.scheduling.AbstractSchedulingManager.execute(AbstractSchedulingManager.java:127)
at org.hisp.dhis.scheduling.AbstractSchedulingManager.execute(AbstractSchedulingManager.java:93)
at org.hisp.dhis.scheduling.DefaultSchedulingManager.lambda$scheduleTask$3(DefaultSchedulingManager.java:126)
at org.hisp.dhis.scheduling.DefaultSchedulingManager.lambda$runIfPossible$5(DefaultSchedulingManager.java:209)
at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
(AbstractSchedulingManager.java [taskScheduler-10])
```

The fix is based on simplification of cache handling just to be sure the default value is applied whenever there is no cached value.