### PR TITLE
chore: tune Postgres for integration tests TECH-784

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/IntegrationTestConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/IntegrationTestConfig.java
@@ -90,6 +90,9 @@ public class IntegrationTestConfig
         DhisPostgreSQLContainer<?> postgisContainer = ((DhisPostgreSQLContainer<?>) new DhisPostgisContainerProvider()
             .newInstance()) // NOSONAR
                 .appendCustomPostgresConfig( "max_locks_per_transaction=100" )
+                .appendCustomPostgresConfig( "fsync=off" )
+                .appendCustomPostgresConfig( "synchronous_commit=off" )
+                .appendCustomPostgresConfig( "full_page_writes=off" )
                 .withDatabaseName( POSTGRES_DATABASE_NAME )
                 .withUsername( POSTGRES_CREDENTIALS )
                 .withPassword( POSTGRES_CREDENTIALS );


### PR DESCRIPTION
does this https://www.endpointdev.com/blog/2012/06/speeding-up-integration-tests-postgresql/
have an impact on our top 5 tests?