### PR TITLE
build: allow overriding skipTests in default profile

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build analytics with dependencies
         env:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn --threads 2C clean install -DskipTests -Dmaven.tests.skip=true --batch-mode --no-transfer-progress -f dhis-2/pom.xml -pl=dhis-services/dhis-service-analytics/pom.xml --also-make
+        run: mvn --threads 2C clean install -DskipTests -Dmaven.test.skip=true --batch-mode --no-transfer-progress -f dhis-2/pom.xml -pl=dhis-services/dhis-service-analytics/pom.xml --also-make
 
       - name: Run analytics integration tests
         env:

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -53,6 +53,10 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <surefireArgLine>-Xmx1024m --illegal-access=permit</surefireArgLine>
 
+        <!-- Needed so we can disable running tests when the default profile is used (activated by default). It does not
+          honor -DskipTests otherwise https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html -->
+        <skipTests>false</skipTests>
+
         <!-- *Dependencies* -->
 
         <!-- DHIS2 Rule Engine-->
@@ -352,7 +356,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${maven-surefire-plugin.version}</version>
                         <configuration>
-                            <skipTests>false</skipTests>
+                            <skipTests>${skipTests}</skipTests>
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>${surefireArgLine}</argLine>
                             <excludedGroups>org.hisp.dhis.IntegrationTest</excludedGroups>


### PR DESCRIPTION
We are running unit tests even when passing '-DskipTests'
since activating the default profile by default.

Expose a user property, ensuring we run unit tests by default
but can opt out if we want to.

https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html

A typo in the analytics job lead to compiling test code which we do not need.