### PR TITLE
fix: dhis-services should also target JDK11

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -19,14 +19,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>9</source>
-                <target>9</target>
-            </configuration>
-        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
we configure the JDK11 release in the pluginManagement of our root pom
child projects inherit the config. core plugins like the compiler plugin
do not need to be declared explicitly they are activated by default
https://www.baeldung.com/maven-plugin-management