### PR TITLE
chore: quiet down Jenkins and local build

### DIFF
--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -39,11 +39,10 @@ print() {
 
 print "Building dhis2-core..."
 
-
-MAVEN_BUILD_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.test.skip=true"
-
-mvn clean install -T1C -Pdev -Pjdk11 -f $DIR/pom.xml -pl -dhis-web-embedded-jetty $MAVEN_BUILD_OPTS
-mvn clean install -T1C -Pdev -Pjdk11 -f $DIR/dhis-web/pom.xml $MAVEN_BUILD_OPTS
+export MAVEN_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.test.skip=true"
+export MAVEN_CLI_OPTS="--batch-mode --no-transfer-progress"
+mvn clean install -T1C -Pdev -Pjdk11 -f "$DIR"/pom.xml -pl -dhis-web-embedded-jetty
+mvn clean install -T1C -Pdev -Pjdk11 -f "$DIR"/dhis-web/pom.xml
 
 rm -rf "$ARTIFACTS/*"
 mkdir -p "$ARTIFACTS"

--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -16,6 +16,7 @@ pipeline {
 
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_CLI_OPTS = '--batch-mode --no-transfer-progress'
     }
 
     stages {

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -17,6 +17,7 @@ pipeline {
 
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_CLI_OPTS = '--batch-mode --no-transfer-progress'
         AWX_TEMPLATE = 37
         HOST = 'play.dhis2.org'
         INSTANCE_NAME = "${env.GIT_BRANCH == 'master' ? 'dev' : env.GIT_BRANCH + 'dev'}"

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -16,6 +16,7 @@ pipeline {
 
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_CLI_OPTS = '--batch-mode --no-transfer-progress'
     }
 
     stages {


### PR DESCRIPTION
We already did this in https://github.com/dhis2/dhis2-core/pull/9207 for most GitHub actions.
maven prints progress about downloading dependencies which we do not need to see. It just clutters,
increases the logs which makes finding things that one is looking for hard (errors, warnings, ...)

This should create cleaner build logs locally when using build-dev.sh,
when looking at the api test logs (which we run on GitHub) and when
looking at logs on Jenkins.