### PR TITLE
fix: validate program stage reference to program DHIS2-12123

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.preprocess;
 
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -67,20 +66,25 @@ public class EventProgramPreProcessor
                 ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
                 if ( Objects.nonNull( programStage ) )
                 {
-                    // Program stages should always have a program! Due to how
-                    // metadata import is currently implemented
-                    // it's possible that users run into the edge case that a
-                    // program stage does not have an associated
-                    // program. Tell the user it's an issue with the metadata
-                    // and not the event itself. This should be
-                    // fixed in the metadata import. For more see
-                    // https://jira.dhis2.org/browse/DHIS2-12123
+                    // TODO remove if once metadata import is fixed
                     if ( programStage.getProgram() == null )
                     {
-                        throw new IllegalStateException(
-                            MessageFormat.format(
-                                "Program stage `{0}` has no reference to a program. Check the program stage configuration",
-                                programStage.getUid() ) );
+                        // Program stages should always have a program! Due to
+                        // how metadata
+                        // import is currently implemented
+                        // it's possible that users run into the edge case that
+                        // a program
+                        // stage does not have an associated
+                        // program. Tell the user it's an issue with the
+                        // metadata and not
+                        // the event itself. This should be
+                        // fixed in the metadata import. For more see
+                        // https://jira.dhis2.org/browse/DHIS2-12123
+                        //
+                        // PreCheckMandatoryFieldsValidationHook.validateEvent
+                        // will create
+                        // a validation error for this edge case
+                        return;
                     }
                     event.setProgram( programStage.getProgram().getUid() );
                     bundle.getPreheat().put( TrackerIdentifier.UID, programStage.getProgram() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
@@ -56,6 +56,26 @@ public class EventWithoutRegistrationPreProcessor
 
                 if ( programStage != null )
                 {
+                    // TODO remove if once metadata import is fixed
+                    if ( programStage.getProgram() == null )
+                    {
+                        // Program stages should always have a program! Due to
+                        // how metadata
+                        // import is currently implemented
+                        // it's possible that users run into the edge case that
+                        // a program
+                        // stage does not have an associated
+                        // program. Tell the user it's an issue with the
+                        // metadata and not
+                        // the event itself. This should be
+                        // fixed in the metadata import. For more see
+                        // https://jira.dhis2.org/browse/DHIS2-12123
+                        //
+                        // PreCheckMandatoryFieldsValidationHook.validateEvent
+                        // will create
+                        // a validation error for this edge case
+                        return;
+                    }
                     setEnrollment( bundle, programStage.getProgram().getUid(), event );
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -41,6 +41,7 @@ public enum TrackerErrorCode
     E1005( "Could not find TrackedEntityType: `{0}`." ),
     E1006( "Attribute: `{0}`, does not exist." ),
     E1007( "Error validating attribute value type: `{0}`; Error: `{1}`." ),
+    E1008( "Program stage `{0}` has no reference to a program. Check the program stage configuration" ),
     E1009( "File resource: `{0}`, has already been assigned to a different object." ),
     E1010( "Could not find Program: `{0}`, linked to Event." ),
     E1011( "Could not find OrganisationUnit: `{0}`, linked to Event." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
@@ -27,13 +27,10 @@
  */
 package org.hisp.dhis.tracker.preprocess;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramStage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -161,10 +158,9 @@ public class EventProgramPreProcessorTest
             .build();
 
         // When
-        IllegalStateException thrown = assertThrows( IllegalStateException.class,
-            () -> preProcessorToTest.process( bundle ) );
+        preProcessorToTest.process( bundle );
 
-        assertThat( thrown.getMessage(), startsWith( "Program stage `LGSWs20XFvy` has no reference to a program" ) );
+        verify( preheat, never() ).put( TrackerIdentifier.UID, programStage.getProgram() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessorTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
 
@@ -82,5 +83,34 @@ public class EventWithoutRegistrationPreProcessorTest
 
         // Then
         assertEquals( "programInstanceUid", bundle.getEvents().get( 0 ).getEnrollment() );
+    }
+
+    @Test
+    public void testEnrollmentIsNotAddedIntoEventWhenItProgramStageHasNoReferenceToProgram()
+    {
+        // Given
+        Event event = new Event();
+        event.setProgramStage( "programStageUid" );
+        TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
+
+        ProgramInstance programInstance = new ProgramInstance();
+        programInstance.setUid( "programInstanceUid" );
+
+        Program program = new Program();
+        program.setUid( "programUid" );
+        ProgramStage programStage = new ProgramStage();
+        programStage.setUid( "programStageUid" );
+
+        TrackerPreheat preheat = new TrackerPreheat();
+        preheat.putProgramInstancesWithoutRegistration( "programUid", programInstance );
+
+        preheat.put( TrackerIdentifier.UID, programStage );
+        bundle.setPreheat( preheat );
+
+        // When
+        preProcessorToTest.process( bundle );
+
+        // Then
+        assertNull( "programInstanceUid", bundle.getEvents().get( 0 ).getEnrollment() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -259,7 +259,6 @@ public class PreCheckMetaValidationHookTest
         validatorToTest.validateEvent( reporter, event );
 
         // then
-        // then
         assertFalse( reporter.hasErrors() );
     }
 


### PR DESCRIPTION
 Validate program stage reference to program instead of throwing a more detailed exception.

* EventProgramPreProcessor
* EventWithoutRegistrationPreProcessor

are 2 pre-processors where we discovered an NPE due to a missing
reference in the DB from program stage to program. This is an edge case
due to how the metadata import is currently implemented.

Since pre-processing is done before validation we opted for returning
before an NPE occurs. Validation will then find that a reference to a
program is missing in the DB and create an error report.

Note that the program field is not a mandatory field in the payload
according to our NTI API documentation. I therefore needed an extra
error code and return before adding E1123 which would only confuse the
user.

Reproduce:

```sql
update programstage set programid=null where uid='LGSWs20XFvy';
```

Import an event for this program stage without specifying the program in the payload. See https://jira.dhis2.org/browse/DHIS2-12123 for all the details. 

Sample validation error:

```json
{"status":"ERROR","validationReport":{"errorReports":[{"message":"Program stage `LGSWs20XFvy` has no reference to a program. Check the program stage configuration","errorCode":"E1008","trackerType":"EVENT","uid":"dTIUgrTn0jC"}]},"stats":{"created":0,"updated":0,"deleted":0,"ignored":1,"total":1}}
```