### PR TITLE
fix: flaky test job parallel runs

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
@@ -259,7 +259,6 @@ public class JobProgressTest
         assertEquals( itemCount, enterCount.get() );
         assertEquals( itemCount, exitCount.get() );
         assertTrue( "too much parallel work", maxConcurrentCount.get() <= parallelism );
-        assertTrue( "too little parallel work", maxConcurrentCount.get() >= max( 1, parallelism - 2 ) );
         verify( progress, times( itemCount ) ).startingWorkItem( anyString() );
         verify( progress, times( itemCount ) ).completedWorkItem( null );
         verify( progress ).completedStage( null );


### PR DESCRIPTION
@Ivo noticed that the removed assert could fail on CI - there isn't a easy way to make sure we actually got close to the target parallelism so the assert got just removed.