### PR TITLE
fix: compile with JDK11 using maven compiler plugin

### DIFF
--- a/dhis-2/dhis-e2e-test/pom.xml
+++ b/dhis-2/dhis-e2e-test/pom.xml
@@ -11,8 +11,6 @@
   <properties>
     <rootDir>..</rootDir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
   </properties>
 
@@ -89,6 +87,15 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <release>11</release>
+            <encoding>${project.build.sourceEncoding}</encoding>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -47,7 +47,6 @@
 
         <minimum-maven.version>3.6.0</minimum-maven.version>
         <minimum-java.version>11</minimum-java.version>
-        <maven.compiler.release>11</maven.compiler.release>
 
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
         <sonar.organization>dhis2</sonar.organization>
@@ -505,8 +504,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <release>${minimum-java.version}</release>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <annotationProcessorPaths>
                             <path>


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/9258 left it at JDK8

It was a bit confusing since we mix different ways of configuring the compiler plugin 
like the build plugins configuration and the user property
https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html

I'll stick to the build plugins configuration so there is one place where we declare how to configure the compiler plugin