### PR TITLE
chore: extracts spring independent HTTP request test API

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithApiTokenAuthTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithApiTokenAuthTest.java
@@ -29,11 +29,11 @@ package org.hisp.dhis.webapi;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 
-import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
 import org.hisp.dhis.webapi.json.JsonResponse;
 import org.hisp.dhis.webapi.security.config.WebMvcConfig;
+import org.hisp.dhis.webapi.utils.DhisMockMvcControllerTest;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +47,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 /**
  * Base class for convenient testing of the web API on basis of
@@ -63,7 +62,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @ContextConfiguration( classes = { WebMvcConfig.class, WebTestConfigurationWithAuth.class } )
 @ActiveProfiles( "test-h2" )
 @Transactional
-public abstract class DhisControllerWithApiTokenAuthTest extends DhisConvenienceTest implements WebClient
+public abstract class DhisControllerWithApiTokenAuthTest extends DhisMockMvcControllerTest
 {
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -82,10 +81,6 @@ public abstract class DhisControllerWithApiTokenAuthTest extends DhisConvenience
     {
         userService = _userService;
 
-        CharacterEncodingFilter characterEncodingFilter = new CharacterEncodingFilter();
-        characterEncodingFilter.setEncoding( "UTF-8" );
-        characterEncodingFilter.setForceEncoding( true );
-
         mvc = MockMvcBuilders.webAppContextSetup( webApplicationContext )
             .addFilter( springSecurityFilterChain ).build();
 
@@ -93,9 +88,9 @@ public abstract class DhisControllerWithApiTokenAuthTest extends DhisConvenience
     }
 
     @Override
-    public HttpResponse webRequest( MockHttpServletRequestBuilder request )
+    protected final HttpResponse webRequest( MockHttpServletRequestBuilder request )
     {
         return failOnException(
-            () -> new HttpResponse( mvc.perform( request ).andReturn().getResponse() ) );
+            () -> new HttpResponse( toResponse( mvc.perform( request ).andReturn().getResponse() ) ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
@@ -29,11 +29,11 @@ package org.hisp.dhis.webapi;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 
-import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
 import org.hisp.dhis.webapi.json.JsonResponse;
 import org.hisp.dhis.webapi.security.config.WebMvcConfig;
+import org.hisp.dhis.webapi.utils.DhisMockMvcControllerTest;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +47,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 /**
  * Base class for convenient testing of the web API on basis of
@@ -60,7 +59,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @ContextConfiguration( classes = { WebMvcConfig.class, WebTestConfigurationWithJwtTokenAuth.class } )
 @ActiveProfiles( "test-h2" )
 @Transactional
-public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenienceTest implements WebClient
+public abstract class DhisControllerWithJwtTokenAuthTest extends DhisMockMvcControllerTest
 {
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -79,10 +78,6 @@ public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenience
     {
         userService = _userService;
 
-        CharacterEncodingFilter characterEncodingFilter = new CharacterEncodingFilter();
-        characterEncodingFilter.setEncoding( "UTF-8" );
-        characterEncodingFilter.setForceEncoding( true );
-
         mvc = MockMvcBuilders.webAppContextSetup( webApplicationContext )
             .addFilter( springSecurityFilterChain ).build();
 
@@ -90,9 +85,9 @@ public abstract class DhisControllerWithJwtTokenAuthTest extends DhisConvenience
     }
 
     @Override
-    public HttpResponse webRequest( MockHttpServletRequestBuilder request )
+    protected final HttpResponse webRequest( MockHttpServletRequestBuilder request )
     {
         return failOnException(
-            () -> new HttpResponse( mvc.perform( request ).andReturn().getResponse() ) );
+            () -> new HttpResponse( toResponse( mvc.perform( request ).andReturn().getResponse() ) ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebSnippet.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebSnippet.java
@@ -58,7 +58,7 @@ public abstract class WebSnippet<T> implements WebClient
     public final HttpResponse webRequest( HttpMethod method, String url, List<Header> headers, MediaType contentType,
         String content )
     {
-        return client.webRequest( method, null, headers, contentType, content );
+        return client.webRequest( method, url, headers, contentType, content );
     }
 
     /**

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebSnippet.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebSnippet.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.webapi;
 
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import java.util.List;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 
 /**
  * Base class to create context free reusable snippets.
@@ -52,9 +55,10 @@ public abstract class WebSnippet<T> implements WebClient
     }
 
     @Override
-    public final HttpResponse webRequest( MockHttpServletRequestBuilder request )
+    public final HttpResponse webRequest( HttpMethod method, String url, List<Header> headers, MediaType contentType,
+        String content )
     {
-        return client.webRequest( request );
+        return client.webRequest( method, null, headers, contentType, content );
     }
 
     /**

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/DhisMockMvcControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/DhisMockMvcControllerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.webapi.WebClient;
+import org.hisp.dhis.webapi.json.JsonResponse;
+import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+/**
+ * Base class for all Spring Mock MVC based controller tests.
+ *
+ * @author Jan Bernitt
+ */
+public abstract class DhisMockMvcControllerTest extends DhisConvenienceTest implements WebClient
+{
+
+    public static JsonWebMessage assertWebMessage( String httpStatus, int httpStatusCode, String status, String message,
+        JsonResponse actual )
+    {
+        return assertWebMessage( httpStatus, httpStatusCode, status, message, actual.as( JsonWebMessage.class ) );
+    }
+
+    public static JsonWebMessage assertWebMessage( String httpStatus, int httpStatusCode, String status, String message,
+        JsonWebMessage actual )
+    {
+        assertTrue( "response appears to be something other than a WebMessage: " + actual.toString(),
+            actual.has( "httpStatusCode", "httpStatus", "status" ) );
+        assertEquals( "unexpected HTTP status code", httpStatusCode, actual.getHttpStatusCode() );
+        assertEquals( "unexpected HTTP status", httpStatus, actual.getHttpStatus() );
+        assertEquals( "unexpected status", status, actual.getStatus() );
+        assertEquals( "unexpected message", message, actual.getMessage() );
+        return actual;
+    }
+
+    public static ResponseAdapter toResponse( MockHttpServletResponse response )
+    {
+        return new MockMvcResponseAdapter( response );
+    }
+
+    @Override
+    public HttpResponse webRequest( HttpMethod method, String url, List<Header> headers, MediaType contentType,
+        String content )
+    {
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.request( method, url );
+        for ( Header header : headers )
+        {
+            request.header( header.getName(), header.getValue() );
+        }
+        if ( contentType != null )
+        {
+            request.contentType( contentType );
+        }
+        if ( content != null )
+        {
+            request.content( content );
+        }
+        return webRequest( request );
+    }
+
+    protected abstract HttpResponse webRequest( MockHttpServletRequestBuilder request );
+
+    private static class MockMvcResponseAdapter implements ResponseAdapter
+    {
+
+        private final MockHttpServletResponse response;
+
+        MockMvcResponseAdapter( MockHttpServletResponse response )
+        {
+            this.response = response;
+        }
+
+        @Override
+        public int getStatus()
+        {
+            return response.getStatus();
+        }
+
+        @Override
+        public String getContent()
+        {
+            try
+            {
+                return response.getContentAsString( StandardCharsets.UTF_8 );
+            }
+            catch ( UnsupportedEncodingException ex )
+            {
+                throw new RuntimeException( ex );
+            }
+        }
+
+        @Override
+        public String getErrorMessage()
+        {
+            return response.getErrorMessage();
+        }
+
+        @Override
+        public String getHeader( String name )
+        {
+            return response.getHeader( name );
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Makes the `WebClient` layer independent of spring Mock MVC so we can use it in e.g. e2e as a layer on top of actual web request or in container integration tests.

Th make the layer independent both request and response need a indirection so they can be adopted to different underlying layers like sping Mock MVC or real requests. 

The spring Mock MVC adoption has been moved to a new base test class `DhisMockMvcControllerTest` that contains the request and response adopters.

Special HTTP methods like multipart files or file uploads are not supported by the generic layer the support methods have been moved to the base test for Mock MVC and will just be supported there. Other implementations can go the same route of implementing special handling in their base class. From the user point of view this difference is indistinguishable. 

This is the essential step to allow reusing the `WebClient` layer in other setups. 2nd step will be to extract it to an independent module so e2e can depend on the artifact.
