### PR TITLE
chore(deps): bump log4j-core from 2.14.1 to 2.15.0 in /dhis-2 (#9431)

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -184,9 +184,9 @@
     <micrometer-spring-legacy.version>1.3.5</micrometer-spring-legacy.version>
     <micrometer-registry-prometheus.version>1.3.5</micrometer-registry-prometheus.version>
 
-    <!-- Logging-->
-    <log4j.version>2.14.0</log4j.version>
-    <slf4j.version>1.7.30</slf4j.version>
+        <!-- Logging-->
+        <log4j.version>2.14.1</log4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
 
     <!-- Test -->
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
Bumps log4j-core from 2.14.1 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

(cherry picked from commit d68ea622f36aa98bb04c59f554a886445fd03c27)