### PR TITLE
refactor: Support compressed ADX output

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/render/RenderFormat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/render/RenderFormat.java
@@ -27,17 +27,23 @@
  */
 package org.hisp.dhis.render;
 
+import lombok.AllArgsConstructor;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@AllArgsConstructor
 public enum RenderFormat
 {
-    JSON,
-    XML,
-    CSV;
+    JSON( "json" ),
+    XML( "xml" ),
+    ADX_XML( "adx+xml" ),
+    CSV( "csv" );
+
+    private String format;
 
     public boolean isEqual( String format )
     {
-        return name().equalsIgnoreCase( format );
+        return this.format.equals( format );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.common.DhisApiVersion.V38;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.importSummary;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
+import static org.hisp.dhis.render.RenderFormat.ADX_XML;
 import static org.hisp.dhis.render.RenderFormat.CSV;
 import static org.hisp.dhis.render.RenderFormat.XML;
 import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
@@ -126,7 +127,8 @@ public class DataValueSetController
         @RequestParam( required = false ) String compression,
         @RequestParam( required = false ) String format,
         IdSchemes idSchemes, HttpServletResponse response )
-        throws IOException
+        throws IOException,
+        AdxException
     {
         setNoStore( response );
 
@@ -135,6 +137,12 @@ public class DataValueSetController
             response.setContentType( CONTENT_TYPE_XML );
             OutputStream outputStream = compress( response, attachment, Compression.fromValue( compression ), "xml" );
             dataValueSetService.writeDataValueSetXml( dataValueSetService.getFromUrl( params ), outputStream );
+        }
+        else if ( ADX_XML.isEqual( format ) )
+        {
+            response.setContentType( CONTENT_TYPE_XML_ADX );
+            OutputStream outputStream = compress( response, attachment, Compression.fromValue( compression ), "xml" );
+            adxDataService.writeDataValueSet( adxDataService.getFromUrl( params ), outputStream );
         }
         else if ( CSV.isEqual( format ) )
         {


### PR DESCRIPTION
[pull/8826](https://github.com/dhis2/dhis2-core/pull/8826) fixed a problem where the backend had added the extension twice for a compressed data export, "so attachment=data.xml.zip ends up data.xml.zip.xml.zip". That PR supported xml, json, and csv.

This PR adds support for adx+xml compressed data export. This is required so [DHIS2-4978](https://jira.dhis2.org/browse/DHIS2-4978) can be implemented.