### PR TITLE
chore: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,4 +63,8 @@ updates:
           - ">= 2.13.0"
       - dependency-name: "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" # later versions have failing tests
         versions:
-          - ">= 2.13.0"          
+          - ">= 2.13.0" 
+      - dependency-name: "org.eclipse.jetty:*" # later versions have failing tests
+        versions:
+          - ">= 9.4.41.v20210516"
+          

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,36 @@ updates:
       - dependency-name: "com.zaxxer:HikariCP" # remove once we update minimum JDK to JDK11; https://github.com/brettwooldridge/HikariCP#artifacts
         versions:
           - ">= 5.0"
+      - dependency-name: "org.hibernate:hibernate-core" # later versions have failing tests
+        versions:
+          - ">= 5.4.28.Final"
+      - dependency-name: "org.hibernate:hibernate-validator" # later versions have failing tests
+        versions:
+          - ">= 5.4.28.Final"
+      - dependency-name: "org.hibernate:hibernate-echache" # later versions have failing tests
+        versions:
+          - ">= 5.4.28.Final"
+      - dependency-name: "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5" # later versions have failing tests
+        versions:
+          - ">= 2.11.2"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-core" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-annotations" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"
+      - dependency-name: "com.fasterxml.jackson.dataformat:jackson-dataformat-xml" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"
+      - dependency-name: "com.fasterxml.jackson.dataformat:jackson-dataformat-csv" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"
+      - dependency-name: "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"
+      - dependency-name: "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" # later versions have failing tests
+        versions:
+          - ">= 2.13.0"          


### PR DESCRIPTION
Add ignore config for Hibernate and Jackson, since they are failing tests on higher versions.