### PR TITLE
chore: pin hikariCP to 4.x due to JDK8 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,5 +29,5 @@ updates:
       - "run-api-tests"
     ignore:
       - dependency-name: "com.zaxxer:HikariCP" # remove once we update minimum JDK to JDK11; https://github.com/brettwooldridge/HikariCP#artifacts
-          versions:
-            - ">= 5.0"
+        versions:
+          - ">= 5.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "com.zaxxer:HikariCP" # remove once we update minimum JDK to JDK11; https://github.com/brettwooldridge/HikariCP#artifacts
+          versions:
+            - ">= 5.0"

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -91,7 +91,7 @@
         <javassist.version>3.27.0-GA</javassist.version>
         <!-- Data sources,db pools and db drivers-->
         <c3p0.version>0.9.5.5</c3p0.version>
-        <HikariCP.version>5.0.0</HikariCP.version>
+        <HikariCP.version>4.0.3</HikariCP.version>
         <postgresql-driver.version>42.2.19</postgresql-driver.version>
         <postgis-jdbc.version>2.5.0</postgis-jdbc.version>
         <datasource-proxy.version>1.7</datasource-proxy.version>


### PR DESCRIPTION
hikariCP was updated in
https://github.com/dhis2/dhis2-core/pull/9222

to 5.x which needs JDK11 at minimum
see
https://github.com/brettwooldridge/HikariCP/blob/ed2da5f1f4ef19f871fac12effc0b199706905dc/README.md#artifacts

we run using JDK8 profile on Jenkins which fails due to it.
Pin version to 4.x and update once our minimum JDK version changes