### PR TITLE
feat: Program.openDaysAfterCoEndDate DHIS2-11234

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -239,29 +239,6 @@ public class CategoryOption
         return (new DailyPeriodType()).getRewindedDate( endDate, -program.getOpenDaysAfterCoEndDate() );
     }
 
-    /**
-     * Gets an adjusted end date for a data set, data element, or program.
-     *
-     * @param dataSet the data set to adjust for, or
-     * @param dataElement the data element to adjust for, or
-     * @param dataElement the program to adjust for
-     * @return the adjusted end date
-     */
-    public Date getAdjustedEndDate( DataSet dataSet, DataElement dataElement, Program program )
-    {
-        if ( dataSet != null )
-        {
-            return getAdjustedEndDate( dataSet );
-        }
-
-        if ( dataElement != null )
-        {
-            return getAdjustedEndDate( dataElement );
-        }
-
-        return getAdjustedEndDate( program );
-    }
-
     // -------------------------------------------------------------------------
     // DimensionalItemObject
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -41,6 +41,8 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.DailyPeriodType;
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -221,18 +223,43 @@ public class CategoryOption
     }
 
     /**
-     * Gets an adjusted end date for a data set or, if that is not present, a
-     * data element.
+     * Gets an adjusted end date, adjusted if this program has open days after
+     * the end date.
      *
-     * @param dataSet the data set to adjust for
-     * @param dataElement the data element to adjust for
+     * @param program the program to adjust for
      * @return the adjusted end date
      */
-    public Date getAdjustedEndDate( DataSet dataSet, DataElement dataElement )
+    public Date getAdjustedEndDate( Program program )
     {
-        return dataSet != null
-            ? getAdjustedEndDate( dataSet )
-            : getAdjustedEndDate( dataElement );
+        if ( endDate == null || program.getOpenDaysAfterCoEndDate() == 0 )
+        {
+            return endDate;
+        }
+
+        return (new DailyPeriodType()).getRewindedDate( endDate, -program.getOpenDaysAfterCoEndDate() );
+    }
+
+    /**
+     * Gets an adjusted end date for a data set, data element, or program.
+     *
+     * @param dataSet the data set to adjust for, or
+     * @param dataElement the data element to adjust for, or
+     * @param dataElement the program to adjust for
+     * @return the adjusted end date
+     */
+    public Date getAdjustedEndDate( DataSet dataSet, DataElement dataElement, Program program )
+    {
+        if ( dataSet != null )
+        {
+            return getAdjustedEndDate( dataSet );
+        }
+
+        if ( dataElement != null )
+        {
+            return getAdjustedEndDate( dataElement );
+        }
+
+        return getAdjustedEndDate( program );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -217,7 +218,7 @@ public class CategoryOptionCombo
      */
     public DateRange getDateRange( DataSet dataSet )
     {
-        return getDateRange( dataSet, null );
+        return getDateRange( dataSet, null, null );
     }
 
     /**
@@ -235,7 +236,25 @@ public class CategoryOptionCombo
      */
     public DateRange getDateRange( DataElement dataElement )
     {
-        return getDateRange( null, dataElement );
+        return getDateRange( null, dataElement, null );
+    }
+
+    /**
+     * Gets a range of valid dates for this (attribute) cateogry option combo
+     * for a program.
+     * <p>
+     * The earliest valid date is the latest start date (if any) from all the
+     * category options associated with this option combo.
+     * <p>
+     * The latest valid date is the earliest end date (if any) from all the
+     * category options associated with this option combo.
+     *
+     * @param program the data set for which to check dates.
+     * @return valid date range for this (attribute) category option combo.
+     */
+    public DateRange getDateRange( Program program )
+    {
+        return getDateRange( null, null, program );
     }
 
     /**
@@ -338,10 +357,11 @@ public class CategoryOptionCombo
      * for a data set or, if that is not present, a data element.
      *
      * @param dataSet the data set to get the range for, or
-     * @param dataElement the data element to get the range for
+     * @param dataElement the data element to get the range for, or
+     * @param program the program to get the range for
      * @return valid date range for this (attribute) category option combo.
      */
-    private DateRange getDateRange( DataSet dataSet, DataElement dataElement )
+    private DateRange getDateRange( DataSet dataSet, DataElement dataElement, Program program )
     {
         Date latestStartDate = null;
         Date earliestEndDate = null;
@@ -353,9 +373,7 @@ public class CategoryOptionCombo
                 latestStartDate = co.getStartDate();
             }
 
-            Date coEndDate = dataSet != null
-                ? co.getAdjustedEndDate( dataSet )
-                : co.getAdjustedEndDate( dataElement );
+            Date coEndDate = co.getAdjustedEndDate( dataSet, dataElement, program );
 
             if ( coEndDate != null && (earliestEndDate == null || coEndDate.before( earliestEndDate )) )
             {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -167,6 +167,12 @@ public class Program
     private int completeEventsExpiryDays;
 
     /**
+     * Number of days to open for data capture that are after the category
+     * option's end date.
+     */
+    private int openDaysAfterCoEndDate;
+
+    /**
      * Property indicating minimum number of attributes required to fill before
      * search is triggered
      */
@@ -809,6 +815,18 @@ public class Program
     public void setCompleteEventsExpiryDays( int completeEventsExpiryDays )
     {
         this.completeEventsExpiryDays = completeEventsExpiryDays;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public int getOpenDaysAfterCoEndDate()
+    {
+        return openDaysAfterCoEndDate;
+    }
+
+    public void setOpenDaysAfterCoEndDate( int openDaysAfterCoEndDate )
+    {
+        this.openDaysAfterCoEndDate = openDaysAfterCoEndDate;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
@@ -268,4 +268,20 @@ public class CategoryOptionComboTest
         assertEquals( jan2, dateRange.getStartDate() );
         assertEquals( jan6, dateRange.getEndDate() );
     }
+
+    @Test
+    public void testGetLatestStartDate()
+    {
+        assertNull( optionComboA.getLatestStartDate() );
+        assertEquals( jan1, optionComboB.getLatestStartDate() );
+        assertEquals( jan2, optionComboC.getLatestStartDate() );
+    }
+
+    @Test
+    public void testGetEarliestEndDate()
+    {
+        assertNull( optionComboA.getEarliestEndDate() );
+        assertEquals( jan4, optionComboB.getEarliestEndDate() );
+        assertEquals( jan4, optionComboC.getEarliestEndDate() );
+    }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.period.DailyPeriodType;
+import org.hisp.dhis.program.Program;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,6 +84,8 @@ public class CategoryOptionComboTest
     private DataSet dataSetB;
 
     private DataSet dataSetC;
+
+    private Program program;
 
     @Before
     public void before()
@@ -148,6 +151,8 @@ public class CategoryOptionComboTest
         dataSetA.setOpenPeriodsAfterCoEndDate( 0 );
         dataSetB.setOpenPeriodsAfterCoEndDate( 1 );
         dataSetC.setOpenPeriodsAfterCoEndDate( 2 );
+
+        program = new Program();
     }
 
     @Test
@@ -228,6 +233,38 @@ public class CategoryOptionComboTest
         dateRange = optionComboC.getDateRange( dataElement ); // [null, Jan 1-4,
                                                               // Jan 2-5] +0,
                                                               // +1, +2
+        assertEquals( jan2, dateRange.getStartDate() );
+        assertEquals( jan6, dateRange.getEndDate() );
+    }
+
+    @Test
+    public void testGetDateRangeProgram()
+    {
+        DateRange dateRange;
+
+        dateRange = optionComboA.getDateRange( program );
+        assertNull( dateRange.getStartDate() );
+        assertNull( dateRange.getEndDate() );
+
+        dateRange = optionComboB.getDateRange( program );
+        assertEquals( jan1, dateRange.getStartDate() );
+        assertEquals( jan4, dateRange.getEndDate() );
+
+        dateRange = optionComboC.getDateRange( program );
+        assertEquals( jan2, dateRange.getStartDate() );
+        assertEquals( jan4, dateRange.getEndDate() );
+
+        program.setOpenDaysAfterCoEndDate( 2 );
+
+        dateRange = optionComboA.getDateRange( program );
+        assertNull( dateRange.getStartDate() );
+        assertNull( dateRange.getEndDate() );
+
+        dateRange = optionComboB.getDateRange( program );
+        assertEquals( jan1, dateRange.getStartDate() );
+        assertEquals( jan6, dateRange.getEndDate() );
+
+        dateRange = optionComboC.getDateRange( program );
         assertEquals( jan2, dateRange.getStartDate() );
         assertEquals( jan6, dateRange.getEndDate() );
     }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionTest.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.period.MonthlyPeriodType;
+import org.hisp.dhis.program.Program;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
@@ -108,5 +109,20 @@ public class CategoryOptionTest
 
         dataSetB.setOpenPeriodsAfterCoEndDate( 4 );
         assertEquals( new DateTime( 2020, 5, 1, 0, 0 ).toDate(), categoryOption.getAdjustedEndDate( dataElement ) );
+    }
+
+    @Test
+    public void getAdjustedDate_Program()
+    {
+        CategoryOption categoryOption = new CategoryOption();
+        Program program = new Program( "program" );
+
+        assertNull( categoryOption.getAdjustedEndDate( program ) );
+
+        categoryOption.setEndDate( new DateTime( 2020, 1, 1, 0, 0 ).toDate() );
+        assertEquals( new DateTime( 2020, 1, 1, 0, 0 ).toDate(), categoryOption.getAdjustedEndDate( program ) );
+
+        program.setOpenDaysAfterCoEndDate( 3 );
+        assertEquals( new DateTime( 2020, 1, 4, 0, 0 ).toDate(), categoryOption.getAdjustedEndDate( program ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
@@ -61,7 +61,9 @@
     <property name="expiryDays" />
 
     <property name="completeEventsExpiryDays" />
-    
+
+    <property name="openDaysAfterCoEndDate" />
+
     <property name="minAttributesRequiredToSearch" />
     
     <property name="maxTeiCountToReturn" />

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
@@ -271,7 +271,7 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
         IdScheme idScheme = idSchemes.getProgramIdScheme();
 
         String sqlSelect = "select p.programid as id, p.uid, p.code, p.name, p.sharing as program_sharing, "
-            + "p.type, tet.trackedentitytypeid, tet.sharing  as tet_sharing, "
+            + "p.type, p.opendaysaftercoenddate, tet.trackedentitytypeid, tet.sharing  as tet_sharing, "
             + "tet.uid           as tet_uid, c.categorycomboid as catcombo_id, "
             + "c.uid             as catcombo_uid, c.name            as catcombo_name, "
             + "c.code            as catcombo_code, ps.programstageid as ps_id, ps.uid as ps_uid, "
@@ -308,6 +308,7 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
                     program.setUid( rs.getString( "uid" ) );
                     program.setName( rs.getString( "name" ) );
                     program.setCode( rs.getString( "code" ) );
+                    program.setOpenDaysAfterCoEndDate( rs.getInt( "opendaysaftercoenddate" ) );
 
                     program.setProgramType( ProgramType.fromValue( rs.getString( "type" ) ) );
                     program.setSharing( toSharing( rs.getString( "program_sharing" ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/AttributeOptionComboDateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/AttributeOptionComboDateCheck.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.dxf2.events.importer.Checker;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
 import org.hisp.dhis.dxf2.events.importer.shared.ImmutableEvent;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.util.DateUtils;
 
 /**
@@ -72,20 +73,25 @@ public class AttributeOptionComboDateCheck implements Checker
             return error( "Event date can not be empty", event.getEvent() );
         }
 
+        Program program = ctx.getProgramsMap().get( event.getProgram() );
+
         for ( CategoryOption categoryOption : attributeOptionCombo.getCategoryOptions() )
         {
-            if ( categoryOption.getStartDate() != null && eventDate.compareTo( categoryOption.getStartDate() ) < 0 )
+            if ( categoryOption.getStartDate() != null &&
+                eventDate.compareTo( categoryOption.getStartDate() ) < 0 )
             {
-                return error( "Event date " + getMediumDateString( eventDate ) + " is before start date "
-                    + getMediumDateString( categoryOption.getStartDate() ) + " for attributeOption '"
-                    + categoryOption.getName() + "'", event.getEvent() );
+                return error( "Event date " + getMediumDateString( eventDate )
+                    + " is before start date " + getMediumDateString( categoryOption.getStartDate() )
+                    + " for attributeOption '" + categoryOption.getName() + "'", event.getEvent() );
             }
 
-            if ( categoryOption.getEndDate() != null && eventDate.compareTo( categoryOption.getEndDate() ) > 0 )
+            if ( categoryOption.getEndDate() != null &&
+                eventDate.compareTo( categoryOption.getAdjustedEndDate( program ) ) > 0 )
             {
-                return error( "Event date " + getMediumDateString( eventDate ) + " is after end date "
-                    + getMediumDateString( categoryOption.getEndDate() ) + " for attributeOption '"
-                    + categoryOption.getName() + "'", event.getEvent() );
+                return error( "Event date " + getMediumDateString( eventDate )
+                    + " is after end date " + getMediumDateString( categoryOption.getAdjustedEndDate( program ) )
+                    + " for attributeOption '" + categoryOption.getName()
+                    + "' in program '" + program.getName() + "'", event.getEvent() );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierTest.java
@@ -89,6 +89,7 @@ public class ProgramSupplierTest extends AbstractSupplierTest<Program>
         when( mockResultSet.getString( "name" ) ).thenReturn( "My Program" );
         when( mockResultSet.getString( "type" ) ).thenReturn( ProgramType.WITHOUT_REGISTRATION.getValue() );
         when( mockResultSet.getString( "program_sharing" ) ).thenReturn( generateSharing( null, "rw------", false ) );
+        when( mockResultSet.getInt( "opendaysaftercoenddate" ) ).thenReturn( 42 );
 
         when( mockResultSet.getLong( "catcombo_id" ) ).thenReturn( 200L );
         when( mockResultSet.getString( "catcombo_uid" ) ).thenReturn( "389dh83" );
@@ -126,6 +127,7 @@ public class ProgramSupplierTest extends AbstractSupplierTest<Program>
         assertThat( program.getName(), is( "My Program" ) );
         assertThat( program.getProgramType(), is( ProgramType.WITHOUT_REGISTRATION ) );
         assertThat( program.getSharing().getPublicAccess(), is( "rw------" ) );
+        assertThat( program.getOpenDaysAfterCoEndDate(), is( 42 ) );
         assertThat( program.getCategoryCombo(), is( notNullValue() ) );
         assertThat( program.getCategoryCombo().getId(), is( 200L ) );
         assertThat( program.getCategoryCombo().getUid(), is( "389dh83" ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -72,7 +72,7 @@ public enum TrackerErrorCode
     E1050( "Event ScheduledAt date is missing." ),
     E1055( "Default AttributeOptionCombo is not allowed since program has non-default CategoryCombo." ),
     E1056( "Event date: `{0}`, is before start date: `{1}`, for AttributeOption: `{2}`." ),
-    E1057( "Event date: `{0}`, is after end date: `{1}`, for AttributeOption; `{2}`." ),
+    E1057( "Event date: `{0}`, is after end date: `{1}`, for AttributeOption: `{2}` in program: `{3}`." ),
     E1063( "TrackedEntityInstance: `{0}`, does not exist." ),
     E1064( "Non-unique attribute value `{0}` for attribute `{1}`" ),
     E1068( "Could not find TrackedEntityInstance: `{0}`, linked to Enrollment." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -112,9 +112,11 @@ public class EventCategoryOptValidationHook
                     i18nFormat.formatDate( option.getStartDate() ), option.getName() );
             }
 
-            if ( option.getEndDate() != null && eventDate.compareTo( option.getEndDate() ) > 0 )
+            if ( option.getEndDate() != null && eventDate.compareTo( option.getAdjustedEndDate( program ) ) > 0 )
             {
-                addError( reporter, E1057, eventDate, option.getEndDate(), categoryOptionCombo );
+                addError( reporter, E1057, i18nFormat.formatDate( eventDate ),
+                    i18nFormat.formatDate( option.getAdjustedEndDate( program ) ), option.getName(),
+                    program.getName() );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation.hooks;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
+import static org.hisp.dhis.category.CategoryOption.DEFAULT_NAME;
+import static org.hisp.dhis.tracker.ValidationMode.FULL;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.i18n.I18nFormat;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.mock.MockI18nFormat;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
+import org.hisp.dhis.user.User;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Jim Grace
+ */
+public class EventCategoryOptValidationHookTest
+    extends DhisConvenienceTest
+{
+    @Mock
+    private I18nManager i18nManager;
+
+    @Mock
+    private TrackerImportValidationContext validationContext;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private static final I18nFormat I18N_FORMAT = new MockI18nFormat();
+
+    private EventCategoryOptValidationHook hook;
+
+    private CategoryOption catOption;
+
+    private Category category;
+
+    private CategoryCombo catCombo;
+
+    private CategoryOptionCombo attOptionCombo;
+
+    private CategoryOption defaultCatOption;
+
+    private CategoryCombo defaultCatCombo;
+
+    private CategoryOptionCombo defaultCatOptionCombo;
+
+    private Program program;
+
+    private Event event;
+
+    private ValidationErrorReporter reporter;
+
+    private final Date ONE_YEAR_BEFORE_EVENT = getDate( 2020, 1, 1 );
+
+    private final Instant EVENT_INSTANT = getDate( 2021, 1, 1 ).toInstant();
+
+    private final Date ONE_YEAR_AFTER_EVENT = getDate( 2022, 1, 1 );
+
+    private final int OPEN_DAYS_AFTER_CO_END_DATE = 400;
+
+    @Before
+    public void setUp()
+    {
+        initServices();
+
+        hook = new EventCategoryOptValidationHook( i18nManager );
+
+        catOption = createCategoryOption( 'A' );
+
+        category = createCategory( 'A', catOption );
+
+        catCombo = createCategoryCombo( 'A', category );
+
+        attOptionCombo = createCategoryOptionCombo( catCombo, catOption );
+
+        defaultCatCombo = new CategoryCombo();
+        defaultCatCombo.setName( DEFAULT_CATEGORY_COMBO_NAME );
+
+        defaultCatOption = new CategoryOption();
+        defaultCatOption.setName( DEFAULT_NAME );
+
+        defaultCatOptionCombo = createCategoryOptionCombo( defaultCatCombo, defaultCatOption );
+
+        program = createProgram( 'A' );
+        program.setCategoryCombo( catCombo );
+
+        event = new Event();
+        event.setProgram( program.getUid() );
+        event.setOccurredAt( EVENT_INSTANT );
+
+        User user = createUser( 'A' );
+
+        TrackerBundle bundle = TrackerBundle.builder()
+            .user( user )
+            .validationMode( FULL )
+            .build();
+
+        when( validationContext.getBundle() ).thenReturn( bundle );
+
+        when( validationContext.getProgram( program.getUid() ) )
+            .thenReturn( program );
+
+        when( i18nManager.getI18nFormat() )
+            .thenReturn( I18N_FORMAT );
+
+        reporter = new ValidationErrorReporter( validationContext, event );
+    }
+
+    @Test
+    public void testDefaultCoc()
+    {
+        // given
+        program.setCategoryCombo( defaultCatCombo );
+
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( defaultCatOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void testDefaultCocWithNonDefaultCatCombo()
+    {
+        // given
+        program.setCategoryCombo( catCombo );
+
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( defaultCatOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1055 ) );
+    }
+
+    @Test
+    public void testNoCategoryOptionDates()
+    {
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( attOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void testBetweenCategoryOptionDates()
+    {
+        // given
+        catOption.setStartDate( ONE_YEAR_BEFORE_EVENT );
+        catOption.setEndDate( ONE_YEAR_AFTER_EVENT );
+
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( attOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
+    public void testBeforeCategoryOptionStart()
+    {
+        // given
+        catOption.setStartDate( ONE_YEAR_AFTER_EVENT );
+
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( attOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1056 ) );
+    }
+
+    @Test
+    public void testAfterCategoryOptionEnd()
+    {
+        // given
+        catOption.setEndDate( ONE_YEAR_BEFORE_EVENT );
+
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( attOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertTrue( reporter.hasErrors() );
+        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1057 ) );
+    }
+
+    @Test
+    public void testBeforeOpenDaysAfterCoEndDate()
+    {
+        // given
+        catOption.setEndDate( ONE_YEAR_BEFORE_EVENT );
+        program.setOpenDaysAfterCoEndDate( OPEN_DAYS_AFTER_CO_END_DATE );
+
+        // when
+        when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
+            .thenReturn( attOptionCombo );
+
+        hook.validateEvent( reporter, event );
+
+        // then
+        assertFalse( reporter.hasErrors() );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_14__Add_program_opendaysaftercoenddate.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_14__Add_program_opendaysaftercoenddate.sql
@@ -1,0 +1,4 @@
+-- Add column 'opendaysaftercoenddate' to 'program'
+
+ALTER TABLE program
+  ADD COLUMN IF NOT EXISTS opendaysaftercoenddate integer default 0;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValidator.java
@@ -357,11 +357,14 @@ public class DataValidator
                     getMediumDateString( option.getStartDate() ), option.getUid() ) );
             }
 
-            if ( option.getEndDate() != null
-                && period.getStartDate().after( option.getAdjustedEndDate( dataSet, dataElement, null ) ) )
+            Date adjustedEndDate = (dataSet != null)
+                ? option.getAdjustedEndDate( dataSet )
+                : option.getAdjustedEndDate( dataElement );
+
+            if ( adjustedEndDate != null && period.getStartDate().after( adjustedEndDate ) )
             {
                 throw new IllegalQueryException( new ErrorMessage( ErrorCode.E2024, period.getIsoDate(),
-                    getMediumDateString( option.getAdjustedEndDate( dataSet, dataElement, null ) ), option.getUid() ) );
+                    getMediumDateString( adjustedEndDate ), option.getUid() ) );
             }
         }
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValidator.java
@@ -148,7 +148,7 @@ public class DataValidator
      *
      * @param uid the category option combo identifier.
      * @param requireCategoryOptionCombo flag used as part of the validation.
-     * @return the {@link CategoryOtionComb}.
+     * @return the {@link CategoryOptionCombo}.
      * @throws IllegalQueryException if the validation fails.
      */
     public CategoryOptionCombo getAndValidateCategoryOptionCombo( final String uid,
@@ -358,10 +358,10 @@ public class DataValidator
             }
 
             if ( option.getEndDate() != null
-                && period.getStartDate().after( option.getAdjustedEndDate( dataSet, dataElement ) ) )
+                && period.getStartDate().after( option.getAdjustedEndDate( dataSet, dataElement, null ) ) )
             {
                 throw new IllegalQueryException( new ErrorMessage( ErrorCode.E2024, period.getIsoDate(),
-                    getMediumDateString( option.getAdjustedEndDate( dataSet, dataElement ) ), option.getUid() ) );
+                    getMediumDateString( option.getAdjustedEndDate( dataSet, dataElement, null ) ), option.getUid() ) );
             }
         }
     }


### PR DESCRIPTION
### Feature

See [DHIS2-11234](https://jira.dhis2.org/browse/DHIS2-11234). This adds `Program.openDaysAfterCoEndDate`. It allows program events to be entered for a given number of days beyond the `CategoryOption.endDate`.

This is analogous to `DataSet.openPeriodsAfterCoEndDate` which allows DataSet data to be entered for a given number of periods beyond the `CategoryOption.endDate`.

### Implementation

There are two places in the code where event dates are checked against the `CategoryOption.endDate`: `EventCategoryOptValidationHook` and `AttributeOptionComboDateCheck`. Both of these have been changed to check for `Program.openDaysAfterCoEndDate` as well.

Supporting methods in `CategoryOption` and `CategoryOptionCombo` were added or enhanced to facilitate these checks. These classes already checked for how a `CategoryOption.endDate` could be extended by a `DataSet` or by a `DataElement` (which might belong to one or more `DataSets`). They now also check for how the end date could be extended by a `Program`.

### Test

Unit tests were added or extended as appropriate.

The Testing suggestions in [DHIS2-11234](https://jira.dhis2.org/browse/DHIS2-11234) complete successfully.