### PR TITLE
chore: dependabot fails semantic PR check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     pull-request-branch-name:
       separator: "-"
     commit-message:
-      prefix: "github-actions"
+      prefix: "chore"
       include: "scope"
   - package-ecosystem: "maven"
     directory: "/dhis-2"
@@ -17,5 +17,5 @@ updates:
     pull-request-branch-name:
       separator: "-"
     commit-message:
-      prefix: "maven"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
The PR title is equal to the commit title. Prefix commit messages with
chore. Lets see if the scope added by dependabot is considered valid
without having to configure
https://github.com/zeke/semantic-pull-requests