### PR TITLE
chore: quiet down maven in api test runs

### DIFF
--- a/dhis-2/dhis-e2e-test/Dockerfile
+++ b/dhis-2/dhis-e2e-test/Dockerfile
@@ -5,7 +5,7 @@ COPY config/dhis2_home/dhis.conf /config/dhis2_home/dhis.conf
 COPY src /src
 
 RUN chmod +x wait-for-it.sh && \
-    mvn compile
+    mvn --batch-mode --no-transfer-progress compile
 
 VOLUME /target
 

--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -5,3 +5,8 @@ services:
     stdin_open: true
     image: "${IMAGE_NAME}"
     command: ./wait-for-it.sh web:8080 -t 0 -- mvn test -Dinstance.url=http://web:8080/api -Dtest.cleanup=false -Duser.default.username=admin -Duser.default.password=district
+    environment:
+      # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
+      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
+      # This is to quiet down maven logs on CI
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress


### PR DESCRIPTION
using the same maven configuration we use in all our GitHub workflows. Also
use the same configuration when it comes to fetching dependencies

https://github.com/dhis2/dhis2-core/pull/9243 had no effect on building tests inside the e2e test container as the environment variables are not forwarded into the container.