### PR TITLE
ci: publish canary docker images [skip-ci]

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -23,7 +23,7 @@ pipeline {
             steps {
                 echo "Publishing docker image to dhis2/core-canary"
                 script {
-                    def branch="2.37"
+                    def branch="${GIT_BRANCH}"
                     def today = new Date()
                     def formatted = "${today.format('yyyyMMdd')}"
                     def source = "dhis2/core-dev:${branch}"

--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -19,6 +19,26 @@ pipeline {
     }
 
     stages {
+        stage ('Publish canary docker image') {
+            steps {
+                echo "Publishing docker image to dhis2/core-canary"
+                script {
+                    def branch="2.37"
+                    def today = new Date()
+                    def formatted = "${today.format('yyyyMMdd')}"
+                    def source = "dhis2/core-dev:${branch}"
+                    def target = "dhis2/core-canary:${branch}"
+                    
+                    sh "docker pull ${source}"
+                    sh "docker tag ${source} ${target}"
+                    sh "docker tag ${source} ${target}-${formatted}"
+                    withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                        sh "docker push ${target}"
+                        sh "docker push ${target}-${formatted}"
+                    }           
+                }
+            }
+        }
         stage ('Build') {
             steps {
                 echo 'Building DHIS2 ...'


### PR DESCRIPTION
Once in a while we get a request for canary docker images, eg when faulty migration breaks on SL db and devs are blocked. This pipeline change will publish latest docker image from core-dev to core-canary using the naming scheme that we agreed on [here](https://github.com/dhis2/notes/blob/00ae685fd3e7ecd8fcdb67ff544f7ad39101b862/minutes/2019/05/25-war-docker-schemes.md): 

eg: 
```
dhis2/core-canary:2.32
dhis2/core-canary:2.32-20190522
```

Tested on: https://ci-backup.dhis2.org/job/gintare-test/