### PR TITLE
fix: fix running dhis war using maven jetty plugin

### DIFF
--- a/dhis-2/dhis-web-embedded-jetty/src/main/resources/jetty-logging.properties
+++ b/dhis-2/dhis-web-embedded-jetty/src/main/resources/jetty-logging.properties
@@ -26,4 +26,4 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.Slf4jLog
+# File to add Jetty specific logging config https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-troubleshooting-logging

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -135,13 +135,6 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty.version}</version>
         <configuration>
-          <requestLog implementation="org.eclipse.jetty.server.NCSARequestLog">
-            <filename>/tmp/request.log</filename>
-            <retainDays>2</retainDays>
-            <append>true</append>
-            <extended>false</extended>
-            <logTimeZone>GMT</logTimeZone>
-          </requestLog>
           <systemProperties>
             <systemProperty>
               <name>org.eclipse.jetty.server.Request.maxFormContentSize</name>


### PR DESCRIPTION
https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/server/NCSARequestLog.html
was deprecated and subsequently removed
Jetty 10 changed quite a lot regarding logging
https://github.com/eclipse/jetty.project/issues/4572

there might be other settings we find have changed, that we need to adapt