### PR TITLE
fix: enable translatable schema property for embedded object

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
@@ -65,6 +65,16 @@ public class TranslatablePropertyIntrospector implements PropertyIntrospector
                 String i18nKey = CaseFormat.LOWER_CAMEL.to( CaseFormat.LOWER_UNDERSCORE, property.getFieldName() );
                 property.setI18nTranslationKey( i18nKey );
             }
+
+            /**
+             * Embedded objects can have their own translatable properties.
+             */
+            if ( property.isEmbeddedObject()
+                && !AnnotationUtils.getTranslatableAnnotatedFields( property.getKlass() ).isEmpty() )
+            {
+                property.setTranslatable( true );
+            }
         }
+
     }
 }

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
@@ -37,16 +37,17 @@ import java.util.Map;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.predictor.Predictor;
 import org.hisp.dhis.schema.introspection.TranslatablePropertyIntrospector;
 import org.junit.Test;
 
 public class TranslatablePropertyIntrospectorTest extends DhisSpringTest
 {
+    private final TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
+
     @Test
     public void testGetTranslatableProperties()
     {
-        TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
-
         Property propTranslation = new Property( DataElement.class );
         propTranslation.setName( "translations" );
         propTranslation.setFieldName( "translations" );
@@ -83,8 +84,6 @@ public class TranslatablePropertyIntrospectorTest extends DhisSpringTest
     @Test
     public void testNonTranslatableObject()
     {
-        TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
-
         Property propName = new Property( DataElement.class );
         propName.setName( "name" );
         propName.setPersisted( true );
@@ -122,9 +121,32 @@ public class TranslatablePropertyIntrospectorTest extends DhisSpringTest
         propertyMap.put( "formName", property );
         propertyMap.put( "translations", propTranslation );
 
-        TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();
         introspector.introspect( DataSet.class, propertyMap );
         assertEquals( "form_name", propertyMap.get( "formName" ).getI18nTranslationKey() );
+    }
 
+    @Test
+    public void testTranslatableEmbeddedProperty()
+    {
+        Property propTranslation = new Property( Predictor.class );
+        propTranslation.setName( "translations" );
+        propTranslation.setFieldName( "translations" );
+        propTranslation.setPersisted( true );
+
+        Property propGenerator = new Property( Predictor.class );
+        propGenerator.setName( "generator" );
+        propGenerator.setFieldName( "generator" );
+        propGenerator.setEmbeddedObject( true );
+        propGenerator.setPersisted( true );
+
+        Map<String, Property> propertyMap = new HashMap<>();
+        propertyMap.put( "generator", propGenerator );
+        propertyMap.put( "translations", propTranslation );
+
+        assertFalse( propertyMap.get( "generator" ).isTranslatable() );
+
+        introspector.introspect( Predictor.class, propertyMap );
+
+        assertTrue( propertyMap.get( "generator" ).isTranslatable() );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11748

This is to allow `api/schemas` consumer know whether an embedded object property is translatable.
Example:

_Predictor class_
```
class Predictor 
{
  private Expression generator;
}
```

_Expression class_
```
class Expression  
  implements Serializable, EmbeddedObject
{
  @Translatable( propertyName = "description", key = "DESCRIPTION" )
  private String description;
}
```

_api/schemas/predictor.json_
```
{
"klass": "org.hisp.dhis.predictor.Predictor",
"name": "Predictor",
"properties": [
  {
    "klass": "org.hisp.dhis.expression.Expression",
    "propertyType": "COMPLEX",
    "name": "generator",
    "fieldName": "generator",
    "translatable": true
  }
}
```