### PR TITLE
fix: Test failing on jenkins due to race conditions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -208,7 +208,7 @@ public class TrackerIdentifierCollector
     private void collectRelationships(
         Map<Class<?>, Set<String>> map, List<Relationship> relationships )
     {
-        relationships.parallelStream().forEach( relationship -> {
+        relationships.forEach( relationship -> {
 
             RelationshipKey relationshipKey = RelationshipPreheatKeySupport.getRelationshipKey( relationship );
 
@@ -234,28 +234,16 @@ public class TrackerIdentifierCollector
     private <T> void addIdentifier( Map<Class<?>, Set<String>> map,
         Class<T> klass, TrackerIdScheme identifier, String str )
     {
-        try
+        if ( StringUtils.isEmpty( str ) || map == null || klass == null || identifier == null )
         {
-            if ( StringUtils.isEmpty( str ) || map == null || klass == null || identifier == null )
-            {
-                return;
-            }
-
-            if ( !map.containsKey( klass ) )
-            {
-                map.put( klass, new HashSet<>() );
-            }
-
-            map.get( klass ).add( str );
+            return;
         }
-        catch ( NullPointerException e )
+
+        if ( !map.containsKey( klass ) )
         {
-            System.err.println( "map: " + map );
-            System.err.println( "klass: " + klass );
-            System.err.println( "map.containsKey(klass): " + map.containsKey( klass ) );
-            System.err.println( "map.get(klass): " + map.get( klass ) );
-            System.err.println( "str: " + str );
-            throw e;
+            map.put( klass, new HashSet<>() );
         }
+
+        map.get( klass ).add( str );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -27,7 +27,12 @@
  */
 package org.hisp.dhis.tracker;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -229,16 +234,28 @@ public class TrackerIdentifierCollector
     private <T> void addIdentifier( Map<Class<?>, Set<String>> map,
         Class<T> klass, TrackerIdScheme identifier, String str )
     {
-        if ( StringUtils.isEmpty( str ) || map == null || klass == null || identifier == null )
+        try
         {
-            return;
-        }
+            if ( StringUtils.isEmpty( str ) || map == null || klass == null || identifier == null )
+            {
+                return;
+            }
 
-        if ( !map.containsKey( klass ) )
+            if ( !map.containsKey( klass ) )
+            {
+                map.put( klass, new HashSet<>() );
+            }
+
+            map.get( klass ).add( str );
+        }
+        catch ( NullPointerException e )
         {
-            map.put( klass, new HashSet<>() );
+            System.err.println( "map: " + map );
+            System.err.println( "klass: " + klass );
+            System.err.println( "map.containsKey(klass): " + map.containsKey( klass ) );
+            System.err.println( "map.get(klass): " + map.get( klass ) );
+            System.err.println( "str: " + str );
+            throw e;
         }
-
-        map.get( klass ).add( str );
     }
 }


### PR DESCRIPTION
Removed the paralellStream from the code. Not sure it actually made any difference, since it would be split amount any relationships, which usually is just a small portion of the payload sent in. If it becomes relevant to parallelise this process, it should include the other entities as well, not just relationships.