### PR TITLE
fix: Newly created Continuous Analytics Job fails [2.38-DHIS2-12094]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -198,17 +198,17 @@ public class DefaultSystemSettingManager
      */
     private SerializableOptional getSystemSettingOptional( String name, Serializable defaultValue )
     {
-        SystemSetting setting = systemSettingStore.getByName( name );
+        Serializable displayValue = getSettingDisplayValue( name );
 
-        if ( setting != null && setting.hasValue() )
+        if ( displayValue != null )
         {
             if ( isConfidential( name ) )
             {
                 try
                 {
-                    return SerializableOptional.of( pbeStringEncryptor.decrypt( (String) setting.getDisplayValue() ) );
+                    return SerializableOptional.of( pbeStringEncryptor.decrypt( (String) displayValue ) );
                 }
-                catch ( EncryptionOperationNotPossibleException e )
+                catch ( ClassCastException | EncryptionOperationNotPossibleException e )
                 {
                     log.warn( "Could not decrypt system setting '" + name + "'" );
                     return SerializableOptional.empty();
@@ -216,13 +216,25 @@ public class DefaultSystemSettingManager
             }
             else
             {
-                return SerializableOptional.of( setting.getDisplayValue() );
+                return SerializableOptional.of( displayValue );
             }
         }
         else
         {
             return SerializableOptional.of( defaultValue );
         }
+    }
+
+    private Serializable getSettingDisplayValue( String name )
+    {
+        SystemSetting setting = systemSettingStore.getByName( name );
+
+        if ( setting != null && setting.hasValue() )
+        {
+            return setting.getDisplayValue();
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
see https://github.com/dhis2/dhis2-core/pull/9179

Problem description:
Any "null" string in the systemsettings table (column value) can raise the application exception instead of set the setting value for later usage. This behavior is derived from the way, how json deserializer uses the "null" string. It is deserialized to non referenced object (null).

Workflow description:
Application tries to obtain the setting value from:
1. Cache
2. if not present, from database
3. if not present, default value will be applied

the value presence is determined by null reference to the value object

Solution description:

- modify the DefaultSystemSettingManager - value will be checked after the json deserialization instead of before this action. The deserialization is done by calling the convertValueToSerializable method called by getDisplayValue (calling chain: getSettingDisplayValue -> getDisplayValue -> convertValueToSerializable).

```java
//convertValueToSerializable code snippet
if ( settingKey.isPresent() )
                {
                    Object valueAsObject = objectMapper.readValue( value, settingKey.get().getClazz() );
                    valueAsSerializable = (Serializable) valueAsObject;
                }
```