### PR TITLE
fix: consistently require alphanumeric + dash + underscore SQL view var names [DHIS2-11946]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -211,6 +211,7 @@ public enum ErrorCode
     E4310( "SQL query contains references to protected tables" ),
     E4311( "SQL query contains illegal keywords" ),
     E4312( "Current user is not authorised to read data from SQL view: `{0}`" ),
+    E4313( "SQL query contains variable names that are invalid: `{0}`" ),
 
     /* Preheat */
     E5000( "Found matching object for reference, but import mode is CREATE. Identifier was {0}, and object was {1}." ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
@@ -78,6 +77,8 @@ public class SqlView
 
     private static final String QUERY_VALUE_REGEX = "^[\\w\\s\\-]*$";
 
+    private static final String QUERY_NAME_REGEX = "^[-a-zA-Z0-9_]+$";
+
     // -------------------------------------------------------------------------
     // Properties
     // -------------------------------------------------------------------------
@@ -113,18 +114,16 @@ public class SqlView
     {
         final Pattern p = Pattern.compile( "\\W" );
 
-        String input = name;
+        String[] items = p.split( name.trim().replace( "_", "" ) );
 
-        String[] items = p.split( input.trim().replaceAll( "_", "" ) );
-
-        input = "";
+        StringBuilder input = new StringBuilder();
 
         for ( String s : items )
         {
-            input += s.isEmpty() ? "" : ("_" + s);
+            input.append( s.isEmpty() ? "" : ("_" + s) );
         }
 
-        return PREFIX_VIEWNAME + input.toLowerCase();
+        return PREFIX_VIEWNAME + input.toString().toLowerCase();
     }
 
     public static Map<String, String> getCriteria( Set<String> params )
@@ -169,7 +168,7 @@ public class SqlView
      */
     public static boolean isValidQueryParam( String param )
     {
-        return StringUtils.isAlphanumeric( param );
+        return param.matches( QUERY_NAME_REGEX );
     }
 
     public static Set<String> getInvalidQueryValues( Collection<String> values )
@@ -197,7 +196,7 @@ public class SqlView
 
     public static String getProtectedTablesRegex()
     {
-        StringBuffer regex = new StringBuffer( "^(.*\\W)?(" );
+        StringBuilder regex = new StringBuilder( "^(.*\\W)?(" );
 
         for ( String table : PROTECTED_TABLES )
         {
@@ -211,7 +210,7 @@ public class SqlView
 
     public static String getIllegalKeywordsRegex()
     {
-        StringBuffer regex = new StringBuffer( "^(.*\\W)?(" );
+        StringBuilder regex = new StringBuilder( "^(.*\\W)?(" );
 
         for ( String word : ILLEGAL_KEYWORDS )
         {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.sqlview;
 import static org.hisp.dhis.sqlview.SqlView.CURRENT_USERNAME_VARIABLE;
 import static org.hisp.dhis.sqlview.SqlView.CURRENT_USER_ID_VARIABLE;
 import static org.hisp.dhis.sqlview.SqlView.STANDARD_VARIABLES;
+import static org.hisp.dhis.sqlview.SqlView.getInvalidQueryParams;
+import static org.hisp.dhis.sqlview.SqlView.getInvalidQueryValues;
 
 import java.util.List;
 import java.util.Map;
@@ -350,24 +352,24 @@ public class DefaultSqlViewService
             error = new ErrorMessage( ErrorCode.E4302 );
         }
 
-        if ( variables != null && variables.keySet().contains( null ) )
+        if ( variables != null && variables.containsKey( null ) )
         {
             error = new ErrorMessage( ErrorCode.E4303 );
         }
 
-        if ( variables != null && variables.values().contains( null ) )
+        if ( variables != null && variables.containsValue( null ) )
         {
             error = new ErrorMessage( ErrorCode.E4304 );
         }
 
-        if ( variables != null && !SqlView.getInvalidQueryParams( variables.keySet() ).isEmpty() )
+        if ( variables != null && !getInvalidQueryParams( variables.keySet() ).isEmpty() )
         {
-            error = new ErrorMessage( ErrorCode.E4305, SqlView.getInvalidQueryParams( variables.keySet() ) );
+            error = new ErrorMessage( ErrorCode.E4305, getInvalidQueryParams( variables.keySet() ) );
         }
 
-        if ( variables != null && !SqlView.getInvalidQueryValues( variables.values() ).isEmpty() )
+        if ( variables != null && !getInvalidQueryValues( variables.values() ).isEmpty() )
         {
-            error = new ErrorMessage( ErrorCode.E4306, SqlView.getInvalidQueryValues( variables.values() ) );
+            error = new ErrorMessage( ErrorCode.E4306, getInvalidQueryValues( variables.values() ) );
         }
 
         if ( sqlView.isQuery() && !sqlVars.isEmpty() && (!allowedVariables.containsAll( sqlVars )) )
@@ -375,14 +377,19 @@ public class DefaultSqlViewService
             error = new ErrorMessage( ErrorCode.E4307, sqlVars );
         }
 
-        if ( criteria != null && !SqlView.getInvalidQueryParams( criteria.keySet() ).isEmpty() )
+        if ( sqlView.isQuery() && !sqlVars.isEmpty() && !getInvalidQueryParams( sqlVars ).isEmpty() )
         {
-            error = new ErrorMessage( ErrorCode.E4308, SqlView.getInvalidQueryParams( criteria.keySet() ) );
+            error = new ErrorMessage( ErrorCode.E4313, getInvalidQueryParams( sqlVars ) );
         }
 
-        if ( criteria != null && !SqlView.getInvalidQueryValues( criteria.values() ).isEmpty() )
+        if ( criteria != null && !getInvalidQueryParams( criteria.keySet() ).isEmpty() )
         {
-            error = new ErrorMessage( ErrorCode.E4309, SqlView.getInvalidQueryValues( criteria.values() ) );
+            error = new ErrorMessage( ErrorCode.E4308, getInvalidQueryParams( criteria.keySet() ) );
+        }
+
+        if ( criteria != null && !getInvalidQueryValues( criteria.values() ).isEmpty() )
+        {
+            error = new ErrorMessage( ErrorCode.E4309, getInvalidQueryValues( criteria.values() ) );
         }
 
         if ( !ignoreSqlViewTableProtection && sql.matches( SqlView.getProtectedTablesRegex() ) )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/SqlViewUtils.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/SqlViewUtils.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.sqlview;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,9 +39,14 @@ import java.util.regex.Pattern;
  */
 public class SqlViewUtils
 {
-    public static final String VARIABLE_EXPRESSION = "\\$\\{(\\w+)\\}";
+    private SqlViewUtils()
+    {
+        // hide
+    }
 
-    public static final Pattern VARIABLE_PATTERN = Pattern.compile( VARIABLE_EXPRESSION, Pattern.DOTALL );
+    private static final String VARIABLE_EXPRESSION = "\\$\\{([^}]+)}";
+
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile( VARIABLE_EXPRESSION, Pattern.DOTALL );
 
     /**
      * Returns the variables contained in the given SQL string.
@@ -76,11 +82,12 @@ public class SqlViewUtils
 
         if ( variables != null )
         {
-            for ( String param : variables.keySet() )
+            for ( Entry<String, String> param : variables.entrySet() )
             {
-                if ( param != null && SqlView.isValidQueryParam( param ) )
+                String name = param.getKey();
+                if ( SqlView.isValidQueryParam( name ) )
                 {
-                    sqlQuery = substituteSqlVariable( sqlQuery, param, variables.get( param ) );
+                    sqlQuery = substituteSqlVariable( sqlQuery, name, param.getValue() );
                 }
             }
         }
@@ -99,7 +106,7 @@ public class SqlViewUtils
      */
     public static String substituteSqlVariable( String sql, String name, String value )
     {
-        if ( value != null && SqlView.isValidQueryValue( value ) )
+        if ( SqlView.isValidQueryValue( value ) )
         {
             return sql.replace( "${" + name + "}", value );
         }

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -380,6 +380,18 @@ public class SqlViewServiceTest
     }
 
     @Test
+    public void testValidate_InvalidVarName()
+    {
+        SqlView sqlView = getSqlView(
+            "select * from dataelement where valueType = '${typö}' and aggregationtype = '${aggregationType}'" );
+
+        IllegalQueryException ex = assertThrows( IllegalQueryException.class,
+            () -> sqlViewService.validateSqlView( sqlView, null, null ) );
+        assertEquals( ErrorCode.E4313, ex.getErrorCode() );
+        assertEquals( "SQL query contains variable names that are invalid: `[typö]`", ex.getMessage() );
+    }
+
+    @Test
     public void testGetSqlViewGrid()
     {
         User admin = createAndInjectAdminUser(); // makes admin current user


### PR DESCRIPTION
### Summary
Makes the requirements for SQL variable names consistently require the names to only contain `a-z`, `A-Z`, `0-9` and `-` and `_` symbols. 

The validation and handling so far was inconsistent. While the variable names for the actual values provided were restricted to plain alphanumeric names the placeholders in the SQL would be restricted to any letter/digit character when extracted but not further checked. This means overall the name restrictions were slightly relaxed.

As placeholder and replacement should have a common rule I adjusted the `SqlView#isValidQueryParam` to be used by both and to allow the set of ASCII letters and digits as well as dash and underscore symbols.
The `SqlViewUtils#getVariables` in contrast does not make any limitations on the name (except it cannot contain `}`) as we will validate the names extracted from the SQL query using the same method `SqlView#getInvalidQueryParams` (which is based on `SqlView#isValidQueryParam`) for both variables used in the SQL query and their replacements.

This will be validated by a new validation with a new error code to get a understandable message.

### Cleanup
I also did a cleanup of sonar warnings around the touched code.

### Automatic Testing
Added a new test scenario for the added validation.
Also checked that the successful case is tested.