### PR TITLE
chore: build but exclude analytics tests from integration-test TECH-784

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run integration tests
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn --threads 1C clean install -Pintegration -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty,-"dhis-services/dhis-service-analytics" $MAVEN_BUILD_OPTS
+        run: mvn --threads 1C clean install -Pintegration -DexcludeAnalyticsTests=true -Pjdk11 --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
 
       - name: Archive surefire reports
         uses: actions/upload-artifact@v2
@@ -63,7 +63,9 @@ jobs:
       - name: Run analytics integration tests
         env:
           MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn clean install -Pintegration -Pjdk11 --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml $MAVEN_BUILD_OPTS
+        run: |
+          mvn --threads 2C clean install -DskipTests -Dmaven.tests.skip=true -Pjdk11 --batch-mode --no-transfer-progress -f dhis-2/pom.xml -pl=dhis-services/dhis-service-analytics/pom.xml --also-make $MAVEN_BUILD_OPTS
+          mvn test -Pintegration -Pjdk11 --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml $MAVEN_BUILD_OPTS
 
       - name: Archive surefire reports
         uses: actions/upload-artifact@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,12 +60,15 @@ jobs:
           distribution: zulu
           cache: maven
 
+      - name: Build analytics with dependencies
+        env:
+          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
+        run: mvn --threads 2C clean install -DskipTests -Dmaven.tests.skip=true -Pjdk11 --batch-mode --no-transfer-progress -f dhis-2/pom.xml -pl=dhis-services/dhis-service-analytics/pom.xml --also-make
+
       - name: Run analytics integration tests
         env:
-          MAVEN_BUILD_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: |
-          mvn --threads 2C clean install -DskipTests -Dmaven.tests.skip=true -Pjdk11 --batch-mode --no-transfer-progress -f dhis-2/pom.xml -pl=dhis-services/dhis-service-analytics/pom.xml --also-make $MAVEN_BUILD_OPTS
-          mvn test -Pintegration -Pjdk11 --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml $MAVEN_BUILD_OPTS
+          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
+        run: mvn test -Pintegration -Pjdk11 --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml
 
       - name: Archive surefire reports
         uses: actions/upload-artifact@v2

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -12,7 +12,30 @@
   <artifactId>dhis-service-analytics</artifactId>
   <packaging>jar</packaging>
   <name>DHIS Analytics</name>
-  
+
+  <profiles>
+    <profile>
+      <id>excludeAnalyticsTests</id>
+      <activation>
+        <property>
+          <name>excludeAnalyticsTests</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     
     <!-- DHIS -->


### PR DESCRIPTION
excluding the entire project from the maven build will cause a
dependency of the report service to be missing. So we have to build it
but exclude its tests from executing