### PR TITLE
feat: Gist API support case-insensitive like filters [DHIS2-12073]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -812,6 +812,10 @@ final class GistBuilder
         {
             fieldTemplate = "size(%s)";
         }
+        else if ( operator.isCaseInsensitive() )
+        {
+            fieldTemplate = "lower(%s)";
+        }
         str.append( String.format( fieldTemplate, field ) );
         str.append( " " ).append( createOperatorLeftSideHQL( operator ) );
         if ( !operator.isUnary() )
@@ -994,12 +998,20 @@ final class GistBuilder
                 Object value = filter.isAttribute()
                     ? filter.getValue()[0]
                     : getParameterValue( context.resolveMandatory( filter.getPropertyPath() ), filter, argumentParser );
-                dest.accept( "f_" + i, operator.isStringCompare()
-                    ? completeLikeExpression( operator, (String) value )
-                    : value );
+                dest.accept( "f_" + i,
+                    operator.isStringCompare()
+                        ? completeLikeExpression( operator, stringParameterValue( operator, value ) )
+                        : value );
             }
             i++;
         }
+    }
+
+    private String stringParameterValue( Comparison operator, Object value )
+    {
+        return value == null
+            ? null
+            : operator.isCaseInsensitive() ? value.toString().toLowerCase() : (String) value;
     }
 
     private Object getParameterValue( Property property, Filter filter,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -393,6 +393,11 @@ public final class GistQuery
         {
             return ordinal() >= CAN_READ.ordinal();
         }
+
+        public boolean isCaseInsensitive()
+        {
+            return ordinal() >= ILIKE.ordinal() && ordinal() <= NOT_ENDS_WITH.ordinal();
+        }
     }
 
     @Getter

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistDescribeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistDescribeControllerTest.java
@@ -115,7 +115,8 @@ public class GistDescribeControllerTest extends AbstractGistControllerTest
         JsonObject parameters = hql.getObject( "parameters" );
         assertTrue( parameters.isObject() );
         assertEquals( 1, parameters.size() );
-        assertEquals( "Jo%", parameters.getString( "f_0" ).string() );
+        // starts with is case-insensitive so both term and DB field are lowered
+        assertEquals( "jo%", parameters.getString( "f_0" ).string() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -142,7 +142,6 @@ public class GistFilterControllerTest extends AbstractGistControllerTest
     public void testFilter_Like()
     {
         assertEquals( 1, GET( "/users/gist?filter=surname:like:mi&headless=true" ).content().size() );
-        assertEquals( 1, GET( "/users/gist?filter=surname:ilike:mi&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=surname:like:?dmin&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=surname:like:ad*&headless=true" ).content().size() );
         assertEquals( 0, GET( "/users/gist?filter=surname:like:Zulu&headless=true" ).content().size() );
@@ -153,10 +152,28 @@ public class GistFilterControllerTest extends AbstractGistControllerTest
     {
         assertEquals( 1,
             GET( "/users/gist?filter=userCredentials.username:!like:mike&headless=true" ).content().size() );
-        assertEquals( 1, GET( "/users/gist?filter=surname:!ilike:?min&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=surname:!like:?min&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=surname:!like:ap*&headless=true" ).content().size() );
         assertEquals( 0, GET( "/users/gist?filter=surname:!like:ad?in&headless=true" ).content().size() );
+    }
+
+    @Test
+    public void testFilter_ILike()
+    {
+        assertEquals( 1, GET( "/users/gist?filter=surname:ilike:Mi&headless=true" ).content().size() );
+        assertEquals( 1, GET( "/users/gist?filter=surname:ilike:?dmin&headless=true" ).content().size() );
+        assertEquals( 1, GET( "/users/gist?filter=surname:ilike:aD*&headless=true" ).content().size() );
+        assertEquals( 0, GET( "/users/gist?filter=surname:ilike:Zulu&headless=true" ).content().size() );
+    }
+
+    @Test
+    public void testFilter_NotILike()
+    {
+        assertEquals( 1,
+            GET( "/users/gist?filter=userCredentials.username:!ilike:Mike&headless=true" ).content().size() );
+        assertEquals( 1, GET( "/users/gist?filter=surname:!ilike:?min&headless=true" ).content().size() );
+        assertEquals( 1, GET( "/users/gist?filter=surname:!ilike:aP*&headless=true" ).content().size() );
+        assertEquals( 0, GET( "/users/gist?filter=surname:!ilike:Ad?in&headless=true" ).content().size() );
     }
 
     @Test
@@ -165,9 +182,9 @@ public class GistFilterControllerTest extends AbstractGistControllerTest
         assertEquals( 1,
             GET( "/users/gist?filter=userCredentials.username:$like:ad&headless=true" ).content().size() );
         assertEquals( 1,
-            GET( "/users/gist?filter=userCredentials.username:$ilike:adm&headless=true" ).content().size() );
+            GET( "/users/gist?filter=userCredentials.username:$ilike:Adm&headless=true" ).content().size() );
         assertEquals( 1,
-            GET( "/users/gist?filter=userCredentials.username:startsWith:admi&headless=true" ).content().size() );
+            GET( "/users/gist?filter=userCredentials.username:startsWith:Admi&headless=true" ).content().size() );
         assertEquals( 0,
             GET( "/users/gist?filter=userCredentials.username:startsWith:bat&headless=true" ).content().size() );
     }
@@ -186,7 +203,7 @@ public class GistFilterControllerTest extends AbstractGistControllerTest
     {
         assertEquals( 1, GET( "/users/gist?filter=firstName:like$:dmin&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=firstName:ilike$:in&headless=true" ).content().size() );
-        assertEquals( 1, GET( "/users/gist?filter=firstName:endsWith:min&headless=true" ).content().size() );
+        assertEquals( 1, GET( "/users/gist?filter=firstName:endsWith:MIN&headless=true" ).content().size() );
         assertEquals( 0, GET( "/users/gist?filter=firstName:endsWith:bat&headless=true" ).content().size() );
     }
 
@@ -196,7 +213,7 @@ public class GistFilterControllerTest extends AbstractGistControllerTest
         assertEquals( 1, GET( "/users/gist?filter=firstName:!like$:mike&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=firstName:!ilike$:bat&headless=true" ).content().size() );
         assertEquals( 1, GET( "/users/gist?filter=firstName:!endsWith:tic&headless=true" ).content().size() );
-        assertEquals( 0, GET( "/users/gist?filter=firstName:!endsWith:min&headless=true" ).content().size() );
+        assertEquals( 0, GET( "/users/gist?filter=firstName:!endsWith:MiN&headless=true" ).content().size() );
     }
 
     @Test


### PR DESCRIPTION
### Summary
Upon @mediremi request I added support for case-insensitive like filters to the Gist API.
As we use HQL there is no equivalent building block to hibernate's `Restrictions.ilike` for the criteria API so we do a `lower(field) like $parameter` where the value of `$parameter` is also lower cased before passing it to query.

### Automatic Testing
Adopted existing tests a bit so they use wrong case where case-insensitivity is expected to work and added some more test scenarios especially for the `ilke` and `!ilike` filters.

### Documentation
PR https://github.com/dhis2/dhis2-docs/pull/887