### PR TITLE
feat: Add username regexp validation

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -196,6 +196,7 @@ public enum ErrorCode
     E4046( "TrackedEntityAttribute `{0}` associated with program rule `{1}` does not exist" ),
     E4047( "DataElement `{0}` is not linked to any ProgramStageDataElement for program rule `{1}`" ),
     E4048( "TrackedEntityAttribute `{0}` is not linked to ProgramTrackedEntityAttribute for program rule `{1}`" ),
+    E4049( "Property `{0}` requires a valid username, was given `{1}`." ),
 
     /* ProgramRuleVariable validation */
     E4051( "A program rule variable with name `{0}` and program uid `{1}` already exists" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/PropertyType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/PropertyType.java
@@ -42,6 +42,7 @@ public enum PropertyType
     NUMBER,
     INTEGER,
     BOOLEAN,
+    USERNAME,
     EMAIL,
     PASSWORD,
     URL,
@@ -58,7 +59,7 @@ public enum PropertyType
     public boolean isSimple()
     {
         return IDENTIFIER == this || TEXT == this || NUMBER == this || INTEGER == this || EMAIL == this
-            || PASSWORD == this || URL == this
-            || DATE == this || PHONENUMBER == this || GEOLOCATION == this || COLOR == this || CONSTANT == this;
+            || USERNAME == this || PASSWORD == this || URL == this || DATE == this || PHONENUMBER == this
+            || GEOLOCATION == this || COLOR == this || CONSTANT == this;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -713,7 +713,6 @@ public class UserCredentials
     @Override
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @Property( PropertyType.USERNAME )
     public String getUsername()
     {
         return username;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserCredentials.java
@@ -713,6 +713,7 @@ public class UserCredentials
     @Override
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @Property( PropertyType.USERNAME )
     public String getUsername()
     {
         return username;

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/LoginTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/LoginTests.java
@@ -61,7 +61,7 @@ public class LoginTests
 
     private String secret = "1e6db50c-0fee-11e5-98d0-3c15c2c6caf6";
 
-    private String userName = "LoginTestsUser" + DataGenerator.randomString();
+    private String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
 
     private String password = Constants.USER_PASSWORD;
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_export/MetadataExportTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_export/MetadataExportTests.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 public class MetadataExportTests
     extends ApiTest
 {
-    private String userWithoutAccessUsername = "MetadataExportTestsUser" + DataGenerator.randomString();
+    private String userWithoutAccessUsername = ("MetadataExportTestsUser" + DataGenerator.randomString()).toLowerCase();
 
     private String userWithoutAccessPassword = Constants.USER_PASSWORD;
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/orgunits/OrgUnitsTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/orgunits/OrgUnitsTest.java
@@ -68,7 +68,7 @@ public class OrgUnitsTest
     @Test
     public void shouldNotCreateWithoutPermissions()
     {
-        String userName = DataGenerator.randomString();
+        String userName = (DataGenerator.randomString()).toLowerCase();
         String psw = "!XPTOqwerty1";
 
         userActions.addUser( userName, psw );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserDisableTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserDisableTest.java
@@ -59,7 +59,7 @@ public class UserDisableTest
         userActions = new UserActions();
         loginActions = new LoginActions();
 
-        userName = DataGenerator.randomString();
+        userName = (DataGenerator.randomString()).toLowerCase();
 
         loginActions.loginAsSuperUser();
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
@@ -72,7 +72,7 @@ public class UserPaginationTest
         {
             userActions
                 .addUser( DataGenerator.randomString() + i, DataGenerator.randomString() + i,
-                    DataGenerator.randomString() + i,
+                    (DataGenerator.randomString() + i).toLowerCase(),
                     DataGenerator.randomString() + "Abcd1234!" + i );
         }
     }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
@@ -68,7 +68,7 @@ public class UserTest extends ApiTest
         loginActions = new LoginActions();
         meActions = new RestApiActions( "/me" );
 
-        username = ("user-tests-" + DataGenerator.randomString()).toLowerCase();
+        username = ("user_tests_" + DataGenerator.randomString()).toLowerCase();
         loginActions.loginAsSuperUser();
         userActions.addUser( username, password );
         loginActions.loginAsUser( username, password );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
@@ -68,7 +68,7 @@ public class UserTest extends ApiTest
         loginActions = new LoginActions();
         meActions = new RestApiActions( "/me" );
 
-        username = "user-tests-" + DataGenerator.randomString();
+        username = ("user-tests-" + DataGenerator.randomString()).toLowerCase();
         loginActions.loginAsSuperUser();
         userActions.addUser( username, password );
         loginActions.loginAsUser( username, password );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UsersRemovalTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UsersRemovalTests.java
@@ -63,11 +63,11 @@ public class UsersRemovalTests
         optionActions = new OptionActions();
         loginActions = new LoginActions();
 
-        userName = DataGenerator.randomString();
+        userName = (DataGenerator.randomString()).toLowerCase();
 
         loginActions.loginAsSuperUser();
 
-        userId = userActions.addUser( "johnny", "bravo", userName.toLowerCase(), password );
+        userId = userActions.addUser( "johnny", "bravo", userName, password );
     }
 
     @Test

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UsersRemovalTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/users/UsersRemovalTests.java
@@ -67,7 +67,7 @@ public class UsersRemovalTests
 
         loginActions.loginAsSuperUser();
 
-        userId = userActions.addUser( "johnny", "bravo", userName, password );
+        userId = userActions.addUser( "johnny", "bravo", userName.toLowerCase(), password );
     }
 
     @Test

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesApiTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicatesApiTest.java
@@ -76,7 +76,7 @@ public class PotentialDuplicatesApiTest
 
     protected String createUserWithAccessToMerge()
     {
-        String username = DataGenerator.randomString();
+        String username = (DataGenerator.randomString()).toLowerCase();
         String auth = new UserRoleActions().createWithAuthorities( MERGE_AUTHORITY );
         String userid = userActions.addUser( username, USER_PASSWORD );
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/events/EventExportTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/events/EventExportTests.java
@@ -83,7 +83,7 @@ public class EventExportTests
 
     private final String withRegistrationProgramStage = "nlXNK4b7LVr";
 
-    private final String userName = "TA_EVENTS_ACL_USER" + DataGenerator.randomString();
+    private final String userName = ("TA_EVENTS_ACL_USER" + DataGenerator.randomString()).toLowerCase();
 
     private final String password = Constants.USER_PASSWORD;
 

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/events/UserAssignmentFilterTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/events/UserAssignmentFilterTests.java
@@ -90,7 +90,7 @@ public class UserAssignmentFilterTests
         metadataActions = new MetadataActions();
         userActions = new UserActions();
 
-        userUsername = "EventFiltersUser" + DataGenerator.randomString();
+        userUsername = ("EventFiltersUser" + DataGenerator.randomString()).toLowerCase();
 
         loginActions.loginAsSuperUser();
         metadataActions.importAndValidateMetadata( new File( "src/test/resources/tracker/eventProgram.json" ) );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/OwnershipTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/OwnershipTests.java
@@ -156,7 +156,7 @@ public class OwnershipTests
 
     protected String createUserWithAccessToOu()
     {
-        String username = DataGenerator.randomEntityName() + "user";
+        String username = (DataGenerator.randomEntityName() + "user").replace(" ",""  ).toLowerCase();
         String userid = userActions.addUser( username, Constants.USER_PASSWORD );
 
         //userActions.addRoleToUser( userid, auth );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -147,10 +147,10 @@ public class UserServiceTest
         addUser( 'A' );
         addUser( 'B' );
 
-        assertEquals( 2, userService.getUserCredentialsByUsernames( asList( "UsernameA", "UsernameB" ) ).size() );
+        assertEquals( 2, userService.getUserCredentialsByUsernames( asList( "usernamea", "usernameb" ) ).size() );
         assertEquals( 2,
-            userService.getUserCredentialsByUsernames( asList( "UsernameA", "UsernameB", "usernameX" ) ).size() );
-        assertEquals( 0, userService.getUserCredentialsByUsernames( asList( "usernameC" ) ).size() );
+            userService.getUserCredentialsByUsernames( asList( "usernamea", "usernameb", "usernamex" ) ).size() );
+        assertEquals( 0, userService.getUserCredentialsByUsernames( asList( "usernamec" ) ).size() );
     }
 
     @Test
@@ -608,16 +608,16 @@ public class UserServiceTest
         List<UserAccountExpiryInfo> soonExpiringAccounts = userService.getExpiringUserAccounts( 7 );
         Set<String> soonExpiringAccountNames = soonExpiringAccounts.stream()
             .map( UserAccountExpiryInfo::getUsername ).collect( toSet() );
-        assertEquals( new HashSet<>( asList( "UsernameB", "UsernameD" ) ), soonExpiringAccountNames );
+        assertEquals( new HashSet<>( asList( "usernameb", "usernamed" ) ), soonExpiringAccountNames );
 
         soonExpiringAccounts = userService.getExpiringUserAccounts( 9 );
         soonExpiringAccountNames = soonExpiringAccounts.stream()
             .map( UserAccountExpiryInfo::getUsername ).collect( toSet() );
-        assertEquals( new HashSet<>( asList( "UsernameB", "UsernameD", "UsernameE" ) ), soonExpiringAccountNames );
+        assertEquals( new HashSet<>( asList( "usernameb", "usernamed", "usernamee" ) ), soonExpiringAccountNames );
 
         for ( UserAccountExpiryInfo expiryInfo : soonExpiringAccounts )
         {
-            assertEquals( expiryInfo.getUsername().replace( "Username", "Email" ), expiryInfo.getEmail() );
+            assertEquals( expiryInfo.getUsername().replace( "username", "email" ), expiryInfo.getEmail() );
         }
     }
 
@@ -673,11 +673,11 @@ public class UserServiceTest
         addUser( 'C', UserCredentials::setLastLogin, twentyTwoDaysAgo );
         addUser( 'D' );
 
-        assertEquals( singleton( "EmailA" ),
+        assertEquals( singleton( "emaila" ),
             userService.findNotifiableUsersWithLastLoginBetween( threeMonthAgo, twoMonthsAgo ) );
-        assertEquals( singleton( "EmailA" ),
+        assertEquals( singleton( "emaila" ),
             userService.findNotifiableUsersWithLastLoginBetween( fourMonthAgo, oneMonthsAgo ) );
-        assertEquals( new HashSet<>( asList( "EmailA", "EmailC" ) ),
+        assertEquals( new HashSet<>( asList( "emaila", "emailc" ) ),
             userService.findNotifiableUsersWithLastLoginBetween( fourMonthAgo, Date.from( now.toInstant() ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -73,6 +73,11 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
     public void validate( User user, ObjectBundle bundle,
         Consumer<ErrorReport> addReports )
     {
+        if ( bundle.getImportMode().isCreate() && !ValidationUtils.usernameIsValid( user.getUsername() ) )
+        {
+            addReports.accept( new ErrorReport( User.class, ErrorCode.E4049, "Username", user.getUsername() ) );
+        }
+
         if ( user.getWhatsApp() != null && !ValidationUtils.validateWhatsapp( user.getWhatsApp() ) )
         {
             addReports.accept( new ErrorReport( User.class, ErrorCode.E4027, user.getWhatsApp(), "Whatsapp" ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
@@ -111,13 +111,13 @@ public class ObjectBundleServiceUserTest
         User userA = userService.getUser( "sPWjoHSY03y" );
         User userB = userService.getUser( "MwhEJUnTHkn" );
 
-        assertUsernameEquals( userA, UserCredentials::getUserInfo, "UserA" );
+        assertUsernameEquals( userA, UserCredentials::getUserInfo, "usera" );
         assertUsernameEquals( userA, UserCredentials::getCreatedBy, "admin" );
         assertEquals( "user@a.org", userA.getEmail() );
         assertEquals( new Integer( 3 ), userA.getDataViewMaxOrganisationUnitLevel() );
         assertEquals( 1, userA.getOrganisationUnits().size() );
 
-        assertUsernameEquals( userB, UserCredentials::getUserInfo, "UserB" );
+        assertUsernameEquals( userB, UserCredentials::getUserInfo, "userb" );
         assertUsernameEquals( userB, UserCredentials::getCreatedBy, "admin" );
         assertEquals( "user@b.org", userB.getEmail() );
         assertEquals( new Integer( 4 ), userB.getDataViewMaxOrganisationUnitLevel() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/users.json
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/resources/dxf2/users.json
@@ -110,7 +110,7 @@
             "id": "tHEWGwIMsJk"
           }
         ],
-        "username": "UserB",
+        "username": "userb",
         "invitation": false,
         "disabled": false,
         "externalAuth": false
@@ -140,7 +140,7 @@
       "dataViewMaxOrganisationUnitLevel": 3,
       "userCredentials": {
         "id": "m3ww4DWJtMf",
-        "username": "UserA",
+        "username": "usera",
         "userRoles": [
           {
             "id": "tHEWGwIMsJk"

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
@@ -184,6 +184,10 @@ public class DefaultSchemaValidator implements SchemaValidator
         {
             errorReports.add( createNameReport( ErrorCode.E4003, klass, property, value ) );
         }
+        else if ( isInvalidUsername( property, value ) )
+        {
+            errorReports.add( createNameReport( ErrorCode.E4049, klass, property, value ) );
+        }
         else if ( isInvalidUrl( property, value ) )
         {
             errorReports.add( createNameReport( ErrorCode.E4004, klass, property, value ) );
@@ -218,6 +222,11 @@ public class DefaultSchemaValidator implements SchemaValidator
     {
         return !BCRYPT_PATTERN.matcher( value ).matches() && PropertyType.PASSWORD == property.getPropertyType()
             && !ValidationUtils.passwordIsValid( value );
+    }
+
+    private boolean isInvalidUsername( Property property, String value )
+    {
+        return PropertyType.USERNAME == property.getPropertyType() && !ValidationUtils.usernameIsValid( value );
     }
 
     private boolean isInvalidEmail( Property property, String value )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -75,7 +75,7 @@ public class EventTrackerConverterServiceTest
 
     private final static String PROGRAM_UID = "ProgramUid";
 
-    private final static String USERNAME = "usernameU";
+    private final static String USERNAME = "usernameu";
 
     private final static Date today = new Date();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/NotesConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/NotesConverterServiceTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
  */
 public class NotesConverterServiceTest extends DhisConvenienceTest
 {
-    private static final String CURRENT_USER = "usernameA";
+    private static final String CURRENT_USER = "usernamea";
 
     private NotesConverterService notesConverterService;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_metadata.json
@@ -1012,7 +1012,7 @@
             "externalAccess": false,
             "externalAuth": false,
             "twoFA": false,
-            "username": "---USER5---",
+            "username": "testusername5",
             "id": "oajYcE7VMBs",
             "userGroupAccesses": [],
             "created": "2019-03-29T08:57:41.766",
@@ -1030,8 +1030,8 @@
             "translations": [],
             "passwordLastUpdated": "2019-03-29T08:57:41.766"
           },
-          "firstName": "---USER5---",
-          "surname": "---USER5---",
+          "firstName": "testusername5",
+          "surname": "testusername5",
           "id": "oajYcE7VMBs",
           "attributeValues": []
         },

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_metadata_mandatory_attr.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_metadata_mandatory_attr.json
@@ -854,7 +854,7 @@
         "externalAccess": false,
         "externalAuth": false,
         "twoFA": false,
-        "username": "---USER5---",
+        "username": "testusername5",
         "id": "oajYcE7VMBs",
         "userGroupAccesses": [],
         "created": "2019-03-29T08:57:41.766",
@@ -872,8 +872,8 @@
         "translations": [],
         "passwordLastUpdated": "2019-03-29T08:57:41.766"
       },
-      "firstName": "---USER5---",
-      "surname": "---USER5---",
+      "firstName": "testusername5",
+      "surname": "testusername5",
       "id": "oajYcE7VMBs",
       "attributeValues": []
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.render.ObjectValueTypeRenderingOption;
 import org.hisp.dhis.render.StaticRenderingConfiguration;
 import org.hisp.dhis.render.type.ValueTypeRenderingType;
-import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.util.DateUtils;
 
 import com.google.common.collect.ImmutableSet;
@@ -64,6 +63,8 @@ import com.google.common.collect.Sets;
  */
 public class ValidationUtils
 {
+    private static final Pattern USERNAME_PATTERN = Pattern.compile(
+        "^[a-z0-9]([._-](?![._-])|[a-z0-9]){4,255}[a-z0-9]$" );
 
     private static final String NUM_PAT = "((-?[0-9]+)(\\.[0-9]+)?)";
 
@@ -222,7 +223,12 @@ public class ValidationUtils
      */
     public static boolean usernameIsValid( String username )
     {
-        return username != null && username.length() <= UserCredentials.USERNAME_MAX_LENGTH;
+        if ( username == null )
+        {
+            return false;
+        }
+        Matcher matcher = USERNAME_PATTERN.matcher( username );
+        return matcher.matches();
     }
 
     /**

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -64,7 +64,7 @@ import com.google.common.collect.Sets;
 public class ValidationUtils
 {
     private static final Pattern USERNAME_PATTERN = Pattern.compile(
-        "^(?=.{4,255}$)(?![_.])(?!.*[_.]{2})[a-z0-9._]+(?<![_.])$" );
+        "^(?=.{4,255}$)(?![_.@])(?!.*[_.]{2})[a-z0-9._@]+(?<![_.@])$" );
 
     private static final String NUM_PAT = "((-?[0-9]+)(\\.[0-9]+)?)";
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -64,7 +64,7 @@ import com.google.common.collect.Sets;
 public class ValidationUtils
 {
     private static final Pattern USERNAME_PATTERN = Pattern.compile(
-        "^[a-z0-9]([._-](?![._-])|[a-z0-9]){4,255}[a-z0-9]$" );
+        "^(?=.{4,255}$)(?![_.])(?!.*[_.]{2})[a-z0-9._]+(?<![_.])$" );
 
     private static final String NUM_PAT = "((-?[0-9]+)(\\.[0-9]+)?)";
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -64,7 +64,7 @@ import com.google.common.collect.Sets;
 public class ValidationUtils
 {
     private static final Pattern USERNAME_PATTERN = Pattern.compile(
-        "^(?=.{4,255}$)(?![_.@])(?!.*[_.]{2})[a-z0-9._@]+(?<![_.@])$" );
+        "^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-z0-9._@]+(?<![_.@])$" );
 
     private static final String NUM_PAT = "((-?[0-9]+)(\\.[0-9]+)?)";
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -161,6 +161,19 @@ public class ValidationUtilsTest
         assertTrue( usernameIsValid( "johnmichaeldoe" ) );
         assertTrue( usernameIsValid( "ted@johnson.com" ) );
         assertTrue( usernameIsValid( "harry@gmail.com" ) );
+        assertTrue( usernameIsValid( "har_ry@gmail.com" ) );
+
+        assertFalse( usernameIsValid( "Harry@gmail.com" ) );
+        assertFalse( usernameIsValid( "_harry@gmail.com" ) );
+        assertFalse( usernameIsValid( "harry@gmail.com_" ) );
+        assertFalse( usernameIsValid( ".harry@gmail.com" ) );
+        assertFalse( usernameIsValid( "harry@gmail.com." ) );
+        assertFalse( usernameIsValid( "@harry@gmail.com" ) );
+        assertFalse( usernameIsValid( "harry@gmail.com@" ) );
+        assertFalse( usernameIsValid( "harry_@gmail.com" ) );
+        assertFalse( usernameIsValid( "har__ry@gmail.com" ) );
+        assertFalse( usernameIsValid( "harry@@gmail.com" ) );
+        assertFalse( usernameIsValid( "harry..gmail.com" ) );
 
         assertFalse( usernameIsValid( null ) );
         assertFalse( usernameIsValid( CodeGenerator.generateCode( 400 ) ) );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1334,7 +1335,7 @@ public abstract class DhisConvenienceTest
         credentials.setCreatedBy( user );
         user.setUserCredentials( credentials );
 
-        credentials.setUsername( "username" + uniqueCharacter );
+        credentials.setUsername( ("username" + uniqueCharacter).toLowerCase() );
         credentials.setPassword( "password" + uniqueCharacter );
 
         if ( auths != null && !auths.isEmpty() )
@@ -1346,7 +1347,7 @@ public abstract class DhisConvenienceTest
 
         user.setFirstName( "FirstName" + uniqueCharacter );
         user.setSurname( "Surname" + uniqueCharacter );
-        user.setEmail( "Email" + uniqueCharacter );
+        user.setEmail( ("Email" + uniqueCharacter).toLowerCase() );
         user.setPhoneNumber( "PhoneNumber" + uniqueCharacter );
         user.setCode( "UserCode" + uniqueCharacter );
         user.setAutoFields();
@@ -1375,7 +1376,7 @@ public abstract class DhisConvenienceTest
     {
         UserCredentials credentials = new UserCredentials();
         credentials.setName( "UserCredentials" + uniqueCharacter );
-        credentials.setUsername( "Username" + uniqueCharacter );
+        credentials.setUsername( ("username" + uniqueCharacter).toLowerCase() );
         credentials.setPassword( "Password" + uniqueCharacter );
         credentials.setUserInfo( user );
         user.setUserCredentials( credentials );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -245,7 +246,7 @@ public abstract class DhisConvenienceTest
 
     protected static CategoryService categoryService;
 
-    private char nextUserName = 'a';
+    private char nextUserName = 'k';
 
     @PostConstruct
     protected void initServices()
@@ -2535,7 +2536,7 @@ public abstract class DhisConvenienceTest
         credentials.setCode( username );
         credentials.setCreatedBy( user );
         credentials.setUserInfo( user );
-        credentials.setUsername( username );
+        credentials.setUsername( username.toLowerCase() );
         credentials.getUserAuthorityGroups().add( group );
 
         if ( !Strings.isNullOrEmpty( openIDIdentifier ) )

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -44,7 +44,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -79,7 +79,7 @@ public class AccountControllerTest extends DhisControllerConvenienceTest
     public void testValidateUserNameGet_UserNameAvailable()
     {
         assertMessage( "response", "success", "",
-            GET( "/account/username?username=abc" ).content( HttpStatus.OK ) );
+            GET( "/account/username?username=abcd" ).content( HttpStatus.OK ) );
     }
 
     @Test
@@ -93,7 +93,7 @@ public class AccountControllerTest extends DhisControllerConvenienceTest
     public void testValidateUserNamePost_UserNameAvailable()
     {
         assertMessage( "response", "success", "",
-            POST( "/account/validateUsername?username=abc" ).content( HttpStatus.OK ) );
+            POST( "/account/validateUsername?username=abcd" ).content( HttpStatus.OK ) );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/BulkPatchSharingControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/BulkPatchSharingControllerTest.java
@@ -71,9 +71,9 @@ public class BulkPatchSharingControllerTest
     public void testApplyPatchOk()
         throws IOException
     {
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userA", userAId ) ) );
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userB", userBId ) ) );
-        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userC" ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "usera", userAId ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userb", userBId ) ) );
+        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userc" ) ) );
 
         assertStatus( HttpStatus.CREATED,
             POST( "/dataElements", jsonMapper.writeValueAsString( createDataElement( 'A', deAId, userCId ) ) ) );
@@ -100,9 +100,9 @@ public class BulkPatchSharingControllerTest
     public void testApplyPatchWithInvalidUid()
         throws IOException
     {
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userA", userAId ) ) );
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userB", userBId ) ) );
-        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userC" ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "usera", userAId ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userb", userBId ) ) );
+        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userc" ) ) );
 
         assertStatus( HttpStatus.CREATED,
             POST( "/dataElements", toJsonString( createDataElement( 'B', deBId, userCId ) ) ) );
@@ -128,9 +128,9 @@ public class BulkPatchSharingControllerTest
     public void testApplyPatchWithInvalidUidAtomic()
         throws IOException
     {
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userA", userAId ) ) );
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userB", userBId ) ) );
-        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userC" ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "usera", userAId ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userb", userBId ) ) );
+        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userc" ) ) );
 
         assertStatus( HttpStatus.CREATED,
             POST( "/dataElements", jsonMapper.writeValueAsString( createDataElement( 'B', deBId, userCId ) ) ) );
@@ -148,9 +148,9 @@ public class BulkPatchSharingControllerTest
     public void testApplyPatches()
         throws IOException
     {
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userA", userAId ) ) );
-        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userB", userBId ) ) );
-        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userC" ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "usera", userAId ) ) );
+        assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userb", userBId ) ) );
+        userCId = assertStatus( HttpStatus.CREATED, POST( "/users", createUser( "userc" ) ) );
 
         assertStatus( HttpStatus.CREATED,
             POST( "/dataSets", jsonMapper.writeValueAsString( createDataSet( 'A', dsIdA, userCId ) ) ) );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -216,6 +216,15 @@ public class UserControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    public void testPostJsonObjectInvalidUsername()
+    {
+        assertWebMessage( "Conflict", 409, "ERROR",
+            "One more more errors occurred, please see full details in import report.",
+            POST( "/users/", "{'surname':'S.','firstName':'Harry','userCredentials':{'username':'Harrys'}}" )
+                .content( HttpStatus.CONFLICT ) );
+    }
+
+    @Test
     public void testPostJsonInvite()
     {
         assertWebMessage( "Created", 201, "OK", null,

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -127,8 +127,8 @@ public class UserControllerTest extends DhisControllerConvenienceTest
     @Test
     public void testReplicateUser_UserNameAlreadyTaken()
     {
-        assertWebMessage( "Conflict", 409, "ERROR", "Username already taken: Peter",
-            POST( "/users/" + peter.getUid() + "/replica", "{'username':'Peter','password':'Saf€sEcre1'}" )
+        assertWebMessage( "Conflict", 409, "ERROR", "Username already taken: peter",
+            POST( "/users/" + peter.getUid() + "/replica", "{'username':'peter','password':'Saf€sEcre1'}" )
                 .content( HttpStatus.CONFLICT ) );
     }
 
@@ -211,7 +211,7 @@ public class UserControllerTest extends DhisControllerConvenienceTest
     public void testPostJsonObject()
     {
         assertWebMessage( "Created", 201, "OK", null,
-            POST( "/users/", "{'surname':'S.','firstName':'Harry','userCredentials':{'username':'HarryS'}}" )
+            POST( "/users/", "{'surname':'S.','firstName':'Harry','userCredentials':{'username':'harrys'}}" )
                 .content( HttpStatus.CREATED ) );
     }
 
@@ -220,7 +220,7 @@ public class UserControllerTest extends DhisControllerConvenienceTest
     {
         assertWebMessage( "Created", 201, "OK", null,
             POST( "/users/invite",
-                "{'surname':'S.','firstName':'Harry', 'email':'test@example.com', 'userCredentials':{'username':'HarryS'}}" )
+                "{'surname':'S.','firstName':'Harry', 'email':'test@example.com', 'userCredentials':{'username':'harrys'}}" )
                     .content( HttpStatus.CREATED ) );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -581,6 +581,10 @@ public class AccountController
         {
             result.put( "message", "Username is already taken" );
         }
+        else
+        {
+            result.put( "message", "" );
+        }
 
         return result;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -559,14 +559,28 @@ public class AccountController
 
     private Map<String, String> validateUserName( String username )
     {
-        boolean valid = username != null && userService.getUserCredentialsByUsername( username ) == null;
+        boolean isNull = username == null;
+        boolean usernameNotTaken = userService.getUserCredentialsByUsername( username ) == null;
+        boolean isValidSyntax = ValidationUtils.usernameIsValid( username );
+        boolean isValid = !isNull && usernameNotTaken && isValidSyntax;
 
         // Custom code required because of our hacked jQuery validation
-
         Map<String, String> result = new HashMap<>();
 
-        result.put( "response", valid ? "success" : "error" );
-        result.put( "message", valid ? "" : "Username is already taken" );
+        result.put( "response", isValid ? "success" : "error" );
+
+        if ( isNull )
+        {
+            result.put( "message", "Username is null" );
+        }
+        else if ( !isValidSyntax )
+        {
+            result.put( "message", "Username is not valid" );
+        }
+        else if ( !usernameNotTaken )
+        {
+            result.put( "message", "Username is already taken" );
+        }
 
         return result;
     }


### PR DESCRIPTION
### Summary 
This PR adds regexp validation of the username.
Allowed usernames must match this regular expression: 
```
^(?=.{4,255}$)   (?![_.@])   (?!.*[_.@]{2})   [a-z0-9._@]+   (?<![_.@])$
```
1. username is 4-255 characters long
2. no _ or . or @ at the beginning
3. no __ or .. or @@ inside
4. allowed characters
5. no _ or . or @ at the end


### Automatic tests:

* ValidationUtilsTest.testUsernameIsValid()
* UserControllerTest.testPostJsonObjectInvalidUsername()

Jira: [DHIS2-10886](https://jira.dhis2.org/browse/DHIS2-10886)