### PR TITLE
fix: allow non ASCII letters for SQL view var values [DHIS2-11932]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
@@ -76,7 +76,7 @@ public class SqlView
 
     private static final String REGEX_SEP = "|";
 
-    private static final String QUERY_VALUE_REGEX = "^[\\w\\s\\-]*$";
+    private static final String QUERY_VALUE_REGEX = "^[\\p{L}\\w\\s\\-]*$";
 
     // -------------------------------------------------------------------------
     // Properties

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.sqlview;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -320,6 +321,13 @@ public class SqlViewServiceTest
             assertThrows( IllegalQueryException.class,
                 () -> sqlViewService.getSqlViewGrid( sqlView, null, null, null, null ) ),
             ErrorCode.E4312 );
+    }
+
+    @Test
+    public void testValidateSuccess_NonAsciiLetterVariableValues()
+    {
+        sqlViewService.validateSqlView( getSqlView( "select * from dataelement where valueType = '${valueType}'" ),
+            null, singletonMap( "valueType", "å" ) );
     }
 
     @Test


### PR DESCRIPTION
Just relaxed the restrictions on the SQL view variable value pattern so that it allows for all non ASCII letter symbols.
Kept the `\\w` as the `\\p{L}` does not include digits.

Added a test scenario to confirm. 

Kept this change small as #9186 was touching same files.