### PR TITLE
refactor: Diagnostic info for prediction error

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
@@ -122,6 +122,8 @@ public class PredictionDataValueFetcher
 
     private String producerOrgUnitPath;
 
+    private List<String> producerOrgUnitPaths;
+
     private String consumerOrgUnitPath;
 
     private List<String> consumerOrgUnitPaths;
@@ -172,6 +174,7 @@ public class PredictionDataValueFetcher
 
         consumerOrgUnitPath = BEFORE_PATHS;
         consumerOrgUnitPaths = new ArrayList<>();
+        producerOrgUnitPaths = new ArrayList<>();
         producerException = null;
 
         blockingQueue = new ArrayBlockingQueue<>( DDV_BLOCKING_QUEUE_SIZE );
@@ -188,6 +191,8 @@ public class PredictionDataValueFetcher
         executor.shutdown();
 
         getNextDataValue(); // Prime the algorithm with the first data value.
+
+        producerOrgUnitPaths.add( producerOrgUnitPath );
     }
 
     /**
@@ -253,7 +258,7 @@ public class PredictionDataValueFetcher
 
         if ( !consumerOrgUnitPath.equals( producerOrgUnitPath ) )
         {
-            throw new IllegalArgumentException( "getDataValues ready for " + producerOrgUnitPath
+            throw new IllegalArgumentException( "getDataValues ready for " + String.join( ",", producerOrgUnitPaths )
                 + " but called with " + String.join( ",", consumerOrgUnitPaths ) );
         }
 
@@ -311,6 +316,8 @@ public class PredictionDataValueFetcher
             getNextDataValue();
         }
         while ( producerOrgUnitPath.equals( startingOrgUnitPath ) );
+
+        producerOrgUnitPaths.add( producerOrgUnitPath );
 
         return dataValues;
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
@@ -124,6 +124,8 @@ public class PredictionDataValueFetcher
 
     private String consumerOrgUnitPath;
 
+    private List<String> consumerOrgUnitPaths;
+
     private RuntimeException producerException;
 
     ExecutorService executor;
@@ -169,6 +171,7 @@ public class PredictionDataValueFetcher
         cocLookup = new CachingMap<>();
 
         consumerOrgUnitPath = BEFORE_PATHS;
+        consumerOrgUnitPaths = new ArrayList<>();
         producerException = null;
 
         blockingQueue = new ArrayBlockingQueue<>( DDV_BLOCKING_QUEUE_SIZE );
@@ -241,6 +244,8 @@ public class PredictionDataValueFetcher
 
         consumerOrgUnitPath = orgUnit.getPath();
 
+        consumerOrgUnitPaths.add( consumerOrgUnitPath );
+
         if ( consumerOrgUnitPath.compareTo( producerOrgUnitPath ) < 0 )
         {
             return Collections.emptyList(); // No data fetched for this orgUnit
@@ -249,7 +254,7 @@ public class PredictionDataValueFetcher
         if ( !consumerOrgUnitPath.equals( producerOrgUnitPath ) )
         {
             throw new IllegalArgumentException( "getDataValues ready for " + producerOrgUnitPath
-                + " but called with " + orgUnit.toString() );
+                + " but called with " + String.join( ",", consumerOrgUnitPaths ) );
         }
 
         return getDataValuesForProducerOrgUnit();


### PR DESCRIPTION
On play/dev, predictor runs are still reliably failing for Malaria Outbreak Threshold, and still working just fine on my test machine. The first attempt to solve this, [pull/9174](https://github.com/dhis2/dhis2-core/pull/9174), didn't work.

This PR compiles diagnostic information to be returned on the failing error message, to gain further insight as to where the problem lies.

### Possible causes

`DefaultPredictionService` fetches a list of orgUnits at the prediction orgUnit level using `organisationUnitService.getOrganisationUnitsAtOrgUnitLevels()`, puts these orUnits into a new ArrayList (as of [pull/9174](https://github.com/dhis2/dhis2-core/pull/9174)), sorts the array by orgUnit.path, and calls `PredictionDataValueFetcher.getDataValues()` for each orgUnit, in path order.

Meanwhile, `PredictionDataValueFetcher` has called `dataValueService.getDeflatedDataValues()` to find data for the prediction, also returned in orgUnit path order through a BlockingQueue. This data is returned to `DefaultPredictionService` in orgUnit path order. `PredictionDataValueFetcher` should never get a request for a path later than the data it has ready to return next. The exception on play/dev is thrown when this is not the case.

One of two things is happening: (1) `PredictionDataValueFetcher` isn't calling for all the orgUnits in path order up to where the data is ready but somehow jumps ahead to a later orgUnit, or (2) `PredictionDataValueFetcher` is calling all the orgUnits correctly in path order but there is some other logic problem.

Both of these causes seem improbable on reading the code, and the code works perfectly on my system. Knowing which of these is the culprit can help narrow the investigation.

### Diagnostic information

This PR creates a list of orgUnit paths to save the paths called by `DefaultPredictionService` to `PredictionDataValueFetcher`. When the exception occurs, it includes the list of paths in the exception message. This should tell whether the problem is case (1) or (2) above.