### PR TITLE
chore: provide meaningful error message DHIS2-12123

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
@@ -36,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramStore;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
@@ -53,6 +54,9 @@ public class ProgramInstanceSupplier extends AbstractPreheatSupplier
     @NonNull
     private final ProgramInstanceStore programInstanceStore;
 
+    @NonNull
+    private final ProgramStore programStore;
+
     @Override
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
@@ -60,7 +64,10 @@ public class ProgramInstanceSupplier extends AbstractPreheatSupplier
             .stream()
             .filter( program -> program.getProgramType().equals( ProgramType.WITHOUT_REGISTRATION ) )
             .collect( Collectors.toList() );
-
+        if ( programsWithoutRegistration.isEmpty() )
+        {
+            programsWithoutRegistration = programStore.getByType( ProgramType.WITHOUT_REGISTRATION );
+        }
         if ( !programsWithoutRegistration.isEmpty() )
         {
             List<ProgramInstance> programInstances = DetachUtils.detach( ProgramInstanceMapper.INSTANCE,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.preprocess;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -66,6 +67,21 @@ public class EventProgramPreProcessor
                 ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
                 if ( Objects.nonNull( programStage ) )
                 {
+                    // Program stages should always have a program! Due to how
+                    // metadata import is currently implemented
+                    // it's possible that users run into the edge case that a
+                    // program stage does not have an associated
+                    // program. Tell the user it's an issue with the metadata
+                    // and not the event itself. This should be
+                    // fixed in the metadata import. For more see
+                    // https://jira.dhis2.org/browse/DHIS2-12123
+                    if ( programStage.getProgram() == null )
+                    {
+                        throw new IllegalStateException(
+                            MessageFormat.format(
+                                "Program stage `{0}` has no reference to a program. Check the program stage configuration",
+                                programStage.getUid() ) );
+                    }
                     event.setProgram( programStage.getProgram().getUid() );
                     bundle.getPreheat().put( TrackerIdentifier.UID, programStage.getProgram() );
                 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramStore;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
@@ -63,7 +64,10 @@ public class ProgramInstanceSupplierTest extends DhisConvenienceTest
     private ProgramInstanceSupplier supplier;
 
     @Mock
-    private ProgramInstanceStore store;
+    private ProgramInstanceStore programInstanceStore;
+
+    @Mock
+    private ProgramStore programStore;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -95,8 +99,8 @@ public class ProgramInstanceSupplierTest extends DhisConvenienceTest
         programInstances.get( 0 ).setProgram( programWithRegistration );
         programInstances.get( 1 ).setProgram( programWithoutRegistration );
 
-        when( store.getByPrograms( Lists.newArrayList( programWithoutRegistration ) ) ).thenReturn( programInstances );
-
+        when( programInstanceStore.getByPrograms( Lists.newArrayList( programWithoutRegistration ) ) )
+            .thenReturn( programInstances );
     }
 
     @Test
@@ -118,6 +122,26 @@ public class ProgramInstanceSupplierTest extends DhisConvenienceTest
         {
             assertNull( preheat.getProgramInstancesWithoutRegistration( programUid ) );
         }
+    }
+
+    @Test
+    public void verifySupplierWhenNoProgramsArePresent()
+    {
+        // given
+        TrackerPreheat preheat = new TrackerPreheat();
+        when( programStore.getByType( WITHOUT_REGISTRATION ) ).thenReturn( List.of( programWithoutRegistration ) );
+        programInstances = rnd.randomObjects( ProgramInstance.class, 1 );
+        // set the OrgUnit parent to null to avoid recursive errors when mapping
+        programInstances.forEach( p -> p.getOrganisationUnit().setParent( null ) );
+        programInstances.get( 0 ).setProgram( programWithoutRegistration );
+        when( programInstanceStore.getByPrograms( List.of( programWithoutRegistration ) ) )
+            .thenReturn( programInstances );
+
+        // when
+        this.supplier.preheatAdd( params, preheat );
+
+        // then
+        assertNotNull( preheat.getProgramInstancesWithoutRegistration( programWithoutRegistration.getUid() ) );
     }
 
     @Test


### PR DESCRIPTION
The failed event import in NTI is due to

1. no program instance in the tracker preheat
2. occasionally it is also due to a missing reference from a program stage to a program. This is happening because of the way the metadata import is implemented.

1. is fixed by putting program instances without registration into the preheat
2. is alleviated by providing an error message guiding the user to a solution for this edge
case. The root cause will be fixed in the metadata import.

After merging this change

The SQL insert error (1.) is fixed.

2. HTTP request

```sh
curl -i -u $AUTH \
  -H 'content-type: application/json' \
  --data @events.json \
  "${HOST}/api/tracker?async=false"
```

that fails due to a program stage missing a reference to a program gets an HTTP response like

HTTP/1.1 409 Conflict
Set-Cookie: JSESSIONID=node01y0j43eo2acmp2cw8i67685d71.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Content-Type: application/json
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
X-Frame-Options: SAMEORIGIN
Transfer-Encoding: chunked
Server: Jetty(10.0.7)

```json
{"status":"ERROR","validationReport":{"errorReports":[]},"message":"Exception:Program stage `LGSWs20XFvy` has no reference to a program. Check the program stage (DHIS2-12123)"}
```

The logs will show a stacktrace like

```
08:26:59.751  INFO [qtp106999035-19] o.h.d.d.m.DefaultMetadataImportService   : (system) Import:Start
08:26:59.941  INFO [qtp106999035-19] o.h.d.p.DefaultPreheatService            : (system) Import:Preheat[REFERENCE] took 0.175735 sec.
08:26:59.967  INFO [qtp106999035-19] m.o.DefaultObjectBundleValidationService : (system) Import:Validation took 0.012552 sec.
08:26:59.973  INFO [qtp106999035-19] o.h.d.d.m.o.DefaultObjectBundleService   : (system) Creating 2 object(s) of type DataElement
08:26:59.989  INFO [qtp106999035-19] o.h.d.d.m.o.DefaultObjectBundleService   : (system) Creating 1 object(s) of type ProgramStage
08:27:00.003  INFO [qtp106999035-19] o.h.d.d.m.o.DefaultObjectBundleService   : (system) Creating 1 object(s) of type Program
08:27:00.043  INFO [qtp106999035-19] o.h.d.c.DefaultHibernateCacheManager     : Hibernate caches cleared
08:27:00.044  INFO [qtp106999035-19] o.h.d.d.m.DefaultMetadataImportService   : (system) Import:Commit took 0.075649 sec.
08:27:00.044  INFO [qtp106999035-19] o.h.d.d.m.DefaultMetadataImportService   : (system) Import:Done took 0.293855 sec.
08:27:00.196  INFO [qtp106999035-24] o.h.d.s.AuthenticationLoggerListener     : Authentication event: AuthenticationSuccessEvent; username: system;
08:27:00.243  INFO [qtp106999035-24] o.h.d.s.n.NotificationLoggerUtil         : TRACKER_IMPORT_JOB ( vLGCRa8BdWW ) started by system ( GOLswS44mh8 ) Import:Start
08:27:00.500 ERROR [qtp106999035-24] o.h.d.t.r.DefaultTrackerImportService    : Exception thrown during import.
java.lang.IllegalStateException: Program stage `LGSWs20XFvy` has no reference to a program. Check the program stage (DHIS2-12123)
        at org.hisp.dhis.tracker.preprocess.EventProgramPreProcessor.process(EventProgramPreProcessor.java:78)
        at org.hisp.dhis.tracker.preprocess.DefaultTrackerPreprocessService.preprocess(DefaultTrackerPreprocessService.java:57)
        at org.hisp.dhis.tracker.report.DefaultTrackerImportService.preProcessBundle(DefaultTrackerImportService.java:272)
        at org.hisp.dhis.tracker.report.DefaultTrackerImportService.lambda$preProcess$1(DefaultTrackerImportService.java:157)
        at org.hisp.dhis.tracker.report.TrackerTimingsStats.execVoid(TrackerTimingsStats.java:152)
        at org.hisp.dhis.tracker.report.DefaultTrackerImportService.preProcess(DefaultTrackerImportService.java:156)
        at org.hisp.dhis.tracker.report.DefaultTrackerImportService.importTracker(DefaultTrackerImportService.java:111)
        at org.hisp.dhis.webapi.strategy.tracker.imports.impl.TrackerImportSyncStrategyImpl.importReport(TrackerImportSyncStrategyImpl.java:51)
        at org.hisp.dhis.webapi.strategy.tracker.imports.impl.TrackerImportStrategyImpl.importReport(TrackerImportStrategyImpl.java:75)
        at org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportController.syncPostJsonTracker(TrackerImportController.java:138)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```