### PR TITLE
chore: provide meaningful error message DHIS2-12123 (#9312) 2.37

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
@@ -36,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramStore;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
@@ -53,6 +54,9 @@ public class ProgramInstanceSupplier extends AbstractPreheatSupplier
     @NonNull
     private final ProgramInstanceStore programInstanceStore;
 
+    @NonNull
+    private final ProgramStore programStore;
+
     @Override
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
@@ -60,7 +64,10 @@ public class ProgramInstanceSupplier extends AbstractPreheatSupplier
             .stream()
             .filter( program -> program.getProgramType().equals( ProgramType.WITHOUT_REGISTRATION ) )
             .collect( Collectors.toList() );
-
+        if ( programsWithoutRegistration.isEmpty() )
+        {
+            programsWithoutRegistration = programStore.getByType( ProgramType.WITHOUT_REGISTRATION );
+        }
         if ( !programsWithoutRegistration.isEmpty() )
         {
             List<ProgramInstance> programInstances = DetachUtils.detach( ProgramInstanceMapper.INSTANCE,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.preprocess;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -66,6 +67,21 @@ public class EventProgramPreProcessor
                 ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
                 if ( Objects.nonNull( programStage ) )
                 {
+                    // Program stages should always have a program! Due to how
+                    // metadata import is currently implemented
+                    // it's possible that users run into the edge case that a
+                    // program stage does not have an associated
+                    // program. Tell the user it's an issue with the metadata
+                    // and not the event itself. This should be
+                    // fixed in the metadata import. For more see
+                    // https://jira.dhis2.org/browse/DHIS2-12123
+                    if ( programStage.getProgram() == null )
+                    {
+                        throw new IllegalStateException(
+                            MessageFormat.format(
+                                "Program stage `{0}` has no reference to a program. Check the program stage configuration",
+                                programStage.getUid() ) );
+                    }
                     event.setProgram( programStage.getProgram().getUid() );
                     bundle.getPreheat().put( TrackerIdentifier.UID, programStage.getProgram() );
                 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceStore;
+import org.hisp.dhis.program.ProgramStore;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
@@ -63,7 +64,10 @@ public class ProgramInstanceSupplierTest extends DhisConvenienceTest
     private ProgramInstanceSupplier supplier;
 
     @Mock
-    private ProgramInstanceStore store;
+    private ProgramInstanceStore programInstanceStore;
+
+    @Mock
+    private ProgramStore programStore;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -95,8 +99,8 @@ public class ProgramInstanceSupplierTest extends DhisConvenienceTest
         programInstances.get( 0 ).setProgram( programWithRegistration );
         programInstances.get( 1 ).setProgram( programWithoutRegistration );
 
-        when( store.getByPrograms( Lists.newArrayList( programWithoutRegistration ) ) ).thenReturn( programInstances );
-
+        when( programInstanceStore.getByPrograms( Lists.newArrayList( programWithoutRegistration ) ) )
+            .thenReturn( programInstances );
     }
 
     @Test
@@ -118,6 +122,27 @@ public class ProgramInstanceSupplierTest extends DhisConvenienceTest
         {
             assertNull( preheat.getProgramInstancesWithoutRegistration( programUid ) );
         }
+    }
+
+    @Test
+    public void verifySupplierWhenNoProgramsArePresent()
+    {
+        // given
+        TrackerPreheat preheat = new TrackerPreheat();
+        when( programStore.getByType( WITHOUT_REGISTRATION ) )
+            .thenReturn( Lists.newArrayList( programWithoutRegistration ) );
+        programInstances = rnd.randomObjects( ProgramInstance.class, 1 );
+        // set the OrgUnit parent to null to avoid recursive errors when mapping
+        programInstances.forEach( p -> p.getOrganisationUnit().setParent( null ) );
+        programInstances.get( 0 ).setProgram( programWithoutRegistration );
+        when( programInstanceStore.getByPrograms( Lists.newArrayList( programWithoutRegistration ) ) )
+            .thenReturn( programInstances );
+
+        // when
+        this.supplier.preheatAdd( params, preheat );
+
+        // then
+        assertNotNull( preheat.getProgramInstancesWithoutRegistration( programWithoutRegistration.getUid() ) );
     }
 
     @Test


### PR DESCRIPTION
backport of #9312

* chore: provide meaningful error message DHIS2-12123

the failed event import in NTI is due to a missing reference from a
program stage to a program. this should not happen but it does
occasionally, due to the way the metadata import is implemented.

provide an error message guiding the user to a solution for this edge
case, until the root cause is fixed.

* fix: add programs without registration to preheat DHIS2-12123

https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/new-tracker.html\#events
states that program is not required. In this case the program and then
program instance are not in the preheat. This leads to an error in
the SQL insert statement as program instance needs to be specified
on the program stage instance. Since programs without registration
are expected/estimated to be in the order of a dozen we are fetching
all of them