### PR TITLE
chore: run dependabot outside of working hours and run e2e tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    labels:
+      - "dependencies"
+      - "java"
+      - "run-api-tests"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       interval: "daily"
       time: "02:17" # GitHub says 'High load times include the start of every hour'
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: "-"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "02:17" # GitHub says 'High load times include the start of every hour'
+      timezone: "Europe/Oslo"
     pull-request-branch-name:
       separator: "-"
     commit-message:
@@ -13,6 +15,8 @@ updates:
     directory: "/dhis-2"
     schedule:
       interval: "daily"
+      time: "02:17" # GitHub says 'High load times include the start of every hour'
+      timezone: "Europe/Oslo"
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
There is a limit of 20 concurrent jobs (I think for the entire
organization) that we can run
https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration\#usage-limits

* so limit number of total open PRs
* run dependabot updates at times where most are probably not working, so
it does not take up the quota. dependabot would otherwise randomly
choose a time which can fall into our working day.

Choosing an odd time as GitHub says that high load times are at the
start of every hour.
https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows\#scheduled-events

* run API tests on changes to java dependencies as we sometimes forget to do that on dependency updates. The API tests might catch some issues our other tests don't.