### PR TITLE
chore(deps): update to mockito 4.x and remove powermock usage

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -163,18 +163,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerCrudTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerCrudTest.java
@@ -60,14 +60,17 @@ import org.hisp.dhis.user.UserService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Luca Cambi <luca@dhis2.org>
  */
+@RunWith( MockitoJUnitRunner.class )
 public class TrackerCrudTest
 {
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -40,8 +40,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
@@ -91,15 +91,11 @@ import org.hisp.dhis.user.User;
 import org.hisp.quick.BatchHandler;
 import org.hisp.quick.BatchHandlerFactory;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
 
 import com.google.common.collect.Sets;
@@ -107,10 +103,7 @@ import com.google.common.collect.Sets;
 /**
  * @author Luciano Fiandesio
  */
-@RunWith( PowerMockRunner.class )
-@PrepareForTest( DefaultCompleteDataSetRegistrationExchangeService.class )
-@PowerMockIgnore( { "javax.management.*", "javax.xml.*", "org.apache.logging.*", "org.apache.xerces.*",
-    "org.cache2k.*", "org.slf4j.*" } )
+@RunWith( MockitoJUnitRunner.class )
 public class DefaultCompleteDataSetRegistrationExchangeServiceTest
 {
     @Mock
@@ -158,9 +151,6 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
     @Mock
     private BatchHandler<CompleteDataSetRegistration> batchHandler;
 
-    @Mock
-    private MetadataCaches metaDataCaches;
-
     // Cache mocks //
 
     @Mock
@@ -195,9 +185,6 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
 
     private DefaultCompleteDataSetRegistrationExchangeService subject;
 
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
-
     private CategoryOptionCombo DEFAULT_COC;
 
     @Before
@@ -227,7 +214,6 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
 
     @Test
     public void verifyUserHasNoWritePermissionOnCategoryOption()
-        throws Exception
     {
         OrganisationUnit organisationUnit = createOrganisationUnit( 'A' );
         DataSet dataSetA = createDataSet( 'A', new MonthlyPeriodType() );
@@ -241,71 +227,75 @@ public class DefaultCompleteDataSetRegistrationExchangeServiceTest
         String payload = createPayload( period, organisationUnit, dataSetA, categoryCombo, categoryOptionA,
             categoryOptionB );
 
-        whenNew( MetadataCaches.class ).withNoArguments().thenReturn( metaDataCaches );
-        when( currentUserService.getCurrentUser() ).thenReturn( user );
-        when( batchHandler.init() ).thenReturn( batchHandler );
-        when( idObjManager.get( CategoryCombo.class, categoryCombo.getUid() ) ).thenReturn( categoryCombo );
-        when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionA.getUid() ) )
-            .thenReturn( categoryOptionA );
-        when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionB.getUid() ) )
-            .thenReturn( categoryOptionB );
+        try ( MockedConstruction<MetadataCaches> mocked = mockConstruction( MetadataCaches.class,
+            ( mock, context ) -> {
+                when( mock.getDataSets() ).thenReturn( datasetCache );
+                when( mock.getPeriods() ).thenReturn( periodCache );
+                when( mock.getOrgUnits() ).thenReturn( orgUnitCache );
+                aocCache = new CachingMap<>();
+                when( mock.getAttrOptionCombos() ).thenReturn( aocCache );
+                when( mock.getOrgUnitInHierarchyMap() ).thenReturn( orgUnitInHierarchyCache );
+                when( mock.getAttrOptComboOrgUnitMap() ).thenReturn( attrOptComboOrgUnitCache );
+            } ) )
+        {
+            when( currentUserService.getCurrentUser() ).thenReturn( user );
+            when( batchHandler.init() ).thenReturn( batchHandler );
+            when( idObjManager.get( CategoryCombo.class, categoryCombo.getUid() ) ).thenReturn( categoryCombo );
+            when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionA.getUid() ) )
+                .thenReturn( categoryOptionA );
+            when( idObjManager.getObject( CategoryOption.class, IdScheme.UID, categoryOptionB.getUid() ) )
+                .thenReturn( categoryOptionB );
 
-        when( categoryService.getCategoryOptionCombo( categoryCombo,
-            Sets.newHashSet( categoryOptionA, categoryOptionB ) ) ).thenReturn( categoryOptionCombo );
+            when( categoryService.getCategoryOptionCombo( categoryCombo,
+                Sets.newHashSet( categoryOptionA, categoryOptionB ) ) ).thenReturn( categoryOptionCombo );
 
-        when( datasetCache.get( eq( dataSetA.getUid() ), any() ) ).thenReturn( dataSetA );
-        when( periodCache.get( eq( period.getIsoDate() ), any() ) ).thenReturn( period );
-        when( orgUnitCache.get( eq( organisationUnit.getUid() ), any() ) ).thenReturn( createOrganisationUnit( 'A' ) );
+            when( datasetCache.get( eq( dataSetA.getUid() ), any() ) ).thenReturn( dataSetA );
+            when( periodCache.get( eq( period.getIsoDate() ), any() ) ).thenReturn( period );
+            when( orgUnitCache.get( eq( organisationUnit.getUid() ), any() ) )
+                .thenReturn( createOrganisationUnit( 'A' ) );
 
-        when( orgUnitInHierarchyCache.get( eq( organisationUnit.getUid() ), any() ) ).thenReturn( Boolean.TRUE );
-        when( attrOptComboOrgUnitCache.get( eq( categoryOptionCombo.getUid() + organisationUnit.getUid() ), any() ) )
-            .thenReturn( Boolean.TRUE );
-        when( categoryService.getCategoryOptionCombo( categoryOptionCombo.getUid() ) )
-            .thenReturn( categoryOptionCombo );
+            when( orgUnitInHierarchyCache.get( eq( organisationUnit.getUid() ), any() ) ).thenReturn( Boolean.TRUE );
+            when(
+                attrOptComboOrgUnitCache.get( eq( categoryOptionCombo.getUid() + organisationUnit.getUid() ), any() ) )
+                    .thenReturn( Boolean.TRUE );
+            when( categoryService.getCategoryOptionCombo( categoryOptionCombo.getUid() ) )
+                .thenReturn( categoryOptionCombo );
 
-        // force error on access check for Category Option Combo
-        when( aclService.canDataWrite( user, dataSetA ) ).thenReturn( true );
-        when( aclService.canDataWrite( user, categoryOptionA ) ).thenReturn( false );
-        when( aclService.canDataWrite( user, categoryOptionB ) ).thenReturn( true );
+            // force error on access check for Category Option Combo
+            when( aclService.canDataWrite( user, dataSetA ) ).thenReturn( true );
+            when( aclService.canDataWrite( user, categoryOptionA ) ).thenReturn( false );
+            when( aclService.canDataWrite( user, categoryOptionB ) ).thenReturn( true );
 
-        when( notifier.clear( null ) ).thenReturn( notifier );
-        when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS ) )
-            .thenReturn( false );
-        when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS ) )
-            .thenReturn( false );
-        when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS ) )
-            .thenReturn( false );
-        when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO ) )
-            .thenReturn( false );
+            when( notifier.clear( null ) ).thenReturn( notifier );
+            when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_STRICT_PERIODS ) )
+                .thenReturn( false );
+            when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_STRICT_ATTRIBUTE_OPTION_COMBOS ) )
+                .thenReturn( false );
+            when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_STRICT_ORGANISATION_UNITS ) )
+                .thenReturn( false );
+            when( systemSettingManager.getBoolSetting( SettingKey.DATA_IMPORT_REQUIRE_ATTRIBUTE_OPTION_COMBO ) )
+                .thenReturn( false );
 
-        when( currentUserService.getCurrentUserOrganisationUnits() )
-            .thenReturn( Collections.singleton( createOrganisationUnit( 'A' ) ) );
-        when( i18nManager.getI18n() ).thenReturn( i18n );
+            when( currentUserService.getCurrentUserOrganisationUnits() )
+                .thenReturn( Collections.singleton( createOrganisationUnit( 'A' ) ) );
+            when( i18nManager.getI18n() ).thenReturn( i18n );
 
-        when( categoryService.getDefaultCategoryOptionCombo() ).thenReturn( DEFAULT_COC );
-        when( batchHandlerFactory.createBatchHandler( CompleteDataSetRegistrationBatchHandler.class ) )
-            .thenReturn( batchHandler );
+            when( categoryService.getDefaultCategoryOptionCombo() ).thenReturn( DEFAULT_COC );
+            when( batchHandlerFactory.createBatchHandler( CompleteDataSetRegistrationBatchHandler.class ) )
+                .thenReturn( batchHandler );
 
-        // caches
-        when( metaDataCaches.getDataSets() ).thenReturn( datasetCache );
-        when( metaDataCaches.getPeriods() ).thenReturn( periodCache );
-        when( metaDataCaches.getOrgUnits() ).thenReturn( orgUnitCache );
-        aocCache = new CachingMap<>();
-        when( metaDataCaches.getAttrOptionCombos() ).thenReturn( aocCache );
-        when( metaDataCaches.getOrgUnitInHierarchyMap() ).thenReturn( orgUnitInHierarchyCache );
-        when( metaDataCaches.getAttrOptComboOrgUnitMap() ).thenReturn( attrOptComboOrgUnitCache );
+            when( notifier.notify( null, NotificationLevel.INFO, "Import done", true ) ).thenReturn( notifier );
 
-        when( notifier.notify( null, NotificationLevel.INFO, "Import done", true ) ).thenReturn( notifier );
+            // call method under test
+            ImportSummary summary = subject.saveCompleteDataSetRegistrationsJson(
+                new ByteArrayInputStream( payload.getBytes() ), new ImportOptions() );
 
-        // call method under test
-        ImportSummary summary = subject.saveCompleteDataSetRegistrationsJson(
-            new ByteArrayInputStream( payload.getBytes() ), new ImportOptions() );
-
-        assertThat( summary.getStatus(), is( ImportStatus.ERROR ) );
-        assertThat( summary.getImportCount().getIgnored(), is( 1 ) );
-        assertEquals( 1, summary.getConflictCount() );
-        assertThat( summary.getConflicts().iterator().next().getValue(),
-            is( "User has no data write access for CategoryOption: " + categoryOptionA.getUid() ) );
+            assertThat( summary.getStatus(), is( ImportStatus.ERROR ) );
+            assertThat( summary.getImportCount().getIgnored(), is( 1 ) );
+            assertEquals( 1, summary.getConflictCount() );
+            assertThat( summary.getConflicts().iterator().next().getValue(),
+                is( "User has no data write access for CategoryOption: " + categoryOptionA.getUid() ) );
+        }
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
@@ -77,12 +77,15 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserCredentials;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Tests the {@link DataValueSetImportValidator}
  *
  * @author Jan Bernitt
  */
+@RunWith( MockitoJUnitRunner.class )
 public class DataValueSetImportValidatorTest
 {
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
@@ -28,7 +28,13 @@
 package org.hisp.dhis.dxf2.events.event;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -36,7 +42,9 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.google.common.collect.ImmutableList;
@@ -44,6 +52,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
+@RunWith( MockitoJUnitRunner.class )
 public class JdbcEventCommentStoreTest
 {
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheckTest.java
@@ -48,10 +48,13 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.user.User;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Luciano Fiandesio
  */
+@RunWith( MockitoJUnitRunner.class )
 public class ExpirationDaysCheckTest extends BaseValidationTest
 {
     private ExpirationDaysCheck rule;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
@@ -41,19 +41,11 @@ import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.system.SystemInfo;
 import org.hisp.dhis.system.SystemService;
-import org.hisp.dhis.system.util.HttpUtils;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,13 +53,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author aamerm
  */
-@RunWith( PowerMockRunner.class )
-@PrepareForTest( HttpUtils.class )
-@PowerMockIgnore( { "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*", "org.w3c.*" } )
+@RunWith( MockitoJUnitRunner.class )
 public class MetadataSyncDelegateTest
 {
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @InjectMocks
     private MetadataSyncDelegate metadataSyncDelegate;
@@ -80,13 +68,6 @@ public class MetadataSyncDelegateTest
 
     @Mock
     private RenderService renderService;
-
-    @Before
-    public void setup()
-    {
-        PowerMockito.mockStatic( HttpUtils.class );
-
-    }
 
     @Test
     public void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInLocal()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,24 +57,17 @@ import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.system.util.DhisHttpResponse;
 import org.hisp.dhis.system.util.HttpUtils;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 
 /**
  * @author anilkumk
  */
-@RunWith( PowerMockRunner.class )
-@PrepareForTest( HttpUtils.class )
-@PowerMockIgnore( { "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*", "org.w3c.*" } )
+@RunWith( MockitoJUnitRunner.class )
 public class MetadataVersionDelegateTest
 {
     private MetadataVersionDelegate target;
@@ -89,9 +83,6 @@ public class MetadataVersionDelegateTest
 
     @Mock
     private RenderService renderService;
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     private HttpResponse httpResponse;
 
@@ -116,7 +107,6 @@ public class MetadataVersionDelegateTest
     @Before
     public void setup()
     {
-        PowerMockito.mockStatic( HttpUtils.class );
         httpResponse = mock( HttpResponse.class );
         metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
         metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
@@ -141,14 +131,20 @@ public class MetadataVersionDelegateTest
 
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        MetadataVersion version = target.getRemoteMetadataVersion( "testVersion" );
 
-        assertNull( version );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( null );
+
+            MetadataVersion version = target.getRemoteMetadataVersion( "testVersion" );
+
+            assertNull( version );
+        }
     }
 
     @Test
     public void testShouldThrowExceptionWhenHTTPRequestFails()
-        throws Exception
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -157,11 +153,15 @@ public class MetadataVersionDelegateTest
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenThrow( new Exception( "" ) );
 
-        assertThrows( MetadataVersionServiceException.class,
-            () -> target.getRemoteMetadataVersion( "testVersion" ) );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenThrow( new Exception( "" ) );
+
+            assertThrows( MetadataVersionServiceException.class,
+                () -> target.getRemoteMetadataVersion( "testVersion" ) );
+        }
     }
 
     @Test
@@ -176,15 +176,20 @@ public class MetadataVersionDelegateTest
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
-        when( renderService.fromJson( response, MetadataVersion.class ) ).thenReturn( metadataVersion );
-        MetadataVersion remoteMetadataVersion = target.getRemoteMetadataVersion( "testVersion" );
 
-        assertEquals( metadataVersion.getType(), remoteMetadataVersion.getType() );
-        assertEquals( metadataVersion.getHashCode(), remoteMetadataVersion.getHashCode() );
-        assertEquals( metadataVersion.getName(), remoteMetadataVersion.getName() );
-        assertEquals( metadataVersion, remoteMetadataVersion );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
+
+            when( renderService.fromJson( response, MetadataVersion.class ) ).thenReturn( metadataVersion );
+            MetadataVersion remoteMetadataVersion = target.getRemoteMetadataVersion( "testVersion" );
+
+            assertEquals( metadataVersion.getType(), remoteMetadataVersion.getType() );
+            assertEquals( metadataVersion.getHashCode(), remoteMetadataVersion.getHashCode() );
+            assertEquals( metadataVersion.getName(), remoteMetadataVersion.getName() );
+            assertEquals( metadataVersion, remoteMetadataVersion );
+        }
     }
 
     @Test
@@ -208,27 +213,26 @@ public class MetadataVersionDelegateTest
         HttpResponse httpResponse = mock( HttpResponse.class );
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
 
-        PowerMockito.mockStatic( HttpUtils.class );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
 
-        PowerMockito.when( HttpUtils.httpGET( url, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
+            List<MetadataVersion> metadataVersionList = new ArrayList<>();
+            metadataVersionList.add( metadataVersion );
 
-        List<MetadataVersion> metadataVersionList = new ArrayList<>();
-        metadataVersionList.add( metadataVersion );
+            when( metadataSystemSettingService.getMetaDataDifferenceURL( "testVersion" ) ).thenReturn( baselineUrl );
+            when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
+            when( renderService.fromMetadataVersion( any( ByteArrayInputStream.class ), eq( RenderFormat.JSON ) ) )
+                .thenReturn( metadataVersionList );
 
-        when( metadataSystemSettingService.getMetaDataDifferenceURL( "testVersion" ) ).thenReturn( baselineUrl );
-        when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
-        when( renderService.fromMetadataVersion( any( ByteArrayInputStream.class ), eq( RenderFormat.JSON ) ) )
-            .thenReturn( metadataVersionList );
+            List<MetadataVersion> metaDataDifference = target.getMetaDataDifference( metadataVersion );
 
-        List<MetadataVersion> metaDataDifference = target.getMetaDataDifference( metadataVersion );
-
-        assertEquals( metaDataDifference.size(), metadataVersionList.size() );
-        assertEquals( metadataVersionList.get( 0 ).getType(), metaDataDifference.get( 0 ).getType() );
-        assertEquals( metadataVersionList.get( 0 ).getName(), metaDataDifference.get( 0 ).getName() );
-        assertEquals( metadataVersionList.get( 0 ).getHashCode(), metaDataDifference.get( 0 ).getHashCode() );
+            assertEquals( metaDataDifference.size(), metadataVersionList.size() );
+            assertEquals( metadataVersionList.get( 0 ).getType(), metaDataDifference.get( 0 ).getType() );
+            assertEquals( metadataVersionList.get( 0 ).getName(), metaDataDifference.get( 0 ).getName() );
+            assertEquals( metadataVersionList.get( 0 ).getHashCode(), metaDataDifference.get( 0 ).getHashCode() );
+        }
     }
 
     @Test
@@ -252,19 +256,21 @@ public class MetadataVersionDelegateTest
 
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
 
-        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
-        when( renderService.fromMetadataVersion( any( ByteArrayInputStream.class ), eq( RenderFormat.JSON ) ) )
-            .thenThrow( new IOException( "" ) );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
+            when( renderService.fromMetadataVersion( any( ByteArrayInputStream.class ), eq( RenderFormat.JSON ) ) )
+                .thenThrow( new IOException( "" ) );
 
-        assertThrows( "Exception occurred while trying to do JSON conversion. Caused by: ",
-            MetadataVersionServiceException.class,
-            () -> target.getMetaDataDifference( metadataVersion ) );
+            assertThrows( "Exception occurred while trying to do JSON conversion. Caused by: ",
+                MetadataVersionServiceException.class,
+                () -> target.getMetaDataDifference( metadataVersion ) );
+        }
     }
 
     @Test
     public void testShouldReturnEmptyMetadataDifference()
-        throws Exception
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -284,18 +290,20 @@ public class MetadataVersionDelegateTest
         DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response,
             HttpStatus.BAD_REQUEST.value() );
 
-        PowerMockito.when( HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( baselineUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
 
-        assertThrows(
-            "Client Error. Http call failed with status code: 400 Caused by: " + dhisHttpResponse.getResponse(),
-            MetadataVersionServiceException.class,
-            () -> target.getMetaDataDifference( metadataVersion ) );
+            assertThrows(
+                "Client Error. Http call failed with status code: 400 Caused by: " + dhisHttpResponse.getResponse(),
+                MetadataVersionServiceException.class,
+                () -> target.getMetaDataDifference( metadataVersion ) );
+        }
     }
 
     @Test
     public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithClientError()
-        throws Exception
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -312,19 +320,22 @@ public class MetadataVersionDelegateTest
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
 
-        assertThrows(
-            "Client Error. Http call failed with status code: "
-                + HttpStatus.CONFLICT.value() + " Caused by: " + response,
-            MetadataVersionServiceException.class,
-            () -> target.getRemoteMetadataVersion( "testVersion" ) );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
+
+            assertThrows(
+                "Client Error. Http call failed with status code: "
+                    + HttpStatus.CONFLICT.value() + " Caused by: " + response,
+                MetadataVersionServiceException.class,
+                () -> target.getRemoteMetadataVersion( "testVersion" ) );
+        }
     }
 
     @Test
     public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithServerError()
-        throws Exception
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -343,15 +354,17 @@ public class MetadataVersionDelegateTest
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
 
-        assertThrows(
-            "Server Error. Http call failed with status code: "
-                + HttpStatus.GATEWAY_TIMEOUT.value() + " Caused by: " + response,
-            MetadataVersionServiceException.class,
-            () -> target.getRemoteMetadataVersion( "testVersion" ) );
-
+            assertThrows(
+                "Server Error. Http call failed with status code: "
+                    + HttpStatus.GATEWAY_TIMEOUT.value() + " Caused by: " + response,
+                MetadataVersionServiceException.class,
+                () -> target.getRemoteMetadataVersion( "testVersion" ) );
+        }
     }
 
     @Test
@@ -366,60 +379,89 @@ public class MetadataVersionDelegateTest
 
         when( metadataSystemSettingService.getVersionDetailsUrl( "testVersion" ) ).thenReturn( versionUrl );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
-        when( renderService.fromJson( response, MetadataVersion.class ) )
-            .thenThrow( new MetadataVersionServiceException( "" ) );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked.when( () -> HttpUtils.httpGET( versionUrl, true, username, password, null, VERSION_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
+            when( renderService.fromJson( response, MetadataVersion.class ) )
+                .thenThrow( new MetadataVersionServiceException( "" ) );
 
-        assertThrows(
-            "Exception occurred while trying to do JSON conversion for metadata version",
-            MetadataVersionServiceException.class,
-            () -> target.getRemoteMetadataVersion( "testVersion" ) );
+            assertThrows(
+                "Exception occurred while trying to do JSON conversion for metadata version",
+                MetadataVersionServiceException.class,
+                () -> target.getRemoteMetadataVersion( "testVersion" ) );
+        }
     }
 
     @Test
     public void testShouldDownloadMetadataVersion()
-        throws Exception
     {
+        when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) )
+            .thenReturn( downloadUrl );
+        when( synchronizationManager.isRemoteServerAvailable() )
+            .thenReturn( new AvailabilityStatus( true, "test_message", null ) );
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
 
-        MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
-        metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
+            DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
+            mocked
+                .when( () -> HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) )
+                .thenReturn( dhisHttpResponse );
+            MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
+            metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
 
-        String url = "http://localhost:9080/api/metadata/version/testVersion/data.gz";
+            String actualVersionSnapShot = target.downloadMetadataVersionSnapshot( metadataVersion );
 
-        String response = "{\"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
-
-        when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) ).thenReturn( url );
-
-        AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
-        DhisHttpResponse dhisHttpResponse = new DhisHttpResponse( httpResponse, response, HttpStatus.OK.value() );
-
-        when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        PowerMockito.when( HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) )
-            .thenReturn( dhisHttpResponse );
-        String actualVersionSnapShot = target.downloadMetadataVersionSnapshot( metadataVersion );
-
-        assertEquals( response, actualVersionSnapShot );
+            assertEquals( response, actualVersionSnapShot );
+        }
     }
 
     @Test
-    public void testShouldNotDownloadMetadataVersion()
+    public void testShouldReturnNullOnInValidDHISResponse()
     {
-        MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.BEST_EFFORT );
-        metadataVersion.setHashCode( "12wa32d4f2et3tyt5yu6i" );
+        when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) )
+            .thenReturn( downloadUrl );
+        when( synchronizationManager.isRemoteServerAvailable() )
+            .thenReturn( new AvailabilityStatus( true, "test_message", null ) );
+        when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
+        when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
 
-        String url = "http://localhost:9080/api/metadata/version/testVersion/data.gz";
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked
+                .when( () -> HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) )
+                .thenReturn( null );
 
-        when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) ).thenReturn( url );
+            String actualVersionSnapShot = target
+                .downloadMetadataVersionSnapshot( new MetadataVersion( "testVersion", VersionType.BEST_EFFORT ) );
 
-        AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
+            assertNull( actualVersionSnapShot );
+        }
+    }
 
-        when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
-        String actualMetadataVersionSnapshot = target.downloadMetadataVersionSnapshot( metadataVersion );
+    @Test
+    public void testShouldNotGetMetadataVersionIfRemoteServerIsUnavailable()
+    {
+        when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) )
+            .thenReturn( downloadUrl );
+        when( synchronizationManager.isRemoteServerAvailable() )
+            .thenReturn( new AvailabilityStatus( false, "test_message", null ) );
 
-        assertNull( actualMetadataVersionSnapshot );
+        try ( MockedStatic<HttpUtils> mocked = mockStatic( HttpUtils.class ) )
+        {
+            mocked
+                .when( () -> HttpUtils.httpGET( downloadUrl, true, username, password, null, DOWNLOAD_TIMEOUT, true ) )
+                .thenReturn( null );
+
+            assertThrows( RemoteServerUnavailableException.class,
+                () -> target
+                    .downloadMetadataVersionSnapshot( new MetadataVersion( "testVersion", VersionType.BEST_EFFORT ) ) );
+
+            mocked.verifyNoInteractions();
+        }
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -57,14 +57,17 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
 
 /**
  * Unit tests for {@link DefaultFieldFilterService}.
  */
+@RunWith( MockitoJUnitRunner.class )
 public class DefaultFieldFilterServiceTest
 {
     private FieldParser fieldParser = new DefaultFieldParser();

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -197,7 +197,7 @@
 
         <!-- Test -->
         <junit.version>4.13.2</junit.version>
-        <mockito-core.version>3.4.6</mockito-core.version>
+        <mockito-core.version>4.1.0</mockito-core.version>
         <powermock.version>2.0.9</powermock.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hamcrest-date.version>2.0.7</hamcrest-date.version>
@@ -711,6 +711,10 @@
                                 <bannedDependencies>
                                     <excludes>
                                         <exclude>org.slf4j:slf4j-simple</exclude>
+                                        <!-- let's stick to mockito only to allow easy migration to JUnit 5 as mockito
+                                        & powermock are lead to trouble -->
+                                        <exclude>org.powermock:powermock-api-mockito2</exclude>
+                                        <exclude>org.powermock:powermock-module-junit4</exclude>
                                     </excludes>
                                 </bannedDependencies>
                                 <banDuplicatePomDependencyVersions/>
@@ -2255,30 +2259,12 @@
                 <version>${mockito-core.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- Depend only on mockito-inline (includes mockito-core already) if you must use mockStatic (can you
+            rewrite your code, so it's not necessary ;)), otherwise depend on mockito-core only -->
             <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.javassist</groupId>
-                        <artifactId>javassist</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>net.bytebuddy</groupId>
-                        <artifactId>byte-buddy-agent</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>net.bytebuddy</groupId>
-                        <artifactId>byte-buddy</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito-core.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Since 3.4 you can mockStatic with mockito which seems to be good enough
for our use cases. Only relying on mockito makes a transition to JUnit 5
easier as well. So double bonus :yum:

https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#static_mocks