### PR TITLE
fix: allow non ASCII letters for SQL view var values [DHIS2-11932] (2.35)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
@@ -76,7 +76,7 @@ public class SqlView
 
     private static final String REGEX_SEP = "|";
 
-    private static final String QUERY_VALUE_REGEX = "^[\\w\\s\\-]*$";
+    private static final String QUERY_VALUE_REGEX = "^[\\p{L}\\w\\s\\-]*$";
 
     // -------------------------------------------------------------------------
     // Properties

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.sqlview;
 
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -46,7 +45,8 @@ import org.hisp.dhis.user.UserCredentials;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.*;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -304,13 +304,6 @@ public class SqlViewServiceTest
         sqlViewService.saveSqlView( sqlView );
 
         sqlViewService.getSqlViewGrid( sqlView, null, null, null, null );
-    }
-
-    @Test
-    public void testValidateSuccess_NonAsciiLetterVariableValues()
-    {
-        sqlViewService.validateSqlView( getSqlView( "select * from dataelement where valueType = '${valueType}'" ),
-            null, singletonMap( "valueType", "å" ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.sqlview;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -303,6 +304,13 @@ public class SqlViewServiceTest
         sqlViewService.saveSqlView( sqlView );
 
         sqlViewService.getSqlViewGrid( sqlView, null, null, null, null );
+    }
+
+    @Test
+    public void testValidateSuccess_NonAsciiLetterVariableValues()
+    {
+        sqlViewService.validateSqlView( getSqlView( "select * from dataelement where valueType = '${valueType}'" ),
+            null, singletonMap( "valueType", "å" ) );
     }
 
     @Test


### PR DESCRIPTION
2.35 backport of #9187 where test changes got removed as they required other changes that were never backported.