### PR TITLE
feat: Gist API string length and ieq filters [DHIS2-12168]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -892,6 +892,7 @@ final class GistBuilder
         case NOT_NULL:
             return "is not null";
         case EQ:
+        case IEQ:
             return "=";
         case NE:
             return "!=";
@@ -1032,6 +1033,10 @@ final class GistBuilder
     private Object getParameterValue( Property property, Filter filter, String value,
         BiFunction<String, Class<?>, Object> argumentParser )
     {
+        if ( isStringLengthFilter( filter, property ) )
+        {
+            return argumentParser.apply( value, Integer.class );
+        }
         if ( value == null || property.getKlass() == String.class )
         {
             return value;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.gist;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.PropertyType;
@@ -115,13 +116,17 @@ final class GistLogic
 
     static boolean isCollectionSizeFilter( Filter filter, Property property )
     {
-        return filter.getOperator().isSizeCompare() ||
+        return filter.getOperator().isEmptinessCompare() ||
             (filter.getOperator().isNumericCompare() && property.isCollection());
     }
 
     static boolean isStringLengthFilter( Filter filter, Property property )
     {
-        return filter.getOperator().isSizeCompare() && property.isSimple() && property.getKlass() == String.class;
+        Comparison op = filter.getOperator();
+        return property.isSimple() && property.getKlass() == String.class &&
+            (op.isEmptinessCompare()
+                || (op.isOrderCompare() && filter.getValue().length == 1
+                    && filter.getValue()[0].matches( "[0-9]+" )));
     }
 
     static Transform effectiveTransform( Property property, Transform fallback, Transform target )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -289,6 +289,7 @@ public final class GistQuery
         NULL( "null" ),
         NOT_NULL( "!null" ),
         EQ( "eq" ),
+        IEQ( "ieq" ),
         NE( "!eq", "ne", "neq" ),
 
         // numeric comparison
@@ -356,12 +357,12 @@ public final class GistQuery
 
         public boolean isIdentityCompare()
         {
-            return this == NULL || this == NOT_NULL || this == EQ || this == NE;
+            return this == NULL || this == NOT_NULL || this == EQ || this == IEQ || this == NE;
         }
 
         public boolean isOrderCompare()
         {
-            return this == EQ || this == NE || isNumericCompare();
+            return this == EQ || this == IEQ || this == NE || isNumericCompare();
         }
 
         public boolean isNumericCompare()
@@ -371,10 +372,10 @@ public final class GistQuery
 
         public boolean isCollectionCompare()
         {
-            return isContainsCompare() || isSizeCompare();
+            return isContainsCompare() || isEmptinessCompare();
         }
 
-        public boolean isSizeCompare()
+        public boolean isEmptinessCompare()
         {
             return this == EMPTY || this == NOT_EMPTY;
         }
@@ -396,7 +397,7 @@ public final class GistQuery
 
         public boolean isCaseInsensitive()
         {
-            return ordinal() >= ILIKE.ordinal() && ordinal() <= NOT_ENDS_WITH.ordinal();
+            return this == IEQ || ordinal() >= ILIKE.ordinal() && ordinal() <= NOT_ENDS_WITH.ordinal();
         }
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractGistControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractGistControllerTest.java
@@ -81,6 +81,15 @@ abstract class AbstractGistControllerTest extends DhisControllerConvenienceTest
         }
     }
 
+    protected final void createDataSetsForOrganisationUnit( String organisationUnitId, String... names )
+    {
+        for ( String name : names )
+        {
+            assertStatus( HttpStatus.CREATED, POST( "/dataSets/", "{'name':'" + name
+                + "', 'organisationUnits': [{'id':'" + organisationUnitId + "'}], 'periodType':'Daily'}" ) );
+        }
+    }
+
     static void assertHasPager( JsonObject response, int page, int pageSize )
     {
         assertHasPager( response, page, pageSize, null );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -364,4 +364,86 @@ public class GistFilterControllerTest extends AbstractGistControllerTest
         assertEquals( "alpha4", matches.getObject( 0 ).getString( "name" ).string() );
         assertEquals( "beta1", matches.getObject( 1 ).getString( "name" ).string() );
     }
+
+    @Test
+    public void testFilter_EqLength()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Mary", "Ringo", "John", "George" );
+
+        assertEquals( List.of( "John", "Mary", "Paul", "set1" ),
+            GET( "/dataSets/gist?fields=name&filter=name:eq:4&headless=true&order=name" ).content().stringValues() );
+        assertEquals( List.of( "Peter", "Ringo" ),
+            GET( "/dataSets/gist?fields=name&filter=name:eq:5&headless=true&order=name" ).content().stringValues() );
+        assertEquals( List.of( "George" ),
+            GET( "/dataSets/gist?fields=name&filter=name:eq:6&headless=true&order=name" ).content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_NeqLength()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Mary", "Ringo", "John", "George" );
+
+        assertEquals( List.of( "George", "Peter", "Ringo" ),
+            GET( "/dataSets/gist?fields=name&filter=name:neq:4&headless=true&order=name" ).content().stringValues() );
+        assertEquals( List.of( "George", "John", "Mary", "Paul", "set1" ),
+            GET( "/dataSets/gist?fields=name&filter=name:neq:5&headless=true&order=name" ).content().stringValues() );
+        assertEquals( List.of( "John", "Mary", "Paul", "Peter", "Ringo", "set1" ),
+            GET( "/dataSets/gist?fields=name&filter=name:neq:6&headless=true&order=name" ).content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_GeLength()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Mary", "Ringo", "John", "George" );
+
+        assertEquals( List.of( "George", "Peter", "Ringo" ),
+            GET( "/dataSets/gist?fields=name&filter=name:ge:5&headless=true&order=name" ).content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_GtLength()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Mary", "Ringo", "John", "George" );
+
+        assertEquals( List.of( "George", "Peter", "Ringo" ),
+            GET( "/dataSets/gist?fields=name&filter=name:gt:4&headless=true&order=name" ).content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_LtLength()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Mary", "Ringo", "John", "George" );
+
+        assertEquals( List.of( "John", "Mary", "Paul", "set1" ),
+            GET( "/dataSets/gist?fields=name&filter=name:lt:5&headless=true&order=name" ).content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_LeLength()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Mary", "Ringo", "John", "George" );
+
+        assertEquals( List.of( "John", "Mary", "Paul", "set1" ),
+            GET( "/dataSets/gist?fields=name&filter=name:le:4&headless=true&order=name" ).content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_Ieq()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Paula", "Ringo", "John", "George", "paul" );
+
+        assertEquals( List.of( "Paul", "paul" ),
+            GET( "/dataSets/gist?fields=name&filter=name:ieq:paul&headless=true&order=name" )
+                .content().stringValues() );
+    }
+
+    @Test
+    public void testFilter_IeqViaILike()
+    {
+        createDataSetsForOrganisationUnit( orgUnitId, "Peter", "Paul", "Paula", "Ringo", "John", "George", "paul" );
+
+        assertEquals( List.of( "Paul", "paul" ),
+            GET( "/dataSets/gist?fields=name&filter=name:ilike:paul&filter=name:eq:4&headless=true&order=name" )
+                .content().stringValues() );
+    }
 }


### PR DESCRIPTION
### Summary
Adds string field filters:
* `ieq` for case insensitive comparison (uses equivalent of `lower(field) = lower(value)`)
* `str-field:eq:<length>`: is length of the field equal to _length?
* `str-field:neq:<length>`: is length of the field not equal to _length?
* `str-field:gt:<length>`: is length of the field greater than _length?
* `str-field:lt:<length>`: is length of the field less than _length?
* `str-field:ge:<length>`: is length of the field greater than or equal to _length?
* `str-field:le:<length>`: is length of the field less than or equal to _length?

The length comparison for string fields is automatically identified. If the value given is a decimal number and the field is a string field this will assume this is a length comparison, not a string character comparison for the number characters.

### Automatic Testing
Unit tests were added for each new filter type.

### Manual Testing
* test described filters, e.g. `name:eq:4` (length 4), `name:gt:4` (longer than 4), ...
* test that text field filters filtering for text continue to work, e.g. `name:eq:Peter`, `name:neq:Peter`

### Documentation
https://github.com/dhis2/dhis2-docs/pull/896