### PR TITLE
feat: collection TEI endpoint now performs ACL on TEAs [DHIS2-12088]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -188,7 +188,7 @@ public interface TrackedEntityAttributeService
      *
      * @return a Set of {@link TrackedEntityAttribute}
      */
-    Set<TrackedEntityAttribute> getTrackedEntityAttributesByTrackedEntityTypes();
+    Map<String, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByTrackedEntityTypes();
 
     /**
      * Get all {@link TrackedEntityAttribute} grouped by {@link Program}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -186,7 +186,7 @@ public interface TrackedEntityAttributeService
      * Get all {@link TrackedEntityAttribute} linked to all
      * {@link TrackedEntityType} present in the system
      *
-     * @return a Set of {@link TrackedEntityAttribute}
+     * @return a Map of {@link TrackedEntityAttribute} where keys are TrackedEntityType uids
      */
     Map<String, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByTrackedEntityTypes();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -186,7 +186,8 @@ public interface TrackedEntityAttributeService
      * Get all {@link TrackedEntityAttribute} linked to all
      * {@link TrackedEntityType} present in the system
      *
-     * @return a Map of {@link TrackedEntityAttribute} where keys are TrackedEntityType uids
+     * @return a Map of {@link TrackedEntityAttribute} where keys are
+     *         TrackedEntityType uids
      */
     Map<String, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByTrackedEntityTypes();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStore.java
@@ -74,7 +74,7 @@ public interface TrackedEntityAttributeStore
      * Fetches all {@link TrackedEntityAttribute} linked to all
      * {@link TrackedEntityType} present in the system
      *
-     * @return a Set of {@link TrackedEntityAttribute}
+     * @return a Map of {@link TrackedEntityAttribute}
      */
     Map<String, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByTrackedEntityTypes();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStore.java
@@ -76,7 +76,7 @@ public interface TrackedEntityAttributeStore
      *
      * @return a Set of {@link TrackedEntityAttribute}
      */
-    Set<TrackedEntityAttribute> getTrackedEntityAttributesByTrackedEntityTypes();
+    Map<String, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByTrackedEntityTypes();
 
     /**
      * Fetches all {@link TrackedEntityAttribute} and groups them by

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -367,7 +367,7 @@ public class DefaultTrackedEntityAttributeService
 
     @Override
     @Transactional( readOnly = true )
-    public Set<TrackedEntityAttribute> getTrackedEntityAttributesByTrackedEntityTypes()
+    public Map<String, Set<TrackedEntityAttribute>> getTrackedEntityAttributesByTrackedEntityTypes()
     {
         return this.trackedEntityAttributeStore.getTrackedEntityAttributesByTrackedEntityTypes();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
@@ -245,7 +245,10 @@ public class TrackedEntityAttributeStoreTest
     {
 
         Set<TrackedEntityAttribute> trackedEntityAttributes = attributeService
-            .getTrackedEntityAttributesByTrackedEntityTypes();
+            .getTrackedEntityAttributesByTrackedEntityTypes()
+            .values().stream()
+            .flatMap( Set::stream )
+            .collect( Collectors.toSet() );
 
         assertThat( trackedEntityAttributes, hasSize( 20 ) );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/AggregateContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/AggregateContext.java
@@ -73,6 +73,12 @@ public class AggregateContext
     List<Long> relationshipTypes;
 
     /**
+     * A List of TrackedEntityAttribute ID to which the user has READ ONLY
+     * access
+     */
+    List<Long> trackedEntityAttributes;
+
+    /**
      * The tei params to specify depth of tei graph
      */
     TrackedEntityInstanceParams params;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -263,12 +263,9 @@ public class TrackedEntityInstanceAggregate
         Set<TrackedEntityAttribute> trackedEntityTypeAttributes, Map<Program, Set<TrackedEntityAttribute>> teaByProgram,
         AggregateContext ctx )
     {
-        List<Attribute> attributeList = new ArrayList<>();
-
-        // Nothing to filter from, return empty
         if ( attributes.isEmpty() )
         {
-            return attributeList;
+            return Collections.emptyList();
         }
 
         Stream<TrackedEntityAttribute> trackedEntityTypeAttributesStream = Optional
@@ -288,15 +285,9 @@ public class TrackedEntityInstanceAggregate
             .map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
-        for ( Attribute attributeValue : attributes )
-        {
-            if ( allowedAttributeUids.contains( attributeValue.getAttribute() ) )
-            {
-                attributeList.add( attributeValue );
-            }
-        }
-
-        return attributeList;
+        return attributes.stream()
+                .filter(attribute -> allowedAttributeUids.contains(attribute.getAttribute()))
+                .collect(Collectors.toList());
     }
 
     private boolean isNotSyncQueryOrIsNotSkipSync( AggregateContext ctx, TrackedEntityAttribute att )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -307,7 +307,7 @@ public class TrackedEntityInstanceAggregate
     private boolean isAccessible( TrackedEntityAttribute trackedEntityAttribute,
         AggregateContext ctx )
     {
-        return ctx.getTrackedEntityAttributes().contains( trackedEntityAttribute.getId() );
+        return ctx.isSuperUser() || ctx.getTrackedEntityAttributes().contains( trackedEntityAttribute.getId() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -279,7 +279,7 @@ public class TrackedEntityInstanceAggregate
         Stream<TrackedEntityAttribute> programAttributesStream = Optional.ofNullable( teaByProgram )
             .orElse( Collections.emptyMap() )
             .entrySet().stream()
-            .filter( entry -> ownedPrograms.contains( entry.getKey().getUid() ) )
+            .filter( entry -> ctx.isSuperUser() || ownedPrograms.contains( entry.getKey().getUid() ) )
             .flatMap( entry -> entry.getValue().stream() );
 
         Set<String> allowedAttributeUids = Stream.concat( trackedEntityTypeAttributesStream, programAttributesStream )
@@ -307,7 +307,7 @@ public class TrackedEntityInstanceAggregate
     private boolean isAccessible( TrackedEntityAttribute trackedEntityAttribute,
         AggregateContext ctx )
     {
-        return ctx.isSuperUser() || ctx.getTrackedEntityAttributes().contains( trackedEntityAttribute.getId() );
+        return ctx.getTrackedEntityAttributes().contains( trackedEntityAttribute.getId() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -286,8 +286,8 @@ public class TrackedEntityInstanceAggregate
             .collect( Collectors.toSet() );
 
         return attributes.stream()
-                .filter(attribute -> allowedAttributeUids.contains(attribute.getAttribute()))
-                .collect(Collectors.toList());
+            .filter( attribute -> allowedAttributeUids.contains( attribute.getAttribute() ) )
+            .collect( Collectors.toList() );
     }
 
     private boolean isNotSyncQueryOrIsNotSkipSync( AggregateContext ctx, TrackedEntityAttribute att )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -284,7 +284,7 @@ public class TrackedEntityInstanceAggregate
 
         Set<String> allowedAttributeUids = Stream.concat( trackedEntityTypeAttributesStream, programAttributesStream )
             .filter( att -> isAccessible( att, ctx ) )
-            .filter( att -> isNotSynchQueryAndIsNotSkipSynch( ctx, att ) )
+            .filter( att -> isNotSyncQueryOrIsNotSkipSync( ctx, att ) )
             .map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
@@ -299,7 +299,7 @@ public class TrackedEntityInstanceAggregate
         return attributeList;
     }
 
-    private boolean isNotSynchQueryAndIsNotSkipSynch( AggregateContext ctx, TrackedEntityAttribute att )
+    private boolean isNotSyncQueryOrIsNotSkipSync(AggregateContext ctx, TrackedEntityAttribute att )
     {
         return !ctx.getParams().isDataSynchronizationQuery() || !att.getSkipSynchronization();
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -299,7 +299,7 @@ public class TrackedEntityInstanceAggregate
         return attributeList;
     }
 
-    private boolean isNotSyncQueryOrIsNotSkipSync(AggregateContext ctx, TrackedEntityAttribute att )
+    private boolean isNotSyncQueryOrIsNotSkipSync( AggregateContext ctx, TrackedEntityAttribute att )
     {
         return !ctx.getParams().isDataSynchronizationQuery() || !att.getSkipSynchronization();
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -33,8 +33,10 @@ import static org.hisp.dhis.dxf2.events.aggregates.ThreadPoolManager.getPool;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -269,9 +271,14 @@ public class TrackedEntityInstanceAggregate
             return attributeList;
         }
 
-        Stream<TrackedEntityAttribute> trackedEntityTypeAttributesStream = trackedEntityTypeAttributes.stream();
+        Stream<TrackedEntityAttribute> trackedEntityTypeAttributesStream = Optional
+            .ofNullable( trackedEntityTypeAttributes )
+            .map( Collection::stream )
+            .orElse( Stream.empty() );
 
-        Stream<TrackedEntityAttribute> programAttributesStream = teaByProgram.entrySet().stream()
+        Stream<TrackedEntityAttribute> programAttributesStream = Optional.ofNullable( teaByProgram )
+            .orElse( Collections.emptyMap() )
+            .entrySet().stream()
             .filter( entry -> ownedPrograms.contains( entry.getKey().getUid() ) )
             .flatMap( entry -> entry.getValue().stream() );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AclStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AclStore.java
@@ -41,4 +41,6 @@ public interface AclStore
     List<Long> getAccessibleProgramStages( String userUID, List<String> userGroupUIDs );
 
     List<Long> getAccessibleRelationshipTypes( String userUID, List<String> userGroupUIDs );
+
+    List<Long> getAccessibleTrackedEntityAttributes( String userUID, List<String> userGroupUIDs );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/DefaultAclStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/DefaultAclStore.java
@@ -74,6 +74,10 @@ public class DefaultAclStore
         + "FROM relationshiptype rs"
         + " WHERE " + PUBLIC_ACCESS_CONDITION + " OR " + USERACCESS_CONDITION;
 
+    private final static String GET_TRACKED_ENTITY_ATTRIBUTE_ACL = "SELECT tea.trackedentityattributeid "
+        + "FROM trackedentityattribute tea"
+        + " WHERE " + PUBLIC_ACCESS_CONDITION + " OR " + USERACCESS_CONDITION;
+
     public DefaultAclStore( @Qualifier( "readOnlyJdbcTemplate" ) JdbcTemplate jdbcTemplate )
     {
         this.jdbcTemplate = new NamedParameterJdbcTemplate( jdbcTemplate );
@@ -101,6 +105,12 @@ public class DefaultAclStore
     public List<Long> getAccessibleRelationshipTypes( String userUID, List<String> userGroupUIDs )
     {
         return executeAclQuery( userUID, userGroupUIDs, GET_RELATIONSHIPTYPE_ACL, "relationshiptypeid" );
+    }
+
+    @Override
+    public List<Long> getAccessibleTrackedEntityAttributes( String userUID, List<String> userGroupUIDs )
+    {
+        return executeAclQuery( userUID, userGroupUIDs, GET_TRACKED_ENTITY_ATTRIBUTE_ACL, "trackedentityattributeid" );
     }
 
     private List<Long> executeAclQuery( String userUID, List<String> userGroupUIDs, String sql, String primaryKey )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/TrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/TrackedEntityInstanceStore.java
@@ -86,5 +86,5 @@ public interface TrackedEntityInstanceStore
      * @return Tei uids mapped to a list of program uids to which user has
      *         ownership
      */
-    Multimap<String, String> getOwnedTeis( List<Long> ids, AggregateContext ctx );
+    Multimap<String, String> getOwnedProgramsByTei( List<Long> ids, AggregateContext ctx );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAttributesAggregateTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.events.aggregates;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.security.acl.AccessStringHelper.DATA_READ;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -56,6 +57,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
@@ -251,8 +253,15 @@ public class TrackedEntityInstanceAttributesAggregateTest extends TrackerTest
             ProgramStage programStageA2 = createProgramStage( programA, true );
 
             // Create 5 Tracked Entity Attributes (named A .. E)
-            IntStream.range( A, F ).mapToObj( i -> Character.toString( (char) i ) ).forEach( c -> attributeService
-                .addTrackedEntityAttribute( createTrackedEntityAttribute( c.charAt( 0 ), ValueType.TEXT ) ) );
+            IntStream.range( A, F ).mapToObj( i -> Character.toString( (char) i ) )
+                .forEach( c -> {
+                    long attrId = attributeService.addTrackedEntityAttribute(
+                        createTrackedEntityAttribute( c.charAt( 0 ), ValueType.TEXT ) );
+                    TrackedEntityAttribute trackedEntityAttribute = attributeService
+                        .getTrackedEntityAttribute( attrId );
+                    trackedEntityAttribute.setPublicAccess( DATA_READ );
+                    attributeService.updateTrackedEntityAttribute( trackedEntityAttribute );
+                } );
 
             // Transform the Tracked Entity Attributes into a List of
             // TrackedEntityTypeAttribute


### PR DESCRIPTION
Currently TEA miss ACL check. TEAs are returned based on TrackedEntityType/Program ACL.
However, in FE seems that a user can specify TEA level permissions.
This PR implements ACL check on TEAs when returned by the collection TEI endpoint.
However, we should consider the implications that this PR can have on clients.
So this PR can be reviewed but will not be merged until we do an analysis on the impacts it can have.