### PR TITLE
chore: Unify the boolean switch in the configuration.

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/StartupConfig.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/StartupConfig.java
@@ -149,7 +149,7 @@ public class StartupConfig
         MessageService messageService, DhisConfigurationProvider configurationProvider )
     {
         SchedulerStart schedulerStart = new SchedulerStart( systemSettingManager,
-            configurationProvider.getProperty( ConfigurationKey.REDIS_ENABLED ),
+            configurationProvider.isEnabled( ConfigurationKey.REDIS_ENABLED ),
             configurationProvider.getProperty( ConfigurationKey.LEADER_TIME_TO_LIVE ), jobConfigurationService,
             schedulingManager, messageService );
         schedulerStart.setRunlevel( 15 );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Wso2Provider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Wso2Provider.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
@@ -110,7 +111,7 @@ public class Wso2Provider extends AbstractOidcProvider
         builder.userInfoAuthenticationMethod( AuthenticationMethod.HEADER );
         builder.userNameAttributeName( IdTokenClaimNames.SUB );
 
-        if ( Boolean.parseBoolean( config.getProperty( OIDC_PROVIDER_WSO2_ENABLE_LOGOUT.getKey() ) ) )
+        if ( DhisConfigurationProvider.isOn( config.getProperty( OIDC_PROVIDER_WSO2_ENABLE_LOGOUT.getKey() ) ) )
         {
             builder.providerConfigurationMetadata( ImmutableMap
                 .of( "end_session_endpoint", providerBaseUrl + "/oidc/logout" ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -118,7 +118,7 @@ public class SchedulerStart extends AbstractStartupRoutine
 
     private final SystemSettingManager systemSettingManager;
 
-    private final String redisEnabled;
+    private final boolean redisEnabled;
 
     private final String leaderElectionTime;
 
@@ -128,7 +128,7 @@ public class SchedulerStart extends AbstractStartupRoutine
 
     private final MessageService messageService;
 
-    public SchedulerStart( SystemSettingManager systemSettingManager, String redisEnabled, String leaderElectionTime,
+    public SchedulerStart( SystemSettingManager systemSettingManager, boolean redisEnabled, String leaderElectionTime,
         JobConfigurationService jobConfigurationService, SchedulingManager schedulingManager,
         MessageService messageService )
     {
@@ -205,8 +205,7 @@ public class SchedulerStart extends AbstractStartupRoutine
         addDefaultJob( SystemJob.REMOVE_EXPIRED_OR_USED_RESERVED_VALUES, jobConfigurations );
         addDefaultJob( SystemJob.SYSTEM_VERSION_UPDATE_CHECK, jobConfigurations );
 
-        if ( verifyNoJobExist( SystemJob.LEADER_ELECTION.name, jobConfigurations )
-            && "true".equalsIgnoreCase( redisEnabled ) )
+        if ( redisEnabled && verifyNoJobExist( SystemJob.LEADER_ELECTION.name, jobConfigurations ) )
         {
             JobConfiguration leaderElectionJobConfiguration = new JobConfiguration(
                 SystemJob.LEADER_ELECTION.name,
@@ -251,7 +250,7 @@ public class SchedulerStart extends AbstractStartupRoutine
         {
             JobConfiguration leaderElection = maybeLeaderElection.get();
             leaderElection.setCronExpression( format( LEADER_JOB_CRON_FORMAT, leaderElectionTime ) );
-            leaderElection.setEnabled( "true".equalsIgnoreCase( redisEnabled ) );
+            leaderElection.setEnabled( redisEnabled );
             jobConfigurationService.updateJobConfiguration( leaderElection );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
@@ -212,7 +212,7 @@ public class DefaultSystemService
         info.setSystemMonitoringUrl( dhisConfig.getProperty( ConfigurationKey.SYSTEM_MONITORING_URL ) );
         info.setSystemId( config.getSystemId() );
         info.setClusterHostname( dhisConfig.getProperty( ConfigurationKey.CLUSTER_HOSTNAME ) );
-        info.setRedisEnabled( Boolean.parseBoolean( dhisConfig.getProperty( ConfigurationKey.REDIS_ENABLED ) ) );
+        info.setRedisEnabled( dhisConfig.isEnabled( ConfigurationKey.REDIS_ENABLED ) );
 
         if ( info.isRedisEnabled() )
         {

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/HibernateListenerConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/HibernateListenerConfigurer.java
@@ -95,7 +95,7 @@ public class HibernateListenerConfigurer
     @PostConstruct
     protected void init()
     {
-        boolean auditEnabled = config.getBoolean( ConfigurationKey.AUDIT_ENABLED );
+        boolean auditEnabled = config.isEnabled( ConfigurationKey.AUDIT_ENABLED );
 
         boolean isTestAndNotAuditTest = isTestRun() && !isAuditTest();
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfig.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfig.java
@@ -236,10 +236,8 @@ public class ArtemisConfig
         artemisConfigData.setPassword( dhisConfig.getProperty( ConfigurationKey.ARTEMIS_PASSWORD ) );
 
         ArtemisEmbeddedConfig artemisEmbeddedConfig = new ArtemisEmbeddedConfig();
-        artemisEmbeddedConfig.setSecurity(
-            Boolean.parseBoolean( dhisConfig.getProperty( ConfigurationKey.ARTEMIS_EMBEDDED_SECURITY ) ) );
-        artemisEmbeddedConfig.setPersistence(
-            Boolean.parseBoolean( dhisConfig.getProperty( ConfigurationKey.ARTEMIS_EMBEDDED_PERSISTENCE ) ) );
+        artemisEmbeddedConfig.setSecurity( dhisConfig.isEnabled( ConfigurationKey.ARTEMIS_EMBEDDED_SECURITY ) );
+        artemisEmbeddedConfig.setPersistence( dhisConfig.isEnabled( ConfigurationKey.ARTEMIS_EMBEDDED_PERSISTENCE ) );
         artemisEmbeddedConfig.setNioRemotingThreads(
             Integer.parseInt( dhisConfig.getProperty( ConfigurationKey.ARTEMIS_EMBEDDED_THREADS ) ) );
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
@@ -60,8 +60,7 @@ public class FlywayConfig
 
         classicConfiguration.setDataSource( dataSource );
         classicConfiguration.setBaselineOnMigrate( true );
-        classicConfiguration.setOutOfOrder(
-            Boolean.parseBoolean( configurationProvider.getProperty( FLYWAY_OUT_OF_ORDER_MIGRATION ) ) );
+        classicConfiguration.setOutOfOrder( configurationProvider.isEnabled( FLYWAY_OUT_OF_ORDER_MIGRATION ) );
         classicConfiguration.setIgnoreMissingMigrations( true );
         classicConfiguration.setIgnoreFutureMigrations( false );
         classicConfiguration.setGroup( true );
@@ -69,7 +68,7 @@ public class FlywayConfig
         classicConfiguration.setMixed( true );
 
         return new DhisFlyway( classicConfiguration,
-            Boolean.parseBoolean( configurationProvider.getProperty( FLYWAY_REPAIR_BEFORE_MIGRATION ) ) );
+            configurationProvider.isEnabled( FLYWAY_REPAIR_BEFORE_MIGRATION ) );
 
     }
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -172,14 +172,14 @@ public enum ConfigurationKey
      * If true, an operation will be performed at every connection checkout to
      * verify that the connection is valid (default: false).
      */
-    CONNECTION_POOL_TEST_ON_CHECKOUT( "connection.pool.test.on.checkout", Constants.FALSE, false ),
+    CONNECTION_POOL_TEST_ON_CHECKOUT( "connection.pool.test.on.checkout", Constants.OFF, false ),
 
     /**
      * If true, an operation will be performed asynchronously at every
      * connection checkin to verify that the connection is valid (default:
      * true).
      */
-    CONNECTION_POOL_TEST_ON_CHECKIN( "connection.pool.test.on.checkin", Constants.TRUE, false ),
+    CONNECTION_POOL_TEST_ON_CHECKIN( "connection.pool.test.on.checkin", Constants.ON, false ),
 
     /**
      * Hikari DB pool feature. Connection pool timeout: Set the maximum number
@@ -308,12 +308,12 @@ public enum ConfigurationKey
     /**
      * Use SSL for connecting to redis. (default: false)
      */
-    REDIS_USE_SSL( "redis.use.ssl", Constants.FALSE, false ),
+    REDIS_USE_SSL( "redis.use.ssl", Constants.OFF, false ),
 
     /**
      * Enable redis cache. (default: false)
      */
-    REDIS_ENABLED( "redis.enabled", Constants.FALSE, false ),
+    REDIS_ENABLED( "redis.enabled", Constants.OFF, false ),
 
     /**
      * Allows Flyway migrations to be run "out of order".
@@ -322,13 +322,13 @@ public enum ConfigurationKey
      * found, it will be applied too instead of being ignored.
      * </p>
      */
-    FLYWAY_OUT_OF_ORDER_MIGRATION( "flyway.migrate_out_of_order", Constants.FALSE, false ),
+    FLYWAY_OUT_OF_ORDER_MIGRATION( "flyway.migrate_out_of_order", Constants.OFF, false ),
 
     /**
      * Repairs the Flyway schema history table on startup before Flyway
      * migrations is applied. (default: false).
      */
-    FLYWAY_REPAIR_BEFORE_MIGRATION( "flyway.repair_before_migration", Constants.FALSE, false ),
+    FLYWAY_REPAIR_BEFORE_MIGRATION( "flyway.repair_before_migration", Constants.OFF, false ),
 
     PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT( "tracker.temporary.ownership.timeout", "3", false ),
 
@@ -377,7 +377,7 @@ public enum ConfigurationKey
      * If enabled will use {@link #ARTEMIS_USERNAME} and
      * {@link #ARTEMIS_PASSWORD}.
      */
-    ARTEMIS_EMBEDDED_SECURITY( "artemis.embedded.security", Constants.FALSE ),
+    ARTEMIS_EMBEDDED_SECURITY( "artemis.embedded.security", Constants.OFF ),
 
     /**
      * Enable/disable Artemis persistence. (default. false).
@@ -386,7 +386,7 @@ public enum ConfigurationKey
      * should only be set if the volume on the queue is too high, and we want to
      * fall back to disk storage.
      */
-    ARTEMIS_EMBEDDED_PERSISTENCE( "artemis.embedded.persistence", Constants.FALSE ),
+    ARTEMIS_EMBEDDED_PERSISTENCE( "artemis.embedded.persistence", Constants.OFF ),
 
     /**
      * Number of threads to use for processing incoming packets. (default: 5).
@@ -582,7 +582,7 @@ public enum ConfigurationKey
     /**
      * WSO2 IdP specific parameters. Enable logout
      */
-    OIDC_PROVIDER_WSO2_ENABLE_LOGOUT( "oidc.provider.wso2.enable_logout", Constants.TRUE, false ),
+    OIDC_PROVIDER_WSO2_ENABLE_LOGOUT( "oidc.provider.wso2.enable_logout", Constants.ON, false ),
 
     /**
      * Database debugging feature. Defines threshold for logging of slow queries
@@ -595,17 +595,17 @@ public enum ConfigurationKey
      * Database debugging feature. Enables logging of all SQL queries to the
      * log.
      */
-    ENABLE_QUERY_LOGGING( "enable.query.logging", Constants.FALSE, false ),
+    ENABLE_QUERY_LOGGING( "enable.query.logging", Constants.OFF, false ),
 
     /**
      * Database debugging feature. Defines database logging before/after methods
      */
-    METHOD_QUERY_LOGGING_ENABLED( "method.query.logging.enabled", Constants.FALSE, false ),
+    METHOD_QUERY_LOGGING_ENABLED( "method.query.logging.enabled", Constants.OFF, false ),
 
     /**
      * Database debugging feature. Enable time query logging.
      */
-    ELAPSED_TIME_QUERY_LOGGING_ENABLED( "elapsed.time.query.logging.enabled", Constants.FALSE, false ),
+    ELAPSED_TIME_QUERY_LOGGING_ENABLED( "elapsed.time.query.logging.enabled", Constants.OFF, false ),
 
     /**
      * Database datasource pool type. Supported pool types are: c3p0 (default)
@@ -619,7 +619,7 @@ public enum ConfigurationKey
      * Allows enabling/disabling audits system-wide (without configuring the
      * audit matrix). (default: true)
      */
-    AUDIT_ENABLED( "system.audit.enabled", Constants.TRUE, false ),
+    AUDIT_ENABLED( "system.audit.enabled", Constants.ON, false ),
 
     /**
      * OAuth2 authorization server feature. Enable or disable.
@@ -753,10 +753,6 @@ public enum ConfigurationKey
 
     private static final class Constants
     {
-        public static final String FALSE = Boolean.FALSE.toString();
-
-        public static final String TRUE = Boolean.TRUE.toString();
-
         public static final String OFF = "off";
 
         public static final String ON = "on";

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
@@ -78,10 +78,6 @@ public class DefaultDhisConfigurationProvider extends LogOnceLogger
 
     private static final String GOOGLE_EE_SCOPE = "https://www.googleapis.com/auth/earthengine";
 
-    private static final String ENABLED_VALUE = "on";
-
-    private static final String DISABLED_VALUE = "off";
-
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -205,24 +201,6 @@ public class DefaultDhisConfigurationProvider extends LogOnceLogger
         }
 
         return StringUtils.isNotEmpty( value );
-    }
-
-    @Override
-    public boolean isEnabled( ConfigurationKey key )
-    {
-        return ENABLED_VALUE.equals( getProperty( key ) );
-    }
-
-    @Override
-    public boolean getBoolean( ConfigurationKey key )
-    {
-        return Boolean.parseBoolean( getProperty( key ) );
-    }
-
-    @Override
-    public boolean isDisabled( ConfigurationKey key )
-    {
-        return DISABLED_VALUE.equals( getProperty( key ) );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
@@ -44,6 +44,55 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
  */
 public interface DhisConfigurationProvider
 {
+    String ENABLED_VALUE = "on";
+
+    String DISABLED_VALUE = "off";
+
+    /**
+     * Indicates whether a value for the given key is equal to "on" or "true"
+     * (case-insensitive).
+     *
+     * @param value input value.
+     *
+     * @return true if the value is equal to "on" or "true" (case-insensitive).
+     */
+    static boolean isOn( String value )
+    {
+        boolean b1 = Boolean.parseBoolean( value );
+        boolean b2 = ENABLED_VALUE.equalsIgnoreCase( value );
+
+        return b1 || b2;
+    }
+
+    static boolean isOff( String value )
+    {
+        return !isOn( value );
+    }
+
+    /**
+     * Indicates whether a value for the given key is equal to "on".
+     *
+     * @param key the configuration key.
+     *
+     * @return true if the configuration key is enabled.
+     */
+    default boolean isEnabled( ConfigurationKey key )
+    {
+        return DhisConfigurationProvider.isOn( getProperty( key ) );
+    }
+
+    /**
+     * Indicates whether a value for the given key is equal to "off".
+     *
+     * @param key the configuration key.
+     *
+     * @return true if the configuration key is disabled.
+     */
+    default boolean isDisabled( ConfigurationKey key )
+    {
+        return !DhisConfigurationProvider.isOn( getProperty( key ) );
+    }
+
     /**
      * Get configuration as a set of properties.
      *
@@ -79,30 +128,6 @@ public interface DhisConfigurationProvider
      * @return true if a value exists.
      */
     boolean hasProperty( ConfigurationKey key );
-
-    /**
-     * Indicates whether a value for the given key is equal to "on".
-     *
-     * @param key the configuration key.
-     * @return true if the configuration key is enabled.
-     */
-    boolean isEnabled( ConfigurationKey key );
-
-    /**
-     * Returns value as boolean, will return false if value is null.
-     *
-     * @param key the configuration key.
-     * @return Will return true if the value is "true" or "TRUE"
-     */
-    boolean getBoolean( ConfigurationKey key );
-
-    /**
-     * Indicates whether a value for the given key is equal to "off".
-     *
-     * @param key the configuration key.
-     * @return true if the configuration key is disabled.
-     */
-    boolean isDisabled( ConfigurationKey key );
 
     /**
      * Returns a GoogleCredential, if a Google service account has been

--- a/dhis-2/dhis-support/dhis-support-external/src/test/java/org/hisp/dhis/external/conf/DhisConfigurationProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/test/java/org/hisp/dhis/external/conf/DhisConfigurationProviderTest.java
@@ -66,6 +66,6 @@ public class DhisConfigurationProviderTest
         assertFalse( configProvider.isEnabled( ConfigurationKey.MONITORING_API_ENABLED ) );
         assertTrue( configProvider.isEnabled( ConfigurationKey.DEBEZIUM_ENABLED ) );
         assertTrue( configProvider.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING ) );
-        assertTrue( configProvider.isEnabled( ConfigurationKey.METHOD_QUERY_LOGGING_ENABLED ) );
+        assertFalse( configProvider.isEnabled( ConfigurationKey.METHOD_QUERY_LOGGING_ENABLED ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-external/src/test/java/org/hisp/dhis/external/conf/DhisConfigurationProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/test/java/org/hisp/dhis/external/conf/DhisConfigurationProviderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.external.conf;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.external.location.DefaultLocationManager;
+import org.junit.Test;
+
+public class DhisConfigurationProviderTest
+{
+
+    @Test
+    public void isOn()
+    {
+        assertTrue( DhisConfigurationProvider.isOn( "on" ) );
+        assertTrue( DhisConfigurationProvider.isOn( "ON" ) );
+        assertTrue( DhisConfigurationProvider.isOn( "true" ) );
+        assertTrue( DhisConfigurationProvider.isOn( "TRUE" ) );
+
+        assertFalse( DhisConfigurationProvider.isOn( "off" ) );
+        assertFalse( DhisConfigurationProvider.isOn( "OFF" ) );
+        assertFalse( DhisConfigurationProvider.isOn( "false" ) );
+        assertFalse( DhisConfigurationProvider.isOn( "FALSE" ) );
+
+        assertFalse( DhisConfigurationProvider.isOn( "" ) );
+        assertFalse( DhisConfigurationProvider.isOn( null ) );
+    }
+
+    @Test
+    public void isEnabled()
+    {
+        System.setProperty( "dhis2.home", "src/test/resources" );
+        DefaultLocationManager locationManager = DefaultLocationManager.getDefault();
+        locationManager.init();
+        DefaultDhisConfigurationProvider configProvider = new DefaultDhisConfigurationProvider( locationManager );
+        configProvider.init();
+
+        assertFalse( configProvider.isEnabled( ConfigurationKey.REDIS_ENABLED ) );
+        assertFalse( configProvider.isEnabled( ConfigurationKey.MONITORING_API_ENABLED ) );
+        assertTrue( configProvider.isEnabled( ConfigurationKey.DEBEZIUM_ENABLED ) );
+        assertTrue( configProvider.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING ) );
+        assertTrue( configProvider.isEnabled( ConfigurationKey.METHOD_QUERY_LOGGING_ENABLED ) );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-external/src/test/resources/dhis.conf
+++ b/dhis-2/dhis-support/dhis-support-external/src/test/resources/dhis.conf
@@ -1,0 +1,6 @@
+monitoring.api.enabled = off
+debezium.enabled = on
+enable.query.logging = true
+method.query.logging.enabled = false
+
+

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/DataSourceConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/DataSourceConfig.java
@@ -135,7 +135,7 @@ public class DataSourceConfig
     @Primary
     public DataSource dataSource( @Qualifier( "actualDataSource" ) DataSource actualDataSource )
     {
-        boolean enableQueryLogging = dhisConfig.getBoolean( ConfigurationKey.ENABLE_QUERY_LOGGING );
+        boolean enableQueryLogging = dhisConfig.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING );
 
         if ( !enableQueryLogging )
         {
@@ -163,8 +163,8 @@ public class DataSourceConfig
             .listener( listener )
             .proxyResultSet();
 
-        boolean elapsedTimeLogging = dhisConfig.getBoolean( ConfigurationKey.ELAPSED_TIME_QUERY_LOGGING_ENABLED );
-        boolean methodLoggingEnabled = dhisConfig.getBoolean( ConfigurationKey.METHOD_QUERY_LOGGING_ENABLED );
+        boolean elapsedTimeLogging = dhisConfig.isEnabled( ConfigurationKey.ELAPSED_TIME_QUERY_LOGGING_ENABLED );
+        boolean methodLoggingEnabled = dhisConfig.isEnabled( ConfigurationKey.METHOD_QUERY_LOGGING_ENABLED );
 
         if ( methodLoggingEnabled )
         {

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
@@ -173,10 +173,8 @@ public class DatabasePoolUtils
         final int minPoolSize = Integer.parseInt( dhisConfig.getProperty( ConfigurationKey.CONNECTION_POOL_MIN_SIZE ) );
         final int initialSize = Integer
             .parseInt( dhisConfig.getProperty( ConfigurationKey.CONNECTION_POOL_INITIAL_SIZE ) );
-        boolean testOnCheckIn = Boolean
-            .parseBoolean( dhisConfig.getProperty( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN ) );
-        boolean testOnCheckOut = Boolean
-            .parseBoolean( dhisConfig.getProperty( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT ) );
+        boolean testOnCheckIn = dhisConfig.isEnabled( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN );
+        boolean testOnCheckOut = dhisConfig.isEnabled( ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT );
         final int maxIdleTimeExcessConnections = Integer
             .parseInt( dhisConfig.getProperty( ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON ) );
         final int idleConnectionTestPeriod = Integer

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/ExtendedCacheBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/ExtendedCacheBuilder.java
@@ -114,7 +114,7 @@ public class ExtendedCacheBuilder<V> extends SimpleCacheBuilder<V>
             log.info( String.format( "Local Cache (forced) instance created for region:'%s'", getRegion() ) );
             return new LocalCache<>( this );
         }
-        if ( configuration.getProperty( ConfigurationKey.REDIS_ENABLED ).equalsIgnoreCase( "true" ) )
+        if ( configuration.isEnabled( ConfigurationKey.REDIS_ENABLED ) )
         {
             log.info( String.format( "Redis Cache instance created for region:'%s'", getRegion() ) );
             return new RedisCache<>( this );

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/RedisDisabledCondition.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/RedisDisabledCondition.java
@@ -45,7 +45,7 @@ public class RedisDisabledCondition extends PropertiesAwareConfigurationConditio
     {
         if ( !isTestRun( context ) )
         {
-            return !getConfiguration().getProperty( ConfigurationKey.REDIS_ENABLED ).equalsIgnoreCase( "true" );
+            return !getConfiguration().isEnabled( ConfigurationKey.REDIS_ENABLED );
         }
 
         return true;

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/RedisEnabledCondition.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/RedisEnabledCondition.java
@@ -45,7 +45,7 @@ public class RedisEnabledCondition extends PropertiesAwareConfigurationCondition
     {
         if ( !isTestRun( context ) )
         {
-            return getConfiguration().getProperty( ConfigurationKey.REDIS_ENABLED ).equalsIgnoreCase( "true" );
+            return getConfiguration().isEnabled( ConfigurationKey.REDIS_ENABLED );
         }
         return false;
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/configuration/RedisConfiguration.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/configuration/RedisConfiguration.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.configuration;
 import org.hisp.dhis.condition.RedisEnabledCondition;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.ConfigurationPropertyFactoryBean;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -58,7 +59,7 @@ public class RedisConfiguration
     public LettuceConnectionFactory lettuceConnectionFactory()
     {
         LettuceClientConfigurationBuilder builder = LettuceClientConfiguration.builder();
-        if ( Boolean.parseBoolean( (String) redisSslEnabled().getObject() ) )
+        if ( DhisConfigurationProvider.isOn( (String) redisSslEnabled().getObject() ) )
         {
             builder.useSsl();
         }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -181,7 +181,7 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
             TestUtils.executeIntegrationTestDataScript( this.getClass(), jdbcTemplate );
         }
 
-        boolean enableQueryLogging = dhisConfigurationProvider.getBoolean( ConfigurationKey.ENABLE_QUERY_LOGGING );
+        boolean enableQueryLogging = dhisConfigurationProvider.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING );
 
         // Enable to query logger to log only what's happening inside the test
         // method

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisSpringTest.java
@@ -68,7 +68,7 @@ public abstract class DhisSpringTest extends BaseSpringTest
     {
         TestUtils.executeStartupRoutines( applicationContext );
 
-        boolean enableQueryLogging = dhisConfigurationProvider.getBoolean( ConfigurationKey.ENABLE_QUERY_LOGGING );
+        boolean enableQueryLogging = dhisConfigurationProvider.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING );
 
         if ( enableQueryLogging )
         {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisTest.java
@@ -60,7 +60,7 @@ public abstract class DhisTest extends BaseSpringTest
 
         TestUtils.executeStartupRoutines( applicationContext );
 
-        boolean enableQueryLogging = dhisConfigurationProvider.getBoolean( ConfigurationKey.ENABLE_QUERY_LOGGING );
+        boolean enableQueryLogging = dhisConfigurationProvider.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING );
 
         if ( enableQueryLogging )
         {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/H2DhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/H2DhisConfigurationProvider.java
@@ -124,12 +124,6 @@ public class H2DhisConfigurationProvider implements DhisConfigurationProvider
     }
 
     @Override
-    public boolean getBoolean( ConfigurationKey key )
-    {
-        return Boolean.parseBoolean( getProperty( key ) );
-    }
-
-    @Override
     public Optional<GoogleCredential> getGoogleCredential()
     {
         return Optional.empty();


### PR DESCRIPTION
### Summary:
There is a mix of true/false and on/off for boolean configuration properties. This is confusing, and there should only be one.
This task sets out to make/refactor code to only use the on/off, but still allow of both usage in the configuration file to maintain backward compatibility. Also, the methods used for checking and converting a property from a string to a boolean value is refactored.
The documentation should also be refactored to only show on/off as option for boolean config properties.

### Automatic tests:
A new test class was made to test the new methods: DhisConfigurationProviderTest

JIRA: 