### PR TITLE
chore: fix dependabot maven directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       prefix: "github-actions"
       include: "scope"
   - package-ecosystem: "maven"
-    directory: "/"
+    directory: "/dhis-2"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
dependabot cannot find a pom.xml in the root of our repository