### PR TITLE
ci: trigger api-tests on [opened] event

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   pull_request: 
-    types: [ labeled, synchronize ]
+    types: [ opened, labeled, synchronize ]
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
Seems that sometimes api-test action is not executed, although it should. This is an attempt to fix that.