### PR TITLE
feat: prevent simultaneous jobs in a cluster [DHIS2-12018]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
@@ -82,6 +82,14 @@ public interface Cache<V>
     Stream<V> getAll();
 
     /**
+     * Should only be used with caution in cases where the set of keys is known
+     * to be a small set.
+     *
+     * @return an unmodifiable set of all keys set
+     */
+    Iterable<String> keys();
+
+    /**
      * Associates the {@code value} with the {@code key} in this cache. If the
      * cache previously contained a value associated with the {@code key}, the
      * old value is replaced by the new {@code value}. Prefer
@@ -106,6 +114,17 @@ public interface Cache<V>
      * @throws IllegalArgumentException if the specified value is null
      */
     void put( String key, V value, long ttlInSeconds );
+
+    /**
+     * Associates the {@code value} with the {@code key} in this cache if and
+     * only of the cache does not already contain a value for the key.
+     *
+     * @param key the key for the value
+     * @param value value to be mapped to the key
+     * @return true, if the value was put, false otherwise
+     * @throws IllegalArgumentException if the specified value is null
+     */
+    boolean putIfAbsent( String key, V value );
 
     /**
      * Discards any cached value for the {@code key}. The behavior of this

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -129,6 +129,12 @@ public class LocalCache<V> implements Cache<V>
     }
 
     @Override
+    public Iterable<String> keys()
+    {
+        return cache2kInstance.keys();
+    }
+
+    @Override
     public void put( String key, V value )
     {
         if ( null == value )
@@ -144,6 +150,16 @@ public class LocalCache<V> implements Cache<V>
         hasText( key, "Value cannot be null" );
         cache2kInstance.invoke( key,
             e -> e.setValue( value ).setExpiryTime( currentTimeMillis() + SECONDS.toMillis( ttlInSeconds ) ) );
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        if ( null == value )
+        {
+            throw new IllegalArgumentException( "Value cannot be null" );
+        }
+        return cache2kInstance.putIfAbsent( key, value );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -149,7 +149,7 @@ public class LocalCache<V> implements Cache<V>
     @Override
     public void put( String key, V value, long ttlInSeconds )
     {
-        hasText( key, "Value cannot be null" );
+        hasText( key, VALUE_CANNOT_BE_NULL );
         cache2kInstance.invoke( key,
             e -> e.setValue( value ).setExpiryTime( currentTimeMillis() + SECONDS.toMillis( ttlInSeconds ) ) );
     }
@@ -159,7 +159,7 @@ public class LocalCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         return cache2kInstance.putIfAbsent( key, value );
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -45,6 +45,8 @@ import org.cache2k.Cache2kBuilder;
  */
 public class LocalCache<V> implements Cache<V>
 {
+    private static final String VALUE_CANNOT_BE_NULL = "Value cannot be null";
+
     private org.cache2k.Cache<String, V> cache2kInstance;
 
     private V defaultValue;
@@ -139,7 +141,7 @@ public class LocalCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         cache2kInstance.put( key, value );
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
@@ -43,6 +43,8 @@ import java.util.stream.Stream;
  */
 public class NoOpCache<V> implements Cache<V>
 {
+    private static final String VALUE_CANNOT_BE_NULL = "Value cannot be null";
+
     private final V defaultValue;
 
     public NoOpCache( CacheBuilder<V> cacheBuilder )
@@ -99,7 +101,7 @@ public class NoOpCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         // No operation
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.cache;
 
+import static java.util.Collections.emptySet;
 import static org.springframework.util.Assert.hasText;
 
 import java.util.Optional;
@@ -88,6 +89,12 @@ public class NoOpCache<V> implements Cache<V>
     }
 
     @Override
+    public Iterable<String> keys()
+    {
+        return emptySet();
+    }
+
+    @Override
     public void put( String key, V value )
     {
         if ( null == value )
@@ -102,6 +109,17 @@ public class NoOpCache<V> implements Cache<V>
     {
         hasText( key, "Value cannot be null" );
         // No operation
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        if ( null == value )
+        {
+            throw new IllegalArgumentException( "Value cannot be null" );
+        }
+        // No operation
+        return false;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
@@ -109,7 +109,7 @@ public class NoOpCache<V> implements Cache<V>
     @Override
     public void put( String key, V value, long ttlInSeconds )
     {
-        hasText( key, "Value cannot be null" );
+        hasText( key, VALUE_CANNOT_BE_NULL );
         // No operation
     }
 
@@ -118,7 +118,7 @@ public class NoOpCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         // No operation
         return false;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -511,12 +511,15 @@ public interface JobProgress
     {
         public static Date completedTime( Collection<Process> job, Date defaultValue )
         {
-            return job.isEmpty() ? defaultValue
-                : job instanceof Deque
-                    ? ((Deque<Process>) job).getLast().getCompletedTime()
-                    : job.stream().reduce( ( first, second ) -> second )
-                        .map( Process::getCancelledTime )
-                        .orElse( defaultValue );
+            if ( job.isEmpty() )
+            {
+                return defaultValue;
+            }
+            return job instanceof Deque
+                ? ((Deque<Process>) job).getLast().getCompletedTime()
+                : job.stream().reduce( ( first, second ) -> second )
+                    .map( Process::getCancelledTime )
+                    .orElse( defaultValue );
         }
 
         private final Date startedTime = new Date();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.scheduling;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Deque;
@@ -455,7 +456,7 @@ public interface JobProgress
     }
 
     @Getter
-    abstract class Node
+    abstract class Node implements Serializable
     {
         @JsonProperty
         private String error;
@@ -508,6 +509,16 @@ public interface JobProgress
     @RequiredArgsConstructor
     final class Process extends Node
     {
+        public static Date completedTime( Collection<Process> job, Date defaultValue )
+        {
+            return job.isEmpty() ? defaultValue
+                : job instanceof Deque
+                    ? ((Deque<Process>) job).getLast().getCompletedTime()
+                    : job.stream().reduce( ( first, second ) -> second )
+                        .map( Process::getCancelledTime )
+                        .orElse( defaultValue );
+        }
+
         private final Date startedTime = new Date();
 
         @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -509,17 +509,9 @@ public interface JobProgress
     @RequiredArgsConstructor
     final class Process extends Node
     {
-        public static Date completedTime( Collection<Process> job, Date defaultValue )
+        public static Date startedTime( Collection<Process> job, Date defaultValue )
         {
-            if ( job.isEmpty() )
-            {
-                return defaultValue;
-            }
-            return job instanceof Deque
-                ? ((Deque<Process>) job).getLast().getCompletedTime()
-                : job.stream().reduce( ( first, second ) -> second )
-                    .map( Process::getCancelledTime )
-                    .orElse( defaultValue );
+            return job.isEmpty() ? defaultValue : job.iterator().next().getStartedTime();
         }
 
         private final Date startedTime = new Date();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -161,7 +161,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             whenAlreadyRunning( configuration );
             return;
         }
-        if ( !canRunInCluster( type, progress.getProcesses() ) )
+        if ( !clusterCanRun( type, progress.getProcesses() ) )
         {
             runningJobProgress.remove( type );
             whenAlreadyRunning( configuration );
@@ -195,14 +195,19 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         finally
         {
             completedJobProgress.put( type, runningJobProgress.remove( type ) );
-
+            clusterRunDone( type );
             whenRunIsDone( configuration, clock );
         }
     }
 
-    protected boolean canRunInCluster( JobType type, Deque<Process> initialState )
+    protected boolean clusterCanRun( JobType type, Deque<Process> initialState )
     {
         return true;
+    }
+
+    protected void clusterRunDone( JobType type )
+    {
+        // noop by default
     }
 
     private ControlledJobProgress createJobProgress( JobConfiguration configuration )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
@@ -28,20 +28,13 @@
 package org.hisp.dhis.scheduling;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableCollection;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collection;
 import java.util.Date;
-import java.util.Deque;
-import java.util.EnumSet;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -49,12 +42,10 @@ import java.util.function.Function;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.AsyncTaskExecutor;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.message.MessageService;
-import org.hisp.dhis.scheduling.JobProgress.Process;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
@@ -65,9 +56,8 @@ import org.springframework.stereotype.Service;
  * A {@link SchedulingManager} that runs {@link #schedule(JobConfiguration)} and
  * {@link #executeNow(JobConfiguration)} asynchronously.
  *
- * Whether or not a job can run is solely determined by
- * {@link #isRunning(JobType)} which makes sure only one asynchronous task can
- * run at a time.
+ * Whether a job can run is solely determined by {@link #isRunning(JobType)}
+ * which makes sure only one asynchronous task can run at a time.
  *
  * The {@link DefaultSchedulingManager} manages its private state with the sole
  * goal of being able to cancel asynchronously running tasks.
@@ -89,18 +79,12 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
 
     private final AsyncTaskExecutor taskExecutor;
 
-    private final Cache<Deque<Process>> runningJobsInfo;
-
-    private final Cache<Deque<Process>> completedJobsInfo;
-
-    private final Cache<Boolean> cancelRequested;
-
     public DefaultSchedulingManager( JobService jobService, JobConfigurationService jobConfigurationService,
         MessageService messageService, Notifier notifier,
         LeaderManager leaderManager, @Qualifier( "taskScheduler" ) TaskScheduler jobScheduler,
         AsyncTaskExecutor taskExecutor, CacheProvider cacheProvider )
     {
-        super( jobService, jobConfigurationService, messageService, leaderManager, notifier );
+        super( jobService, jobConfigurationService, messageService, leaderManager, notifier, cacheProvider );
         checkNotNull( jobConfigurationService );
         checkNotNull( messageService );
         checkNotNull( leaderManager );
@@ -110,106 +94,8 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
 
         this.jobScheduler = jobScheduler;
         this.taskExecutor = taskExecutor;
-        this.runningJobsInfo = cacheProvider.createRunningJobsInfoCache();
-        this.completedJobsInfo = cacheProvider.createCompletedJobsInfoCache();
-        this.cancelRequested = cacheProvider.createJobCancelRequestedCache();
 
         jobScheduler.scheduleWithFixedDelay( this::clusterHeartbeat, Duration.ofSeconds( 30 ) );
-    }
-
-    private void clusterHeartbeat()
-    {
-        for ( Entry<JobType, ControlledJobProgress> info : runningJobProgress.entrySet() )
-        {
-            String key = info.getKey().name();
-            if ( cancelRequested.getIfPresent( key ).isPresent() )
-            {
-                super.cancel( info.getKey() );
-                cancelRequested.invalidate( key );
-            }
-            else
-            {
-                // heart beat update so the entry does not expire
-                runningJobsInfo.put( key, info.getValue().getProcesses() );
-            }
-        }
-        // always use most recent local in the cache
-        for ( Entry<JobType, ControlledJobProgress> localInfo : completedJobProgress.entrySet() )
-        {
-            String key = localInfo.getKey().name();
-            Optional<Deque<Process>> clusterInfo = completedJobsInfo.getIfPresent( key );
-            Date now = new Date();
-            if ( clusterInfo.isEmpty() || Process.startedTime( clusterInfo.get(), now )
-                .before( Process.startedTime( localInfo.getValue().getProcesses(), now ) ) )
-            {
-                completedJobsInfo.put( key, localInfo.getValue().getProcesses() );
-            }
-        }
-    }
-
-    @Override
-    public Collection<JobType> getRunningTypes()
-    {
-        EnumSet<JobType> inCluster = EnumSet.noneOf( JobType.class );
-        inCluster.addAll( super.getRunningTypes() );
-        runningJobsInfo.keys().forEach( key -> inCluster.add( JobType.valueOf( key ) ) );
-        return inCluster;
-    }
-
-    @Override
-    public Collection<JobType> getCompletedTypes()
-    {
-        EnumSet<JobType> inCluster = EnumSet.noneOf( JobType.class );
-        inCluster.addAll( super.getCompletedTypes() );
-        completedJobsInfo.keys().forEach( key -> inCluster.add( JobType.valueOf( key ) ) );
-        return inCluster;
-    }
-
-    @Override
-    public Collection<Process> getRunningProgress( JobType type )
-    {
-        Collection<Process> localInfo = super.getRunningProgress( type );
-        if ( !localInfo.isEmpty() )
-        {
-            return localInfo;
-        }
-        var clusterInfo = runningJobsInfo.getIfPresent( type.name() );
-        return clusterInfo.isEmpty() ? emptyList() : unmodifiableCollection( clusterInfo.get() );
-    }
-
-    @Override
-    public Collection<Process> getCompletedProgress( JobType type )
-    {
-        Collection<Process> localInfo = super.getCompletedProgress( type );
-        var clusterInfo = completedJobsInfo.getIfPresent( type.name() );
-        if ( clusterInfo.isEmpty() )
-        {
-            return localInfo;
-        }
-        Date now = new Date();
-        return localInfo.isEmpty()
-            || Process.startedTime( clusterInfo.get(), now ).after( Process.startedTime( localInfo, now ) )
-                ? unmodifiableCollection( clusterInfo.get() )
-                : localInfo;
-    }
-
-    @Override
-    public void cancel( JobType type )
-    {
-        cancelRequested.put( type.name(), true );
-        super.cancel( type );
-    }
-
-    @Override
-    protected boolean clusterCanRun( JobType type, Deque<Process> initialState )
-    {
-        return runningJobsInfo.putIfAbsent( type.name(), initialState );
-    }
-
-    @Override
-    protected void clusterRunDone( JobType type )
-    {
-        runningJobsInfo.invalidate( type.name() );
     }
 
     @Override
@@ -275,7 +161,7 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
     public void stop( JobConfiguration configuration )
     {
         JobType type = configuration.getJobType();
-        if ( type != null && isRunning( type ) )
+        if ( type != null && isRunningLocally( type ) )
         {
             stoppedSuccessful( type );
         }
@@ -316,7 +202,7 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
                 return;
             }
             scheduled.remove( type, cancelable );
-            if ( type == null || isRunning( type ) && !stoppedSuccessful( type ) )
+            if ( type == null || isRunningLocally( type ) && !stoppedSuccessful( type ) || isRunningRemotely( type ) )
             {
                 return;
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -53,6 +53,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.cache.TestCache;
 import org.hisp.dhis.common.AsyncTaskExecutor;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.message.MessageService;
@@ -98,9 +99,14 @@ public class SchedulingManagerTest
     {
         when( applicationContext.getBeansOfType( any() ) ).thenReturn( Collections.singletonMap( "test", job ) );
 
+        CacheProvider cacheProvider = mock( CacheProvider.class );
+        when( cacheProvider.createJobCancelRequestedCache() ).thenReturn( new TestCache<>() );
+        when( cacheProvider.createRunningJobsInfoCache() ).thenReturn( new TestCache<>() );
+        when( cacheProvider.createCompletedJobsInfoCache() ).thenReturn( new TestCache<>() );
+
         schedulingManager = new DefaultSchedulingManager( new DefaultJobService( applicationContext ),
             jobConfigurationService, mock( MessageService.class ), mock( Notifier.class ),
-            mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ), mock( CacheProvider.class ) );
+            mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ), cacheProvider );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.AsyncTaskExecutor;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.message.MessageService;
@@ -99,7 +100,7 @@ public class SchedulingManagerTest
 
         schedulingManager = new DefaultSchedulingManager( new DefaultJobService( applicationContext ),
             jobConfigurationService, mock( MessageService.class ), mock( Notifier.class ),
-            mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ) );
+            mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ), mock( CacheProvider.class ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -123,4 +123,10 @@ public interface CacheProvider
     <V> Cache<V> createUserGroupUIDCache();
 
     <V> Cache<V> createSecurityCache();
+
+    <V> Cache<V> createRunningJobsInfoCache();
+
+    <V> Cache<V> createCompletedJobsInfoCache();
+
+    <V> Cache<V> createJobCancelRequestedCache();
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
@@ -242,7 +242,7 @@ public class CappedLocalCache
         {
             long entrySize = emptyEntrySize + sizeof.sizeof( key ) + sizeof.sizeof( value );
             long now = currentTimeMillis();
-            CacheEntry<V> newEntry = new CacheEntry<V>( region, key, value, now, now + (defaultTtlInSeconds * 1000L),
+            CacheEntry<V> newEntry = new CacheEntry<>( region, key, value, now, now + (defaultTtlInSeconds * 1000L),
                 entrySize );
             var oldEntry = entries.putIfAbsent( key, newEntry );
             long sizeDelta = entrySize - (oldEntry == null ? 0L : oldEntry.size);

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.cache;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
 
 import java.time.Duration;
@@ -123,8 +124,10 @@ public class DefaultCacheProvider
         teiAttributesCache,
         programTeiAttributesCache,
         userGroupUIDCache,
-        securityCache
-
+        securityCache,
+        runningJobsInfo,
+        completedJobsInfo,
+        jobCancelRequested
     }
 
     private final Map<String, Cache<?>> allCaches = new ConcurrentHashMap<>();
@@ -570,5 +573,28 @@ public class DefaultCacheProvider
             .withInitialCapacity( (int) getActualSize( SIZE_100 ) )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_1K ) ) ) );
+    }
+
+    @Override
+    public <V> Cache<V> createRunningJobsInfoCache()
+    {
+        return registerCache( this.<V> newBuilder()
+            .forRegion( Region.runningJobsInfo.name() )
+            .expireAfterWrite( 60, SECONDS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createCompletedJobsInfoCache()
+    {
+        return registerCache( this.<V> newBuilder()
+            .forRegion( Region.completedJobsInfo.name() )
+            .expireAfterWrite( 60, SECONDS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createJobCancelRequestedCache()
+    {
+        return registerCache( this.<V> newBuilder()
+            .forRegion( Region.jobCancelRequested.name() ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -595,6 +595,7 @@ public class DefaultCacheProvider
     public <V> Cache<V> createJobCancelRequestedCache()
     {
         return registerCache( this.<V> newBuilder()
-            .forRegion( Region.jobCancelRequested.name() ) );
+            .forRegion( Region.jobCancelRequested.name() )
+            .expireAfterWrite( 60, SECONDS ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
@@ -48,6 +48,8 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 public class RedisCache<V> implements Cache<V>
 {
+    private static final String VALUE_CANNOT_BE_NULL = "Value cannot be null";
+
     private RedisTemplate<String, V> redisTemplate;
 
     private boolean refreshExpriryOnAccess;
@@ -184,7 +186,7 @@ public class RedisCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         String redisKey = generateKey( key );
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
@@ -157,7 +157,7 @@ public class RedisCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
 
         String redisKey = generateKey( key );
@@ -174,7 +174,7 @@ public class RedisCache<V> implements Cache<V>
     @Override
     public void put( String key, V value, long ttlInSeconds )
     {
-        hasText( key, "Value cannot be null" );
+        hasText( key, VALUE_CANNOT_BE_NULL );
 
         String redisKey = generateKey( key );
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.cache;
 
+import static java.util.Collections.unmodifiableSet;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +74,12 @@ public class TestCache<V> implements Cache<V>
     }
 
     @Override
+    public Iterable<String> keys()
+    {
+        return unmodifiableSet( mapCache.keySet() );
+    }
+
+    @Override
     public void put( String key, V value )
     {
         mapCache.put( key, value );
@@ -82,6 +90,12 @@ public class TestCache<V> implements Cache<V>
     {
         // Ignoring ttl for this testing cache
         mapCache.put( key, value );
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        return mapCache.putIfAbsent( key, value ) != value;
     }
 
     @Override

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -36,6 +36,7 @@ import javax.transaction.Transactional;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.config.DataSourceConfig;
@@ -226,10 +227,10 @@ public class WebTestConfiguration
     @Primary
     public SchedulingManager synchronousSchedulingManager( JobService jobService,
         JobConfigurationService jobConfigurationService,
-        MessageService messageService, Notifier notifier, LeaderManager leaderManager )
+        MessageService messageService, Notifier notifier, LeaderManager leaderManager, CacheProvider cacheProvider )
     {
         return new TestSchedulingManager( jobService, jobConfigurationService, messageService, notifier,
-            leaderManager );
+            leaderManager, cacheProvider );
     }
 
     public static class TestSchedulingManager extends AbstractSchedulingManager
@@ -237,9 +238,9 @@ public class WebTestConfiguration
         private boolean enabled = true;
 
         public TestSchedulingManager( JobService jobService, JobConfigurationService jobConfigurationService,
-            MessageService messageService, Notifier notifier, LeaderManager leaderManager )
+            MessageService messageService, Notifier notifier, LeaderManager leaderManager, CacheProvider cacheProvider )
         {
-            super( jobService, jobConfigurationService, messageService, leaderManager, notifier );
+            super( jobService, jobConfigurationService, messageService, leaderManager, notifier, cacheProvider );
         }
 
         @Override


### PR DESCRIPTION
### Summary
Implements cluster wide coordination of job execution using (redis) caches.
This affects:
* preventing same job from being started more than once at a same time
* sharing of job running and job completed information (tracking)
* cancelling of jobs

In case of a non cluster setup the the coordination still takes place just that it is stored in a local cache and that is has no actual effect that way.

### Coordination of Starting Jobs
The main mechanism is that a background job is running every 30 seconds to update the caches used to coordinate between nodes. These are set to become outdated after 60 seconds so that should they not be refreshed regularly they out-date quite fast and open for other nodes to run a job of the same type.

If this coordination is "transactional" in the cluster depends on the spring `RedisTemplate` => `BoundValueOperations#setIfAbsent` semantics that we also use in leader election.  

### Coordination of Cancelling Jobs
When a job is cancelled en entry is made in a dedicated cache. This state is checked in the background loop that updates the state of running jobs. If a running job should be cancelled the cancel is made effective locally and the cluster wide cancel request is invalidated. As only one node should be able to run a job of the same type this should be safely cancel all running jobs of that type and return state to an idle state for that type. 

Since the checking loop is only running every 30 seconds there can be a delay in the cancellation request of up to 30 seconds depending on if the request hits the node that is running the job or hits another node.

### Sharing of Job Info
The background loop also transfers local job execution state to the cluster wide state. 
For running jobs this simply overrides/sets the info by type as there is only one node actively running that job anyway.
For completed job the run started most recently per type is kept in the cache.

Again the information can have a delay of up to 30 seconds before it becomes visible for remote notes while actual local state stays immediately visible.

 ### Cache API
To coordinate using the `Cache` API two new methods needed to be added:
* `keys()`
* `putIfAbsent`

### Automatic Testing
Existing tests were adopted. As the main implementation of the cluster feature is located in the `DefaultSchedulingManager` which is **not** used in tests this feature needs manual testing. 

### Manual Testing
Below is just one meaningful scenario of many that can be used to test the different aspects of this.

1. Start server and open the scheduler app.
2. create a job configuration for analytics table job. 
3. start the created job manually
4. check the running status both in overview http://localhost:8080/api/scheduling/running and details http://localhost:8080/api/scheduling/running/ANALYTICS_TABLE 
5. when job is done check the completed status both in overview http://localhost:8080/api/completed/running and details http://localhost:8080/api/scheduling/completed/ANALYTICS_TABLE 