### PR TITLE
DO NOT MERGE feat: use buildkit cache mount to speed up builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.3
 #
 # Build the base DHIS2 image
 #
@@ -17,8 +18,8 @@ WORKDIR /src
 COPY . .
 
 # TODO: We should be able to achieve much faster incremental builds and cached dependencies using
-RUN mvn clean install --batch-mode --no-transfer-progress -Pdev -f dhis-2/pom.xml -DskipTests -pl -dhis-web-embedded-jetty
-RUN mvn clean install --batch-mode --no-transfer-progress -Pdev -U -f dhis-2/dhis-web/pom.xml -DskipTests
+RUN --mount=type=cache,target=/root/.m2/repository mvn clean install --batch-mode --no-transfer-progress -Pdev -f dhis-2/pom.xml -DskipTests -pl -dhis-web-embedded-jetty
+RUN --mount=type=cache,target=/root/.m2/repository mvn clean install --batch-mode --no-transfer-progress -Pdev -U -f dhis-2/dhis-web/pom.xml -DskipTests
 
 RUN cp dhis-2/dhis-web/dhis-web-portal/target/dhis.war /dhis.war && \
     cd / && \

--- a/dhis-2/dhis-e2e-test/Dockerfile
+++ b/dhis-2/dhis-e2e-test/Dockerfile
@@ -1,10 +1,12 @@
+# syntax=docker/dockerfile:1.3
+
 FROM maven:3.6.3-openjdk-11-slim
 
 COPY pom.xml wait-for-it.sh /
 COPY config/dhis2_home/dhis.conf /config/dhis2_home/dhis.conf
 COPY src /src
 
-RUN chmod +x wait-for-it.sh && \
+RUN --mount=type=cache,target=/root/.m2/repository chmod +x wait-for-it.sh && \
     mvn --batch-mode --no-transfer-progress compile
 
 VOLUME /target


### PR DESCRIPTION
NOTE: This is just to verify that it would work on GitHub

We are already using [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds) on GitHub. Just not this feature
https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md\#run---mounttypecache
Create a cache for the local maven repository which will be shared between different
docker build invocations. So if the cache is present we will only have the compile/package cost of our
maven build incurred in these RUN commands

> Contents of the cache directories persists between builder invocations without invalidating the instruction cache. Cache mounts should only be used for better performance. Your build should work with any contents of the cache directory as another build may overwrite the files or GC may clean it if more storage space is needed.

Some sample logs from local builds with/without cache

With cache already populated

```
⏵ core git:(buildkit-cache) ✗ docker build . -t foo
[+] Building 105.1s (21/21) FINISHED
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 1.26kB                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 199B                                                                                                                  0.0s
 => resolve image config for docker.io/docker/dockerfile:1.3                                                                                       1.9s
 => CACHED docker-image://docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2                  0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                   0.0s
 => [internal] load metadata for docker.io/library/maven:3.8.1-jdk-11-slim                                                                         0.0s
 => [build 1/7] FROM docker.io/library/maven:3.8.1-jdk-11-slim                                                                                     0.0s
 => [stage-1 1/4] FROM docker.io/library/alpine:latest                                                                                             0.0s
 => [internal] load build context                                                                                                                  0.5s
 => => transferring context: 23.10MB                                                                                                               0.4s
 => CACHED [build 2/7] RUN apt-get update &&     apt-get install --no-install-recommends -y git                                                    0.0s
 => CACHED [build 3/7] WORKDIR /src                                                                                                                0.0s
 => [build 4/7] COPY . .                                                                                                                           1.1s
 => [build 5/7] RUN --mount=type=cache,target=/root/.m2/repository mvn clean install --batch-mode --no-transfer-progress -Pdev -f dhis-2/pom.xml  53.6s
 => [build 6/7] RUN --mount=type=cache,target=/root/.m2/repository mvn clean install --batch-mode --no-transfer-progress -Pdev -U -f dhis-2/dhis  37.3s
 => [build 7/7] RUN cp dhis-2/dhis-web/dhis-web-portal/target/dhis.war /dhis.war &&     cd / &&     sha256sum dhis.war > /sha256sum.txt &&     md  4.4s
 => [stage-1 2/4] COPY --from=build /dhis.war /srv/dhis2/dhis.war                                                                                  0.7s
 => [stage-1 3/4] COPY --from=build /sha256sum.txt /srv/dhis2/sha256sum.txt                                                                        0.1s
 => [stage-1 4/4] COPY --from=build /md5sum.txt /srv/dhis2/md5sum.txt                                                                              0.2s
 => exporting to image                                                                                                                             2.1s
 => => exporting layers                                                                                                                            2.0s
 => => writing image sha256:5ebfd8223d3f05434e199f331d6a7e9229ea48c0d66dc0a38c97517d302d9738                                                       0.0s
 => => naming to docker.io/library/foo                                                                                                             0.0s
```

Removing the cache and building again

` docker builder prune --filter type=exec.cachemount`

```
[+] Building 266.5s (21/21) FINISHED
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 38B                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                  0.1s
 => => transferring context: 35B                                                                                                                   0.0s
 => resolve image config for docker.io/docker/dockerfile:1.3                                                                                       1.1s
 => CACHED docker-image://docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2                  0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                   0.0s
 => [internal] load metadata for docker.io/library/maven:3.8.1-jdk-11-slim                                                                         0.0s
 => CACHED [build 1/7] FROM docker.io/library/maven:3.8.1-jdk-11-slim                                                                              0.0s
 => CACHED [stage-1 1/4] FROM docker.io/library/alpine:latest                                                                                      0.0s
 => [internal] load build context                                                                                                                  0.4s
 => => transferring context: 1.01MB                                                                                                                0.3s
 => [build 2/7] RUN apt-get update &&     apt-get install --no-install-recommends -y git                                                           7.8s
 => [build 3/7] WORKDIR /src                                                                                                                       0.1s
 => [build 4/7] COPY . .                                                                                                                           0.8s
 => [build 5/7] RUN --mount=type=cache,target=/root/.m2/repository mvn clean install --batch-mode --no-transfer-progress -Pdev -f dhis-2/pom.xm  205.9s
 => [build 6/7] RUN --mount=type=cache,target=/root/.m2/repository mvn clean install --batch-mode --no-transfer-progress -Pdev -U -f dhis-2/dhis  40.3s
 => [build 7/7] RUN cp dhis-2/dhis-web/dhis-web-portal/target/dhis.war /dhis.war &&     cd / &&     sha256sum dhis.war > /sha256sum.txt &&     md  4.4s
 => [stage-1 2/4] COPY --from=build /dhis.war /srv/dhis2/dhis.war                                                                                  0.7s
 => [stage-1 3/4] COPY --from=build /sha256sum.txt /srv/dhis2/sha256sum.txt                                                                        0.1s
 => [stage-1 4/4] COPY --from=build /md5sum.txt /srv/dhis2/md5sum.txt                                                                              0.1s
 => exporting to image                                                                                                                             2.2s
 => => exporting layers                                                                                                                            2.2s
 => => writing image sha256:224a8099079b96011c330e5914c3badb34037a145a57da980d117d6e46503c39                                                       0.0s
 => => naming to docker.io/library/foo                                                                                                             0.0s
```

You can see the `mvn clean install -f dhis-2/pom.xml` takes `205.9s` if cache is empty and  `53.6s` when it has already been populated by a previous build.

205.9s-53.6s=152.3s=2.5min (or 73% reduction) for this one `RUN` command.

The `run-api-test.yml` workflow will profit from this as it builds the DHIS2 Docker image. The publishing Docker images pipeline on Jenkins would also benefit from this.