### PR TITLE
[2.38-DHIS2-TECH842] Grid Caching is not properly used in analytics 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -315,6 +315,11 @@ public class MetadataItem
         return indicatorType;
     }
 
+    public void setIndicatorType( IndicatorType indicatorType )
+    {
+        this.indicatorType = HibernateProxyUtils.unproxy( indicatorType );
+    }
+
     @JsonProperty
     public TotalAggregationType getTotalAggregationType()
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -315,11 +315,6 @@ public class MetadataItem
         return indicatorType;
     }
 
-    public void setIndicatorType( AggregationType itemSpecificType )
-    {
-        this.aggregationType = itemSpecificType;
-    }
-
     @JsonProperty
     public TotalAggregationType getTotalAggregationType()
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -315,6 +315,11 @@ public class MetadataItem
         return indicatorType;
     }
 
+    public void setIndicatorType( AggregationType itemSpecificType )
+    {
+        this.aggregationType = itemSpecificType;
+    }
+
     @JsonProperty
     public TotalAggregationType getTotalAggregationType()
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -32,6 +32,7 @@ import java.util.Date;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.period.Period;
@@ -185,7 +186,7 @@ public class MetadataItem
 
             if ( indicator.getIndicatorType() != null )
             {
-                this.indicatorType = indicator.getIndicatorType();
+                this.indicatorType = HibernateProxyUtils.unproxy( indicator.getIndicatorType() );
             }
         }
     }
@@ -312,11 +313,6 @@ public class MetadataItem
     public IndicatorType getIndicatorType()
     {
         return indicatorType;
-    }
-
-    public void setIndicatorType( IndicatorType indicatorType )
-    {
-        this.indicatorType = indicatorType;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/AnalyticsCache.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/AnalyticsCache.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.logging.Log;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.cache.Cache;
@@ -75,7 +76,7 @@ public class AnalyticsCache
 
     public Optional<Grid> get( final String key )
     {
-        return queryCache.get( key );
+        return getGridClone( queryCache.get( key ) );
     }
 
     /**
@@ -98,7 +99,7 @@ public class AnalyticsCache
 
         if ( cachedGrid.isPresent() )
         {
-            return cachedGrid.get();
+            return getGridClone( cachedGrid.get() );
         }
         else
         {
@@ -106,7 +107,7 @@ public class AnalyticsCache
 
             put( params, grid );
 
-            return grid;
+            return getGridClone( grid );
         }
     }
 
@@ -145,7 +146,7 @@ public class AnalyticsCache
      */
     public void put( final String key, final Grid grid, final long ttlInSeconds )
     {
-        queryCache.put( key, grid, ttlInSeconds );
+        queryCache.put( key, getGridClone( grid ), ttlInSeconds );
     }
 
     /**
@@ -161,5 +162,20 @@ public class AnalyticsCache
     public boolean isEnabled()
     {
         return analyticsCacheSettings.isCachingEnabled();
+    }
+
+    private Grid getGridClone( Grid grid )
+    {
+        if ( grid != null )
+        {
+            return SerializationUtils.clone( grid );
+        }
+
+        return null;
+    }
+
+    private Optional<Grid> getGridClone( Optional<Grid> grid )
+    {
+        return grid.map( SerializationUtils::clone );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.cache;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheBuilder;
+import org.hisp.dhis.cache.DefaultCacheProvider;
+import org.hisp.dhis.cache.LocalCache;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.grid.ListGrid;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoRule;
+
+import com.google.common.collect.Lists;
+
+/**
+ * @author Dusan Bernat
+ */
+public class AnalyticsCacheTest
+{
+    @Mock
+    private SystemSettingManager systemSettingManager;
+
+    @Mock
+    private DefaultCacheProvider cacheProvider;
+
+    @Rule
+    public MockitoRule mockitoRule = rule();
+
+    @Test
+    public void returnSameObjectAfterModifyCachedObject()
+    {
+        // arrange
+        final AnalyticsCacheSettings settings = new AnalyticsCacheSettings( systemSettingManager );
+
+        final CacheBuilder<Grid> cacheBuilder = new SimpleCacheBuilder<>();
+
+        cacheBuilder.expireAfterWrite( 1L, TimeUnit.MINUTES );
+
+        final Cache<Grid> cache = new LocalCache<>( cacheBuilder );
+
+        Mockito.<Cache<Grid>> when( cacheProvider.createAnalyticsResponseCache( any( Duration.class ) ) )
+            .thenReturn( cache );
+
+        final AnalyticsCache analyticsCache = new AnalyticsCache( cacheProvider, settings );
+
+        final Grid grid = new ListGrid();
+        grid.addHeader( new GridHeader( "Header1" ) )
+            .addHeader( new GridHeader( "Header2" ) )
+            .addRow()
+            .addValue( "Value11" )
+            .addValue( "Value12" )
+            .addRow()
+            .addValue( "Value21" )
+            .addValue( "Value22" );
+
+        DataQueryParams params = DataQueryParams.newBuilder()
+            .withDataElements(
+                Lists.newArrayList( new DataElement( "dataElementA" ), new DataElement( "dataElementB" ) ) )
+            .build();
+
+        // act, assert
+        analyticsCache.put( params.getKey(), grid, 60 );
+
+        Optional<Grid> optCachedGrid = analyticsCache.get( params.getKey() );
+
+        Assert.assertTrue( optCachedGrid.isPresent() );
+
+        Assert.assertEquals( 2, optCachedGrid.get().getHeaderWidth() );
+
+        Assert.assertEquals( 2, optCachedGrid.get().getRows().size() );
+
+        // when the cachedGrid is not the clone of grid, next actions will
+        // modify it
+        grid.addHeader( new GridHeader( "Header3" ) )
+            .addRow()
+            .addValue( "31" )
+            .addValue( "32" );
+
+        optCachedGrid = analyticsCache.get( params.getKey() );
+
+        Assert.assertTrue( optCachedGrid.isPresent() );
+
+        Assert.assertEquals( 2, optCachedGrid.get().getHeaderWidth() );
+
+        Assert.assertEquals( 2, optCachedGrid.get().getRows().size() );
+    }
+}


### PR DESCRIPTION
/api/analytics/dataValueSet.json?dimension=dx:SqD0kovH0CS&dimension=ou:m5NxCAOnDg6&dimension=pe:20210902 where dx is a program indicator returns null value, when the request is issued second time and more within AnalyticsCache TTL
(typically 60sec)

first response:
``` json
{
    "dataValues": [
        {
            "dataElement": "SqD0kovH0CS",
            "period": "20210902",
            "orgUnit": "m5NxCAOnDg6",
            "value": "2.0",
            "storedBy": "[aggregated]",
            "created": "2021-11-23",
            "lastUpdated": "2021-11-23",
            "comment": "[aggregated]"
        }
    ]
}
```
second one:
``` json
{
    "dataValues": [
        {
            "dataElement": "SqD0kovH0CS",
            "period": "20210902",
            "orgUnit": "m5NxCAOnDg6",
            "value": "null",
            "storedBy": "[aggregated]",
            "created": "2021-11-23",
            "lastUpdated": "2021-11-23",
            "comment": "[aggregated]"
        }
    ]
}
```
The problem was identified in the caching of analytics Grid object:

this is object coming to cache:
[dy, ou, pe, value]
[SqD0kovH0CS, m5NxCAOnDg6, 20210902, 2.0]

first get:
[dy, ou, pe, value]
[SqD0kovH0CS, m5NxCAOnDg6, 20210902, null, null, 2.0]

second one:
[dy, ou, pe, value]
[SqD0kovH0CS, m5NxCAOnDg6, 20210902, null, null, null, null, 2.0]

We are caching the grid and modifying it later within one single request. Because this is in memory cache inside the runtime JVM, only reference is cached, there is no serialization on the way. After the caching, cached object is modified (add two rows for coc and aoc). Within the next request we modified already modified object so the grid is not readable correctly anymore until the cache expiration.