### PR TITLE
chore(deps): bump log4j-core from 2.15.0 to 2.16.0 in /dhis-2 (#9466)

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -194,7 +194,7 @@
     <micrometer-registry-prometheus.version>1.3.5</micrometer-registry-prometheus.version>
 
         <!-- Logging-->
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <slf4j.version>1.7.32</slf4j.version>
 
     <!-- Test -->


### PR DESCRIPTION
(cherry picked from commit 4f34405c0a4c9add43375735b88ebddd98d7bddf)