### PR TITLE
fix: OrgUnitIdScheme not working when adding enrollment [DHIS2-12181] (2.38)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -475,15 +475,16 @@ public abstract class AbstractEnrollmentService
 
         Program program = getProgram( importOptions.getIdSchemes(), enrollment.getProgram() );
 
-        ImportSummary importSummary = validateRequest( program, daoTrackedEntityInstance, enrollment, importOptions );
+        OrganisationUnit organisationUnit = getOrganisationUnit( importOptions.getIdSchemes(),
+            enrollment.getOrgUnit() );
+
+        ImportSummary importSummary = validateRequest( program, daoTrackedEntityInstance, enrollment, organisationUnit,
+            importOptions );
 
         if ( importSummary.getStatus() != ImportStatus.SUCCESS )
         {
             return importSummary;
         }
-
-        OrganisationUnit organisationUnit = getOrganisationUnit( importOptions.getIdSchemes(),
-            enrollment.getOrgUnit() );
 
         List<String> errors = trackerAccessManager.canCreate( importOptions.getUser(),
             new ProgramInstance( program, daoTrackedEntityInstance, organisationUnit ), false );
@@ -646,11 +647,11 @@ public abstract class AbstractEnrollmentService
 
     private ImportSummary validateRequest( Program program,
         org.hisp.dhis.trackedentity.TrackedEntityInstance entityInstance,
-        Enrollment enrollment, ImportOptions importOptions )
+        Enrollment enrollment, OrganisationUnit organisationUnit, ImportOptions importOptions )
     {
         ImportSummary importSummary = new ImportSummary( enrollment.getEnrollment() );
 
-        String error = validateProgramForEnrollment( program, enrollment );
+        String error = validateProgramForEnrollment( program, enrollment, organisationUnit, importOptions );
         if ( !StringUtils.isEmpty( error ) )
         {
             importSummary.setStatus( ImportStatus.ERROR );
@@ -724,11 +725,17 @@ public abstract class AbstractEnrollmentService
         return importSummary;
     }
 
-    private String validateProgramForEnrollment( Program program, Enrollment enrollment )
+    private String validateProgramForEnrollment( Program program, Enrollment enrollment, OrganisationUnit orgUnit,
+        ImportOptions importOptions )
     {
         if ( program == null )
         {
             return "Program can not be null";
+        }
+
+        if ( orgUnit == null )
+        {
+            return "OrganisationUnit can not be null";
         }
 
         if ( !program.isRegistration() )
@@ -739,9 +746,10 @@ public abstract class AbstractEnrollmentService
 
         SetValuedMap<String, String> programAssociations = programService
             .getProgramOrganisationUnitsAssociations( Collections.singleton( program.getUid() ) );
+
         if ( !CollectionUtils.isEmpty( programAssociations.get( program.getUid() ) ) )
         {
-            if ( !programAssociations.get( program.getUid() ).contains( enrollment.getOrgUnit() ) )
+            if ( !programAssociations.get( program.getUid() ).contains( orgUnit.getUid() ) )
             {
                 return "Program is not assigned to this Organisation Unit: " + enrollment.getOrgUnit();
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -532,8 +532,6 @@ public class EnrollmentSecurityTest
         organisationUnitB.setAttributeValues( Collections.singleton( av ) );
         manager.updateNoAcl( organisationUnitB );
 
-        OrganisationUnit ou = manager.getObject( OrganisationUnit.class, IdScheme.UID, organisationUnitB.getUid() );
-
         en.setOrgUnit( av.getValue() );
         ImportOptions importOptions = new ImportOptions();
         importOptions.getIdSchemes().setOrgUnitIdScheme( "ATTRIBUTE" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -30,15 +30,15 @@ package org.hisp.dhis.dxf2.events.security;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 
 import org.hisp.dhis.TransactionalIntegrationTest;
-import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeService;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
@@ -76,6 +76,9 @@ public class EnrollmentSecurityTest
 
     @Autowired
     private IdentifiableObjectManager manager;
+
+    @Autowired
+    private AttributeService attributeService;
 
     @Autowired
     private UserService _userService;
@@ -505,6 +508,49 @@ public class EnrollmentSecurityTest
 
         importSummary = enrollmentService.addEnrollment(
             en, ImportOptions.getDefaultImportOptions() );
+        assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
+
+    }
+
+    @Test
+    public void testAddEnrollmentWithOrgUnitIdSchemeToOrgUnitWithoutProgramAccess()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.updateNoAcl( programA );
+        Enrollment en = createEnrollment( programA.getUid(), maleA.getUid() );
+        Attribute attribute = new Attribute();
+        attribute.setUnique( true );
+        attribute.setUid( "D1DDOl5hTsL" );
+        attribute.setValueType( ValueType.NUMBER );
+        attribute.setOrganisationUnitAttribute( true );
+        attribute.setName( "OrgUnitAttribute" );
+        attributeService.addAttribute( attribute );
+
+        AttributeValue av = new AttributeValue();
+        av.setAttribute( attribute );
+        av.setValue( "1025" );
+        organisationUnitB.setAttributeValues( Collections.singleton( av ) );
+        manager.updateNoAcl( organisationUnitB );
+
+        OrganisationUnit ou = manager.getObject( OrganisationUnit.class, IdScheme.UID, organisationUnitB.getUid() );
+
+        en.setOrgUnit( av.getValue() );
+        ImportOptions importOptions = new ImportOptions();
+        importOptions.getIdSchemes().setOrgUnitIdScheme( "ATTRIBUTE" );
+        importOptions.getIdSchemes().getOrgUnitIdScheme().setAttribute( "D1DDOl5hTsL" );
+        ImportSummary importSummary = enrollmentService.addEnrollment(
+            en, importOptions );
+
+        assertEquals( ImportStatus.ERROR, importSummary.getStatus() );
+        assertEquals( "Program is not assigned to this Organisation Unit: " + av.getValue(),
+            importSummary.getDescription() );
+
+        programA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        programA.getOrganisationUnits().add( organisationUnitB );
+        manager.updateNoAcl( programA );
+
+        importSummary = enrollmentService.addEnrollment(
+            en, importOptions );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
 
     }


### PR DESCRIPTION
A validation was added to block enrollments for programs added to orgUnits that does not have access to the program [11405](https://jira.dhis2.org/browse/DHIS2-11405)

However, that validation only considered ID scheme and not the other scheme. 

This PR fixes that by using the ID Schemes mentioned in the ImportOptions.