### PR TITLE
chore(deps): update hibernate to 5.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,15 +28,18 @@ updates:
       - "java"
       - "run-api-tests"
     ignore:
-      - dependency-name: "org.hibernate:hibernate-core" # later versions have failing tests
+      - dependency-name: "org.hibernate:hibernate-core" # we cannot yet update to 5.6 or above due to https://github.com/vladmihalcea/hibernate-types#installation
         versions:
-          - ">= 5.4.28.Final"
-      - dependency-name: "org.hibernate:hibernate-validator" # later versions have failing tests
+          - ">= 5.6"
+      - dependency-name: "org.hibernate:hibernate-echache" # needs to stay in sync with hibernate-core, versions are kept in sync in pom via hibernate.version
         versions:
-          - ">= 5.4.28.Final"
-      - dependency-name: "org.hibernate:hibernate-echache" # later versions have failing tests
+          - ">= 5.6"
+      - dependency-name: "org.hibernate:hibernate-spatial" # needs to stay in sync with hibernate-core, versions are kept in sync in pom via hibernate.versions
         versions:
-          - ">= 5.4.28.Final"
+          - ">= 5.6"
+      - dependency-name: "org.hibernate:hibernate-validator" # requires more work due to package changes https://hibernate.org/validator/documentation/migration-guide/#7-0-x
+        versions:
+          - ">= 7.0"
       - dependency-name: "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5" # later versions have failing tests
         versions:
           - ">= 2.11.2"

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>com.vladmihalcea</groupId>
-      <artifactId>hibernate-types-52</artifactId>
+      <artifactId>hibernate-types-55</artifactId>
       <version>${hibernate-types.version}</version>
     </dependency>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -83,8 +83,9 @@
 
         <!--DBMS -->
         <flyway-core.version>8.0.4</flyway-core.version>
-        <hibernate.version>5.4.28.Final</hibernate.version>
-        <hibernate-types.version>2.10.4</hibernate-types.version>
+        <hibernate.version>5.5.8.Final</hibernate.version>
+        <!-- See hibernate compatibility list https://github.com/vladmihalcea/hibernate-types#installation -->
+        <hibernate-types.version>2.14.0</hibernate-types.version>
         <!-- Data sources,db pools and db drivers-->
         <c3p0.version>0.9.5.5</c3p0.version>
         <HikariCP.version>5.0.0</HikariCP.version>


### PR DESCRIPTION
according to https://github.com/hibernate/hibernate-orm/blob/5.5/migration-guide.adoc
there should be no major changes blocking this.
https://github.com/vladmihalcea/hibernate-types\#installation does not yet support > 5.5
so we need to pin our hibernate versions to it