### PR TITLE
feat: Optional predictor lower levels DHIS2-9833

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OrganisationUnitDescendants.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OrganisationUnitDescendants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+/**
+ * Defines the selection of organisation unit descendants.
+ *
+ * <ul>
+ * <li>SELECTED: specified units only.</li>
+ * <li>DESCENDANTS: all units in sub-hierarchy of specified units, including
+ * specified units.</li>
+ * </ul>
+ *
+ * @author Jim Grace
+ */
+public enum OrganisationUnitDescendants
+{
+    SELECTED,
+    DESCENDANTS
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
@@ -81,7 +81,7 @@ public class DataExportParams
 
     private Integer orgUnitLevel;
 
-    private boolean includeChildren;
+    private boolean includeDescendants;
 
     private boolean orderByOrgUnitPath;
 
@@ -193,9 +193,9 @@ public class DataExportParams
         return organisationUnits != null && !organisationUnits.isEmpty();
     }
 
-    public boolean isIncludeChildrenForOrganisationUnits()
+    public boolean isIncludeDescendantsForOrganisationUnits()
     {
-        return includeChildren && hasOrganisationUnits();
+        return includeDescendants && hasOrganisationUnits();
     }
 
     public boolean hasOrgUnitLevel()
@@ -275,7 +275,7 @@ public class DataExportParams
             .add( "org units", organisationUnits )
             .add( "org unit selection mode", ouMode )
             .add( "org unit level", orgUnitLevel )
-            .add( "children", includeChildren )
+            .add( "descendants", includeDescendants )
             .add( "order by org unit path", orderByOrgUnitPath )
             .add( "order by period", orderByPeriod )
             .add( "org unit groups", organisationUnitGroups )
@@ -427,14 +427,14 @@ public class DataExportParams
         return this;
     }
 
-    public boolean isIncludeChildren()
+    public boolean isIncludeDescendants()
     {
-        return includeChildren;
+        return includeDescendants;
     }
 
-    public DataExportParams setIncludeChildren( boolean includeChildren )
+    public DataExportParams setIncludeDescendants( boolean includeDescendants )
     {
-        this.includeChildren = includeChildren;
+        this.includeDescendants = includeDescendants;
         return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/Predictor.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/Predictor.java
@@ -91,6 +91,11 @@ public class Predictor
     private Set<OrganisationUnitLevel> organisationUnitLevels;
 
     /**
+     * Whether data for descendant organisation units should be included
+     */
+    private boolean includeDescendantOrgUnits;
+
+    /**
      * The number of sequential periods from which to collect samples to average
      * (Monitoring-type rules only). Sequential periods are those immediately
      * preceding (or immediately following in previous years) the selected
@@ -215,6 +220,18 @@ public class Predictor
     public void setOrganisationUnitLevels( Set<OrganisationUnitLevel> organisationUnitLevels )
     {
         this.organisationUnitLevels = organisationUnitLevels;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isIncludeDescendantOrgUnits()
+    {
+        return includeDescendantOrgUnits;
+    }
+
+    public void setIncludeDescendantOrgUnits( boolean includeDescendantOrgUnits )
+    {
+        this.includeDescendantOrgUnits = includeDescendantOrgUnits;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/Predictor.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/Predictor.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.BaseNameableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeDeserializer;
 import org.hisp.dhis.common.adapter.JacksonPeriodTypeSerializer;
 import org.hisp.dhis.dataelement.DataElement;
@@ -91,9 +92,9 @@ public class Predictor
     private Set<OrganisationUnitLevel> organisationUnitLevels;
 
     /**
-     * Whether data for descendant organisation units should be included
+     * Mode for including organisation unit descendants
      */
-    private boolean includeDescendantOrgUnits;
+    private OrganisationUnitDescendants organisationUnitDescendants;
 
     /**
      * The number of sequential periods from which to collect samples to average
@@ -224,14 +225,14 @@ public class Predictor
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isIncludeDescendantOrgUnits()
+    public OrganisationUnitDescendants getOrganisationUnitDescendants()
     {
-        return includeDescendantOrgUnits;
+        return organisationUnitDescendants;
     }
 
-    public void setIncludeDescendantOrgUnits( boolean includeDescendantOrgUnits )
+    public void setOrganisationUnitDescendants( OrganisationUnitDescendants organisationUnitDescendants )
     {
-        this.includeDescendantOrgUnits = includeDescendantOrgUnits;
+        this.organisationUnitDescendants = organisationUnitDescendants;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -310,12 +310,12 @@ public class DefaultDataValueService
             error = new ErrorMessage( ErrorCode.E2006 );
         }
 
-        if ( params.isIncludeChildren() && params.hasOrganisationUnitGroups() )
+        if ( params.isIncludeDescendants() && params.hasOrganisationUnitGroups() )
         {
             error = new ErrorMessage( ErrorCode.E2007 );
         }
 
-        if ( params.isIncludeChildren() && !params.hasOrganisationUnits() )
+        if ( params.isIncludeDescendants() && !params.hasOrganisationUnits() )
         {
             error = new ErrorMessage( ErrorCode.E2008 );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -201,7 +201,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
             hql += "and (pe.startDate >= :startDate and pe.endDate < :endDate) ";
         }
 
-        if ( params.isIncludeChildrenForOrganisationUnits() )
+        if ( params.isIncludeDescendantsForOrganisationUnits() )
         {
             hql += "and (";
 
@@ -267,7 +267,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
             query.setParameter( "startDate", params.getStartDate() ).setParameter( "endDate", params.getEndDate() );
         }
 
-        if ( !params.isIncludeChildrenForOrganisationUnits() && !organisationUnits.isEmpty() )
+        if ( !params.isIncludeDescendantsForOrganisationUnits() && !organisationUnits.isEmpty() )
         {
             query.setParameterList( "orgUnits", getIdentifiers( organisationUnits ) );
         }
@@ -313,7 +313,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         boolean joinOrgUnit = params.isOrderByOrgUnitPath()
             || params.hasOrgUnitLevel()
             || params.getOuMode() == DESCENDANTS
-            || params.isIncludeChildren();
+            || params.isIncludeDescendants();
 
         String sql = "select dv.dataelementid, dv.periodid, dv.sourceid" +
             ", dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value" +
@@ -385,7 +385,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         if ( params.hasOrgUnitLevel() )
         {
             where += sqlHelper.whereAnd() + "ou.hierarchylevel " +
-                (params.isIncludeChildren() ? ">" : "") +
+                (params.isIncludeDescendants() ? ">" : "") +
                 "= " + params.getOrgUnitLevel();
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
@@ -39,6 +39,8 @@
         foreign-key="fk_predictororgunitlevels_orgunitlevelid" />
     </set>
 
+    <property name="includeDescendantOrgUnits" column="includedescendantorgunits" />
+
     <property name="sequentialSampleCount" column="sequentialsamplecount" not-null="true" />
 
     <property name="annualSampleCount" column="annualsamplecount" not-null="true" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
@@ -39,7 +39,13 @@
         foreign-key="fk_predictororgunitlevels_orgunitlevelid" />
     </set>
 
-    <property name="includeDescendantOrgUnits" column="includedescendantorgunits" />
+    <property name="organisationUnitDescendants" column="organisationunitdescendants" length="100" not-null="true">
+      <type name="org.hibernate.type.EnumType">
+        <param name="enumClass">org.hisp.dhis.common.OrganisationUnitDescendants</param>
+        <param name="useNamed">true</param>
+        <param name="type">12</param>
+      </type>
+    </property>
 
     <property name="sequentialSampleCount" column="sequentialsamplecount" not-null="true" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/DefaultAdxDataService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/DefaultAdxDataService.java
@@ -181,7 +181,7 @@ public class DefaultAdxDataService
                 .addAll( getByUidOrCode( CategoryOptionCombo.class, urlParams.getAttributeOptionCombo() ) );
         }
 
-        params.setIncludeChildren( urlParams.isChildren() );
+        params.setIncludeDescendants( urlParams.isChildren() );
         params.setIncludeDeleted( urlParams.isIncludeDeleted() );
         params.setLastUpdated( urlParams.getLastUpdated() );
         params.setLastUpdatedDuration( urlParams.getLastUpdatedDuration() );
@@ -224,7 +224,7 @@ public class DefaultAdxDataService
                     DataExportParams queryParams = new DataExportParams()
                         .setDataElements( dataSet.getDataElements() )
                         .setOrganisationUnits( Sets.newHashSet( orgUnit ) )
-                        .setIncludeChildren( params.isIncludeChildren() )
+                        .setIncludeDescendants( params.isIncludeDescendants() )
                         .setIncludeDeleted( params.isIncludeDeleted() )
                         .setLastUpdated( params.getLastUpdated() )
                         .setLastUpdatedDuration( params.getLastUpdatedDuration() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -258,7 +258,7 @@ public class DefaultDataValueSetService
         }
 
         return params
-            .setIncludeChildren( urlParams.isChildren() )
+            .setIncludeDescendants( urlParams.isChildren() )
             .setIncludeDeleted( urlParams.isIncludeDeleted() )
             .setLastUpdated( urlParams.getLastUpdated() )
             .setLastUpdatedDuration( urlParams.getLastUpdatedDuration() )
@@ -307,12 +307,12 @@ public class DefaultDataValueSetService
             error = new ErrorMessage( ErrorCode.E2006 );
         }
 
-        if ( params.isIncludeChildren() && params.hasOrganisationUnitGroups() )
+        if ( params.isIncludeDescendants() && params.hasOrganisationUnitGroups() )
         {
             error = new ErrorMessage( ErrorCode.E2007 );
         }
 
-        if ( params.isIncludeChildren() && !params.hasOrganisationUnits() )
+        if ( params.isIncludeDescendants() && !params.hasOrganisationUnits() )
         {
             error = new ErrorMessage( ErrorCode.E2008 );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
@@ -291,7 +291,7 @@ public class SpringDataValueSetStore
 
         sql += "where de.dataelementid in (" + dataElements + ") ";
 
-        if ( params.isIncludeChildren() )
+        if ( params.isIncludeDescendants() )
         {
             sql += "and (";
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
@@ -397,7 +397,7 @@ public class AdxDataServiceIntegrationTest
             .setDataSets( Sets.newHashSet( dsA ) )
             .setPeriods( Sets.newHashSet( pe202001 ) )
             .setOrganisationUnits( Sets.newHashSet( ouA ) )
-            .setIncludeChildren( true )
+            .setIncludeDescendants( true )
             .setIncludeDeleted( false )
             .setLastUpdated( now )
             .setLimit( 999 )
@@ -430,7 +430,7 @@ public class AdxDataServiceIntegrationTest
             .setOrganisationUnits( Sets.newHashSet( ouB ) )
             .setOrganisationUnitGroups( Sets.newHashSet( ougA ) )
             .setAttributeOptionCombos( Sets.newHashSet( cocMcDonalds ) )
-            .setIncludeChildren( false )
+            .setIncludeDescendants( false )
             .setIncludeDeleted( true )
             .setLastUpdated( now )
             .setOutputIdSchemes( new IdSchemes().setIdScheme( "UID" ) );
@@ -496,7 +496,7 @@ public class AdxDataServiceIntegrationTest
                 .setOrgUnitIdScheme( "NAME" )
                 .setCategoryIdScheme( "UID" )
                 .setCategoryOptionIdScheme( "NAME" ) )
-            .setIncludeChildren( true ) );
+            .setIncludeDescendants( true ) );
     }
 
     @Test
@@ -511,7 +511,7 @@ public class AdxDataServiceIntegrationTest
                 .setOrgUnitIdScheme( "NAME" )
                 .setCategoryIdScheme( "UID" )
                 .setCategoryOptionIdScheme( "NAME" ) )
-            .setIncludeChildren( true )
+            .setIncludeDescendants( true )
             .setAttributeOptionCombos( Sets.newHashSet( cocMcDonalds ) ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceExportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceExportTest.java
@@ -404,7 +404,7 @@ public class DataValueSetServiceExportTest
         DataExportParams params = new DataExportParams()
             .setDataSets( Sets.newHashSet( dsA ) )
             .setOrganisationUnits( Sets.newHashSet( ouA ) )
-            .setIncludeChildren( true )
+            .setIncludeDescendants( true )
             .setPeriods( Sets.newHashSet( peA ) );
 
         dataValueSetService.writeDataValueSetJson( params, out );
@@ -668,7 +668,7 @@ public class DataValueSetServiceExportTest
             .setDataSets( Sets.newHashSet( dsA ) )
             .setPeriods( Sets.newHashSet( peA, peB ) )
             .setOrganisationUnitGroups( Sets.newHashSet( ogA ) )
-            .setIncludeChildren( true );
+            .setIncludeDescendants( true );
 
         assertIllegalQueryEx(
             assertThrows( IllegalQueryException.class, () -> dataValueSetService.writeDataValueSetJson( params, out ) ),

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.predictor;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.common.OrganisationUnitDescendants.DESCENDANTS;
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
@@ -66,6 +67,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ListMap;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.MapMapMap;
+import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.constant.Constant;
@@ -339,10 +341,10 @@ public class DefaultPredictionService
             storedBy = currentUser.getUsername();
         }
 
-        PredictionDataValueFetcher oldPredictionFetcher = new PredictionDataValueFetcher(
-            dataValueService, categoryService ).setIncludeDeleted( true );
-        PredictionDataValueFetcher dataValueFetcher = new PredictionDataValueFetcher(
-            dataValueService, categoryService ).setIncludeChildren( predictor.isIncludeDescendantOrgUnits() );
+        PredictionDataValueFetcher oldPredictionFetcher = new PredictionDataValueFetcher( dataValueService,
+            categoryService ).setIncludeDeleted( true );
+        PredictionDataValueFetcher dataValueFetcher = new PredictionDataValueFetcher( dataValueService,
+            categoryService ).setIncludeDescendants( predictor.getOrganisationUnitDescendants().equals( DESCENDANTS ) );
         PredictionAnalyticsDataFetcher analyticsFetcher = new PredictionAnalyticsDataFetcher( analyticsService );
         PredictionWriter predictionWriter = new PredictionWriter( dataValueService, batchHandlerFactory );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -342,7 +342,7 @@ public class DefaultPredictionService
         PredictionDataValueFetcher oldPredictionFetcher = new PredictionDataValueFetcher(
             dataValueService, categoryService ).setIncludeDeleted( true );
         PredictionDataValueFetcher dataValueFetcher = new PredictionDataValueFetcher(
-            dataValueService, categoryService ).setIncludeChildren( true );
+            dataValueService, categoryService ).setIncludeChildren( predictor.isIncludeDescendantOrgUnits() );
         PredictionAnalyticsDataFetcher analyticsFetcher = new PredictionAnalyticsDataFetcher( analyticsService );
         PredictionWriter predictionWriter = new PredictionWriter( dataValueService, batchHandlerFactory );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -67,7 +67,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ListMap;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.MapMapMap;
-import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.constant.Constant;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
@@ -106,7 +106,7 @@ public class PredictionDataValueFetcher
 
     private Set<DataElementOperand> dataElementOperands;
 
-    private boolean includeChildren = false;
+    private boolean includeDescendants = false;
 
     private boolean includeDeleted = false;
 
@@ -210,7 +210,7 @@ public class PredictionDataValueFetcher
         params.setOrgUnitLevel( orgUnitLevel );
         params.setBlockingQueue( blockingQueue );
         params.setOrderByOrgUnitPath( true );
-        params.setIncludeChildren( includeChildren );
+        params.setIncludeDescendants( includeDescendants );
         params.setIncludeDeleted( includeDeleted );
 
         try
@@ -272,12 +272,12 @@ public class PredictionDataValueFetcher
     /**
      * Sets whether the data should return aggregated to the parent org unit.
      *
-     * @param includeChildren whether the data should include child orgUnits.
+     * @param includeDescendants whether the data includes descendant orgUnits.
      * @return this object (for method chaining).
      */
-    public PredictionDataValueFetcher setIncludeChildren( boolean includeChildren )
+    public PredictionDataValueFetcher setIncludeDescendants( boolean includeDescendants )
     {
-        this.includeChildren = includeChildren;
+        this.includeDescendants = includeDescendants;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.predictor;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static org.hisp.dhis.common.OrganisationUnitDescendants.SELECTED;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
 import static org.junit.Assert.assertEquals;
 
@@ -43,6 +44,7 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -561,7 +563,7 @@ public class PredictionServiceTest
     }
 
     @Test
-    public void testPredictSequentialWithChildren()
+    public void testPredictSequentialWithDescendants()
     {
         setupTestData();
 
@@ -592,14 +594,14 @@ public class PredictionServiceTest
     }
 
     @Test
-    public void testPredictSequentialWithoutChildren()
+    public void testPredictSequentialWithoutDescendants()
     {
         setupTestData();
 
         Predictor p = createPredictor( dataElementX, defaultCombo, "PredictSequential",
             expressionA, null, periodTypeMonthly, orgUnitLevel1, 3, 1, 0 );
 
-        p.setIncludeDescendantOrgUnits( false );
+        p.setOrganisationUnitDescendants( SELECTED );
 
         predictionService.predict( p, monthStart( 2001, 7 ), monthStart( 2001, 12 ), summary );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -561,7 +561,7 @@ public class PredictionServiceTest
     }
 
     @Test
-    public void testPredictSequential()
+    public void testPredictSequentialWithChildren()
     {
         setupTestData();
 
@@ -589,6 +589,34 @@ public class PredictionServiceTest
         predictionService.predict( p, monthStart( 2001, 7 ), monthStart( 2001, 12 ), summary );
 
         assertEquals( "Pred 1 Ins 0 Upd 0 Del 0 Unch 8", shortSummary( summary ) );
+    }
+
+    @Test
+    public void testPredictSequentialWithoutChildren()
+    {
+        setupTestData();
+
+        Predictor p = createPredictor( dataElementX, defaultCombo, "PredictSequential",
+            expressionA, null, periodTypeMonthly, orgUnitLevel1, 3, 1, 0 );
+
+        p.setIncludeDescendantOrgUnits( false );
+
+        predictionService.predict( p, monthStart( 2001, 7 ), monthStart( 2001, 12 ), summary );
+
+        assertEquals( "Pred 1 Ins 4 Upd 0 Del 0 Unch 0", shortSummary( summary ) );
+
+        assertEquals( "5.0", getDataValue( dataElementX, defaultCombo, sourceA, makeMonth( 2001, 8 ) ) );
+        assertEquals( "6.121", getDataValue( dataElementX, defaultCombo, sourceA, makeMonth( 2001, 9 ) ) );
+        assertEquals( "10.8", getDataValue( dataElementX, defaultCombo, sourceA, makeMonth( 2001, 10 ) ) );
+        assertEquals( "10.24", getDataValue( dataElementX, defaultCombo, sourceA, makeMonth( 2001, 11 ) ) );
+
+        // Make sure we can do it again.
+
+        summary = new PredictionSummary();
+
+        predictionService.predict( p, monthStart( 2001, 7 ), monthStart( 2001, 12 ), summary );
+
+        assertEquals( "Pred 1 Ins 0 Upd 0 Del 0 Unch 4", shortSummary( summary ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_16__Add_includedescendantorgunits_to_predictor.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_16__Add_includedescendantorgunits_to_predictor.sql
@@ -1,5 +1,5 @@
--- For legacy predictors, set includedescendantorgunits to true
-ALTER TABLE predictor ADD COLUMN IF NOT EXISTS includedescendantorgunits BOOLEAN DEFAULT true;
+-- For legacy predictors, include descendants for backwards compatibility
+ALTER TABLE predictor ADD COLUMN IF NOT EXISTS organisationUnitDescendants VARCHAR(100) DEFAULT 'DESCENDANTS';
 
--- For future predictors, includedescendantorgunits defaults to false
-ALTER TABLE predictor ALTER COLUMN includedescendantorgunits DROP DEFAULT;
+-- For future predictors, selected only is a better default
+ALTER TABLE predictor ALTER COLUMN organisationUnitDescendants SET DEFAULT 'SELECTED';

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_16__Add_includedescendantorgunits_to_predictor.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_16__Add_includedescendantorgunits_to_predictor.sql
@@ -1,0 +1,5 @@
+-- For legacy predictors, set includedescendantorgunits to true
+ALTER TABLE predictor ADD COLUMN IF NOT EXISTS includedescendantorgunits BOOLEAN DEFAULT true;
+
+-- For future predictors, includedescendantorgunits defaults to false
+ALTER TABLE predictor ALTER COLUMN includedescendantorgunits DROP DEFAULT;

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -32,7 +32,6 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hisp.dhis.common.OrganisationUnitDescendants.DESCENDANTS;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 
 import java.io.File;
@@ -1251,7 +1250,7 @@ public abstract class DhisConvenienceTest
         predictor.setSampleSkipTest( skipTest );
         predictor.setPeriodType( periodType );
         predictor.setOrganisationUnitLevels( organisationUnitLevels );
-        predictor.setOrganisationUnitDescendants( DESCENDANTS );
+        predictor.setOrganisationUnitDescendants( OrganisationUnitDescendants.DESCENDANTS );
         predictor.setSequentialSampleCount( sequentialSampleCount );
         predictor.setAnnualSampleCount( annualSampleCount );
         predictor.setSequentialSkipCount( sequentialSkipCount );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -32,6 +32,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.common.OrganisationUnitDescendants.DESCENDANTS;
 import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 
 import java.io.File;
@@ -73,6 +74,7 @@ import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.cache.CacheStrategy;
@@ -1249,7 +1251,7 @@ public abstract class DhisConvenienceTest
         predictor.setSampleSkipTest( skipTest );
         predictor.setPeriodType( periodType );
         predictor.setOrganisationUnitLevels( organisationUnitLevels );
-        predictor.setIncludeDescendantOrgUnits( true );
+        predictor.setOrganisationUnitDescendants( DESCENDANTS );
         predictor.setSequentialSampleCount( sequentialSampleCount );
         predictor.setAnnualSampleCount( annualSampleCount );
         predictor.setSequentialSkipCount( sequentialSkipCount );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1249,6 +1249,7 @@ public abstract class DhisConvenienceTest
         predictor.setSampleSkipTest( skipTest );
         predictor.setPeriodType( periodType );
         predictor.setOrganisationUnitLevels( organisationUnitLevels );
+        predictor.setIncludeDescendantOrgUnits( true );
         predictor.setSequentialSampleCount( sequentialSampleCount );
         predictor.setAnnualSampleCount( annualSampleCount );
         predictor.setSequentialSkipCount( sequentialSkipCount );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/PredictorControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/PredictorControllerTest.java
@@ -112,7 +112,8 @@ public class PredictorControllerTest extends DhisControllerConvenienceTest
                     "'periodType': 'Monthly'," +
                     "'sequentialSampleCount':4," +
                     "'annualSampleCount':3," +
-                    "'organisationUnitLevels': []" +
+                    "'organisationUnitLevels': []," +
+                    "'organisationUnitDescendants': 'SELECTED'" +
                     " }" ) );
     }
 }


### PR DESCRIPTION
See [DHIS2-9833](https://jira.dhis2.org/browse/DHIS2-9833). This PR implements the predictor property includeDescendantOrgUnits, which allows the user to optionally select whether a predictor includes lower-level orgUnit data.

Until now, predictors always selected lower-level orgUnit data, so in updating the database, any existing predictors will have includeDescendantOrgUnits set to true. However it is a more useful default to have predictors not select lower-level orgUnit data. So for new predictors defined in the future, the default value for includeDescendantOrgUnits will be false.