### PR TITLE
fix: maven dependency:analyze declares lombok/hamcrest-library as unused

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -218,6 +218,7 @@
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <maven-java-formatter-plugin.version>0.4</maven-java-formatter-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <dependency-check-maven.version>6.0.3</dependency-check-maven.version>
         <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
@@ -673,6 +674,20 @@
                             </licenseHeader>
                         </java>
                         <lineEndings>UNIX</lineEndings>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                    <configuration>
+                        <ignoredUnusedDeclaredDependencies>
+                            <ignoredUnusedDeclaredDependency>org.projectlombok:lombok</ignoredUnusedDeclaredDependency>
+                            <!-- dependency on hamcrest-library and this config can be removed once we are on Junit 5 as
+                            it does not depend on hamcrest anymore. See
+                            http://hamcrest.org/JavaHamcrest/distributables#maven-upgrade-example -->
+                            <ignoredUnusedDeclaredDependency>org.hamcrest:hamcrest-library</ignoredUnusedDeclaredDependency>
+                        </ignoredUnusedDeclaredDependencies>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
we declare lombok as scope provided since its a compile time dependency that does not need
to be present at runtime. maven dependency:analyze often tells us lombok is declared but
unused because it does its work at compile time, and as such most annotations are removed after compilation.

We can tell the dependency plugin to ignore such 'declared unused' dependencies since with scope
provided it will not be shipped in our final war even if it was actually unused in one of our modules

Same with the hamcrest-library which is needed until we update to junit
5 which does not depend on hamcrest anymore. See http://hamcrest.org/JavaHamcrest/distributables#maven-upgrade-example