### PR TITLE
fix: Event report download response has wrong content-disposition hea…

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -259,7 +259,7 @@ public class EventAnalyticsController
         throws Exception
     {
         GridUtils.toXml( getListGridWithAttachment( criteria, program, apiVersion, ContextUtils.CONTENT_TYPE_XML,
-            "events.xml", response ), response.getOutputStream() );
+            "events.xml", false, response ), response.getOutputStream() );
     }
 
     @GetMapping( value = RESOURCE_PATH + "/query/{program}.xls" )
@@ -271,7 +271,7 @@ public class EventAnalyticsController
         throws Exception
     {
         GridUtils.toXls( getListGridWithAttachment( criteria, program, apiVersion, ContextUtils.CONTENT_TYPE_EXCEL,
-            "events.xls", response ), response.getOutputStream() );
+            "events.xls", true, response ), response.getOutputStream() );
     }
 
     @GetMapping( value = RESOURCE_PATH + "/query/{program}.csv" )
@@ -283,7 +283,7 @@ public class EventAnalyticsController
         throws Exception
     {
         GridUtils.toCsv( getListGridWithAttachment( criteria, program, apiVersion, ContextUtils.CONTENT_TYPE_CSV,
-            "events.csv", response ), response.getWriter() );
+            "events.csv", true, response ), response.getWriter() );
     }
 
     @GetMapping( value = RESOURCE_PATH + "/query/{program}.html" )
@@ -295,7 +295,7 @@ public class EventAnalyticsController
         throws Exception
     {
         GridUtils.toHtml( getListGridWithAttachment( criteria, program, apiVersion, ContextUtils.CONTENT_TYPE_HTML,
-            "events.html", response ), response.getWriter() );
+            "events.html", false, response ), response.getWriter() );
     }
 
     @GetMapping( value = RESOURCE_PATH + "/query/{program}.html+css" )
@@ -307,7 +307,7 @@ public class EventAnalyticsController
         throws Exception
     {
         GridUtils.toHtmlCss( getListGridWithAttachment( criteria, program, apiVersion, ContextUtils.CONTENT_TYPE_HTML,
-            "events.html", response ), response.getWriter() );
+            "events.html", false, response ), response.getWriter() );
     }
 
     @GetMapping( value = RESOURCE_PATH + "/query/dimensions", produces = { APPLICATION_JSON_VALUE,
@@ -343,12 +343,12 @@ public class EventAnalyticsController
 
     private Grid getListGridWithAttachment( EventsAnalyticsQueryCriteria criteria, String program,
         DhisApiVersion apiVersion,
-        String contentType, String file,
+        String contentType, String file, boolean attachment,
         HttpServletResponse response )
     {
         EventQueryParams params = getEventQueryParams( program, criteria, apiVersion );
 
-        contextUtils.configureResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, file, false );
+        contextUtils.configureResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, file, attachment );
         return analyticsService.getEvents( params );
     }
 


### PR DESCRIPTION
see: https://jira.dhis2.org/browse/DHIS2-12216

When trying to download a file via a URL like below, some/most browsers will try to open the file in the browser instead of downloading it:
api/analytics/events/query/eBAyeGv0exc.xls

(I've omitted all the query params)

The reason for this is that the content-disposition in the response header is incorrect. Currently it is this:
content-disposition: inline; filename="events.xls"
But it should be:
content-disposition: attachment; filename="events.xls"

json, xml, html are inline;
xls, csv are attachment.