### PR TITLE
chore(deps): bump log4j-core from 2.14.1 to 2.15.0 in /dhis-2 (#9431)

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2063,8 +2063,8 @@
     <!-- unit test dependencies-->
     <powermock.version>2.0.4</powermock.version>
     <jackson.version>2.11.2</jackson.version>
-    <log4j.version>2.13.0</log4j.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <log4j.version>2.15.0</log4j.version>
+    <slf4j.version>1.7.32</slf4j.version>
     <testcontainers.version>1.15.1</testcontainers.version>
     <geotools.version>18.0</geotools.version>
     <jasperreports.version>6.3.1</jasperreports.version>


### PR DESCRIPTION
Bumps log4j-core from 2.14.1 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

(cherry picked from commit d68ea622f36aa98bb04c59f554a886445fd03c27)