### PR TITLE
fix: use POST for execute jobs [DHIS2-12146] (2.36)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -88,8 +88,8 @@ public class JobConfigurationController
         return new JobTypes( jobConfigurationService.getJobTypeInfo() );
     }
 
-    @RequestMapping( value = "{uid}/execute", method = RequestMethod.GET, produces = { "application/json",
-        "application/javascript" } )
+    @RequestMapping( value = "{uid}/execute", method = { RequestMethod.GET, RequestMethod.POST }, produces = {
+        "application/json", "application/javascript" } )
     public ObjectReport executeJobConfiguration( @PathVariable( "uid" ) String uid )
         throws WebMessageException
     {


### PR DESCRIPTION
This is not a backport of #9252 by cherry-picking that change since we keep `GET` in 2.36 for backwards compatibility.